### PR TITLE
Change response status code for non-indexed field search

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -569,7 +569,7 @@ Option<nlohmann::json> Collection::search(const std::string & raw_query, const s
 
         if(!search_field.index) {
             std::string error = "Field `" + field_name + "` is marked as a non-indexed field in the schema.";
-            return Option<nlohmann::json>(404, error);
+            return Option<nlohmann::json>(400, error);
         }
 
         if(search_field.type != field_types::STRING && search_field.type != field_types::STRING_ARRAY) {


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
Searching on non-indexed field should not return `404`, sending `400` makes more sense as it's an invalid request 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
