### PR TITLE
Allow maximum hits returned to be configurable

### DIFF
--- a/docker/development.Dockerfile
+++ b/docker/development.Dockerfile
@@ -24,7 +24,7 @@ ADD https://launchpad.net/ubuntu/+archive/primary/+files/snappy_1.1.3.orig.tar.g
 RUN tar -C /opt -xf /opt/snappy_1.1.3.orig.tar.gz
 RUN mkdir /opt/snappy-1.1.3/build && cd /opt/snappy-1.1.3/build && ../configure && make -j8 && make install
 
-ADD https://ssl.icu-project.org/files/icu4c/61.1/icu4c-61_1-src.tgz /opt/icu4c-61_1-src.tgz
+ADD https://github.com/unicode-org/icu/releases/download/release-61-1/icu4c-61_1-src.tgz /opt/icu4c-61_1-src.tgz
 RUN tar -C /opt -xf /opt/icu4c-61_1-src.tgz
 RUN cd /opt/icu/source && echo "#define U_DISABLE_RENAMING 1" >> common/unicode/uconfig.h && \
     echo "#define U_STATIC_IMPLEMENTATION 1" >> common/unicode/uconfig.h && \

--- a/include/collection.h
+++ b/include/collection.h
@@ -211,7 +211,7 @@ public:
                           const size_t drop_tokens_threshold = Index::DROP_TOKENS_THRESHOLD,
                           const spp::sparse_hash_set<std::string> include_fields = spp::sparse_hash_set<std::string>(),
                           const spp::sparse_hash_set<std::string> exclude_fields = spp::sparse_hash_set<std::string>(),
-                          const size_t max_facet_values=10);
+                          const size_t max_facet_values=10, size_t max_hits=512);
 
     Option<nlohmann::json> get(const std::string & id);
 
@@ -234,11 +234,10 @@ public:
     void par_index_in_memory(std::vector<std::vector<index_record>> & iter_batch,
                              batch_index_result & result);
 
-    static void prune_document(nlohmann::json &document, const spp::sparse_hash_set<std::string> include_fields,
-                               const spp::sparse_hash_set<std::string> exclude_fields);
+    static void prune_document(nlohmann::json &document, const spp::sparse_hash_set<std::string> & include_fields,
+                               const spp::sparse_hash_set<std::string> & exclude_fields);
 
     static const int MAX_SEARCH_TOKENS = 10;
-    static const int MAX_RESULTS = 500;
 
     // strings under this length will be fully highlighted, instead of showing a snippet of relevant portion
     enum {SNIPPET_STR_ABOVE_LEN = 30};

--- a/include/collection.h
+++ b/include/collection.h
@@ -203,19 +203,19 @@ public:
 
     Option<nlohmann::json> add_many(const std::string & json_str);
 
-    Option<nlohmann::json> search(std::string query, const std::vector<std::string> search_fields,
+    Option<nlohmann::json> search(const std::string & query, const std::vector<std::string> & search_fields,
                           const std::string & simple_filter_query, const std::vector<std::string> & facet_fields,
-                          const std::vector<sort_by> & sort_fields, const int num_typos,
-                          const size_t per_page = 10, const size_t page = 1,
-                          const token_ordering token_order = FREQUENCY, const bool prefix = false,
-                          const size_t drop_tokens_threshold = Index::DROP_TOKENS_THRESHOLD,
-                          const spp::sparse_hash_set<std::string> include_fields = spp::sparse_hash_set<std::string>(),
-                          const spp::sparse_hash_set<std::string> exclude_fields = spp::sparse_hash_set<std::string>(),
-                          const size_t max_facet_values=10, size_t max_hits=512);
+                          const std::vector<sort_by> & sort_fields, int num_typos,
+                          size_t per_page = 10, size_t page = 1,
+                          token_ordering token_order = FREQUENCY, bool prefix = false,
+                          size_t drop_tokens_threshold = Index::DROP_TOKENS_THRESHOLD,
+                          const spp::sparse_hash_set<std::string> & include_fields = spp::sparse_hash_set<std::string>(),
+                          const spp::sparse_hash_set<std::string> & exclude_fields = spp::sparse_hash_set<std::string>(),
+                          size_t max_facet_values=10, size_t max_hits=500);
 
     Option<nlohmann::json> get(const std::string & id);
 
