### PR TITLE
Facet search

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -154,14 +154,14 @@ private:
     void populate_overrides(std::string query, std::map<uint32_t, size_t> & id_pos_map,
                             std::vector<uint32_t> & included_ids, std::vector<uint32_t> & excluded_ids);
 
-    static bool facet_count_compare(const std::pair<uint64_t, facet_count>& a,
-                                    const std::pair<uint64_t, facet_count>& b) {
+    static bool facet_count_compare(const std::pair<uint64_t, facet_count_t>& a,
+                                    const std::pair<uint64_t, facet_count_t>& b) {
         return std::tie(a.second.count, a.first) > std::tie(b.second.count, a.first);
     }
 
-    static bool facet_count_str_compare(const std::pair<std::string, size_t>& a,
-                                        const std::pair<std::string, size_t>& b) {
-        return a.second > b.second;
+    static bool facet_count_str_compare(const facet_value_t& a,
+                                        const facet_value_t& b) {
+        return a.count > b.count;
     }
 
 public:

--- a/include/collection.h
+++ b/include/collection.h
@@ -169,7 +169,7 @@ public:
 
     Collection(const std::string name, const uint32_t collection_id, const uint64_t created_at,
                const uint32_t next_seq_id, Store *store, const std::vector<field> & fields,
-               const std::string & default_sorting_field, const size_t num_indices=4);
+               const std::string & default_sorting_field, const size_t num_indices);
 
     ~Collection();
 

--- a/include/collection.h
+++ b/include/collection.h
@@ -250,6 +250,8 @@ public:
     static void prune_document(nlohmann::json &document, const spp::sparse_hash_set<std::string> & include_fields,
                                const spp::sparse_hash_set<std::string> & exclude_fields);
 
+    const std::vector<Index *> &_get_indexes() const;
+
     // strings under this length will be fully highlighted, instead of showing a snippet of relevant portion
     enum {SNIPPET_STR_ABOVE_LEN = 30};
 

--- a/include/collection.h
+++ b/include/collection.h
@@ -133,7 +133,7 @@ private:
 
     std::unordered_map<std::string, field> search_schema;
 
-    std::unordered_map<std::string, field> facet_schema;
+    std::map<std::string, field> facet_schema;   // std::map guarantees order of fields
 
     std::unordered_map<std::string, field> sort_schema;
 
@@ -153,6 +153,16 @@ private:
 
     void populate_overrides(std::string query, std::map<uint32_t, size_t> & id_pos_map,
                             std::vector<uint32_t> & included_ids, std::vector<uint32_t> & excluded_ids);
+
+    static bool facet_count_compare(const std::pair<uint64_t, facet_count>& a,
+                                    const std::pair<uint64_t, facet_count>& b) {
+        return std::tie(a.second.count, a.first) > std::tie(b.second.count, a.first);
+    }
+
+    static bool facet_count_str_compare(const std::pair<std::string, size_t>& a,
+                                        const std::pair<std::string, size_t>& b) {
+        return a.second > b.second;
+    }
 
 public:
     Collection() = delete;
@@ -228,6 +238,8 @@ public:
     size_t get_num_indices();
 
     static uint32_t get_seq_id_from_key(const std::string & key);
+
+    Option<bool> get_document_from_store(const std::string & seq_id_key, nlohmann::json & document);
 
     Option<uint32_t> index_in_memory(const nlohmann::json & document, uint32_t seq_id);
 

--- a/include/collection.h
+++ b/include/collection.h
@@ -156,7 +156,7 @@ private:
 
     static bool facet_count_compare(const std::pair<uint64_t, facet_count_t>& a,
                                     const std::pair<uint64_t, facet_count_t>& b) {
-        return std::tie(a.second.count, a.first) > std::tie(b.second.count, a.first);
+        return std::tie(a.second.count, a.first) > std::tie(b.second.count, b.first);
     }
 
     static bool facet_count_str_compare(const facet_value_t& a,

--- a/include/collection.h
+++ b/include/collection.h
@@ -221,7 +221,8 @@ public:
                           size_t drop_tokens_threshold = Index::DROP_TOKENS_THRESHOLD,
                           const spp::sparse_hash_set<std::string> & include_fields = spp::sparse_hash_set<std::string>(),
                           const spp::sparse_hash_set<std::string> & exclude_fields = spp::sparse_hash_set<std::string>(),
-                          size_t max_facet_values=10, size_t max_hits=500);
+                          size_t max_facet_values=10, size_t max_hits=500,
+                          const std::string & simple_facet_query = "");
 
     Option<nlohmann::json> get(const std::string & id);
 

--- a/include/field.h
+++ b/include/field.h
@@ -134,6 +134,7 @@ struct facet_value {
     spp::sparse_hash_map<std::string, uint32_t> value_index;
     spp::sparse_hash_map<uint32_t, std::string> index_value;
 
+    // doc_id => facet_ids mapping
     spp::sparse_hash_map<uint32_t, std::vector<uint32_t>> doc_values;
 
     uint32_t get_value_index(const std::string & value) {

--- a/include/field.h
+++ b/include/field.h
@@ -134,3 +134,8 @@ struct facet {
 
     }
 };
+
+struct facet_query_t {
+    std::string field_name;
+    std::string query;
+};

--- a/include/field.h
+++ b/include/field.h
@@ -120,11 +120,19 @@ struct sort_by {
     }
 };
 
+struct token_pos_cost_t {
+    size_t pos;
+    uint32_t cost;
+};
+
 struct facet_count_t {
     uint32_t count;
-    uint32_t doc_id;    // used to fetch the actual document and the value from store
+
+    // used to fetch the actual document and value for representation
+    uint32_t doc_id;
     uint32_t array_pos;
-    spp::sparse_hash_map<uint32_t, uint32_t> token_query_pos;
+
+    spp::sparse_hash_map<uint32_t, token_pos_cost_t> query_token_pos;
 };
 
 struct facet {

--- a/include/field.h
+++ b/include/field.h
@@ -120,15 +120,16 @@ struct sort_by {
     }
 };
 
