### PR TITLE
Fix typo in TYPESENSE_API_ADDRESS env handling

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -255,7 +255,7 @@ public:
         }
 
         if(!get_env("TYPESENSE_API_ADDRESS").empty()) {
-            this->api_address = get_env("TYPESENSE_LISTEN_ADDRESS");
+            this->api_address = get_env("TYPESENSE_API_ADDRESS");
         }
 
         if(!get_env("TYPESENSE_API_PORT").empty()) {


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
Pull from the correct env variable when set

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
