### PR TITLE
Highlight for string array

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -96,6 +96,7 @@
 - ~~gzip compress responses~~
 - ~~Have a LOG(ERROR) level~~
 - ~~Handle SIGTERM which is sent when process is killed~~
+- Use snappy compression for storage
 - Exact search 
 - NOT operator support
 - Log operations

--- a/TODO.md
+++ b/TODO.md
@@ -100,6 +100,8 @@
 - NOT operator support
 - Log operations
 - Parameterize replica's MAX_UPDATES_TO_SEND
+- NOT operator support
+- 64K token limit
 - > INT32_MAX validation for float field
 - highlight of string arrays?
 - test for token ranking on float field

--- a/docker/development.Dockerfile
+++ b/docker/development.Dockerfile
@@ -2,7 +2,7 @@
 # 
 # $ docker push typesense/typesense-development:latest
 
-FROM typesense/ubuntu-10.04-gcc:6.5.0
+FROM typesense/ubuntu-10-04-gcc:6.4.0
 
 ENV PATH /usr/local/gcc-6.4.0/bin/:$PATH
 ENV LD_LIBRARY_PATH /usr/local/gcc-6.4.0/lib64
@@ -16,26 +16,27 @@ RUN apt-get install -y python-software-properties \
 	libidn11 \
 	git
 
