### PR TITLE
When a write to on-disk storage fails, ensure that in-memory write is rolled back

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -72,6 +72,8 @@ private:
                           const Topster<512>::KV &field_order_kv, const nlohmann::json &document,
                           StringUtils & string_utils, highlight_t &highlight);
 
+    void remove_document(nlohmann::json & document, const uint32_t seq_id, bool remove_from_store);
+
 public:
     Collection() = delete;
 


### PR DESCRIPTION
Otherwise, the memory and disk stores will not be in sync.