-    Option<std::string> remove(const std::string & id, const bool remove_from_store = true);
+    Option<std::string> remove(const std::string & id, bool remove_from_store = true);
 
     Option<uint32_t> add_override(const override_t & override);
 
@@ -236,8 +236,6 @@ public:
 
     static void prune_document(nlohmann::json &document, const spp::sparse_hash_set<std::string> & include_fields,
                                const spp::sparse_hash_set<std::string> & exclude_fields);
-
-    static const int MAX_SEARCH_TOKENS = 10;
 
     // strings under this length will be fully highlighted, instead of showing a snippet of relevant portion
     enum {SNIPPET_STR_ABOVE_LEN = 30};

--- a/include/index.h
+++ b/include/index.h
@@ -31,6 +31,7 @@ struct search_args {
     std::vector<sort_by> sort_fields_std;
     int num_typos;
     size_t max_facet_values;
+    size_t max_hits;
     size_t per_page;
     size_t page;
     token_ordering token_order;
@@ -49,10 +50,11 @@ struct search_args {
     search_args(std::string query, std::vector<std::string> search_fields, std::vector<filter> filters,
                 std::vector<facet> facets, std::vector<uint32_t> included_ids, std::vector<uint32_t> excluded_ids,
                 std::vector<sort_by> sort_fields_std, int num_typos, size_t max_facet_values,
-                size_t per_page, size_t page, token_ordering token_order, bool prefix, size_t drop_tokens_threshold):
+                size_t max_hits, size_t per_page, size_t page, token_ordering token_order, bool prefix,
+                size_t drop_tokens_threshold):
             query(query), search_fields(search_fields), filters(filters), facets(facets), included_ids(included_ids),
             excluded_ids(excluded_ids), sort_fields_std(sort_fields_std), num_typos(num_typos),
-            max_facet_values(max_facet_values), per_page(per_page),
+            max_facet_values(max_facet_values), max_hits(max_hits), per_page(per_page),
             page(page), token_order(token_order), prefix(prefix), drop_tokens_threshold(drop_tokens_threshold),
             all_result_ids_len(0), outcome(0) {
 
@@ -146,15 +148,15 @@ private:
                       std::vector<facet> & facets, const std::vector<sort_by> & sort_fields,
                       const int num_typos, const size_t num_results,
                       std::vector<std::vector<art_leaf*>> & searched_queries,
-                      Topster<512> & topster, uint32_t** all_result_ids,
+                      Topster & topster, uint32_t** all_result_ids,
                       size_t & all_result_ids_len, const token_ordering token_order = FREQUENCY,
                       const bool prefix = false, const size_t drop_tokens_threshold = Index::DROP_TOKENS_THRESHOLD);
 
     void search_candidates(const uint8_t & field_id, uint32_t* filter_ids, size_t filter_ids_length, std::vector<facet> & facets,
                            const std::vector<sort_by> & sort_fields, std::vector<token_candidates> & token_to_candidates,
                            const token_ordering token_order, std::vector<std::vector<art_leaf*>> & searched_queries,
-                           Topster<512> & topster, uint32_t** all_result_ids,
-                           size_t & all_result_ids_len, const size_t & max_results, const bool prefix);
+                           Topster & topster, uint32_t** all_result_ids,
+                           size_t & all_result_ids_len, const size_t & max_results);
 
     void insert_doc(const uint32_t score, art_tree *t, uint32_t seq_id,
                     const std::unordered_map<std::string, std::vector<uint32_t>> &token_to_offsets) const;
@@ -186,7 +188,7 @@ private:
 
     void collate_curated_ids(const std::string & query, const std::string & field, const uint8_t field_id,
                              const std::vector<uint32_t> & included_ids,
-                             Topster<512> & curated_topster, std::vector<std::vector<art_leaf*>> & searched_queries);
+                             Topster & curated_topster, std::vector<std::vector<art_leaf*>> & searched_queries);
 
 public:
     Index() = delete;
@@ -202,7 +204,7 @@ public:
                           const std::vector<filter> & filters, std::vector<facet> & facets,
                           const std::vector<uint32_t> & included_ids, const std::vector<uint32_t> & excluded_ids,
                           const std::vector<sort_by> & sort_fields_std, const int num_typos,
