### PR TITLE
Import multiple documents in one go

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -115,6 +115,8 @@ public:
 
     Option<nlohmann::json> add(const std::string & json_str);
 
+    Option<nlohmann::json> add_many(const std::string & json_str);
+
     Option<nlohmann::json> search(std::string query, const std::vector<std::string> search_fields,
                           const std::string & simple_filter_query, const std::vector<std::string> & facet_fields,
                           const std::vector<sort_by> & sort_fields, const int num_typos,

--- a/include/core_api.h
+++ b/include/core_api.h
@@ -18,9 +18,11 @@ void get_search(http_req & req, http_res & res);
 
 void get_collection_summary(http_req & req, http_res & res);
 
-void get_collection_export(http_req & req, http_res & res);
+void get_export_documents(http_req & req, http_res & res);
 
 void post_add_document(http_req & req, http_res & res);
+
+void post_import_documents(http_req & req, http_res & res);
 
 void get_fetch_document(http_req & req, http_res & res);
 

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -148,7 +148,7 @@ Option<nlohmann::json> Collection::add_many(const std::string & json_lines_str) 
 
         if(!op.ok()) {
             std::string err_msg = std::string("Error importing record in line number ") +
-                                  std::to_string(record_num) + ": " + op.error() + " On record number: ";
+                                  std::to_string(record_num) + ": " + op.error();
             Option<bool> err = Option<bool>(op.code(), err_msg);
             errors.push_back(err);
         } else {

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -362,7 +362,7 @@ void collection_export_handler(http_req* req, http_res* res, void* data) {
     }
 }
 
-void get_collection_export(http_req & req, http_res & res) {
+void get_export_documents(http_req & req, http_res & res) {
     CollectionManager & collectionManager = CollectionManager::get_instance();
     Collection* collection = collectionManager.get_collection(req.params["collection"]);
 
@@ -397,6 +397,24 @@ void post_add_document(http_req & req, http_res & res) {
     } else {
         res.send_201(inserted_doc_op.get().dump());
     }
+}
+
+void post_import_documents(http_req & req, http_res & res) {
+    CollectionManager & collectionManager = CollectionManager::get_instance();
+    Collection* collection = collectionManager.get_collection(req.params["collection"]);
+
+    if(collection == nullptr) {
+        return res.send_404();
+    }
+
+    Option<nlohmann::json> result = collection->add_many(req.body);
+
+    if(!result.ok()) {
+        res.send(result.code(), result.error());
+        return ;
+    }
+
+    res.send_200(result.get().dump());
 }
 
 void get_fetch_document(http_req & req, http_res & res) {

--- a/src/main/typesense_server.cpp
+++ b/src/main/typesense_server.cpp
@@ -12,7 +12,10 @@ void master_server_routes() {
     // document management - `/documents/:id` end-points must be placed last in the list
     server->post("/collections/:collection/documents", post_add_document);
     server->get("/collections/:collection/documents/search", get_search);
-    server->get("/collections/:collection/documents/export", get_collection_export, true);
+
+    server->post("/collections/:collection/documents/import", post_import_documents);
+    server->get("/collections/:collection/documents/export", get_export_documents, true);
+
     server->get("/collections/:collection/documents/:id", get_fetch_document);
     server->del("/collections/:collection/documents/:id", del_remove_document);
 
@@ -31,7 +34,7 @@ void replica_server_routes() {
 
     // document management - `/documents/:id` end-points must be placed last in the list
     server->get("/collections/:collection/documents/search", get_search);
-    server->get("/collections/:collection/documents/export", get_collection_export, true);
+    server->get("/collections/:collection/documents/export", get_export_documents, true);
     server->get("/collections/:collection/documents/:id", get_fetch_document);
 
     // meta


### PR DESCRIPTION
Expects a `POST` request body of documents formatted as JSON lines. So, the API is compatible with the output of the `export` end-point.

Fixes https://github.com/typesense/typesense/issues/35