### PR TITLE
Support wildcard query: using a * would ignore the search query and consider all records for filter+sort.

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -80,7 +80,7 @@ void post_create_collection(http_req & req, http_res & res) {
 
     if(!req_json[DEFAULT_SORTING_FIELD].is_string()) {
         return res.send_400(std::string("`") + DEFAULT_SORTING_FIELD +
-                            "` should be a string. It should be the name of an unsigned integer field.");
+                            "` should be a string. It should be the name of an int32/float field.");
     }
 
     if(collectionManager.get_collection(req_json["name"]) != nullptr) {

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -156,6 +156,12 @@ Option<Collection*> CollectionManager::create_collection(const std::string name,
         field_val[fields::type] = field.type;
         field_val[fields::facet] = field.facet;
         fields_json.push_back(field_val);
+
+        if(field.name == default_sorting_field && !(field.type == field_types::INT32 ||
+                                                    field.type == field_types::FLOAT)) {
+            return Option<Collection*>(400, "Default sorting field `" + default_sorting_field + "` must be of type int32 "
+                                            "or float.");
+        }
     }
 
     collection_meta[COLLECTION_NAME_KEY] = name;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -622,15 +622,22 @@ void Index::search(Option<uint32_t> & outcome, std::string query, const std::vec
 
     Topster<512> topster;
 
-    const size_t num_search_fields = std::min(search_fields.size(), (size_t) FIELD_LIMIT_NUM);
-    for(size_t i = 0; i < num_search_fields; i++) {
-        const std::string & field = search_fields[i];
-        // proceed to query search only when no filters are provided or when filtering produces results
-        if(filters.size() == 0 || filter_ids_length > 0) {
-            uint8_t field_id = (uint8_t)(FIELD_LIMIT_NUM - i);
-            search_field(field_id, query, field, filter_ids, filter_ids_length, facets, sort_fields_std,
-                         num_typos, num_results, searched_queries, topster, &all_result_ids, all_result_ids_len,
-                         token_order, prefix, drop_tokens_threshold);
+    if(query == "*") {
+        uint8_t field_id = (uint8_t)(FIELD_LIMIT_NUM - 0);
+        score_results(sort_fields_std, (uint16_t) searched_queries.size(), field_id, 0, topster, {},
+                      filter_ids, filter_ids_length);
+        all_result_ids_len = filter_ids_length;
+    } else {
+        const size_t num_search_fields = std::min(search_fields.size(), (size_t) FIELD_LIMIT_NUM);
+        for(size_t i = 0; i < num_search_fields; i++) {
+            const std::string & field = search_fields[i];
+            // proceed to query search only when no filters are provided or when filtering produces results
+            if(filters.size() == 0 || filter_ids_length > 0) {
+                uint8_t field_id = (uint8_t)(FIELD_LIMIT_NUM - i);
+                search_field(field_id, query, field, filter_ids, filter_ids_length, facets, sort_fields_std,
+                             num_typos, num_results, searched_queries, topster, &all_result_ids, all_result_ids_len,
+                             token_order, prefix, drop_tokens_threshold);
+            }
         }
     }
 
@@ -897,7 +904,7 @@ void Index::score_results(const std::vector<sort_by> & sort_fields, const uint16
 
         uint64_t match_score = 0;
 
-        if(query_suggestion.size() == 1) {
+        if(query_suggestion.size() <= 1) {
             match_score = single_token_match_score;
         } else {
             std::vector<std::vector<std::vector<uint16_t>>> array_token_positions;


### PR DESCRIPTION
Fixes https://github.com/typesense/typesense/issues/17

@jasonbosco 

You can review and test this PR along with https://github.com/typesense/typesense/pull/28 (since I've merged that now) from `typesense/typesense:wildcard_query_support` Docker image.