-ADD https://cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz /opt/
-RUN tar -C /opt -xvzf /opt/cmake-3.3.2-Linux-x86_64.tar.gz
-RUN cp -r /opt/cmake-3.3.2-Linux-x86_64/* /usr
-
-ADD https://launchpad.net/ubuntu/+archive/primary/+files/snappy_1.1.3.orig.tar.gz /opt/
-RUN tar -C /opt -xf /opt/snappy_1.1.3.orig.tar.gz
-RUN mkdir /opt/snappy-1.1.3/build && cd /opt/snappy-1.1.3/build && ../configure && make && make install
-
-ADD https://openssl.org/source/openssl-1.0.2k.tar.gz /opt/
+RUN curl -L -o /opt/openssl-1.0.2k.tar.gz https://openssl.org/source/openssl-1.0.2k.tar.gz
 RUN tar -C /opt -xvzf /opt/openssl-1.0.2k.tar.gz
 RUN cd /opt/openssl-1.0.2k && sh ./config --prefix=/usr --openssldir=/usr zlib-dynamic
 RUN make -C /opt/openssl-1.0.2k depend
 RUN make -C /opt/openssl-1.0.2k -j4
 RUN make -C /opt/openssl-1.0.2k install
 
-ADD https://github.com/curl/curl/releases/download/curl-7_55_1/curl-7.55.1.tar.bz2 /opt/
+RUN curl -L -o /opt/curl-7.55.1.tar.bz2 https://github.com/curl/curl/releases/download/curl-7_55_1/curl-7.55.1.tar.bz2
 RUN tar -C /opt -xf /opt/curl-7.55.1.tar.bz2
-RUN cd /opt/curl-7.55.1 && ./configure && make && make install
+RUN cd /opt/curl-7.55.1 && LIBS="-ldl -lpthread" ./configure --disable-shared --with-ssl=/usr \
+--with-ca-bundle=/etc/ssl/certs/cacert.pem && make && make install
 
-ADD https://ssl.icu-project.org/files/icu4c/61.1/icu4c-61_1-src.tgz /opt/
+RUN curl -L -o /opt/cmake-3.3.2-Linux-x86_64.tar.gz https://cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz
+RUN tar -C /opt -xvzf /opt/cmake-3.3.2-Linux-x86_64.tar.gz
+RUN cp -r /opt/cmake-3.3.2-Linux-x86_64/* /usr
+
+RUN curl -L -o /opt/snappy_1.1.3.orig.tar.gz https://launchpad.net/ubuntu/+archive/primary/+files/snappy_1.1.3.orig.tar.gz
+RUN tar -C /opt -xf /opt/snappy_1.1.3.orig.tar.gz
+RUN mkdir /opt/snappy-1.1.3/build && cd /opt/snappy-1.1.3/build && ../configure && make && make install
+
+RUN curl -L -o /opt/icu4c-61_1-src.tgz https://ssl.icu-project.org/files/icu4c/61.1/icu4c-61_1-src.tgz
 RUN tar -C /opt -xf /opt/icu4c-61_1-src.tgz
 RUN cd /opt/icu/source && echo "#define U_DISABLE_RENAMING 1" >> common/unicode/uconfig.h && \
     echo "#define U_STATIC_IMPLEMENTATION 1" >> common/unicode/uconfig.h && \

--- a/docker/ubuntu-10-04-gcc.Dockerfile
+++ b/docker/ubuntu-10-04-gcc.Dockerfile
@@ -1,4 +1,4 @@
-# $ docker build --file $PROJECT_DIR/docker/ubuntu-10-04-gcc.Dockerfile --tag typesense/ubuntu-10.04-gcc:latest --tag typesense/ubuntu-10.04-gcc:6.5 $PROJECT_DIR/docker
+# $ docker build --file $PROJECT_DIR/docker/ubuntu-10-04-gcc.Dockerfile --tag typesense/ubuntu-10.04-gcc:latest --tag typesense/ubuntu-10.04-gcc:6.4 $PROJECT_DIR/docker
 # 
 # NOTE: Default build image is bloated. Before publishing, export from a container to squash the image:
 # $ docker run -it typesense/ubuntu-10.04-gcc:latest bash -c "exit"
@@ -12,7 +12,6 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	tar \
-	curl \
 	libmpfr-dev \
 	libgmp3-dev \
 	libmpc-dev \
@@ -20,7 +19,22 @@ RUN apt-get update && apt-get install -y \
 	bison \
 	zlib1g-dev
 
-ADD https://ftp.gnu.org/gnu/gcc/gcc-6.4.0/gcc-6.4.0.tar.gz /opt/
+RUN mkdir -p /etc/ssl/certs
+ADD https://curl.haxx.se/ca/cacert.pem /etc/ssl/certs/cacert.pem
+
+ADD https://openssl.org/source/openssl-1.0.2k.tar.gz /opt/openssl-1.0.2k.tar.gz
+RUN tar -C /opt -xvzf /opt/openssl-1.0.2k.tar.gz
+RUN cd /opt/openssl-1.0.2k && sh ./config --prefix=/usr/local --openssldir=/usr/local zlib-dynamic
+RUN make -C /opt/openssl-1.0.2k depend
+RUN make -C /opt/openssl-1.0.2k -j4
+RUN make -C /opt/openssl-1.0.2k install
+
+ADD https://github.com/curl/curl/releases/download/curl-7_55_1/curl-7.55.1.tar.bz2 /opt/curl-7.55.1.tar.bz2
+RUN tar -C /opt -xf /opt/curl-7.55.1.tar.bz2
+RUN cd /opt/curl-7.55.1 && LIBS="-ldl -lpthread" ./configure --disable-shared --with-ssl=/usr/local \
+--with-ca-bundle=/etc/ssl/certs/cacert.pem && make && make install
+
+RUN curl -L -o /opt/gcc-6.4.0.tar.gz https://ftp.gnu.org/gnu/gcc/gcc-6.4.0/gcc-6.4.0.tar.gz
 RUN tar -C /opt -xf /opt/gcc-6.4.0.tar.gz
 
 RUN mkdir /opt/gcc-6.4.0/build && cd /opt/gcc-6.4.0/build && ../configure --disable-checking --enable-languages=c,c++ \
@@ -32,7 +46,8 @@ RUN cd /opt/gcc-6.4.0/build && make -j8
 RUN cd /opt/gcc-6.4.0/build && make install
 
 RUN apt-get remove -y gcc
-RUN rm -rf /opt/gcc-6.4.0 /opt/gcc-6.4.0.tar.gz
+RUN rm -rf /opt/gcc-6.4.0 /opt/gcc-6.4.0.tar.gz /opt/openssl-1.0.2k /opt/openssl-1.0.2k.tar.gz \
+/opt/curl-7.55.1 /opt/curl-7.55.1.tar.bz2
 
 ENV PATH /usr/local/gcc-6.4.0/bin/:$PATH
 ENV LD_LIBRARY_PATH /usr/local/gcc-6.4.0/lib64

--- a/include/index.h
+++ b/include/index.h
@@ -84,10 +84,6 @@ private:
 
     void do_facets(std::vector<facet> & facets, uint32_t* result_ids, size_t results_size);
 
-    void populate_token_positions(const std::vector<art_leaf *> &query_suggestion,
-                                  spp::sparse_hash_map<const art_leaf *, uint32_t *> &leaf_to_indices,
-                                  size_t result_index, std::vector<std::vector<uint16_t>> &token_positions) const;
-
     void search_field(std::string & query, const std::string & field, uint32_t *filter_ids, size_t filter_ids_length,
                       std::vector<facet> & facets, const std::vector<sort_by> & sort_fields,
                       const int num_typos, const size_t num_results,
@@ -101,6 +97,9 @@ private:
                            const token_ordering token_order, std::vector<std::vector<art_leaf*>> & searched_queries,
                            Topster<512> & topster, size_t & total_results, uint32_t** all_result_ids,
                            size_t & all_result_ids_len, const size_t & max_results, const bool prefix);
+
+    void insert_doc(const uint32_t score, art_tree *t, uint32_t seq_id,
+                    const std::unordered_map<std::string, std::vector<uint32_t>> &token_to_offsets) const;
 
     void index_string_field(const std::string & text, const uint32_t score, art_tree *t, uint32_t seq_id,
                             const bool verbatim) const;
@@ -147,6 +146,11 @@ public:
 
     Option<uint32_t> remove(const uint32_t seq_id, nlohmann::json & document);
 
+    static void populate_token_positions(const std::vector<art_leaf *> &query_suggestion,
+                                         spp::sparse_hash_map<const art_leaf *, uint32_t *> &leaf_to_indices,
+                                         size_t result_index,
+                                         std::vector<std::vector<std::vector<uint16_t>>> &array_token_positions);
+
     void score_results(const std::vector<sort_by> & sort_fields, const int & query_index, const uint32_t total_cost,
                        Topster<512> &topster, const std::vector<art_leaf *> & query_suggestion,
                        const uint32_t *result_ids, const size_t result_size) const;
@@ -161,6 +165,8 @@ public:
 
     // strings under this length will be fully highlighted, instead of showing a snippet of relevant portion
     enum {SNIPPET_STR_ABOVE_LEN = 30};
+
+    enum {ARRAY_SEPARATOR = UINT16_MAX};
 
     // Using a $ prefix so that these meta keys stay above record entries in a lexicographically ordered KV store
     static constexpr const char* COLLECTION_META_PREFIX = "$CM";

--- a/include/index.h
+++ b/include/index.h
@@ -33,7 +33,7 @@ struct search_args {
     token_ordering token_order;
     bool prefix;
     size_t drop_tokens_threshold;
-    std::vector<Topster<512>::KV> field_order_kvs;
+    std::vector<Topster<512>::KV*> field_order_kvs;
     size_t all_result_ids_len;
     std::vector<std::vector<art_leaf*>> searched_queries;
     Option<uint32_t> outcome;
@@ -142,7 +142,7 @@ public:
                           std::vector<sort_by> sort_fields_std, const int num_typos,
                           const size_t per_page, const size_t page,
                           const token_ordering token_order, const bool prefix, const size_t drop_tokens_threshold,
-                          std::vector<Topster<512>::KV> & field_order_kv,
+                          std::vector<Topster<512>::KV*> & field_order_kv,
                           size_t & all_result_ids_len, std::vector<std::vector<art_leaf*>> & searched_queries);
 
     Option<uint32_t> remove(const uint32_t seq_id, nlohmann::json & document);

--- a/include/index.h
+++ b/include/index.h
@@ -96,7 +96,7 @@ private:
     void search_candidates(const uint8_t & field_id, uint32_t* filter_ids, size_t filter_ids_length, std::vector<facet> & facets,
                            const std::vector<sort_by> & sort_fields, std::vector<token_candidates> & token_to_candidates,
                            const token_ordering token_order, std::vector<std::vector<art_leaf*>> & searched_queries,
-                           Topster<512> & topster, size_t & total_results, uint32_t** all_result_ids,
+                           Topster<512> & topster, uint32_t** all_result_ids,
                            size_t & all_result_ids_len, const size_t & max_results, const bool prefix);
 
     void insert_doc(const uint32_t score, art_tree *t, uint32_t seq_id,
@@ -152,7 +152,7 @@ public:
                                          size_t result_index,
                                          std::vector<std::vector<std::vector<uint16_t>>> &array_token_positions);
 
-    void score_results(const std::vector<sort_by> & sort_fields, const int & query_index, const uint8_t & field_id,
+    void score_results(const std::vector<sort_by> & sort_fields, const uint16_t & query_index, const uint8_t & field_id,
                        const uint32_t total_cost, Topster<512> &topster, const std::vector<art_leaf *> & query_suggestion,
                        const uint32_t *result_ids, const size_t result_size) const;
 

--- a/include/index.h
+++ b/include/index.h
@@ -33,7 +33,7 @@ struct search_args {
     token_ordering token_order;
     bool prefix;
     size_t drop_tokens_threshold;
-    std::vector<Topster<512>::KV*> field_order_kvs;
+    std::vector<Topster<512>::KV> field_order_kvs;
     size_t all_result_ids_len;
     std::vector<std::vector<art_leaf*>> searched_queries;
     Option<uint32_t> outcome;
@@ -142,7 +142,7 @@ public:
                           std::vector<sort_by> sort_fields_std, const int num_typos,
                           const size_t per_page, const size_t page,
                           const token_ordering token_order, const bool prefix, const size_t drop_tokens_threshold,
-                          std::vector<Topster<512>::KV*> & field_order_kv,
+                          std::vector<Topster<512>::KV> & field_order_kv,
                           size_t & all_result_ids_len, std::vector<std::vector<art_leaf*>> & searched_queries);
 
     Option<uint32_t> remove(const uint32_t seq_id, nlohmann::json & document);

--- a/include/index.h
+++ b/include/index.h
@@ -33,7 +33,7 @@ struct search_args {
     token_ordering token_order;
     bool prefix;
     size_t drop_tokens_threshold;
-    std::vector<std::pair<int, Topster<512>::KV>> field_order_kvs;
+    std::vector<Topster<512>::KV> field_order_kvs;
     size_t all_result_ids_len;
     std::vector<std::vector<art_leaf*>> searched_queries;
     Option<uint32_t> outcome;
@@ -84,7 +84,8 @@ private:
 
     void do_facets(std::vector<facet> & facets, uint32_t* result_ids, size_t results_size);
 
-    void search_field(std::string & query, const std::string & field, uint32_t *filter_ids, size_t filter_ids_length,
+    void search_field(const uint8_t & field_id, std::string & query,
+                      const std::string & field, uint32_t *filter_ids, size_t filter_ids_length,
                       std::vector<facet> & facets, const std::vector<sort_by> & sort_fields,
                       const int num_typos, const size_t num_results,
                       std::vector<std::vector<art_leaf*>> & searched_queries,
@@ -92,7 +93,7 @@ private:
                       size_t & all_result_ids_len, const token_ordering token_order = FREQUENCY,
                       const bool prefix = false, const size_t drop_tokens_threshold = Index::DROP_TOKENS_THRESHOLD);
 
-    void search_candidates(uint32_t* filter_ids, size_t filter_ids_length, std::vector<facet> & facets,
+    void search_candidates(const uint8_t & field_id, uint32_t* filter_ids, size_t filter_ids_length, std::vector<facet> & facets,
                            const std::vector<sort_by> & sort_fields, std::vector<token_candidates> & token_to_candidates,
                            const token_ordering token_order, std::vector<std::vector<art_leaf*>> & searched_queries,
                            Topster<512> & topster, size_t & total_results, uint32_t** all_result_ids,
@@ -141,7 +142,7 @@ public:
                           std::vector<sort_by> sort_fields_std, const int num_typos,
                           const size_t per_page, const size_t page,
                           const token_ordering token_order, const bool prefix, const size_t drop_tokens_threshold,
-                          std::vector<std::pair<int, Topster<512>::KV>> & field_order_kv,
+                          std::vector<Topster<512>::KV> & field_order_kv,
                           size_t & all_result_ids_len, std::vector<std::vector<art_leaf*>> & searched_queries);
 
     Option<uint32_t> remove(const uint32_t seq_id, nlohmann::json & document);
@@ -151,13 +152,17 @@ public:
                                          size_t result_index,
                                          std::vector<std::vector<std::vector<uint16_t>>> &array_token_positions);
 
-    void score_results(const std::vector<sort_by> & sort_fields, const int & query_index, const uint32_t total_cost,
-                       Topster<512> &topster, const std::vector<art_leaf *> & query_suggestion,
+    void score_results(const std::vector<sort_by> & sort_fields, const int & query_index, const uint8_t & field_id,
+                       const uint32_t total_cost, Topster<512> &topster, const std::vector<art_leaf *> & query_suggestion,
                        const uint32_t *result_ids, const size_t result_size) const;
 
     Option<uint32_t> index_in_memory(const nlohmann::json & document, uint32_t seq_id, int32_t points);
 
-    static const int SEARCH_LIMIT_NUM = 100;      // for limiting number of results on multiple candidates / query rewrites
+    // for limiting number of results on multiple candidates / query rewrites
+    enum {SEARCH_LIMIT_NUM = 100};
+
+    // for limiting number of fields that can be searched on
+    enum {FIELD_LIMIT_NUM = 100};
 
     // If the number of results found is less than this threshold, Typesense will attempt to drop the tokens
     // in the query that have the least individual hits one by one until enough results are found.

--- a/include/match_score.h
+++ b/include/match_score.h
@@ -35,13 +35,21 @@ struct Match {
   uint16_t start_offset;
   char offset_diffs[16];
 
-  Match() {
+  Match(): words_present(0), distance(0), start_offset(0) {
 
   }
 
   Match(uint16_t words_present, uint16_t distance, uint16_t start_offset, char *offset_diffs_stacked):
           words_present(words_present), distance(distance), start_offset(start_offset) {
     memcpy(offset_diffs, offset_diffs_stacked, 16);
+  }
+
+  // Construct a single match score from individual components (for multi-field sort)
+  inline uint64_t get_match_score(const uint32_t total_cost) const {
+    uint64_t match_score = ((int64_t)(words_present) << 24) |
+                            ((int64_t)(255 - total_cost) << 16) |
+                            ((int64_t)(distance));
+    return match_score;
   }
 
   static void print_token_offsets(std::vector<std::vector<uint16_t>> &token_offsets) {
@@ -54,7 +62,8 @@ struct Match {
   }
 
   static inline void addTopOfHeapToWindow(TokenOffsetHeap &heap, std::queue<TokenOffset> &window,
-                                           std::vector<std::vector<uint16_t>> &token_offsets, uint16_t *token_offset) {
+                                          const std::vector<std::vector<uint16_t>> &token_offsets,
+                                          uint16_t *token_offset) {
     TokenOffset top = heap.top();
     heap.pop();
     window.push(top);
@@ -90,7 +99,7 @@ struct Match {
   *  We use a priority queue to read the offset vectors in a sorted manner, slide a window of a given size, and
   *  compute the max_match and min_displacement of target tokens across the windows.
   */