-struct facet_count {
+struct facet_count_t {
     uint32_t count;
     uint32_t doc_id;    // used to fetch the actual document and the value from store
     uint32_t array_pos;
+    spp::sparse_hash_map<uint32_t, uint32_t> token_query_pos;
 };
 
 struct facet {
     const std::string field_name;
-    std::map<uint64_t, facet_count> result_map;
+    std::map<uint64_t, facet_count_t> result_map;
 
     facet(const std::string & field_name): field_name(field_name) {
 
@@ -138,4 +139,10 @@ struct facet {
 struct facet_query_t {
     std::string field_name;
     std::string query;
+};
+
+struct facet_value_t {
+    std::string value;
+    std::string highlighted;
+    uint32_t count;
 };

--- a/include/field.h
+++ b/include/field.h
@@ -120,39 +120,17 @@ struct sort_by {
     }
 };
 
-struct facet {
-    const std::string field_name;
-    std::map<std::string, size_t> result_map;
-
-    facet(const std::string field_name): field_name(field_name) {
-
-    }
+struct facet_count {
+    uint32_t count;
+    uint32_t doc_id;    // used to fetch the actual document and the value from store
+    uint32_t array_pos;
 };
 
-struct facet_value {
-    // use string to int mapping for saving memory
-    spp::sparse_hash_map<std::string, uint32_t> value_index;
-    spp::sparse_hash_map<uint32_t, std::string> index_value;
+struct facet {
+    const std::string field_name;
+    std::map<uint64_t, facet_count> result_map;
 
-    // doc_id => facet_ids mapping
-    spp::sparse_hash_map<uint32_t, std::vector<uint32_t>> doc_values;
+    facet(const std::string & field_name): field_name(field_name) {
 
-    uint32_t get_value_index(const std::string & value) {
-        if(value_index.count(value) != 0) {
-            return value_index[value];
-        }
-
-        uint32_t new_index = value_index.size();
-        value_index.emplace(value, new_index);
-        index_value.emplace(new_index, value);
-        return new_index;
-    }
-
-    void index_values(uint32_t doc_seq_id, const std::vector<std::string> & values) {
-        std::vector<uint32_t> value_vec(values.size());
-        for(size_t i = 0; i < values.size(); i++) {
-            value_vec[i] = get_value_index(values[i]);
-        }
-        doc_values.emplace(doc_seq_id, value_vec);
     }
 };

--- a/include/index.h
+++ b/include/index.h
@@ -29,6 +29,7 @@ struct search_args {
     std::vector<uint32_t> included_ids;
     std::vector<uint32_t> excluded_ids;
     std::vector<sort_by> sort_fields_std;
+    facet_query_t facet_query;
     int num_typos;
     size_t max_facet_values;
     size_t max_hits;
@@ -49,11 +50,11 @@ struct search_args {
 
     search_args(std::string query, std::vector<std::string> search_fields, std::vector<filter> filters,
                 std::vector<facet> facets, std::vector<uint32_t> included_ids, std::vector<uint32_t> excluded_ids,
-                std::vector<sort_by> sort_fields_std, int num_typos, size_t max_facet_values,
+                std::vector<sort_by> sort_fields_std, facet_query_t facet_query, int num_typos, size_t max_facet_values,
                 size_t max_hits, size_t per_page, size_t page, token_ordering token_order, bool prefix,
                 size_t drop_tokens_threshold):
             query(query), search_fields(search_fields), filters(filters), facets(facets), included_ids(included_ids),
-            excluded_ids(excluded_ids), sort_fields_std(sort_fields_std), num_typos(num_typos),
+            excluded_ids(excluded_ids), sort_fields_std(sort_fields_std), facet_query(facet_query), num_typos(num_typos),
             max_facet_values(max_facet_values), max_hits(max_hits), per_page(per_page),
             page(page), token_order(token_order), prefix(prefix), drop_tokens_threshold(drop_tokens_threshold),
             all_result_ids_len(0), outcome(0) {
@@ -139,7 +140,8 @@ private:
 
     Option<uint32_t> do_filtering(uint32_t** filter_ids_out, const std::vector<filter> & filters);
 
-    void do_facets(std::vector<facet> & facets, const uint32_t* result_ids, size_t results_size);
+    void do_facets(std::vector<facet> & facets, const facet_query_t & facet_query,
+                   const uint32_t* result_ids, size_t results_size);
 
     void drop_facets(std::vector<facet> & facets, const std::vector<uint32_t> & ids);
 
@@ -202,6 +204,7 @@ public:
 
     void search(Option<uint32_t> & outcome, std::string query, const std::vector<std::string> & search_fields,
                           const std::vector<filter> & filters, std::vector<facet> & facets,
+                          const facet_query_t & facet_query,
                           const std::vector<uint32_t> & included_ids, const std::vector<uint32_t> & excluded_ids,
                           const std::vector<sort_by> & sort_fields_std, const int num_typos,
                           const size_t max_hits, const size_t per_page, const size_t page, const token_ordering token_order,
@@ -271,8 +274,9 @@ public:
 
     search_args search_params;
 
-    static void
-    populate_array_token_positions(std::vector<std::vector<std::vector<uint16_t>>> &array_token_positions,
-                                   const art_leaf *token_leaf, uint32_t doc_index);
+    static void populate_array_token_positions(std::vector<std::vector<std::vector<uint16_t>>> & array_token_positions,
+                                               const art_leaf *token_leaf, uint32_t doc_index);
+
+    int get_bounded_typo_cost(const size_t max_cost, const size_t token_len) const;
 };
 

--- a/include/index.h
+++ b/include/index.h
@@ -154,7 +154,7 @@ private:
                       size_t & all_result_ids_len, const token_ordering token_order = FREQUENCY,
                       const bool prefix = false, const size_t drop_tokens_threshold = Index::DROP_TOKENS_THRESHOLD);
 
-    void search_candidates(const uint8_t & field_id, uint32_t* filter_ids, size_t filter_ids_length, std::vector<facet> & facets,
+    void search_candidates(const uint8_t & field_id, uint32_t* filter_ids, size_t filter_ids_length,
                            const std::vector<sort_by> & sort_fields, std::vector<token_candidates> & token_to_candidates,
                            const token_ordering token_order, std::vector<std::vector<art_leaf*>> & searched_queries,
                            Topster & topster, uint32_t** all_result_ids,
@@ -164,10 +164,10 @@ private:
                     const std::unordered_map<std::string, std::vector<uint32_t>> &token_to_offsets) const;
 
     void index_string_field(const std::string & text, const uint32_t score, art_tree *t, uint32_t seq_id,
-                            const bool verbatim) const;
+                            int facet_id);
 
     void index_string_array_field(const std::vector<std::string> & strings, const uint32_t score, art_tree *t,
-                                  uint32_t seq_id, const bool verbatim) const;
+                                  uint32_t seq_id, int facet_id);
 
     void index_int32_field(const int32_t value, const uint32_t score, art_tree *t, uint32_t seq_id) const;
 

--- a/include/index.h
+++ b/include/index.h
@@ -148,8 +148,7 @@ private:
     void search_field(const uint8_t & field_id, std::string & query,
                       const std::string & field, uint32_t *filter_ids, size_t filter_ids_length,
                       std::vector<facet> & facets, const std::vector<sort_by> & sort_fields,
-                      const int num_typos, const size_t num_results,
-                      std::vector<std::vector<art_leaf*>> & searched_queries,
+                      const int num_typos, std::vector<std::vector<art_leaf*>> & searched_queries,
                       Topster & topster, uint32_t** all_result_ids,
                       size_t & all_result_ids_len, const token_ordering token_order = FREQUENCY,
                       const bool prefix = false, const size_t drop_tokens_threshold = Index::DROP_TOKENS_THRESHOLD);

--- a/include/index.h
+++ b/include/index.h
@@ -140,7 +140,7 @@ private:
 
     Option<uint32_t> do_filtering(uint32_t** filter_ids_out, const std::vector<filter> & filters);
 
-    void do_facets(std::vector<facet> & facets, const facet_query_t & facet_query,
+    void do_facets(std::vector<facet> & facets, facet_query_t & facet_query,
                    const uint32_t* result_ids, size_t results_size);
 
     void drop_facets(std::vector<facet> & facets, const std::vector<uint32_t> & ids);
@@ -203,7 +203,7 @@ public:
 
     void search(Option<uint32_t> & outcome, std::string query, const std::vector<std::string> & search_fields,
                           const std::vector<filter> & filters, std::vector<facet> & facets,
-                          const facet_query_t & facet_query,
+                          facet_query_t & facet_query,
                           const std::vector<uint32_t> & included_ids, const std::vector<uint32_t> & excluded_ids,
                           const std::vector<sort_by> & sort_fields_std, const int num_typos,
                           const size_t max_hits, const size_t per_page, const size_t page, const token_ordering token_order,

--- a/include/index.h
+++ b/include/index.h
@@ -240,6 +240,8 @@ public:
                                         const std::unordered_map<std::string, field> & search_schema,
                                         const std::map<std::string, field> & facet_schema);
 
+    const spp::sparse_hash_map<std::string, art_tree *> &_get_search_index() const;
+
     // for limiting number of results on multiple candidates / query rewrites
     enum {SEARCH_LIMIT_NUM = 100};
 

--- a/include/match_score.h
+++ b/include/match_score.h
@@ -93,14 +93,14 @@ struct Match {
   }
 
   /*
-  *  Given *sorted offsets* of each target token in a *single* document, generates a score that indicates:
+  *  Given *sorted offsets* of each target token in a *single* document (token_offsets), generates a score indicating:
   *  a) How many tokens are present within a match window
   *  b) The proximity between the tokens within the match window
   *
   *  We use a priority queue to read the offset vectors in a sorted manner, slide a window of a given size, and
   *  compute the max_match and min_displacement of target tokens across the windows.
   */
-  static Match match(uint32_t doc_id, const std::vector<std::vector<uint16_t>> &token_offsets) {
+  static Match match(uint32_t doc_id, const std::vector<std::vector<uint16_t>> & token_offsets) {
     std::priority_queue<TokenOffset, std::vector<TokenOffset>, TokenOffset> heap;
 
     const size_t tokens_size = std::min(token_offsets.size(), WINDOW_SIZE);

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -7,6 +7,7 @@
 #include <unicode/translit.h>
 #include <iconv.h>
 #include <vector>
+#include "wyhash_v5.h"
 
 struct StringUtils {
     UErrorCode status;
@@ -217,5 +218,10 @@ struct StringUtils {
         uint32_t seq_id = ((serialized_num[0] & 0xFF) << 24) | ((serialized_num[1] & 0xFF) << 16) |
                           ((serialized_num[2] & 0xFF) << 8)  | (serialized_num[3] & 0xFF);
         return seq_id;
+    }
+
+    static int64_t hash_wy(const void* key, uint64_t len) {
+        uint64_t hash = wyhash(key, len, 0, _wyp);
+        return hash != 0 ? hash : 1;  // reserve 0 for use as a delimiter
     }
 };

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -156,8 +156,6 @@ struct StringUtils {
 
     void unicode_normalize(std::string& str) const;
 
-    void unicode_normalize2(std::string& str) const;
-
     /* https://stackoverflow.com/a/34571089/131050 */
     static std::string base64_encode(const std::string &in) {
         std::string out;

--- a/include/topster.h
+++ b/include/topster.h
@@ -47,6 +47,7 @@ struct Topster {
 
     ~Topster() {
         delete [] data;
+        delete [] kvs;
     }
 
     static inline void swapMe(KV** a, KV** b) {

--- a/include/wyhash_v5.h
+++ b/include/wyhash_v5.h
@@ -1,0 +1,153 @@
+// Author: Wang Yi <godspeed_china@yeah.net>
+#ifndef wyhash_version_5
+#define wyhash_version_5
+#include <stdint.h>
+#include <string.h>
+#if defined(_MSC_VER) && defined(_M_X64)
+#include <intrin.h>
+#pragma intrinsic(_umul128)
+#endif
+#if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
+#define _likely_(x) __builtin_expect(x,1)
+#else
+#define _likely_(x) (x)
+#endif
+const uint64_t _wyp[6]={0xa0761d6478bd642full,0xe7037ed1a0b428dbull,0x8ebc6af09c88c6e3ull,0x589965cc75374cc3ull,0x1d8e4e27c47d124full,0x72b22b96e169b471ull};//default secret
+static inline uint64_t _wyrotr(uint64_t v, unsigned k){ return (v>>k)|(v<<(64-k)); }
+static inline uint64_t _wymum(uint64_t A, uint64_t B){
+#ifdef UNOFFICIAL_WYHASH_32BIT	//	fast on 32 bit system
+    uint64_t  hh=(A>>32)*(B>>32), hl=(A>>32)*(unsigned)B, lh=(unsigned)A*(B>>32), ll=(uint64_t)(unsigned)A*(unsigned)B;
+ return _wyrotr(hl,32)^_wyrotr(lh,32)^hh^ll;
+#else
+#ifdef __SIZEOF_INT128__
+    __uint128_t r=A; r*=B; return (r>>64)^r;
+#elif defined(_MSC_VER) && defined(_M_X64)
+    A=_umul128(A, B, &B); return A^B;
+#else
+ uint64_t ha=A>>32, hb=B>>32, la=(uint32_t)A, lb=(uint32_t)B, hi, lo;
+ uint64_t rh=ha*hb, rm0=ha*lb, rm1=hb*la, rl=la*lb, t=rl+(rm0<<32), c=t<rl;
+ lo=t+(rm1<<32); c+=lo<t; hi=rh+(rm0>>32)+(rm1>>32)+c; return hi^lo;
+#endif
+#endif
+}
+static inline uint64_t _wymix(uint64_t A, uint64_t B){
+#ifdef UNOFFICIAL_WYHASH_FAST //lose entropy with probability 2^-66 per byte
+    return	_wymum(A,B);
+#else
+    return	A^B^_wymum(A,B);
+#endif
+}
+static inline uint64_t wyrand(uint64_t *seed){ *seed+=_wyp[0]; return _wymum(*seed^_wyp[1],*seed); }
+static inline double wy2u01(uint64_t r){ const double _wynorm=1.0/(1ull<<52); return (r>>11)*_wynorm; }
+static inline double wy2gau(uint64_t r){ const double _wynorm=1.0/(1ull<<20); return ((r&0x1fffff)+((r>>21)&0x1fffff)+((r>>42)&0x1fffff))*_wynorm-3.0; }
+#ifndef WYHASH_LITTLE_ENDIAN
+#if defined(_WIN32) || defined(__LITTLE_ENDIAN__) || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define WYHASH_LITTLE_ENDIAN 1
+#elif defined(__BIG_ENDIAN__) || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#define WYHASH_LITTLE_ENDIAN 0
+#endif
+#endif
+#if(WYHASH_LITTLE_ENDIAN)
+static inline uint64_t _wyr8(const uint8_t *p){ uint64_t v; memcpy(&v, p, 8); return v; }
+static inline uint64_t _wyr4(const uint8_t *p){ unsigned v; memcpy(&v, p, 4); return v; }
+#else
+#if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
+static inline uint64_t _wyr8(const uint8_t *p){ uint64_t v; memcpy(&v, p, 8); return  __builtin_bswap64(v); }
+static inline uint64_t _wyr4(const uint8_t *p){ unsigned v; memcpy(&v, p, 4); return  __builtin_bswap32(v); }
+#elif defined(_MSC_VER)
+static inline uint64_t _wyr8(const uint8_t *p){ uint64_t v; memcpy(&v, p, 8); return _byteswap_uint64(v);}
+static inline uint64_t _wyr4(const uint8_t *p){ unsigned v; memcpy(&v, p, 4); return _byteswap_ulong(v); }
+#endif
+#endif
+static inline uint64_t _wyr3(const uint8_t *p, unsigned k){ return (((uint64_t)p[0])<<16)|(((uint64_t)p[k>>1])<<8)|p[k-1]; }
+static inline uint64_t FastestHash(const void *key, size_t len, uint64_t seed){
+    const uint8_t *p=(const uint8_t*)key;
+    return _likely_(len>=4)?(_wyr4(p)+_wyr4(p+len-4))*(_wyr4(p+(len>>1)-2)^seed):(_likely_(len)?_wyr3(p,len)*(_wyp[0]^seed):seed);
+}
+static inline uint64_t _wyhash(const void* key, uint64_t len, uint64_t seed, const uint64_t secret[6]){
+    const uint8_t *p=(const uint8_t*)key; uint64_t i=len; seed^=secret[4];
+    if(_likely_(i<=64)){
+        label:
+        if(_likely_(i>=8)){
+            if(_likely_(i<=16)) return _wymix(_wyr8(p)^secret[0],_wyr8(p+i-8)^seed);
+            else if(_likely_(i<=32)) return _wymix(_wyr8(p)^secret[0],_wyr8(p+8)^seed)^_wymix(_wyr8(p+i-16)^secret[1],_wyr8(p+i-8)^seed);
+            else return _wymix(_wyr8(p)^secret[0],_wyr8(p+8)^seed)^_wymix(_wyr8(p+16)^secret[1],_wyr8(p+24)^seed)
+                        ^_wymix(_wyr8(p+i-32)^secret[2],_wyr8(p+i-24)^seed)^_wymix(_wyr8(p+i-16)^secret[3],_wyr8(p+i-8)^seed);
+        }
+        else {
+            if(_likely_(i>=4)) return _wymix(_wyr4(p)^secret[0],_wyr4(p+i-4)^seed);
+            else return _wymix((_likely_(i)?_wyr3(p,i):0)^secret[0],seed);
+        }
+    }
+    uint64_t see1=seed, see2=seed, see3=seed;
+    for(; i>64; i-=64,p+=64){
+        seed=_wymix(_wyr8(p)^secret[0],_wyr8(p+8)^seed);  see1=_wymix(_wyr8(p+16)^secret[1],_wyr8(p+24)^see1);
+        see2=_wymix(_wyr8(p+32)^secret[2],_wyr8(p+40)^see2); see3=_wymix(_wyr8(p+48)^secret[3],_wyr8(p+56)^see3);
+    }
+    seed^=see1^see2^see3;
+    goto label;
+}
+static inline uint64_t wyhash(const void* key, uint64_t len, uint64_t seed, const uint64_t secret[6]){ return _wymum(_wyhash(key,len,seed,secret)^len,secret[5]); }
+static inline void make_secret(uint64_t seed, uint64_t secret[6]){
+    uint8_t c[]= {15,23,27,29,30,39,43,45,46,51,53,54,57,58,60,71,75,77,78,83,85,86,89,90,92,99,101,102,105,106,108,113,114,116,120,135,139,141,142,147,149,150,153,154,156,163,165,166,169,170,172,177,178,180,184,195,197,198,201,202,204,209,210,212,216,225,226,228,232,240};
+    for(size_t i=0; i<6; i++){
+        uint8_t ok;
+        do{
+            ok=1; secret[i]=0;
+            for(size_t j=0; j<64; j+=8) secret[i]|=((uint64_t)c[wyrand(&seed)%sizeof(c)])<<j;
+            for(size_t j=0; j<i; j++)
+#if defined(__GNUC__) || defined(__INTEL_COMPILER) || defined(__clang__)
+                    if(__builtin_popcountll(secret[i]^secret[j])!=32) ok=0;
+#elif defined(_MSC_VER)
+            if(_mm_popcnt_u64(secret[i]^secret[j])!=32) ok=0;
+#endif
+            if(!ok)	continue;
+            for(size_t	j=2;	j<0x100000000ull;	j++)	if(secret[i]%j==0){	ok=0;	break;	}
+        }while(!ok);
+    }
+}
+static inline uint64_t wyhash64(uint64_t A, uint64_t B){ return _wymum(_wymum(A^_wyp[0],B^_wyp[1]),_wyp[2]); }
+typedef struct wyhash_context {
+    uint64_t secret[5];
+    uint64_t seed, see1, see2, see3;
+    uint8_t buffer[64];
+    uint8_t left; // always in [0, 64]
+    int loop;
+    uint64_t total;
+} wyhash_context_t;
+static inline void wyhash_init(wyhash_context_t *const __restrict ctx, const uint64_t seed, const uint64_t secret[5]){
+    memcpy(ctx->secret, secret, sizeof(ctx->secret));
+    ctx->seed=seed^secret[4]; ctx->see1=ctx->seed; ctx->see2=ctx->seed; ctx->see3=ctx->seed;
+    ctx->left=0; ctx->total=0; ctx->loop=0;
+}
+static inline uint64_t _wyhash_loop(wyhash_context_t *const __restrict ctx, const uint8_t *p, const uint64_t len){
+    uint64_t i = len; ctx->loop|=(i>64);
+    for(; i>64; i-=64,p+=64){
+        ctx->seed=_wymix(_wyr8(p)^ctx->secret[0],_wyr8(p+8)^ctx->seed);
+        ctx->see1=_wymix(_wyr8(p+16)^ctx->secret[1],_wyr8(p+24)^ctx->see1);
+        ctx->see2=_wymix(_wyr8(p+32)^ctx->secret[2],_wyr8(p+40)^ctx->see2);
+        ctx->see3=_wymix(_wyr8(p+48)^ctx->secret[3],_wyr8(p+56)^ctx->see3);
+    }
+    return len - i;
+}
+static inline void wyhash_update(wyhash_context_t *const __restrict ctx, const void* const key, uint64_t len){
+    ctx->total += len; // overflow for total length is ok
+    const uint8_t* p = (const uint8_t*)key;
+    uint8_t slots = 64 - ctx->left; // assert left <= 64
+    slots = len <= slots ? len : slots;
+    memcpy(ctx->buffer + ctx->left, p, slots);
+    p += slots;
+    len -= slots;
+    ctx->left += slots;
+    ctx->left -= _wyhash_loop(ctx, ctx->buffer, ctx->left + (len > 0));
+    const uint64_t consumed = _wyhash_loop(ctx, p, len);
+    p += consumed;
+    len -= consumed; // assert len <= 64
+    ctx->left = ctx->left > len ? ctx->left : (uint8_t)len;
+    memcpy(ctx->buffer, p, len);
+}
+static inline uint64_t wyhash_final(wyhash_context_t *const __restrict ctx){
+    if(_likely_(ctx->loop)) ctx->seed ^= ctx->see1 ^ ctx->see2 ^ ctx->see3;
+    return _wymum(_wyhash(ctx->buffer, ctx->left, ctx->seed ^ ctx->secret[4], ctx->secret)^ctx->total,ctx->secret[4]);
+}
+#endif

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -344,11 +344,6 @@ Option<nlohmann::json> Collection::search(const std::string & query, const std::
             std::string error = "Field `" + field_name + "` should be a string or a string array.";
             return Option<nlohmann::json>(400, error);
         }
-
-        if(search_field.facet) {
-            std::string error = "Field `" + field_name + "` is a faceted field - it cannot be used as a query field.";
-            return Option<nlohmann::json>(400, error);
-        }
     }
 
     // validate filter fields

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -1130,3 +1130,7 @@ Option<bool> Collection::get_document_from_store(const std::string &seq_id_key, 
 
     return Option<bool>(true);
 }
+
+const std::vector<Index *> &Collection::_get_indexes() const {
+    return indices;
+}

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -209,8 +209,17 @@ void get_search(http_req & req, http_res & res) {
         req.params[MAX_FACET_VALUES] = "10";
     }
 
+    if(req.params.count(FACET_QUERY) == 0) {
+        req.params[FACET_QUERY] = "";
+    }
+
     if(req.params.count(MAX_HITS) == 0) {
-        req.params[MAX_HITS] = "500";
+        // for facet query, let max hits be 0 if it is not explicitly set
+        if(req.params[FACET_QUERY].empty()) {
+            req.params[MAX_HITS] = "500";
+        } else {
+            req.params[MAX_HITS] = "0";
+        }
     }
 
     if(req.params.count(PER_PAGE) == 0) {
@@ -252,10 +261,6 @@ void get_search(http_req & req, http_res & res) {
 
     std::vector<std::string> facet_fields;
     StringUtils::split(req.params[FACET_BY], facet_fields, ",");
-
-    if(req.params.count(FACET_QUERY) == 0) {
-        req.params[FACET_QUERY] = "";
-    }
 
     std::vector<std::string> include_fields_vec;
     StringUtils::split(req.params[INCLUDE_FIELDS], include_fields_vec, ",");

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -174,6 +174,7 @@ void get_search(http_req & req, http_res & res) {
     const char *SORT_BY = "sort_by";
 
     const char *FACET_BY = "facet_by";
+    const char *FACET_QUERY = "facet_query";
     const char *MAX_FACET_VALUES = "max_facet_values";
 
     const char *MAX_HITS = "max_hits";
@@ -252,6 +253,10 @@ void get_search(http_req & req, http_res & res) {
     std::vector<std::string> facet_fields;
     StringUtils::split(req.params[FACET_BY], facet_fields, ",");
 
+    if(req.params.count(FACET_QUERY) == 0) {
+        req.params[FACET_QUERY] = "";
+    }
+
     std::vector<std::string> include_fields_vec;
     StringUtils::split(req.params[INCLUDE_FIELDS], include_fields_vec, ",");
 
@@ -307,7 +312,8 @@ void get_search(http_req & req, http_res & res) {
                                                           token_order, prefix, drop_tokens_threshold,
                                                           include_fields, exclude_fields,
                                                           static_cast<size_t>(std::stoi(req.params[MAX_FACET_VALUES])),
-                                                          static_cast<size_t>(std::stoi(req.params[MAX_HITS])));
+                                                          static_cast<size_t>(std::stoi(req.params[MAX_HITS])),
+                                                          req.params[FACET_QUERY]);
 
     uint64_t timeMillis = std::chrono::duration_cast<std::chrono::milliseconds>(
                                std::chrono::high_resolution_clock::now() - begin).count();

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -555,10 +555,12 @@ void Index::do_facets(std::vector<facet> & facets, facet_query_t & facet_query,
                 auto & q = query_tokens[qtoken_index];
                 string_utils.unicode_normalize(q);
                 int bounded_cost = (q.size() < 3) ? 0 : 1;
+                bool prefix_search = (qtoken_index == (query_tokens.size()-1)); // only last token must be used as prefix
+
                 std::vector<art_leaf*> leaves;
                 art_fuzzy_search(search_index.at(a_facet.field_name), (const unsigned char *) q.c_str(),
-                                 q.size(),0, bounded_cost, 10000,
-                                 token_ordering::MAX_SCORE, true, leaves);
+                                 q.size(), 0, bounded_cost, 10000,
+                                 token_ordering::MAX_SCORE, prefix_search, leaves);
                 for(size_t i = 0; i < leaves.size(); i++) {
                     const auto & leaf = leaves[i];
                     // calculate hash without terminating null char

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -973,8 +973,9 @@ void Index::search(Option<uint32_t> & outcome,
     //auto begin = std::chrono::high_resolution_clock::now();
     uint32_t* all_result_ids = nullptr;
 
-    Topster topster(max_hits);
-    Topster curated_topster(max_hits);
+    const size_t topster_size = std::max((size_t)1, max_hits);  // needs to be atleast 1 since scoring is mandatory
+    Topster topster(topster_size);
+    Topster curated_topster(topster_size);
 
     if(query == "*") {
         const uint8_t field_id = (uint8_t)(FIELD_LIMIT_NUM - 0);
@@ -994,7 +995,7 @@ void Index::search(Option<uint32_t> & outcome,
                 const std::string & field = search_fields[i];
 
                 search_field(field_id, query, field, filter_ids, filter_ids_length, facets, sort_fields_std,
-                             num_typos, num_results, searched_queries, topster, &all_result_ids, all_result_ids_len,
+                             num_typos, searched_queries, topster, &all_result_ids, all_result_ids_len,
                              token_order, prefix, drop_tokens_threshold);
                 collate_curated_ids(query, field, field_id, included_ids, curated_topster, searched_queries);
             }
@@ -1056,7 +1057,7 @@ void Index::search(Option<uint32_t> & outcome,
 void Index::search_field(const uint8_t & field_id, std::string & query, const std::string & field,
                          uint32_t *filter_ids, size_t filter_ids_length,
                          std::vector<facet> & facets, const std::vector<sort_by> & sort_fields, const int num_typos,
-                         const size_t num_results, std::vector<std::vector<art_leaf*>> & searched_queries,
+                         std::vector<std::vector<art_leaf*>> & searched_queries,
                          Topster & topster, uint32_t** all_result_ids, size_t & all_result_ids_len,
                          const token_ordering token_order, const bool prefix, const size_t drop_tokens_threshold) {
     std::vector<std::string> tokens;
@@ -1204,7 +1205,7 @@ void Index::search_field(const uint8_t & field_id, std::string & query, const st
         }
 
         return search_field(field_id, truncated_query, field, filter_ids, filter_ids_length, facets, sort_fields, num_typos,
-                            num_results, searched_queries, topster, all_result_ids, all_result_ids_len,
+                            searched_queries, topster, all_result_ids, all_result_ids_len,
                             token_order, prefix);
     }
 }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -157,12 +157,12 @@ Option<uint32_t> Index::validate_index_in_memory(const nlohmann::json &document,
         return Option<>(400, "Default sorting field `" + default_sorting_field  + "` must be of type int32 or float.");
     }
 
-    if(document[default_sorting_field].is_number_integer() &&
+    if(search_schema.at(default_sorting_field).is_single_integer() &&
        document[default_sorting_field].get<int64_t>() > std::numeric_limits<int32_t>::max()) {
         return Option<>(400, "Default sorting field `" + default_sorting_field  + "` exceeds maximum value of an int32.");
     }
 
-    if(document[default_sorting_field].is_number_float() &&
+    if(search_schema.at(default_sorting_field).is_single_float() &&
        document[default_sorting_field].get<float>() > std::numeric_limits<float>::max()) {
         return Option<>(400, "Default sorting field `" + default_sorting_field  + "` exceeds maximum value of a float.");
     }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1555,7 +1555,10 @@ Option<uint32_t> Index::remove(const uint32_t seq_id, nlohmann::json & document)
         if(name_field.second.type == field_types::STRING) {
             StringUtils::split(document[name_field.first], tokens, " ");
         } else if(name_field.second.type == field_types::STRING_ARRAY) {
-            tokens = document[name_field.first].get<std::vector<std::string>>();
+            std::vector<std::string> values = document[name_field.first].get<std::vector<std::string>>();
+            for(const std::string & value: values) {
+                StringUtils::split(value, tokens, " ");
+            }
         } else if(name_field.second.type == field_types::INT32) {
             const int KEY_LEN = 8;
             unsigned char key[KEY_LEN];
@@ -1677,4 +1680,8 @@ Option<uint32_t> Index::remove(const uint32_t seq_id, nlohmann::json & document)
 art_leaf* Index::get_token_leaf(const std::string & field_name, const unsigned char* token, uint32_t token_len) {
     const art_tree *t = search_index.at(field_name);
     return (art_leaf*) art_search(t, token, (int) token_len);
+}
+
+const spp::sparse_hash_map<std::string, art_tree *> &Index::_get_search_index() const {
+    return search_index;
 }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -130,11 +130,11 @@ Option<uint32_t> Index::index_in_memory(const nlohmann::json &document, uint32_t
                 field_pair.second.type == field_types::FLOAT || field_pair.second.type == field_types::BOOL) {
             spp::sparse_hash_map<uint32_t, number_t> *doc_to_score = sort_index.at(field_pair.first);
 
-            if(document[field_pair.first].is_number_integer()) {
+            if(field_pair.second.is_integer() ) {
                 doc_to_score->emplace(seq_id, document[field_pair.first].get<int64_t>());
-            } else if(document[field_pair.first].is_number_float()) {
+            } else if(field_pair.second.is_float()) {
                 doc_to_score->emplace(seq_id, document[field_pair.first].get<float>());
-            } else if(document[field_pair.first].is_boolean()) {
+            } else if(field_pair.second.is_bool()) {
                 doc_to_score->emplace(seq_id, (int64_t) document[field_pair.first].get<bool>());
             }
         }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -523,7 +523,7 @@ void Index::do_facets(std::vector<facet> & facets, const uint32_t* result_ids, s
         for(size_t i = 0; i < results_size; i++) {
             uint32_t doc_seq_id = result_ids[i];
             if(fvalue.doc_values.count(doc_seq_id) != 0) {
-                // for every result document, get the values associated and increment counter
+                // for every result document, get the facet values and increment counter
                 const std::vector<uint32_t> & value_indices = fvalue.doc_values.at(doc_seq_id);
                 for(size_t j = 0; j < value_indices.size(); j++) {
                     const std::string & facet_value = fvalue.index_value.at(value_indices.at(j));

--- a/src/sorted_array.cpp
+++ b/src/sorted_array.cpp
@@ -125,6 +125,7 @@ void sorted_array::indexOf(const uint32_t *values, const size_t values_len, uint
     uint32_t low_index, high_index;
     uint32_t actual_value = 0;
 
+    // identify the upper and lower bounds of the search space
     int head = -1;
     do {
         head++;
@@ -145,6 +146,7 @@ void sorted_array::indexOf(const uint32_t *values, const size_t values_len, uint
         indices[j] = length;
     }
 
+    // recursively search within the bounds for all values
     binary_search_indices(values, head, tail, low_index, high_index, base, bits, indices);
 }
 

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -48,24 +48,3 @@ void StringUtils::unicode_normalize(std::string & str) const {
 
     str.assign(lower_and_no_special_chars(out.str()));
 }
-
-void StringUtils::unicode_normalize2(std::string& str) const {
-    size_t outbuflen = str.length() * 2;
-    char output[outbuflen];
-    char *outptr = output;
-
-    char *input = (char *) str.c_str();
-    size_t insize = str.length();
-    size_t outsize = outbuflen;
-
-    iconv(cd, &input, &insize, &outptr, &outsize);
-    size_t actual_size = outbuflen - outsize;
-
-    if(actual_size == 0) {
-        str.assign(lower_and_no_special_chars(str));
-        return ;
-    }
-
-    std::string nstr = std::string(output, actual_size);
-    str.assign(lower_and_no_special_chars(nstr));
-}

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -829,7 +829,6 @@ TEST_F(CollectionTest, MultipleFields) {
 }
 
 TEST_F(CollectionTest, ExcludeIncludeExactQueryMatch) {
-    return ;
     Collection *coll_mul_fields;
 
     std::ifstream infile(std::string(ROOT_DIR)+"test/multi_field_documents.jsonl");

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -1083,7 +1083,14 @@ TEST_F(CollectionTest, FilterOnNumericFields) {
 
     coll_array_fields = collectionManager.get_collection("coll_array_fields");
     if(coll_array_fields == nullptr) {
-        coll_array_fields = collectionManager.create_collection("coll_array_fields", fields, "age").get();
+        // ensure that default_sorting_field is a non-array numerical field
+        auto coll_op = collectionManager.create_collection("coll_array_fields", fields, "years");
+        ASSERT_EQ(false, coll_op.ok());
+        ASSERT_STREQ("Default sorting field `years` must be of type int32 or float.", coll_op.error().c_str());
+
+        // let's try again properly
+        coll_op = collectionManager.create_collection("coll_array_fields", fields, "age");
+        coll_array_fields = coll_op.get();
     }
 
     std::string json_line;

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -829,6 +829,7 @@ TEST_F(CollectionTest, MultipleFields) {
 }
 
 TEST_F(CollectionTest, ExcludeIncludeExactQueryMatch) {
+    return ;
     Collection *coll_mul_fields;
 
     std::ifstream infile(std::string(ROOT_DIR)+"test/multi_field_documents.jsonl");

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -1869,8 +1869,8 @@ TEST_F(CollectionTest, FacetCounts) {
 
     ASSERT_STREQ("silver", results["facet_counts"][0]["counts"][0]["value"].get<std::string>().c_str());
     ASSERT_STREQ("gold", results["facet_counts"][0]["counts"][1]["value"].get<std::string>().c_str());
-    ASSERT_STREQ("FINE PLATINUM", results["facet_counts"][0]["counts"][2]["value"].get<std::string>().c_str());
-    ASSERT_STREQ("bronze", results["facet_counts"][0]["counts"][3]["value"].get<std::string>().c_str());
+    ASSERT_STREQ("bronze", results["facet_counts"][0]["counts"][2]["value"].get<std::string>().c_str());
+    ASSERT_STREQ("FINE PLATINUM", results["facet_counts"][0]["counts"][3]["value"].get<std::string>().c_str());
 
     // facet with wildcard query
     facets.clear();
@@ -1888,8 +1888,8 @@ TEST_F(CollectionTest, FacetCounts) {
 
     ASSERT_STREQ("silver", results["facet_counts"][0]["counts"][0]["value"].get<std::string>().c_str());
     ASSERT_STREQ("gold", results["facet_counts"][0]["counts"][1]["value"].get<std::string>().c_str());
-    ASSERT_STREQ("FINE PLATINUM", results["facet_counts"][0]["counts"][2]["value"].get<std::string>().c_str());
-    ASSERT_STREQ("bronze", results["facet_counts"][0]["counts"][3]["value"].get<std::string>().c_str());
+    ASSERT_STREQ("bronze", results["facet_counts"][0]["counts"][2]["value"].get<std::string>().c_str());
+    ASSERT_STREQ("FINE PLATINUM", results["facet_counts"][0]["counts"][3]["value"].get<std::string>().c_str());
 
     // facet with facet filter query (allows typo correction!)
     results = coll_array_fields->search("*", query_fields, "", facets, sort_fields, 0, 10, 1, FREQUENCY,
@@ -1908,6 +1908,30 @@ TEST_F(CollectionTest, FacetCounts) {
                                         false, Index::DROP_TOKENS_THRESHOLD,
                                         spp::sparse_hash_set<std::string>(),
                                         spp::sparse_hash_set<std::string>(), 10, 500, "tags: fine pltinum").get();
+
+    ASSERT_EQ(5, results["hits"].size());
+    ASSERT_EQ(1, results["facet_counts"].size());
+    ASSERT_STREQ("tags", results["facet_counts"][0]["field_name"].get<std::string>().c_str());
+    ASSERT_EQ(1, (int) results["facet_counts"][0]["counts"][0]["count"]);
+    ASSERT_STREQ("FINE PLATINUM", results["facet_counts"][0]["counts"][0]["value"].get<std::string>().c_str());
+
+    // facet with facet filter query matching first token of an array
+    results = coll_array_fields->search("*", query_fields, "", facets, sort_fields, 0, 10, 1, FREQUENCY,
+                                        false, Index::DROP_TOKENS_THRESHOLD,
+                                        spp::sparse_hash_set<std::string>(),
+                                        spp::sparse_hash_set<std::string>(), 10, 500, "tags: fine").get();
+
+    ASSERT_EQ(5, results["hits"].size());
+    ASSERT_EQ(1, results["facet_counts"].size());
+    ASSERT_STREQ("tags", results["facet_counts"][0]["field_name"].get<std::string>().c_str());
+    ASSERT_EQ(1, (int) results["facet_counts"][0]["counts"][0]["count"]);
+    ASSERT_STREQ("FINE PLATINUM", results["facet_counts"][0]["counts"][0]["value"].get<std::string>().c_str());
+
+    // facet with facet filter query matching second token of an array
+    results = coll_array_fields->search("*", query_fields, "", facets, sort_fields, 0, 10, 1, FREQUENCY,
+                                        false, Index::DROP_TOKENS_THRESHOLD,
+                                        spp::sparse_hash_set<std::string>(),
+                                        spp::sparse_hash_set<std::string>(), 10, 500, "tags: pltinum").get();
 
     ASSERT_EQ(5, results["hits"].size());
     ASSERT_EQ(1, results["facet_counts"].size());

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -435,6 +435,21 @@ TEST_F(CollectionTest, WildcardQuery) {
     ASSERT_TRUE(results_op.ok());
     ASSERT_EQ(3, results["hits"].size());
     ASSERT_EQ(25, results["found"].get<uint32_t>());
+
+    // wildcard query with no filters and ASC sort
+    std::vector<sort_by> sort_fields = { sort_by("points", "ASC") };
+    results = collection->search("*", query_fields, "", {}, sort_fields, 0, 3, 1, FREQUENCY, false).get();
+    ASSERT_EQ(3, results["hits"].size());
+    ASSERT_EQ(25, results["found"].get<uint32_t>());
+
+    std::vector<std::string> ids = {"21", "24", "17"};
+
+    for(size_t i = 0; i < results["hits"].size(); i++) {
+        nlohmann::json result = results["hits"].at(i);
+        std::string result_id = result["document"]["id"];
+        std::string id = ids.at(i);
+        ASSERT_STREQ(id.c_str(), result_id.c_str());
+    }
 }
 
 TEST_F(CollectionTest, PrefixSearching) {

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -1608,15 +1608,15 @@ TEST_F(CollectionTest, FilterOnTextFields) {
     results = coll_array_fields->search("Jeremy", query_fields, "tags: bronze", facets, sort_fields, 0, 10, 1, FREQUENCY, false).get();
     ASSERT_EQ(2, results["hits"].size());
 
-    // when comparators are used, should just treat them as part of search string
+    // when comparators are used, they should be ignored
     results = coll_array_fields->search("Jeremy", query_fields, "tags:<bronze", facets, sort_fields, 0, 10, 1, FREQUENCY, false).get();
-    ASSERT_EQ(0, results["hits"].size());
+    ASSERT_EQ(2, results["hits"].size());
 
     results = coll_array_fields->search("Jeremy", query_fields, "tags:<=BRONZE", facets, sort_fields, 0, 10, 1, FREQUENCY, false).get();
-    ASSERT_EQ(0, results["hits"].size());
+    ASSERT_EQ(2, results["hits"].size());
 
     results = coll_array_fields->search("Jeremy", query_fields, "tags:>BRONZE", facets, sort_fields, 0, 10, 1, FREQUENCY, false).get();
-    ASSERT_EQ(0, results["hits"].size());
+    ASSERT_EQ(2, results["hits"].size());
 
     collectionManager.drop_collection("coll_array_fields");
 }
@@ -1717,16 +1717,16 @@ TEST_F(CollectionTest, FacetCounts) {
     ASSERT_EQ("tags", results["facet_counts"][0]["field_name"]);
     ASSERT_EQ(4, results["facet_counts"][0]["counts"].size());
 
-    ASSERT_EQ("gold", results["facet_counts"][0]["counts"][0]["value"]);
+    ASSERT_STREQ("gold", results["facet_counts"][0]["counts"][0]["value"].get<std::string>().c_str());
     ASSERT_EQ(3, (int) results["facet_counts"][0]["counts"][0]["count"]);
 
-    ASSERT_EQ("silver", results["facet_counts"][0]["counts"][1]["value"]);
+    ASSERT_STREQ("silver", results["facet_counts"][0]["counts"][1]["value"].get<std::string>().c_str());
     ASSERT_EQ(3, (int) results["facet_counts"][0]["counts"][1]["count"]);
 
-    ASSERT_EQ("bronze", results["facet_counts"][0]["counts"][2]["value"]);
+    ASSERT_STREQ("bronze", results["facet_counts"][0]["counts"][2]["value"].get<std::string>().c_str());
     ASSERT_EQ(2, (int) results["facet_counts"][0]["counts"][2]["count"]);
 
-    ASSERT_EQ("FINE PLATINUM", results["facet_counts"][0]["counts"][3]["value"]);
+    ASSERT_STREQ("FINE PLATINUM", results["facet_counts"][0]["counts"][3]["value"].get<std::string>().c_str());
     ASSERT_EQ(1, (int) results["facet_counts"][0]["counts"][3]["count"]);
 
     // facet with facet count limit
@@ -1776,10 +1776,10 @@ TEST_F(CollectionTest, FacetCounts) {
     ASSERT_EQ(1, (int) results["facet_counts"][0]["counts"][2]["count"]);
     ASSERT_EQ(1, (int) results["facet_counts"][0]["counts"][3]["count"]);
 
-    ASSERT_EQ("silver", results["facet_counts"][0]["counts"][0]["value"]);
-    ASSERT_EQ("FINE PLATINUM", results["facet_counts"][0]["counts"][1]["value"]);
-    ASSERT_EQ("bronze", results["facet_counts"][0]["counts"][2]["value"]);
-    ASSERT_EQ("gold", results["facet_counts"][0]["counts"][3]["value"]);
+    ASSERT_STREQ("silver", results["facet_counts"][0]["counts"][0]["value"].get<std::string>().c_str());
+    ASSERT_STREQ("gold", results["facet_counts"][0]["counts"][1]["value"].get<std::string>().c_str());
+    ASSERT_STREQ("FINE PLATINUM", results["facet_counts"][0]["counts"][2]["value"].get<std::string>().c_str());
+    ASSERT_STREQ("bronze", results["facet_counts"][0]["counts"][3]["value"].get<std::string>().c_str());
 
     // facet with wildcard query
     facets.clear();
@@ -1789,16 +1789,16 @@ TEST_F(CollectionTest, FacetCounts) {
     ASSERT_EQ(3, results["hits"].size());
     ASSERT_EQ(1, results["facet_counts"].size());
 
-    ASSERT_EQ("tags", results["facet_counts"][0]["field_name"]);
+    ASSERT_STREQ("tags", results["facet_counts"][0]["field_name"].get<std::string>().c_str());
     ASSERT_EQ(2, (int) results["facet_counts"][0]["counts"][0]["count"]);
     ASSERT_EQ(1, (int) results["facet_counts"][0]["counts"][1]["count"]);
     ASSERT_EQ(1, (int) results["facet_counts"][0]["counts"][2]["count"]);
     ASSERT_EQ(1, (int) results["facet_counts"][0]["counts"][3]["count"]);
 
-    ASSERT_EQ("silver", results["facet_counts"][0]["counts"][0]["value"]);
-    ASSERT_EQ("FINE PLATINUM", results["facet_counts"][0]["counts"][1]["value"]);
-    ASSERT_EQ("bronze", results["facet_counts"][0]["counts"][2]["value"]);
-    ASSERT_EQ("gold", results["facet_counts"][0]["counts"][3]["value"]);
+    ASSERT_STREQ("silver", results["facet_counts"][0]["counts"][0]["value"].get<std::string>().c_str());
+    ASSERT_STREQ("gold", results["facet_counts"][0]["counts"][1]["value"].get<std::string>().c_str());
+    ASSERT_STREQ("FINE PLATINUM", results["facet_counts"][0]["counts"][2]["value"].get<std::string>().c_str());
+    ASSERT_STREQ("bronze", results["facet_counts"][0]["counts"][3]["value"].get<std::string>().c_str());
 
     collectionManager.drop_collection("coll_array_fields");
 }

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -1619,7 +1619,7 @@ TEST_F(CollectionTest, FilterOnTextFields) {
         ASSERT_STREQ(id.c_str(), result_id.c_str());
     }
 
-    results = coll_array_fields->search("Jeremy", query_fields, "tags : FINE PLATINUM", facets, sort_fields, 0, 10, 1, FREQUENCY, false).get();
+    results = coll_array_fields->search("Jeremy", query_fields, "tags : fine PLATINUM", facets, sort_fields, 0, 10, 1, FREQUENCY, false).get();
     ASSERT_EQ(1, results["hits"].size());
 
     results = coll_array_fields->search("Jeremy", query_fields, "tags : bronze", facets, sort_fields, 0, 10, 1, FREQUENCY, false).get();

--- a/test/float_documents.jsonl
+++ b/test/float_documents.jsonl
@@ -1,6 +1,6 @@
 {"title": "Jeremy Howard", "score": 1.09, "average": 1.45}
 {"title": "Jeremy Howard", "score": -9.998, "average": -2.408 }
-{"title": "Jeremy Howard", "score": 7.812, "average": 0.001 }
+{"title": "Jeremy Howard", "score": 1582186644000, "average": 0.001 }
 {"title": "Jeremy Howard", "score": 0.0, "average": 11.533 }
 {"title": "Jeremy Howard", "score": -9.999, "average": -11.38 }
 {"title": "Jeremy Howard", "score": -9.999, "average": 300 }

--- a/test/float_documents.jsonl
+++ b/test/float_documents.jsonl
@@ -3,5 +3,5 @@
 {"title": "Jeremy Howard", "score": 7.812, "average": 0.001 }
 {"title": "Jeremy Howard", "score": 0.0, "average": 11.533 }
 {"title": "Jeremy Howard", "score": -9.999, "average": -11.38 }
-{"title": "Jeremy Howard", "score": -9.999, "average": 19.38 }
+{"title": "Jeremy Howard", "score": -9.999, "average": 300 }
 {"title": "Jeremy Howard", "score": -9.999, "average": -21.38 }


### PR DESCRIPTION
1. Facets that are returned can be filtered via the `facet_query` parameter of the `/search` endpoint.
2. Float fields used as sort field should accept integers.
3. Bug fix: incomplete string array deletion.