### PR TITLE
Include exclude fields

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -96,7 +96,7 @@
 - ~~gzip compress responses~~
 - ~~Have a LOG(ERROR) level~~
 - ~~Handle SIGTERM which is sent when process is killed~~
-- Use snappy compression for storage
+- ~~Use snappy compression for storage~~
 - Exact search 
 - NOT operator support
 - Log operations

--- a/include/collection.h
+++ b/include/collection.h
@@ -97,13 +97,18 @@ public:
                           const std::vector<sort_by> & sort_fields, const int num_typos,
                           const size_t per_page = 10, const size_t page = 1,
                           const token_ordering token_order = FREQUENCY, const bool prefix = false,
-                          const size_t drop_tokens_threshold = Index::DROP_TOKENS_THRESHOLD);
+                          const size_t drop_tokens_threshold = Index::DROP_TOKENS_THRESHOLD,
+                          const spp::sparse_hash_set<std::string> include_fields = spp::sparse_hash_set<std::string>(),
+                          const spp::sparse_hash_set<std::string> exclude_fields = spp::sparse_hash_set<std::string>());
 
     Option<nlohmann::json> get(const std::string & id);
 
     Option<std::string> remove(const std::string & id, const bool remove_from_store = true);
 
     Option<uint32_t> index_in_memory(const nlohmann::json & document, uint32_t seq_id);
+
+    static void prune_document(nlohmann::json &document, const spp::sparse_hash_set<std::string> include_fields,
+                               const spp::sparse_hash_set<std::string> exclude_fields);
 
     static const int MAX_SEARCH_TOKENS = 10;
     static const int MAX_RESULTS = 500;

--- a/include/store.h
+++ b/include/store.h
@@ -63,6 +63,7 @@ public:
         options.write_buffer_size = 4*1048576;
         options.max_write_buffer_number = 2;
         options.merge_operator.reset(new UInt64AddOperator);
+        options.compression = rocksdb::CompressionType::kSnappyCompression;
 
         // these need to be high for replication scenarios
         options.WAL_ttl_seconds = wal_ttl_secs;


### PR DESCRIPTION
Fixes https://github.com/typesense/typesense/issues/27

Introduces two additional parameters to the search end-point: `include_fields` and `exclude_fields` that enabled customization of the document fields that are returned in the search result response.

@jasonbosco Use `typesense/typesense:include_exclude_fields` Docker image for testing this.