### PR TITLE
Fix FreeBSD build by upgrading to latest H2O

### DIFF
--- a/cmake/H2O.cmake
+++ b/cmake/H2O.cmake
@@ -1,6 +1,6 @@
 # Download and build H2O
 
-set(H2O_VERSION 6dda7d6f21610ecd5256543384fa4b4b345a88ac)
+set(H2O_VERSION 5f9a03f8463a562f40c77e1d2c7b4ad583c3738c)
 set(H2O_NAME h2o-${H2O_VERSION})
 set(H2O_TAR_PATH ${DEP_ROOT_DIR}/${H2O_NAME}.tar.gz)
 


### PR DESCRIPTION
The fix in h2o: https://github.com/h2o/h2o/commit/662cd8e50397c84c9a4d1cd63db2d88353a3ce38

Latest version of h2o as of September 21, 2022: 5f9a03f8463a562f40c77e1d2c7b4ad583c3738c

## Change Summary
<!--- Described your changes here -->

Upgrade the version of h2o dependency. This will help fix building typesense on FreeBSD 13.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
