### PR TITLE
When a facet field is filtered upon, search should be verbatim

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ create_response = client.collections.create({
   "fields": [
     {"name": "company_name", "type": "string" },
     {"name": "num_employees", "type": "int32" },
-    {"name": "country", "type": "string", "facet": true }
+    {"name": "country", "type": "string", "facet": True }
   ],
   "default_sorting_field": "num_employees"
 })

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -1293,9 +1293,9 @@ TEST_F(CollectionTest, FilterOnTextFields) {
     query_fields = {"name"};
     std::vector<std::string> facets;
     nlohmann::json results = coll_array_fields->search("Jeremy", query_fields, "tags: gold", facets, sort_fields, 0, 10, 1, FREQUENCY, false).get();
-    ASSERT_EQ(4, results["hits"].size());
+    ASSERT_EQ(3, results["hits"].size());
 
-    std::vector<std::string> ids = {"1", "4", "0", "2"};
+    std::vector<std::string> ids = {"4", "0", "2"};
 
     for(size_t i = 0; i < results["hits"].size(); i++) {
         nlohmann::json result = results["hits"].at(i);
@@ -1303,6 +1303,9 @@ TEST_F(CollectionTest, FilterOnTextFields) {
         std::string id = ids.at(i);
         ASSERT_STREQ(id.c_str(), result_id.c_str());
     }
+
+    results = coll_array_fields->search("Jeremy", query_fields, "tags : FINE PLATINUM", facets, sort_fields, 0, 10, 1, FREQUENCY, false).get();
+    ASSERT_EQ(1, results["hits"].size());
 
     results = coll_array_fields->search("Jeremy", query_fields, "tags : bronze", facets, sort_fields, 0, 10, 1, FREQUENCY, false).get();
     ASSERT_EQ(2, results["hits"].size());
@@ -1329,19 +1332,19 @@ TEST_F(CollectionTest, FilterOnTextFields) {
         ASSERT_STREQ(id.c_str(), result_id.c_str());
     }
 
-    // need not be exact matches (normalization can happen)
-    results = coll_array_fields->search("Jeremy", query_fields, "tags: BrONZe", facets, sort_fields, 0, 10, 1, FREQUENCY, false).get();
+    // need to be exact matches
+    results = coll_array_fields->search("Jeremy", query_fields, "tags: bronze", facets, sort_fields, 0, 10, 1, FREQUENCY, false).get();
     ASSERT_EQ(2, results["hits"].size());
 
-    // when comparators are used, should just treat them as part of search string (special chars will be removed)
+    // when comparators are used, should just treat them as part of search string
     results = coll_array_fields->search("Jeremy", query_fields, "tags:<bronze", facets, sort_fields, 0, 10, 1, FREQUENCY, false).get();
-    ASSERT_EQ(2, results["hits"].size());
+    ASSERT_EQ(0, results["hits"].size());
 
     results = coll_array_fields->search("Jeremy", query_fields, "tags:<=BRONZE", facets, sort_fields, 0, 10, 1, FREQUENCY, false).get();
-    ASSERT_EQ(2, results["hits"].size());
+    ASSERT_EQ(0, results["hits"].size());
 
     results = coll_array_fields->search("Jeremy", query_fields, "tags:>BRONZE", facets, sort_fields, 0, 10, 1, FREQUENCY, false).get();
-    ASSERT_EQ(2, results["hits"].size());
+    ASSERT_EQ(0, results["hits"].size());
 
     collectionManager.drop_collection("coll_array_fields");
 }
@@ -1442,7 +1445,7 @@ TEST_F(CollectionTest, FacetCounts) {
     ASSERT_EQ("tags", results["facet_counts"][0]["field_name"]);
 
     ASSERT_EQ("gold", results["facet_counts"][0]["counts"][0]["value"]);
-    ASSERT_EQ(4, (int) results["facet_counts"][0]["counts"][0]["count"]);
+    ASSERT_EQ(3, (int) results["facet_counts"][0]["counts"][0]["count"]);
 
     ASSERT_EQ("silver", results["facet_counts"][0]["counts"][1]["value"]);
     ASSERT_EQ(3, (int) results["facet_counts"][0]["counts"][1]["count"]);
@@ -1476,12 +1479,14 @@ TEST_F(CollectionTest, FacetCounts) {
 
     ASSERT_EQ("tags", results["facet_counts"][0]["field_name"]);
     ASSERT_EQ(2, (int) results["facet_counts"][0]["counts"][0]["count"]);
-    ASSERT_EQ(2, (int) results["facet_counts"][0]["counts"][1]["count"]);
+    ASSERT_EQ(1, (int) results["facet_counts"][0]["counts"][1]["count"]);
     ASSERT_EQ(1, (int) results["facet_counts"][0]["counts"][2]["count"]);
+    ASSERT_EQ(1, (int) results["facet_counts"][0]["counts"][3]["count"]);
 
-    ASSERT_EQ("gold", results["facet_counts"][0]["counts"][0]["value"]);
-    ASSERT_EQ("silver", results["facet_counts"][0]["counts"][1]["value"]);
+    ASSERT_EQ("silver", results["facet_counts"][0]["counts"][0]["value"]);
+    ASSERT_EQ("FINE PLATINUM", results["facet_counts"][0]["counts"][1]["value"]);
     ASSERT_EQ("bronze", results["facet_counts"][0]["counts"][2]["value"]);
+    ASSERT_EQ("gold", results["facet_counts"][0]["counts"][3]["value"]);
 
     collectionManager.drop_collection("coll_array_fields");
 }

--- a/test/numeric_array_documents.jsonl
+++ b/test/numeric_array_documents.jsonl
@@ -1,5 +1,5 @@
 {"name": "Jeremy Howard", "top_3": [1.09, 1.88, 0.001], "rating": 1.09, "age": 24, "years": [2014, 2015, 2016], "timestamps": [1390354022, 1421890022, 1453426022], "tags": ["gold", "silver"]}
-{"name": "Jeremy Howard", "top_3": [9.999, 8.89, 7.713], "rating": 9.999, "age": 44, "years": [2015, 2016], "timestamps": [1421890022, 1453426022], "tags": ["gold"]}
+{"name": "Jeremy Howard", "top_3": [9.999, 8.89, 7.713], "rating": 9.999, "age": 44, "years": [2015, 2016], "timestamps": [1421890022, 1453426022], "tags": ["FINE PLATINUM"]}
 {"name": "Jeremy Howard", "top_3": [7.812, 7.770, 6.66], "rating": 7.812, "age": 21, "years": [2016], "timestamps": [1453426022], "tags": ["bronze", "gold"]}
 {"name": "Jeremy Howard", "top_3": [0.0, 0.0, 0.0], "rating": 0.0, "age": 63, "years": [1981, 1985], "timestamps": [348974822, 475205222], "tags": ["silver"]}
 {"name": "Jeremy Howard", "top_3": [5.5, 5.431, 1.001], "rating": 5.5, "age": 32, "years": [1999, 2000, 2001, 2002], "timestamps": [916968422, 948504422, 980126822, 1011662822], "tags": ["silver", "gold", "bronze"]}


### PR DESCRIPTION
Instead of normalizing the `filter_by` value before searching.

There was also a difference in the behavior between string and string array facet fields which is corrected in this PR.

Fixes https://github.com/typesense/typesense/issues/54