-                          const size_t per_page, const size_t page, const token_ordering token_order,
+                          const size_t max_hits, const size_t per_page, const size_t page, const token_ordering token_order,
                           const bool prefix, const size_t drop_tokens_threshold, std::vector<KV> & raw_result_kvs,
                           size_t & all_result_ids_len, std::vector<std::vector<art_leaf*>> & searched_queries,
                           std::vector<KV> & override_result_kvs);
@@ -217,7 +219,7 @@ public:
                                          std::vector<std::vector<std::vector<uint16_t>>> &array_token_positions);
 
     void score_results(const std::vector<sort_by> & sort_fields, const uint16_t & query_index, const uint8_t & field_id,
-                       const uint32_t total_cost, Topster<512> &topster, const std::vector<art_leaf *> & query_suggestion,
+                       const uint32_t total_cost, Topster &topster, const std::vector<art_leaf *> & query_suggestion,
                        const uint32_t *result_ids, const size_t result_size) const;
 
     static int32_t get_points_from_doc(const nlohmann::json &document, const std::string & default_sorting_field);

--- a/include/topster.h
+++ b/include/topster.h
@@ -21,19 +21,20 @@ struct KV {
 /*
 * Remembers the max-K elements seen so far using a min-heap
 */
-template <size_t MAX_SIZE=512>
 struct Topster {
+    const uint32_t MAX_SIZE;
     KV *data;
     uint32_t size;
 
     spp::sparse_hash_map<uint64_t, KV*> keys;
 
-    KV *kvs[MAX_SIZE];
+    KV* *kvs;
 
-    Topster(): size(0){
-        data = new KV[MAX_SIZE];
+    explicit Topster(size_t capacity): MAX_SIZE(capacity), size(0) {
+        kvs = new KV*[capacity];
+        data = new KV[capacity];
 
-        for(size_t i=0; i<MAX_SIZE; i++) {
+        for(size_t i=0; i<capacity; i++) {
             data[i].field_id = 0;
             data[i].query_index = 0;
             data[i].key = 0;
@@ -185,7 +186,7 @@ struct Topster {
 
     // topster must be sorted before iterated upon to remove dead array entries
     void sort() {
-        std::stable_sort(std::begin(kvs), std::begin(kvs) + size, is_greater_kv);
+        std::stable_sort(kvs, kvs+size, is_greater_kv);
     }
 
     void clear(){

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -264,8 +264,8 @@ void Collection::par_index_in_memory(std::vector<std::vector<index_record>> & it
     }
 }
 
-void Collection::prune_document(nlohmann::json &document, const spp::sparse_hash_set<std::string> include_fields,
-                                const spp::sparse_hash_set<std::string> exclude_fields) {
+void Collection::prune_document(nlohmann::json &document, const spp::sparse_hash_set<std::string>& include_fields,
+                                const spp::sparse_hash_set<std::string>& exclude_fields) {
     auto it = document.begin();
     for(; it != document.end(); ) {
         if(exclude_fields.count(it.key()) != 0 || (include_fields.size() != 0 && include_fields.count(it.key()) == 0)) {
@@ -311,7 +311,7 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
                                   const size_t drop_tokens_threshold,
                                   const spp::sparse_hash_set<std::string> include_fields,
                                   const spp::sparse_hash_set<std::string> exclude_fields,
-                                  const size_t max_facet_values) {
+                                  const size_t max_facet_values, const size_t max_hits) {
 
     std::vector<uint32_t> included_ids;
     std::vector<uint32_t> excluded_ids;
@@ -492,8 +492,8 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
 
     const size_t num_results = (page * per_page);
 
-    if(num_results > MAX_RESULTS) {
-        std::string message = "Only the first " + std::to_string(MAX_RESULTS) + " results are available.";
+    if(num_results > max_hits) {
+        std::string message = "Only the first " + std::to_string(max_hits) + " results are available.";
         return Option<nlohmann::json>(422, message);
     }
 
@@ -508,8 +508,8 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
     for(Index* index: indices) {
         index->search_params = search_args(query, search_fields, filters, facets,
                                            index_to_included_ids[index_id], index_to_excluded_ids[index_id],
-                                           sort_fields_std, num_typos, max_facet_values, per_page, page,
-                                           token_order, prefix, drop_tokens_threshold);
+                                           sort_fields_std, num_typos, max_facet_values, max_hits,
+                                           per_page, page, token_order, prefix, drop_tokens_threshold);
         {
             std::lock_guard<std::mutex> lk(index->m);
             index->ready = true;
@@ -577,7 +577,7 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
     }
 
     // All fields are sorted descending
-    std::sort(raw_result_kvs.begin(), raw_result_kvs.end(), Topster<>::is_greater_kv_value);
+    std::sort(raw_result_kvs.begin(), raw_result_kvs.end(), Topster::is_greater_kv_value);
 
     // Sort based on position in overriden list
     std::sort(

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -303,14 +303,14 @@ void Collection::populate_overrides(std::string query, std::map<uint32_t, size_t
     }
 }
 
-Option<nlohmann::json> Collection::search(std::string query, const std::vector<std::string> search_fields,
+Option<nlohmann::json> Collection::search(const std::string & query, const std::vector<std::string> & search_fields,
                                   const std::string & simple_filter_query, const std::vector<std::string> & facet_fields,
                                   const std::vector<sort_by> & sort_fields, const int num_typos,
                                   const size_t per_page, const size_t page,
                                   const token_ordering token_order, const bool prefix,
                                   const size_t drop_tokens_threshold,
-                                  const spp::sparse_hash_set<std::string> include_fields,
-                                  const spp::sparse_hash_set<std::string> exclude_fields,
+                                  const spp::sparse_hash_set<std::string> & include_fields,
+                                  const spp::sparse_hash_set<std::string> & exclude_fields,
                                   const size_t max_facet_values, const size_t max_hits) {
 
     std::vector<uint32_t> included_ids;

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -176,6 +176,7 @@ void get_search(http_req & req, http_res & res) {
     const char *FACET_BY = "facet_by";
     const char *MAX_FACET_VALUES = "max_facet_values";
 
+    const char *MAX_HITS = "max_hits";
     const char *PER_PAGE = "per_page";
     const char *PAGE = "page";
     const char *CALLBACK = "callback";
@@ -205,6 +206,10 @@ void get_search(http_req & req, http_res & res) {
 
     if(req.params.count(MAX_FACET_VALUES) == 0) {
         req.params[MAX_FACET_VALUES] = "10";
+    }
+
+    if(req.params.count(MAX_HITS) == 0) {
+        req.params[MAX_HITS] = "500";
     }
 
     if(req.params.count(PER_PAGE) == 0) {
@@ -301,7 +306,8 @@ void get_search(http_req & req, http_res & res) {
                                                           static_cast<size_t>(std::stoi(req.params[PAGE])),
                                                           token_order, prefix, drop_tokens_threshold,
                                                           include_fields, exclude_fields,
-                                                          static_cast<size_t>(std::stoi(req.params[MAX_FACET_VALUES])));
+                                                          static_cast<size_t>(std::stoi(req.params[MAX_FACET_VALUES])),
+                                                          static_cast<size_t>(std::stoi(req.params[MAX_HITS])));
 
     uint64_t timeMillis = std::chrono::duration_cast<std::chrono::milliseconds>(
                                std::chrono::high_resolution_clock::now() - begin).count();

--- a/test/topster_test.cpp
+++ b/test/topster_test.cpp
@@ -3,7 +3,7 @@
 #include "match_score.h"
 
 TEST(TopsterTest, MaxIntValues) {
-    Topster<5> topster;
+    Topster topster(5);
 
     struct {
         uint8_t field_id;
@@ -52,7 +52,7 @@ TEST(TopsterTest, MaxIntValues) {
 }
 
 TEST(TopsterTest, MaxFloatValues) {
-    Topster<5> topster;
+    Topster topster(5);
 
     struct {
         uint8_t field_id;


### PR DESCRIPTION
Currently, Typesense limits the total number of hits returned to 500 results (for performance reasons). 

This limit is now configurable as `max_hits` query parameter. Obviously, larger values of `max_hits` parameter has a performance impact, but this won't really matter for smaller data sets (say less than 100K records).

The default of 500 results remains to maintain backward compatibility.