-  static Match match(uint32_t doc_id, std::vector<std::vector<uint16_t>> &token_offsets) {
+  static Match match(uint32_t doc_id, const std::vector<std::vector<uint16_t>> &token_offsets) {
     std::priority_queue<TokenOffset, std::vector<TokenOffset>, TokenOffset> heap;
 
     for(uint8_t token_id=0; token_id < token_offsets.size(); token_id++) {

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -9,14 +9,14 @@
 
 struct StringUtils {
     UErrorCode status;
-    icu::Transliterator* transliterator;
+    //icu::Transliterator* transliterator;
 
-    StringUtils():status(U_ZERO_ERROR),
-                  transliterator(icu::Transliterator::createInstance("Latin-ASCII", UTRANS_FORWARD, status)) {
+    StringUtils(): status(U_ZERO_ERROR) {
+        // transliterator(icu::Transliterator::createInstance("Latin-ASCII", UTRANS_FORWARD, status))
     }
 
     ~StringUtils() {
-        delete transliterator;
+        //delete transliterator;
     }
 
     // Adapted from: http://stackoverflow.com/a/236180/131050

--- a/include/topster.h
+++ b/include/topster.h
@@ -14,8 +14,8 @@
 template <size_t MAX_SIZE=512>
 struct Topster {
     struct KV {
-        uint8_t query_index;
         uint8_t field_id;
+        uint16_t query_index;
         uint64_t key;
         uint64_t match_score;
         number_t primary_attr;
@@ -36,7 +36,7 @@ struct Topster {
         b = c;
     }
 
-    void add(const uint64_t &key, const uint8_t &query_index, const uint8_t &field_id, const uint64_t &match_score,
+    void add(const uint64_t &key, const uint8_t &field_id, const uint16_t &query_index, const uint64_t &match_score,
              const number_t &primary_attr, const number_t &secondary_attr) {
         if (size >= MAX_SIZE) {
             if(!is_greater(data[0], match_score, primary_attr, secondary_attr)) {
@@ -53,8 +53,8 @@ struct Topster {
             dedup_keys.insert(key);
 
             data[0].key = key;
-            data[0].query_index = query_index;
             data[0].field_id = field_id;
+            data[0].query_index = query_index;
             data[0].match_score = match_score;
             data[0].primary_attr = primary_attr;
             data[0].secondary_attr = secondary_attr;
@@ -84,8 +84,8 @@ struct Topster {
             dedup_keys.insert(key);
 
             data[size].key = key;
-            data[size].query_index = query_index;
             data[size].field_id = field_id;
+            data[size].query_index = query_index;
             data[size].match_score = match_score;
             data[size].primary_attr = primary_attr;
             data[size].secondary_attr = secondary_attr;

--- a/include/topster.h
+++ b/include/topster.h
@@ -16,6 +16,7 @@ struct Topster {
     struct KV {
         uint8_t field_id;
         uint16_t query_index;
+        uint16_t array_index;
         uint64_t key;
         uint64_t match_score;
         number_t primary_attr;
@@ -24,98 +25,150 @@ struct Topster {
 
     uint32_t size;
 
-    spp::sparse_hash_set<uint64_t> dedup_keys;
+    spp::sparse_hash_map<uint64_t, KV*> keys;
+
+    KV *kvs[MAX_SIZE];
 
     Topster(): size(0){
-
+        for(size_t i=0; i<MAX_SIZE; i++) {
+            kvs[i] = &data[i];
+            kvs[i]->array_index = i;
+        }
     }
 
-    template <typename T> static inline void swapMe(T& a, T& b) {
-        T c = a;
-        a = b;
-        b = c;
+    static inline void swapMe(KV** a, KV** b) {
+        KV *temp = *a;
+        *a = *b;
+        *b = temp;
+
+        uint16_t a_index = (*a)->array_index;
+        (*a)->array_index = (*b)->array_index;
+        (*b)->array_index = a_index;
     }
 
     void add(const uint64_t &key, const uint8_t &field_id, const uint16_t &query_index, const uint64_t &match_score,
              const number_t &primary_attr, const number_t &secondary_attr) {
         if (size >= MAX_SIZE) {
-            if(!is_greater(data[0], match_score, primary_attr, secondary_attr)) {
+            if(!is_greater(kvs[0], match_score, primary_attr, secondary_attr)) {
                 // when incoming value is less than the smallest in the heap, ignore
                 return;
             }
 
-            if(dedup_keys.count(key) != 0) {
-                // when the key already exists, ignore
-                return ;
+            uint32_t start = 0;
+
+            // When the key already exists and has a greater score, ignore. Otherwise, we have to replace.
+            // NOTE: we don't consider primary and secondary attrs here because they will be the same for a given key.
+            if(keys.count(key) != 0) {
+                const KV* existing = keys.at(key);
+                if(match_score <= existing->match_score) {
+                    return ;
+                }
+
+                // replace and sift down
+                start = existing->array_index;
             }
 
-            dedup_keys.erase(data[0].key);
-            dedup_keys.insert(key);
+            keys.erase(kvs[start]->key);
+            keys.emplace(key, kvs[start]);
 
-            data[0].key = key;
-            data[0].field_id = field_id;
-            data[0].query_index = query_index;
-            data[0].match_score = match_score;
-            data[0].primary_attr = primary_attr;
-            data[0].secondary_attr = secondary_attr;
+            kvs[start]->key = key;
+            kvs[start]->field_id = field_id;
+            kvs[start]->query_index = query_index;
+            kvs[start]->array_index = start;
+            kvs[start]->match_score = match_score;
+            kvs[start]->primary_attr = primary_attr;
+            kvs[start]->secondary_attr = secondary_attr;
 
-            // sift to maintain heap property
-            uint32_t i = 0;
-            while ((2*i+1) < MAX_SIZE) {
-                uint32_t next = (uint32_t) (2 * i + 1);
-                if (next+1 < MAX_SIZE && is_greater_kv(data[next], data[next+1])) {
+            // sift down to maintain heap property
+            while ((2*start+1) < MAX_SIZE) {
+                uint32_t next = (uint32_t) (2 * start + 1);
+                if (next+1 < MAX_SIZE && is_greater_kv(kvs[next], kvs[next+1])) {
                     next++;
                 }
 
-                if (is_greater_kv(data[i], data[next])) {
-                    swapMe(data[i], data[next]);
+                if (is_greater_kv(kvs[start], kvs[next])) {
+                    swapMe(&kvs[start], &kvs[next]);
                 } else {
                     break;
                 }
 
-                i = next;
+                start = next;
             }
         } else {
-            if(dedup_keys.count(key) != 0) {
-                // when the key already exists, ignore
+            uint32_t start = size;
+            bool key_found = false;
+
+            // When the key already exists and has a greater score, ignore. Otherwise, we have to replace
+            if(keys.count(key) != 0) {
+                const KV* existing = keys.at(key);
+                if(match_score <= existing->match_score) {
+                    return ;
+                }
+
+                // replace and sift down
+                start = existing->array_index;
+                key_found = true;
+            }
+
+            kvs[start]->key = key;
+            kvs[start]->field_id = field_id;
+            kvs[start]->query_index = query_index;
+            kvs[start]->array_index = start;
+            kvs[start]->match_score = match_score;
+            kvs[start]->primary_attr = primary_attr;
+            kvs[start]->secondary_attr = secondary_attr;
+
+            keys.emplace(key, kvs[start]);
+
+            if(key_found) {
+                // need to sift down if it's a replace
+                while ((2*start+1) < size) {
+                    uint32_t next = (uint32_t) (2 * start + 1);
+                    if (next+1 < size && is_greater_kv(kvs[next], kvs[next+1])) {
+                        next++;
+                    }
+
+                    if (is_greater_kv(kvs[start], kvs[next])) {
+                        swapMe(&kvs[start], &kvs[next]);
+                    } else {
+                        break;
+                    }
+
+                    start = next;
+                }
+
                 return ;
             }
 
-            dedup_keys.insert(key);
-
-            data[size].key = key;
-            data[size].field_id = field_id;
-            data[size].query_index = query_index;
-            data[size].match_score = match_score;
-            data[size].primary_attr = primary_attr;
-            data[size].secondary_attr = secondary_attr;
-
-            size++;
-            for (uint32_t i = size - 1; i > 0;) {
-                uint32_t parent = (i-1)/2;
-                if (is_greater_kv(data[parent], data[i])) {
-                    swapMe(data[i], data[parent]);
-                    i = parent;
+            while(start > 0) {
+                uint32_t parent = (start-1)/2;
+                if (is_greater_kv(kvs[parent], kvs[start])) {
+                    swapMe(&kvs[start], &kvs[parent]);
+                    start = parent;
                 } else {
                     break;
                 }
+            }
+
+            if(keys.count(key) != 0) {
+                size++;
             }
         }
     }
 
-    static bool is_greater(const struct KV& i, uint64_t match_score, number_t primary_attr, number_t secondary_attr) {
-        return std::tie (match_score, primary_attr, secondary_attr) >
-               std::tie (i.match_score, i.primary_attr, i.secondary_attr);
+    static bool is_greater(const struct KV* i, uint64_t match_score, number_t primary_attr, number_t secondary_attr) {
+        return std::tie(match_score, primary_attr, secondary_attr) >
+               std::tie(i->match_score, i->primary_attr, i->secondary_attr);
     }
 
-    static bool is_greater_kv(const struct KV &i, const struct KV &j) {
-        return std::tie(i.match_score, i.primary_attr, i.secondary_attr, i.field_id, i.key) >
-               std::tie(j.match_score, j.primary_attr, j.secondary_attr, j.field_id, j.key);
+    static bool is_greater_kv(const struct KV* i, const struct KV* j) {
+        return std::tie(i->match_score, i->primary_attr, i->secondary_attr, i->key) >
+               std::tie(j->match_score, j->primary_attr, j->secondary_attr, j->key);
     }
 
     // topster must be sorted before iterated upon to remove dead array entries
     void sort() {
-        std::stable_sort(std::begin(data), std::begin(data) + size, is_greater_kv);
+        std::stable_sort(std::begin(kvs), std::begin(kvs) + size, is_greater_kv);
     }
 
     void clear(){
@@ -123,10 +176,10 @@ struct Topster {
     }
 
     uint64_t getKeyAt(uint32_t index) {
-        return data[index].key;
+        return kvs[index]->key;
     }
 
-    KV getKV(uint32_t index) {
-        return data[index];
+    KV* getKV(uint32_t index) {
+        return kvs[index];
     }
 };

--- a/include/topster.h
+++ b/include/topster.h
@@ -21,8 +21,9 @@ struct Topster {
         uint64_t match_score;
         number_t primary_attr;
         number_t secondary_attr;
-    } data[MAX_SIZE];
+    };
 
+    KV *data;
     uint32_t size;
 
     spp::sparse_hash_map<uint64_t, KV*> keys;
@@ -30,10 +31,21 @@ struct Topster {
     KV *kvs[MAX_SIZE];
 
     Topster(): size(0){
+        data = new KV[MAX_SIZE];
+
         for(size_t i=0; i<MAX_SIZE; i++) {
+            data[i].field_id = 0;
+            data[i].query_index = 0;
+            data[i].key = 0;
+            data[i].match_score = 0;
+            data[i].primary_attr = number_t();
+            data[i].secondary_attr = number_t();
             kvs[i] = &data[i];
-            kvs[i]->array_index = i;
         }
+    }
+
+    ~Topster() {
+        delete [] data;
     }
 
     static inline void swapMe(KV** a, KV** b) {
@@ -164,6 +176,11 @@ struct Topster {
     static bool is_greater_kv(const struct KV* i, const struct KV* j) {
         return std::tie(i->match_score, i->primary_attr, i->secondary_attr, i->key) >
                std::tie(j->match_score, j->primary_attr, j->secondary_attr, j->key);
+    }
+
+    static bool is_greater_kv_value(const struct KV & i, const struct KV & j) {
+        return std::tie(i.match_score, i.primary_attr, i.secondary_attr, i.key) >
+               std::tie(j.match_score, j.primary_attr, j.secondary_attr, j.key);
     }
 
     // topster must be sorted before iterated upon to remove dead array entries

--- a/include/topster.h
+++ b/include/topster.h
@@ -14,7 +14,8 @@
 template <size_t MAX_SIZE=512>
 struct Topster {
     struct KV {
-        uint16_t query_index;
+        uint8_t query_index;
+        uint8_t field_id;
         uint64_t key;
         uint64_t match_score;
         number_t primary_attr;
@@ -35,8 +36,8 @@ struct Topster {
         b = c;
     }
 
-    void add(const uint64_t &key, const uint16_t &query_index, const uint64_t &match_score, const number_t &primary_attr,
-             const number_t &secondary_attr) {
+    void add(const uint64_t &key, const uint8_t &query_index, const uint8_t &field_id, const uint64_t &match_score,
+             const number_t &primary_attr, const number_t &secondary_attr) {
         if (size >= MAX_SIZE) {
             if(!is_greater(data[0], match_score, primary_attr, secondary_attr)) {
                 // when incoming value is less than the smallest in the heap, ignore
@@ -53,6 +54,7 @@ struct Topster {
 
             data[0].key = key;
             data[0].query_index = query_index;
+            data[0].field_id = field_id;
             data[0].match_score = match_score;
             data[0].primary_attr = primary_attr;
             data[0].secondary_attr = secondary_attr;
@@ -83,6 +85,7 @@ struct Topster {
 
             data[size].key = key;
             data[size].query_index = query_index;
+            data[size].field_id = field_id;
             data[size].match_score = match_score;
             data[size].primary_attr = primary_attr;
             data[size].secondary_attr = secondary_attr;
@@ -106,10 +109,11 @@ struct Topster {
     }
 
     static bool is_greater_kv(const struct KV &i, const struct KV &j) {
-        return std::tie(i.match_score, i.primary_attr, i.secondary_attr) >
-               std::tie(j.match_score, j.primary_attr, j.secondary_attr);
+        return std::tie(i.match_score, i.primary_attr, i.secondary_attr, i.field_id, i.key) >
+               std::tie(j.match_score, j.primary_attr, j.secondary_attr, j.field_id, j.key);
     }
 
+    // topster must be sorted before iterated upon to remove dead array entries
     void sort() {
         std::stable_sort(std::begin(data), std::begin(data) + size, is_greater_kv);
     }

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -625,7 +625,12 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
             }
 
             wrapper_doc["highlight"] = nlohmann::json::object();
-            wrapper_doc["highlight"][field_name] = snippet_stream.str();
+            wrapper_doc["highlight"][field_name] = nlohmann::json::object();
+            wrapper_doc["highlight"][field_name]["value"] = snippet_stream.str();
+
+            if(search_field.type == field_types::STRING_ARRAY) {
+                wrapper_doc["highlight"][field_name]["index"] = matched_array_index;
+            }
 
             for (auto it = leaf_to_indices.begin(); it != leaf_to_indices.end(); it++) {
                 delete [] it->second;

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -428,7 +428,7 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
 
     // all search queries that were used for generating the results
     std::vector<std::vector<art_leaf*>> searched_queries;
-    std::vector<Topster<512>::KV*> field_order_kvs;
+    std::vector<Topster<512>::KV> field_order_kvs;
     size_t total_found = 0;
 
     // send data to individual index threads
@@ -463,8 +463,8 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
             continue;
         }
 
-        for(auto* field_order_kv: index->search_params.field_order_kvs) {
-            field_order_kv->query_index += searched_queries.size();
+        for(auto & field_order_kv: index->search_params.field_order_kvs) {
+            field_order_kv.query_index += searched_queries.size();
             field_order_kvs.push_back(field_order_kv);
         }
 
@@ -497,7 +497,7 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
     }
 
     // All fields are sorted descending
-    std::sort(field_order_kvs.begin(), field_order_kvs.end(), Topster<>::is_greater_kv);
+    std::sort(field_order_kvs.begin(), field_order_kvs.end(), Topster<>::is_greater_kv_value);
 
     nlohmann::json result = nlohmann::json::object();
 
@@ -515,8 +515,8 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
 
     // construct results array
     for(int field_order_kv_index = start_result_index; field_order_kv_index <= end_result_index; field_order_kv_index++) {
-        const auto* field_order_kv = field_order_kvs[field_order_kv_index];
-        const std::string& seq_id_key = get_seq_id_key((uint32_t) field_order_kv->key);
+        const auto & field_order_kv = field_order_kvs[field_order_kv_index];
+        const std::string& seq_id_key = get_seq_id_key((uint32_t) field_order_kv.key);
 
         std::string json_doc_str;
         StoreStatus json_doc_status = store->get(seq_id_key, json_doc_str);
@@ -536,19 +536,19 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
         }
 
         wrapper_doc["document"] = document;
-        //wrapper_doc["match_score"] = field_order_kv->match_score;
-        //wrapper_doc["seq_id"] = (uint32_t) field_order_kv->key;
+        //wrapper_doc["match_score"] = field_order_kv.match_score;
+        //wrapper_doc["seq_id"] = (uint32_t) field_order_kv.key;
 
         // highlight query words in the result
-        const std::string & field_name = search_fields[Index::FIELD_LIMIT_NUM - field_order_kv->field_id];
+        const std::string & field_name = search_fields[Index::FIELD_LIMIT_NUM - field_order_kv.field_id];
         field search_field = search_schema.at(field_name);
 
         if(search_field.type == field_types::STRING || search_field.type == field_types::STRING_ARRAY) {
 
             spp::sparse_hash_map<const art_leaf*, uint32_t*> leaf_to_indices;
-            for (const art_leaf *token_leaf : searched_queries[field_order_kv->query_index]) {
+            for (const art_leaf *token_leaf : searched_queries[field_order_kv.query_index]) {
                 std::vector<uint16_t> positions;
-                uint32_t doc_index = token_leaf->values->ids.indexOf(field_order_kv->key);
+                uint32_t doc_index = token_leaf->values->ids.indexOf(field_order_kv.key);
                 uint32_t *indices = new uint32_t[1];
                 indices[0] = doc_index;
                 leaf_to_indices.emplace(token_leaf, indices);
@@ -556,7 +556,7 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
 
             // positions in the field of each token in the query
             std::vector<std::vector<std::vector<uint16_t>>> array_token_positions;
-            Index::populate_token_positions(searched_queries[field_order_kv->query_index],
+            Index::populate_token_positions(searched_queries[field_order_kv.query_index],
                                             leaf_to_indices, 0, array_token_positions);
 
             Match match;
@@ -570,8 +570,8 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
                     continue;
                 }
 
-                const Match & this_match = Match::match(field_order_kv->key, token_positions);
-                uint64_t this_match_score = this_match.get_match_score(1, field_order_kv->field_id);
+                const Match & this_match = Match::match(field_order_kv.key, token_positions);
+                uint64_t this_match_score = this_match.get_match_score(1, field_order_kv.field_id);
                 if(this_match_score > match_score) {
                     match_score = this_match_score;
                     match = this_match;

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include <chrono>
 #include <rocksdb/write_batch.h>
+#include "topster.h"
 #include "logger.h"
 
 Collection::Collection(const std::string name, const uint32_t collection_id, const uint32_t next_seq_id, Store *store,
@@ -416,7 +417,9 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
         return Option<nlohmann::json>(422, message);
     }
 
-    if((page * per_page) > MAX_RESULTS) {
+    const size_t num_results = (page * per_page);
+
+    if(num_results > MAX_RESULTS) {
         std::string message = "Only the first " + std::to_string(MAX_RESULTS) + " results are available.";
         return Option<nlohmann::json>(422, message);
     }
@@ -425,7 +428,7 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
 
     // all search queries that were used for generating the results
     std::vector<std::vector<art_leaf*>> searched_queries;
-    std::vector<std::pair<int, Topster<512>::KV>> field_order_kvs;
+    std::vector<Topster<512>::KV> field_order_kvs;
     size_t total_found = 0;
 
     // send data to individual index threads
@@ -460,9 +463,8 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
             continue;
         }
 
-        // need to remap the search query index before appending
         for(auto & field_order_kv: index->search_params.field_order_kvs) {
-            field_order_kv.second.query_index += searched_queries.size();
+            field_order_kv.query_index += searched_queries.size();
             field_order_kvs.push_back(field_order_kv);
         }
 
@@ -495,11 +497,7 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
     }
 
     // All fields are sorted descending
-    std::sort(field_order_kvs.begin(), field_order_kvs.end(),
-      [](const std::pair<int, Topster<512>::KV> & a, const std::pair<int, Topster<512>::KV> & b) {
-          return std::tie(a.second.match_score, a.second.primary_attr, a.second.secondary_attr, a.first, a.second.key) >
-                 std::tie(b.second.match_score, b.second.primary_attr, b.second.secondary_attr, b.first, b.second.key);
-    });
+    std::sort(field_order_kvs.begin(), field_order_kvs.end(), Topster<>::is_greater_kv);
 
     nlohmann::json result = nlohmann::json::object();
 
@@ -513,12 +511,12 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
         return Option<nlohmann::json>(result);
     }
 
-    const int end_result_index = std::min(int(page * per_page), kvsize) - 1;
+    const int end_result_index = std::min(int(num_results), kvsize) - 1;
 
     // construct results array
     for(int field_order_kv_index = start_result_index; field_order_kv_index <= end_result_index; field_order_kv_index++) {
         const auto & field_order_kv = field_order_kvs[field_order_kv_index];
-        const std::string& seq_id_key = get_seq_id_key((uint32_t) field_order_kv.second.key);
+        const std::string& seq_id_key = get_seq_id_key((uint32_t) field_order_kv.key);
 
         std::string json_doc_str;
         StoreStatus json_doc_status = store->get(seq_id_key, json_doc_str);
@@ -538,19 +536,19 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
         }
 
         wrapper_doc["document"] = document;
-        //wrapper_doc["match_score"] = field_order_kv.second.match_score;
-        //wrapper_doc["seq_id"] = (uint32_t) field_order_kv.second.key;
+        //wrapper_doc["match_score"] = field_order_kv.match_score;
+        //wrapper_doc["seq_id"] = (uint32_t) field_order_kv.key;
 
         // highlight query words in the result
-        const std::string & field_name = search_fields[search_fields.size() - field_order_kv.first];
+        const std::string & field_name = search_fields[Index::FIELD_LIMIT_NUM - field_order_kv.field_id];
         field search_field = search_schema.at(field_name);
 
         if(search_field.type == field_types::STRING || search_field.type == field_types::STRING_ARRAY) {
 
             spp::sparse_hash_map<const art_leaf*, uint32_t*> leaf_to_indices;
-            for (const art_leaf *token_leaf : searched_queries[field_order_kv.second.query_index]) {
+            for (const art_leaf *token_leaf : searched_queries[field_order_kv.query_index]) {
                 std::vector<uint16_t> positions;
-                uint32_t doc_index = token_leaf->values->ids.indexOf(field_order_kv.second.key);
+                uint32_t doc_index = token_leaf->values->ids.indexOf(field_order_kv.key);
                 if(doc_index == token_leaf->values->ids.getLength()) {
                     continue;
                 }
@@ -562,7 +560,7 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
 
             // positions in the field of each token in the query
             std::vector<std::vector<std::vector<uint16_t>>> array_token_positions;
-            Index::populate_token_positions(searched_queries[field_order_kv.second.query_index],
+            Index::populate_token_positions(searched_queries[field_order_kv.query_index],
                                             leaf_to_indices, 0, array_token_positions);
 
             Match match;
@@ -576,7 +574,7 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
                     continue;
                 }
 
-                const Match & this_match = Match::match(field_order_kv.second.key, token_positions);
+                const Match & this_match = Match::match(field_order_kv.key, token_positions);
                 uint64_t this_match_score = this_match.get_match_score(1);
                 if(this_match_score > match_score) {
                     match_score = this_match_score;

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -549,10 +549,6 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
             for (const art_leaf *token_leaf : searched_queries[field_order_kv.query_index]) {
                 std::vector<uint16_t> positions;
                 uint32_t doc_index = token_leaf->values->ids.indexOf(field_order_kv.key);
-                if(doc_index == token_leaf->values->ids.getLength()) {
-                    continue;
-                }
-
                 uint32_t *indices = new uint32_t[1];
                 indices[0] = doc_index;
                 leaf_to_indices.emplace(token_leaf, indices);

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -619,11 +619,11 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
             }
 
             wrapper_doc["highlight"] = nlohmann::json::object();
-            wrapper_doc["highlight"][field_name] = nlohmann::json::object();
-            wrapper_doc["highlight"][field_name]["value"] = snippet_stream.str();
+            wrapper_doc["highlight"]["field"] = field_name;
+            wrapper_doc["highlight"]["snippet"] = snippet_stream.str();
 
             if(search_field.type == field_types::STRING_ARRAY) {
-                wrapper_doc["highlight"][field_name]["index"] = matched_array_index;
+                wrapper_doc["highlight"]["index"] = matched_array_index;
             }
 
             for (auto it = leaf_to_indices.begin(); it != leaf_to_indices.end(); it++) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -600,7 +600,7 @@ void Index::search(Option<uint32_t> & outcome, std::string query, const std::vec
                              std::vector<sort_by> sort_fields_std, const int num_typos,
                              const size_t per_page, const size_t page, const token_ordering token_order,
                              const bool prefix, const size_t drop_tokens_threshold,
-                             std::vector<Topster<512>::KV*> & field_order_kvs,
+                             std::vector<Topster<512>::KV> & field_order_kvs,
                              size_t & all_result_ids_len, std::vector<std::vector<art_leaf*>> & searched_queries) {
 
     const size_t num_results = (page * per_page);
@@ -640,7 +640,7 @@ void Index::search(Option<uint32_t> & outcome, std::string query, const std::vec
     // order of fields specified matter: matching docs from earlier fields are more important
     for(uint32_t t = 0; t < topster.size && t < num_results; t++) {
         Topster<512>::KV* kv = topster.getKV(t);
-        field_order_kvs.push_back(kv);
+        field_order_kvs.push_back(*kv);
     }
 
     delete [] filter_ids;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -600,7 +600,7 @@ void Index::search(Option<uint32_t> & outcome, std::string query, const std::vec
                              std::vector<sort_by> sort_fields_std, const int num_typos,
                              const size_t per_page, const size_t page, const token_ordering token_order,
                              const bool prefix, const size_t drop_tokens_threshold,
-                             std::vector<Topster<512>::KV> & field_order_kvs,
+                             std::vector<Topster<512>::KV*> & field_order_kvs,
                              size_t & all_result_ids_len, std::vector<std::vector<art_leaf*>> & searched_queries) {
 
     const size_t num_results = (page * per_page);
@@ -639,7 +639,7 @@ void Index::search(Option<uint32_t> & outcome, std::string query, const std::vec
 
     // order of fields specified matter: matching docs from earlier fields are more important
     for(uint32_t t = 0; t < topster.size && t < num_results; t++) {
-        const Topster<512>::KV &kv = topster.getKV(t);
+        Topster<512>::KV* kv = topster.getKV(t);
         field_order_kvs.push_back(kv);
     }
 
@@ -890,7 +890,7 @@ void Index::score_results(const std::vector<sort_by> & sort_fields, const uint16
     char empty_offset_diffs[16];
     std::fill_n(empty_offset_diffs, 16, 0);
     Match single_token_match = Match(1, 0, 0, empty_offset_diffs);
-    const uint64_t single_token_match_score = single_token_match.get_match_score(total_cost);
+    const uint64_t single_token_match_score = single_token_match.get_match_score(total_cost, field_id);
 
     for(size_t i=0; i<result_size; i++) {
         const uint32_t seq_id = result_ids[i];
@@ -908,7 +908,7 @@ void Index::score_results(const std::vector<sort_by> & sort_fields, const uint16
                     continue;
                 }
                 const Match & match = Match::match(seq_id, token_positions);
-                uint64_t this_match_score = match.get_match_score(total_cost);
+                uint64_t this_match_score = match.get_match_score(total_cost, field_id);
 
                 if(this_match_score > match_score) {
                     match_score = this_match_score;

--- a/test/array_text_documents.jsonl
+++ b/test/array_text_documents.jsonl
@@ -1,0 +1,3 @@
+{"title": "The Truth About Forever", "tags": ["the truth", "about forever", "truth about"], "points": 100}
+{"title": "Plain Truth", "tags": ["plain", "truth", "plain truth"], "points": 40}
+{"title": "Temple of the Winds", "tags": ["temple", "of", "temple of"], "points": 87}

--- a/test/art_test.cpp
+++ b/test/art_test.cpp
@@ -608,6 +608,26 @@ TEST(ArtTest, test_art_fuzzy_search_single_leaf) {
     ASSERT_TRUE(res == 0);
 }
 
+TEST(ArtTest, test_art_fuzzy_search_single_leaf_prefix) {
+    art_tree t;
+    int res = art_tree_init(&t);
+    ASSERT_TRUE(res == 0);
+
+    const char* key = "application";
+    art_document doc = get_document((uint32_t) 1);
+    ASSERT_TRUE(NULL == art_insert(&t, (unsigned char*)key, strlen(key)+1, &doc, 1));
+
+    art_leaf* l = (art_leaf *) art_search(&t, (const unsigned char *)key, strlen(key)+1);
+    EXPECT_EQ(1, l->values->ids.at(0));
+
+    std::vector<art_leaf*> leaves;
+    art_fuzzy_search(&t, (const unsigned char *) "aplication", strlen(key), 0, 1, 10, FREQUENCY, true, leaves);
+    ASSERT_EQ(1, leaves.size());
+
+    res = art_tree_destroy(&t);
+    ASSERT_TRUE(res == 0);
+}
+
 TEST(ArtTest, test_art_fuzzy_search) {
     art_tree t;
     int res = art_tree_init(&t);
@@ -697,7 +717,7 @@ TEST(ArtTest, test_art_fuzzy_search) {
 
     leaves.clear();
     art_fuzzy_search(&t, (const unsigned char *) "antisocao", strlen("antisocao"), 0, 2, 10, FREQUENCY, true, leaves);
-    ASSERT_EQ(6, leaves.size());
+    ASSERT_EQ(8, leaves.size());
 
     res = art_tree_destroy(&t);
     ASSERT_TRUE(res == 0);

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -138,6 +138,11 @@ TEST_F(CollectionTest, ExactPhraseSearch) {
         ASSERT_STREQ(id.c_str(), result_id.c_str());
     }
 
+    ASSERT_EQ(results["hits"][0]["highlight"].size(), (unsigned long) 2);
+    ASSERT_STREQ(results["hits"][0]["highlight"]["field"].get<std::string>().c_str(), "title");
+    ASSERT_STREQ(results["hits"][0]["highlight"]["snippet"].get<std::string>().c_str(),
+                 "What is the power requirement of a <mark>rocket</mark> <mark>launch</mark> these days?");
+
     // Check ASC sort order
     std::vector<sort_by> sort_fields_asc = { sort_by("points", "ASC") };
     results = collection->search("rocket launch", query_fields, "", facets, sort_fields_asc, 0, 10).get();
@@ -534,9 +539,11 @@ TEST_F(CollectionTest, ArrayStringFieldHighlight) {
         ASSERT_STREQ(id.c_str(), result_id.c_str());
     }
 
-    ASSERT_STREQ(results["hits"][0]["highlight"]["tags"]["value"].get<std::string>().c_str(),
+    ASSERT_EQ(results["hits"][0]["highlight"].size(), 3);
+    ASSERT_STREQ(results["hits"][0]["highlight"]["field"].get<std::string>().c_str(), "tags");
+    ASSERT_STREQ(results["hits"][0]["highlight"]["snippet"].get<std::string>().c_str(),
                  "<mark>truth</mark> <mark>about</mark>");
-    ASSERT_EQ(results["hits"][0]["highlight"]["tags"]["index"].get<size_t>(), 2);
+    ASSERT_EQ(results["hits"][0]["highlight"]["index"].get<size_t>(), 2);
 
     results = coll_array_text->search("forever truth", query_fields, "", facets, sort_fields, 0, 10, 1, FREQUENCY,
                                       false, 0).get();
@@ -551,9 +558,9 @@ TEST_F(CollectionTest, ArrayStringFieldHighlight) {
         ASSERT_STREQ(id.c_str(), result_id.c_str());
     }
 
-    ASSERT_STREQ(results["hits"][0]["highlight"]["tags"]["value"].get<std::string>().c_str(),
-                 "the <mark>truth</mark>");
-    ASSERT_EQ(results["hits"][0]["highlight"]["tags"]["index"].get<size_t>(), 0);
+    ASSERT_STREQ(results["hits"][0]["highlight"]["field"].get<std::string>().c_str(), "tags");
+    ASSERT_STREQ(results["hits"][0]["highlight"]["snippet"].get<std::string>().c_str(), "the <mark>truth</mark>");
+    ASSERT_EQ(results["hits"][0]["highlight"]["index"].get<size_t>(), 0);
 
     results = coll_array_text->search("truth", query_fields, "", facets, sort_fields, 0, 10, 1, FREQUENCY,
                                       false, 0).get();

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -534,7 +534,9 @@ TEST_F(CollectionTest, ArrayStringFieldHighlight) {
         ASSERT_STREQ(id.c_str(), result_id.c_str());
     }
 
-    ASSERT_STREQ(results["hits"][0]["highlight"]["tags"].get<std::string>().c_str(), "<mark>truth</mark> <mark>about</mark>");
+    ASSERT_STREQ(results["hits"][0]["highlight"]["tags"]["value"].get<std::string>().c_str(),
+                 "<mark>truth</mark> <mark>about</mark>");
+    ASSERT_EQ(results["hits"][0]["highlight"]["tags"]["index"].get<size_t>(), 2);
 
     results = coll_array_text->search("forever truth", query_fields, "", facets, sort_fields, 0, 10, 1, FREQUENCY,
                                       false, 0).get();
@@ -549,7 +551,9 @@ TEST_F(CollectionTest, ArrayStringFieldHighlight) {
         ASSERT_STREQ(id.c_str(), result_id.c_str());
     }
 
-    ASSERT_STREQ(results["hits"][0]["highlight"]["tags"].get<std::string>().c_str(), "the <mark>truth</mark>");
+    ASSERT_STREQ(results["hits"][0]["highlight"]["tags"]["value"].get<std::string>().c_str(),
+                 "the <mark>truth</mark>");
+    ASSERT_EQ(results["hits"][0]["highlight"]["tags"]["index"].get<size_t>(), 0);
 
     results = coll_array_text->search("truth", query_fields, "", facets, sort_fields, 0, 10, 1, FREQUENCY,
                                       false, 0).get();

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -671,6 +671,18 @@ TEST_F(CollectionTest, MultipleFields) {
         ASSERT_STREQ(id.c_str(), result_id.c_str());
     }
 
+    // when a token exists in multiple fields of the same document, document should be returned only once
+    query_fields = {"starring", "title", "cast"};
+    results = coll_mul_fields->search("myers", query_fields, "", facets, sort_fields, 0, 10, 1, FREQUENCY, false).get();
+    ASSERT_EQ(1, results["hits"].size());
+    ids = {"17"};
+    for(size_t i = 0; i < results["hits"].size(); i++) {
+        nlohmann::json result = results["hits"].at(i);
+        std::string result_id = result["document"]["id"];
+        std::string id = ids.at(i);
+        ASSERT_STREQ(id.c_str(), result_id.c_str());
+    }
+
     collectionManager.drop_collection("coll_mul_fields");
 }
 

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -479,7 +479,15 @@ TEST_F(CollectionTest, PrefixSearching) {
     ASSERT_EQ(0, results["hits"].size());
 
     results = collection->search("xq", query_fields, "", facets, sort_fields, 2, 2, 1, FREQUENCY, true).get();
-    ASSERT_EQ(0, results["hits"].size());
+    ASSERT_EQ(1, results["hits"].size());
+    ids = {"6"};
+
+    for(size_t i = 0; i < results["hits"].size(); i++) {
+        nlohmann::json result = results["hits"].at(i);
+        std::string result_id = result["document"]["id"];
+        std::string id = ids.at(i);
+        ASSERT_STREQ(id.c_str(), result_id.c_str());
+    }
 
     // prefix with a typo
     results = collection->search("late propx", query_fields, "", facets, sort_fields, 2, 1, 1, FREQUENCY, true).get();

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -622,7 +622,7 @@ TEST_F(CollectionTest, MultipleFields) {
     results = coll_mul_fields->search("thomas", query_fields, "", facets, sort_fields, 0, 10, 1, FREQUENCY, false).get();
     ASSERT_EQ(4, results["hits"].size());
 
-    ids = {"15", "14", "12", "13"};
+    ids = {"15", "12", "13", "14"};
 
     for(size_t i = 0; i < results["hits"].size(); i++) {
         nlohmann::json result = results["hits"].at(i);

--- a/test/multi_field_documents.jsonl
+++ b/test/multi_field_documents.jsonl
@@ -15,4 +15,4 @@
 {"title": "Odd Thomas", "starring": "Matthew Page", "points": 69, "cast": ["Anton Yelchin", "Ashley Sommers"] }
 {"title": "Suffering Man's Charity", "starring": "Henry Thomas", "points": 69, "cast": ["Alan Cumming", "Alison Guh", "David Boreanaz"] }
 {"title": "The Gospel According to St. Matthew", "starring": "Paola Tedesco", "points": 79, "cast": ["Enrique Irazoqui", "Margherita Caruso"] }
-{"title": "Halloween 5: The Revenge of Michael Myers", "starring": "Donald Pleasence", "points": 52, "cast": ["Danielle Harris", "Ellie Cornell"] }
+{"title": "Halloween 5: The Revenge of Michael Myers", "starring": "Donald Myers", "points": 52, "cast": ["Danielle Harris", "Ellie Cornell"] }

--- a/test/topster_test.cpp
+++ b/test/topster_test.cpp
@@ -6,36 +6,37 @@ TEST(TopsterTest, StoreMaxIntValuesWithoutRepetition) {
     Topster<5> topster;
 
     struct {
-        uint16_t query_index;
+        uint8_t query_index;
+        uint8_t field_id;
         uint64_t key;
         uint64_t match_score;
         int64_t primary_attr;
         int64_t secondary_attr;
     } data[14] = {
-        {0, 1, 10, 20, 30},
-        {0, 1, 10, 20, 30},
-        {0, 2, 4, 20, 30},
-        {2, 3, 7, 20, 30},
-        {0, 4, 11, 20, 30},
-        {1, 5, 9, 20, 30},
-        {1, 5, 9, 20, 30},
-        {1, 5, 9, 20, 30},
-        {0, 6, 6, 20, 30},
-        {2, 7, 6, 22, 30},
-        {2, 7, 6, 22, 30},
-        {1, 8, 9, 20, 30},
-        {0, 9, 8, 20, 30},
-        {3, 10, 5, 20, 30},
+        {0, 1, 1, 10, 20, 30},
+        {0, 1, 1, 10, 20, 30},
+        {0, 1, 2, 4, 20, 30},
+        {2, 1, 3, 7, 20, 30},
+        {0, 1, 4, 11, 20, 30},
+        {1, 1, 5, 9, 20, 30},
+        {1, 1, 5, 9, 20, 30},
+        {1, 1, 5, 9, 20, 30},
+        {0, 1, 6, 6, 20, 30},
+        {2, 1, 7, 6, 22, 30},
+        {2, 1, 7, 6, 22, 30},
+        {1, 1, 8, 9, 20, 30},
+        {0, 1, 9, 8, 20, 30},
+        {3, 1, 10, 5, 20, 30},
     };
 
     for(int i = 0; i < 14; i++) {
-        topster.add(data[i].key, data[i].query_index, data[i].match_score, data[i].primary_attr,
+        topster.add(data[i].key, data[i].query_index, 1, data[i].match_score, data[i].primary_attr,
                     data[i].secondary_attr);
     }
 
     topster.sort();
 
-    std::vector<uint64_t> ids = {4, 1, 5, 8, 9};
+    std::vector<uint64_t> ids = {4, 1, 8, 5, 9};
 
     for(uint32_t i = 0; i < topster.size; i++) {
         EXPECT_EQ(ids[i], topster.getKeyAt(i));
@@ -67,7 +68,7 @@ TEST(TopsterTest, StoreMaxFloatValuesWithoutRepetition) {
     };
 
     for(int i = 0; i < 12; i++) {
-        topster.add(data[i].key, data[i].query_index, data[i].match_score, data[i].primary_attr,
+        topster.add(data[i].key, data[i].query_index, 1, data[i].match_score, data[i].primary_attr,
                     data[i].secondary_attr);
     }
 

--- a/test/topster_test.cpp
+++ b/test/topster_test.cpp
@@ -6,31 +6,31 @@ TEST(TopsterTest, StoreMaxIntValuesWithoutRepetition) {
     Topster<5> topster;
 
     struct {
-        uint8_t query_index;
         uint8_t field_id;
+        uint16_t query_index;
         uint64_t key;
         uint64_t match_score;
         int64_t primary_attr;
         int64_t secondary_attr;
     } data[14] = {
-        {0, 1, 1, 10, 20, 30},
-        {0, 1, 1, 10, 20, 30},
-        {0, 1, 2, 4, 20, 30},
-        {2, 1, 3, 7, 20, 30},
-        {0, 1, 4, 11, 20, 30},
+        {1, 0, 1, 10, 20, 30},
+        {1, 0, 1, 10, 20, 30},
+        {1, 0, 2, 4, 20, 30},
+        {1, 2, 3, 7, 20, 30},
+        {1, 0, 4, 11, 20, 30},
         {1, 1, 5, 9, 20, 30},
         {1, 1, 5, 9, 20, 30},
         {1, 1, 5, 9, 20, 30},
-        {0, 1, 6, 6, 20, 30},
-        {2, 1, 7, 6, 22, 30},
-        {2, 1, 7, 6, 22, 30},
+        {1, 0, 6, 6, 20, 30},
+        {1, 2, 7, 6, 22, 30},
+        {1, 2, 7, 6, 22, 30},
         {1, 1, 8, 9, 20, 30},
-        {0, 1, 9, 8, 20, 30},
-        {3, 1, 10, 5, 20, 30},
+        {1, 0, 9, 8, 20, 30},
+        {1, 3, 10, 5, 20, 30},
     };
 
     for(int i = 0; i < 14; i++) {
-        topster.add(data[i].key, data[i].query_index, 1, data[i].match_score, data[i].primary_attr,
+        topster.add(data[i].key, 1, data[i].query_index, data[i].match_score, data[i].primary_attr,
                     data[i].secondary_attr);
     }
 
@@ -68,7 +68,7 @@ TEST(TopsterTest, StoreMaxFloatValuesWithoutRepetition) {
     };
 
     for(int i = 0; i < 12; i++) {
-        topster.add(data[i].key, data[i].query_index, 1, data[i].match_score, data[i].primary_attr,
+        topster.add(data[i].key, 1, data[i].query_index, data[i].match_score, data[i].primary_attr,
                     data[i].secondary_attr);
     }
 

--- a/test/topster_test.cpp
+++ b/test/topster_test.cpp
@@ -2,7 +2,7 @@
 #include "topster.h"
 #include "match_score.h"
 
-TEST(TopsterTest, StoreMaxIntValuesWithoutRepetition) {
+TEST(TopsterTest, MaxIntValues) {
     Topster<5> topster;
 
     struct {
@@ -13,13 +13,13 @@ TEST(TopsterTest, StoreMaxIntValuesWithoutRepetition) {
         int64_t primary_attr;
         int64_t secondary_attr;
     } data[14] = {
-        {1, 0, 1, 10, 20, 30},
-        {1, 0, 1, 10, 20, 30},
+        {1, 0, 1, 11, 20, 30},
+        {1, 0, 1, 12, 20, 32},
         {1, 0, 2, 4, 20, 30},
         {1, 2, 3, 7, 20, 30},
-        {1, 0, 4, 11, 20, 30},
+        {1, 0, 4, 14, 20, 30},
         {1, 1, 5, 9, 20, 30},
-        {1, 1, 5, 9, 20, 30},
+        {1, 1, 5, 10, 20, 32},
         {1, 1, 5, 9, 20, 30},
         {1, 0, 6, 6, 20, 30},
         {1, 2, 7, 6, 22, 30},
@@ -30,45 +30,54 @@ TEST(TopsterTest, StoreMaxIntValuesWithoutRepetition) {
     };
 
     for(int i = 0; i < 14; i++) {
-        topster.add(data[i].key, 1, data[i].query_index, data[i].match_score, data[i].primary_attr,
+        topster.add(data[i].key, data[i].field_id, data[i].query_index, data[i].match_score, data[i].primary_attr,
                     data[i].secondary_attr);
     }
 
     topster.sort();
 
-    std::vector<uint64_t> ids = {4, 1, 8, 5, 9};
+    std::vector<uint64_t> ids = {4, 1, 5, 8, 9};
 
     for(uint32_t i = 0; i < topster.size; i++) {
         EXPECT_EQ(ids[i], topster.getKeyAt(i));
+
+        if(ids[i] == 1) {
+            EXPECT_EQ(12, (int) topster.getKV(i)->match_score);
+        }
+
+        if(ids[i] == 5) {
+            EXPECT_EQ(10, (int) topster.getKV(i)->match_score);
+        }
     }
 }
 
-TEST(TopsterTest, StoreMaxFloatValuesWithoutRepetition) {
+TEST(TopsterTest, MaxFloatValues) {
     Topster<5> topster;
 
     struct {
+        uint8_t field_id;
         uint16_t query_index;
         uint64_t key;
         uint64_t match_score;
         float primary_attr;
         int64_t secondary_attr;
     } data[12] = {
-            {0, 1, 11, 1.09, 30},
-            {0, 2, 11, -20, 30},
-            {2, 3, 11, -20, 30},
-            {0, 4, 11, 7.812, 30},
-            {0, 4, 11, 7.812, 30},
-            {1, 5, 11, 0.0, 34},
-            {0, 6, 11, -22, 30},
-            {2, 7, 11, -22, 30},
-            {1, 8, 11, -9.998, 30},
-            {1, 8, 11, -9.998, 30},
-            {0, 9, 11, -9.999, 30},
-            {3, 10, 11, -20, 30},
+            {1, 0, 1, 11, 1.09, 30},
+            {1, 0, 2, 11, -20, 30},
+            {1, 2, 3, 11, -20, 30},
+            {1, 0, 4, 11, 7.812, 30},
+            {1, 0, 4, 11, 7.912, 30},
+            {1, 1, 5, 11, 0.0, 34},
+            {1, 0, 6, 11, -22, 30},
+            {1, 2, 7, 11, -22, 30},
+            {1, 1, 8, 11, -9.998, 30},
+            {1, 1, 8, 11, -9.998, 30},
+            {1, 0, 9, 11, -9.999, 30},
+            {1, 3, 10, 11, -20, 30},
     };
 
     for(int i = 0; i < 12; i++) {
-        topster.add(data[i].key, 1, data[i].query_index, data[i].match_score, data[i].primary_attr,
+        topster.add(data[i].key, data[i].field_id, data[i].query_index, data[i].match_score, data[i].primary_attr,
                     data[i].secondary_attr);
     }
 


### PR DESCRIPTION
Fixes https://github.com/typesense/typesense/issues/25

This needs a change in the structure of the `highlight` field in response to allow sending the matched array index. For e.g. if a document has a `colors` array with a value of `["green", "blue", "red"]` and the search query is `red`, we need to communicate that matched array index is `2`:

```
...

"highlight": {
  "field": "colors",
  "snippet": "<mark>red</mark">,
  "index": 2
}
```

The `index` property will be present only a `string[]` field.

This PR also contains fixes for 2 other edge cases that should be part of the `0.9.0` change log:

1. A bug in fuzzy search involving prefixes - the prefix was being compared with the entire string for fuzzy matching instead of comparing with only the length of the overlapping segment.
2. When multiple fields were used for searching, in some cases, the same document was being returned multiple times leading to duplicate results.