### PR TITLE
Rate limit update & fixes

### DIFF
--- a/include/core_api.h
+++ b/include/core_api.h
@@ -127,6 +127,10 @@ bool del_rate_limit(const std::shared_ptr<http_req>& req, const std::shared_ptr<
 
 bool post_rate_limit(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 
+bool get_active_rate_limit_throttles(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+
+bool del_rate_limit_ban(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+
 // Misc helpers
 
 void get_collections_for_auth(std::map<std::string, std::string>& req_params, const std::string& body,

--- a/include/core_api.h
+++ b/include/core_api.h
@@ -143,3 +143,5 @@ bool is_doc_import_route(uint64_t route_hash);
 bool is_doc_write_route(uint64_t route_hash);
 
 bool is_doc_del_route(uint64_t route_hash);
+
+Option<std::pair<std::string, std::string>> get_entities(const std::string& metadata);

--- a/include/ratelimit_manager.h
+++ b/include/ratelimit_manager.h
@@ -164,8 +164,13 @@ class RateLimitManager
         // Internal function to set base time
         void _set_base_timestamp(const time_t& base_time);
 
+        // Init
+        Option<bool> init();
+
         // Set store
-        Option<bool> init(Store* store);
+        inline void set_store(Store* store) {
+            this->store = store;
+        }
 
     private:    
 

--- a/include/ratelimit_manager.h
+++ b/include/ratelimit_manager.h
@@ -40,7 +40,7 @@ struct rate_limit_rule_t {
     std::vector<std::string> entity_ids;
     rate_limit_max_requests_t max_requests;
     int64_t auto_ban_threshold_num = -1;
-    int64_t auto_ban_num_days = -1;
+    int64_t auto_ban_num_hours = -1;
 
     const nlohmann::json to_json() const;
 
@@ -211,15 +211,15 @@ class RateLimitManager
         std::shared_mutex rate_limit_mutex;
 
         // Helper function to ban an entity temporarily
-        void temp_ban_entity(const rate_limit_entity_t& entity, const int64_t number_of_days);
+        void temp_ban_entity(const rate_limit_entity_t& entity, const int64_t number_of_hours);
         // Helper function to ban an entity temporarily without locking mutex
-        void temp_ban_entity_unsecure(const rate_limit_entity_t& entity, const int64_t number_of_days);
+        void temp_ban_entity_unsecure(const rate_limit_entity_t& entity, const int64_t number_of_hours);
 
         // Helper function to check if JSON rule is valid
         Option<bool> is_valid_rule(const nlohmann::json &rule_json);
 
         // Parse JSON rule to rate_limit_rule_t
-        Option<rate_limit_rule_t> parse_rule(const nlohmann::json &rule_json, bool alert_if_exists = true);
+        static rate_limit_rule_t parse_rule(const nlohmann::json &rule_json);
 
         // Helper function to insert rule in store
         void insert_rule(const rate_limit_rule_t &rule);

--- a/include/ratelimit_manager.h
+++ b/include/ratelimit_manager.h
@@ -165,14 +165,9 @@ class RateLimitManager
         void _set_base_timestamp(const time_t& base_time);
 
         // Init
-        Option<bool> init();
+        Option<bool> init(Store* store);
 
-        // Set store
-        inline void set_store(Store* store) {
-            this->store = store;
-        }
-
-    private:    
+    private:   
 
         RateLimitManager() {
             rate_limit_request_counts.capacity(10000);

--- a/include/ratelimit_manager.h
+++ b/include/ratelimit_manager.h
@@ -213,7 +213,7 @@ class RateLimitManager
         // Helper function to ban an entity temporarily
         void temp_ban_entity(const rate_limit_entity_t& entity, const int64_t number_of_days);
         // Helper function to ban an entity temporarily without locking mutex
-        void temp_ban_entity_wrapped(const rate_limit_entity_t& entity, const int64_t number_of_days);
+        void temp_ban_entity_unsecure(const rate_limit_entity_t& entity, const int64_t number_of_days);
 
         // Helper function to check if JSON rule is valid
         Option<bool> is_valid_rule(const nlohmann::json &rule_json);

--- a/include/ratelimit_manager.h
+++ b/include/ratelimit_manager.h
@@ -64,6 +64,7 @@ struct request_counter_t {
     int64_t previous_requests_count_minute = 0;
     int64_t previous_requests_count_hour = 0;
     int64_t threshold_exceed_count_minute = 0;
+    time_t last_threshold_exceed_time = 0;
     time_t last_reset_time_minute = 0;
     time_t last_reset_time_hour = 0;
 
@@ -150,6 +151,12 @@ class RateLimitManager
 
         // Get all rules as json
         const nlohmann::json get_all_rules_json();
+
+        // Get all throttled entities as json
+        const nlohmann::json get_all_throttled_entities_json();
+
+        // Delete throttled entity
+        const Option<nlohmann::json> delete_throttle_by_id(const uint64_t id);
 
         // Clear all rules
         void clear_all();

--- a/include/ratelimit_manager.h
+++ b/include/ratelimit_manager.h
@@ -216,7 +216,7 @@ class RateLimitManager
         void temp_ban_entity_unsecure(const rate_limit_entity_t& entity, const int64_t number_of_hours);
 
         // Helper function to check if JSON rule is valid
-        Option<bool> is_valid_rule(const nlohmann::json &rule_json);
+        static Option<bool> is_valid_rule(const nlohmann::json &rule_json);
 
         // Parse JSON rule to rate_limit_rule_t
         static rate_limit_rule_t parse_rule(const nlohmann::json &rule_json);

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -497,6 +497,11 @@ int HttpServer::catch_all_handler(h2o_handler_t *_h2o_handler, h2o_req_t *req) {
 
     //LOG(INFO) << "Init res: " << custom_gen->response << ", ref count: " << custom_gen->response.use_count();
 
+    if(rpath->action == "documents:search" && path_without_query == "/multi_search") {
+        // append api key and ip to metadata
+        request->metadata = api_auth_key_sent + " " + client_ip;
+    }
+
     // routes match and is an authenticated request
     // do any additional pre-request middleware operations here
     if(rpath->action == "keys:create") {

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -497,9 +497,11 @@ int HttpServer::catch_all_handler(h2o_handler_t *_h2o_handler, h2o_req_t *req) {
 
     //LOG(INFO) << "Init res: " << custom_gen->response << ", ref count: " << custom_gen->response.use_count();
 
-    if(rpath->action == "documents:search" && path_without_query == "/multi_search") {
+    if(root_resource == "multi_search") {
         // append api key and ip to metadata
-        request->metadata = api_auth_key_sent + " " + client_ip;
+        std::stringstream ss;
+        ss << api_auth_key_sent.length() << ":" << api_auth_key_sent << client_ip;
+        request->metadata = ss.str();
     }
 
     // routes match and is an authenticated request

--- a/src/main/typesense_server.cpp
+++ b/src/main/typesense_server.cpp
@@ -78,9 +78,11 @@ void master_server_routes() {
 
 
     server->get("/limits", get_rate_limits);
+    server->get("/limits/active", get_active_rate_limit_throttles);
     server->get("/limits/:id", get_rate_limit);
     server->post("/limits", post_rate_limit);
     server->put("/limits/:id", put_rate_limit);
+    server->del("/limits/active/:id", del_rate_limit_ban);
     server->del("/limits/:id", del_rate_limit);
 
     server->post("/config", post_config, false, false);

--- a/src/raft_server.cpp
+++ b/src/raft_server.cpp
@@ -500,14 +500,6 @@ int ReplicationState::init_db() {
         return 1;
     }
 
-    RateLimitManager *rateLimitManager = RateLimitManager::getInstance();
-    auto rate_limit_manager_init = rateLimitManager->init();
-
-    if(!rate_limit_manager_init.ok()) {
-        LOG(ERROR) << "Failed to initialize rate limit manager: " << rate_limit_manager_init.error();
-        return 1;
-    }
-
     return 0;
 }
 

--- a/src/ratelimit_manager.cpp
+++ b/src/ratelimit_manager.cpp
@@ -243,7 +243,7 @@ const nlohmann::json rate_limit_rule_t::to_json() const {
             rule["api_keys"] = entity_ids;
         }
         if(max_requests.minute_threshold >= 0) {
-            rule["max_requests_60s"] = max_requests.minute_threshold;
+            rule["max_requests_1m"] = max_requests.minute_threshold;
         }
         if(max_requests.hour_threshold >= 0) {
             rule["max_requests_1h"] = max_requests.hour_threshold;
@@ -353,11 +353,11 @@ Option<bool> RateLimitManager::is_valid_rule(const nlohmann::json &rule_json) {
         }
         return Option<bool>(true);
     } else if (rule_json["action"] == "throttle") {
-        if (rule_json.count("max_requests_60s") == 0 && rule_json.count("max_requests_1h") == 0) {
-            return Option<bool>(400, "At least  one of `max_requests_60s` or `max_requests_1h` is required.");
+        if (rule_json.count("max_requests_1m") == 0 && rule_json.count("max_requests_1h") == 0) {
+            return Option<bool>(400, "At least  one of `max_requests_1m` or `max_requests_1h` is required.");
         }
-        if (rule_json.count("max_requests_60s") > 0 && rule_json["max_requests_60s"].is_number_integer() == false) {
-            return Option<bool>(400, "Parameter `max_requests_60s` must be an integer.");
+        if (rule_json.count("max_requests_1m") > 0 && rule_json["max_requests_1m"].is_number_integer() == false) {
+            return Option<bool>(400, "Parameter `max_requests_1m` must be an integer.");
         }
         if (rule_json.count("max_requests_1h") > 0 && rule_json["max_requests_1h"].is_number_integer() == false) {
             return Option<bool>(400, "Parameter `max_requests_1h` must be an integer.");
@@ -416,8 +416,8 @@ Option<rate_limit_rule_t> RateLimitManager::parse_rule(const nlohmann::json &rul
             new_rule.entity_ids.push_back(api_key);
         }
     }
-    if(rule_json.count("max_requests_60s") > 0) {
-        new_rule.max_requests.minute_threshold = rule_json["max_requests_60s"];
+    if(rule_json.count("max_requests_1m") > 0) {
+        new_rule.max_requests.minute_threshold = rule_json["max_requests_1m"];
     }
     if(rule_json.count("max_requests_1h") > 0) {
         new_rule.max_requests.hour_threshold = rule_json["max_requests_1h"];

--- a/src/ratelimit_manager.cpp
+++ b/src/ratelimit_manager.cpp
@@ -429,9 +429,8 @@ void RateLimitManager::insert_rule(const rate_limit_rule_t &rule) {
 }
 
 
-Option<bool> RateLimitManager::init(Store *store) {
+Option<bool> RateLimitManager::init() {
     std::unique_lock<std::shared_mutex> lock(rate_limit_mutex);
-    this->store = store;
     // Load rules from database
     std::string last_rule_id_str;
     StoreStatus last_rule_id_status = store->get(std::string(RULES_NEXT_ID), last_rule_id_str);

--- a/src/ratelimit_manager.cpp
+++ b/src/ratelimit_manager.cpp
@@ -562,7 +562,7 @@ const nlohmann::json RateLimitManager::get_all_throttled_entities_json() {
 }
 
 const Option<nlohmann::json> RateLimitManager::delete_throttle_by_id(const uint64_t id) {
-    std::shared_lock lock(rate_limit_mutex);
+    std::unique_lock lock(rate_limit_mutex);
     std::string ban_json_str;
 
     const auto found = store->get(get_ban_key(id), ban_json_str);

--- a/src/ratelimit_manager.cpp
+++ b/src/ratelimit_manager.cpp
@@ -103,7 +103,10 @@ bool RateLimitManager::is_rate_limited(const std::vector<rate_limit_entity_t> &e
             if(rule.max_requests.minute_threshold >= 0 && current_rate_for_minute >= rule.max_requests.minute_threshold) {
                 bool auto_ban_is_enabled = (rule.auto_ban_threshold_num > 0 && rule.auto_ban_num_days > 0);
                 if(auto_ban_is_enabled) {
-                    request_counts.threshold_exceed_count_minute++;
+                    if(get_current_time() - request_counts.last_threshold_exceed_time >= 60) {
+                        request_counts.threshold_exceed_count_minute++;
+                        request_counts.last_threshold_exceed_time = get_current_time();
+                    }
                     if(request_counts.threshold_exceed_count_minute > rule.auto_ban_threshold_num) {
                         temp_ban_entity_wrapped(entity, rule.auto_ban_num_days);
                     }
@@ -144,7 +147,7 @@ bool RateLimitManager::delete_rule_by_id(const uint64_t id) {
         // Remove rule from rule store
         rule_store.erase(id);
         // Remove rule from rate limit rule pointer
-        for(const auto &entity : rule.entity_ids) {
+        for(const auto& entity : rule.entity_ids) {
             rate_limit_entities.erase(rate_limit_entity_t{rule.entity_type,entity});
         }
         return true;
@@ -165,18 +168,19 @@ const std::vector<rate_limit_rule_t> RateLimitManager::get_all_rules() {
 
 const std::vector<rate_limit_status_t> RateLimitManager::get_banned_entities(const RateLimitedEntityType entity_type) {
     std::shared_lock<std::shared_mutex> lock(rate_limit_mutex);
-    std::vector < rate_limit_status_t > banned_entities;
-    for (auto & element: throttled_entities) {
+    std::vector <rate_limit_status_t> banned_entities;
+    for (auto& element: throttled_entities) {
         if (element.second.entity_type == entity_type) {
             banned_entities.push_back(element.second);
         }
     }
     // Get permanent bans
-    for (auto & element: rule_store) {
+    for (auto& element: rule_store) {
         if (element.second.action == RateLimitAction::block && element.second.entity_type == entity_type) {
-            for (auto & entity : element.second.entity_ids) {
+            for (auto& entity : element.second.entity_ids) {
                 banned_entities.push_back(rate_limit_status_t{last_ban_id, 0, 0, entity, entity_type});
                 last_ban_id++;
+                store->increment(std::string(BANS_NEXT_ID), 1);
             }
         }
     }
@@ -203,9 +207,13 @@ void RateLimitManager::temp_ban_entity_wrapped(const rate_limit_entity_t& entity
     // Add entity to throttled_entities for the given number of days
     rate_limit_status_t status{last_ban_id, now, now + (number_of_days * 24 * 60 * 60), entity.entity_id, entity.entity_type};
     std::string ban_key = get_ban_key(last_ban_id);
-    store->insert(ban_key, status.to_json().dump());
+    bool inserted = store->insert(ban_key, status.to_json().dump());
+    if(!inserted) {
+        LOG(INFO) << "Failed to insert ban for entity " << entity.entity_id;
+    }
     throttled_entities.insert({entity, rate_limit_status_t{last_ban_id, now, now + (number_of_days * 24 * 60 * 60), entity.entity_id, entity.entity_type}});
     last_ban_id++;
+    store->increment(std::string(BANS_NEXT_ID), 1);
     if(rate_limit_request_counts.contains(entity)){
         // Reset counters for the given entity
         rate_limit_request_counts.lookup(entity).current_requests_count_minute = 0;
@@ -253,6 +261,7 @@ const nlohmann::json rate_limit_status_t::to_json() const {
     status["throttling_to"] = throttling_to;
     status["value"] = value;
     status["entity_type"] = magic_enum::enum_name(entity_type);
+    status["id"] = status_id;
     return status;
 }
 
@@ -261,6 +270,7 @@ void rate_limit_status_t::parse_json(const nlohmann::json &json) {
     throttling_to = json["throttling_to"];
     value = json["value"];
     entity_type = magic_enum::enum_cast<RateLimitedEntityType>(json["entity_type"].get<std::string>()).value();
+    status_id = json["id"];
 }
 
 
@@ -491,4 +501,55 @@ time_t RateLimitManager::get_current_time() {
 
 void RateLimitManager::_set_base_timestamp(const time_t& timestamp) {
     base_timestamp = timestamp;
+}
+
+
+const nlohmann::json RateLimitManager::get_all_throttled_entities_json() {
+    nlohmann::json throttled_entities_array = nlohmann::json::object();
+
+    for(const auto& entity : throttled_entities) {
+        if(entity.second.throttling_to <= get_current_time()) {
+            store->remove(get_ban_key(entity.second.status_id));
+            throttled_entities.erase(entity.first);
+        }
+        auto entity_json = entity.second.to_json();
+
+        if(entity.second.entity_type == RateLimitedEntityType::api_key) {
+            entity_json["api_key"] = entity_json["value"];
+        } else {
+            entity_json["ip_address"] = entity_json["value"];
+        }
+
+        entity_json.erase("value");
+        entity_json.erase("entity_type");
+        throttled_entities_array["active"].push_back(entity_json);
+    }
+
+    LOG(INFO) << "Returning " << throttled_entities.size() << " throttled entities.";
+    return throttled_entities_array;
+}
+
+const Option<nlohmann::json> RateLimitManager::delete_throttle_by_id(const uint64_t id) {
+    std::unique_lock<std::shared_mutex> lock(rate_limit_mutex);
+    std::string ban_json_str;
+
+    const auto found = store->get(get_ban_key(id), ban_json_str);
+
+    if(found == StoreStatus::NOT_FOUND) {
+        return Option<nlohmann::json>(400, "Could not find any ban with the given ID");
+    }
+
+    nlohmann::json ban_json = nlohmann::json::parse(ban_json_str);
+    rate_limit_status_t ban_status;
+    ban_status.parse_json(ban_json);
+    throttled_entities.erase(rate_limit_entity_t{ban_status.entity_type, ban_status.value});
+    const auto removed = store->remove(get_ban_key(id));
+
+    if(!removed) {
+        return Option<nlohmann::json>(400, "Error while removing the ban from the store");
+    }
+
+    nlohmann::json res;
+    res["id"] = id;
+    return Option<nlohmann::json>(res);
 }

--- a/src/ratelimit_manager.cpp
+++ b/src/ratelimit_manager.cpp
@@ -241,10 +241,10 @@ const nlohmann::json rate_limit_rule_t::to_json() const {
             rule["api_keys"] = entity_ids;
         }
         if(max_requests.minute_threshold >= 0) {
-            rule["max_requests"]["minute_threshold"] = max_requests.minute_threshold;
+            rule["max_requests_60s"] = max_requests.minute_threshold;
         }
         if(max_requests.hour_threshold >= 0) {
-            rule["max_requests"]["hour_threshold"] = max_requests.hour_threshold;
+            rule["max_requests_1h"] = max_requests.hour_threshold;
         }
         if(auto_ban_threshold_num >= 0) {
             rule["auto_ban_threshold_num"] = auto_ban_threshold_num;

--- a/src/ratelimit_manager.cpp
+++ b/src/ratelimit_manager.cpp
@@ -14,18 +14,35 @@ RateLimitManager * RateLimitManager::getInstance() {
 
 bool RateLimitManager::remove_rule_entity(const RateLimitedEntityType entity_type, const std::string &entity) {
     // lock mutex
-    std::shared_lock lock(rate_limit_mutex);
-    // Check if a rule exists for the given IP
-    if (rate_limit_entities.count(rate_limit_entity_t{entity_type,entity}) == 0) {
-        return false;
+    std::unique_lock lock(rate_limit_mutex);
+    bool found_rule = false;
+    // Check if a OR rule exists for the given entity
+    if (rate_limit_entities.count(rate_limit_entity_t{entity_type,entity}) != 0) {
+        // Remove the rule from the rule store
+        rule_store.erase(rate_limit_entities.at(rate_limit_entity_t{entity_type,entity})->id);
+        // Remove the rule from the entity rate limits map
+        rate_limit_entities.erase(rate_limit_entity_t{entity_type,entity});
+        found_rule = true;
     }
-    // Remove the rule from the rule store
-    rule_store.erase(rate_limit_entities.at(rate_limit_entity_t{entity_type,entity})->id);
-    // Remove the rule from the entity rate limits map
-    rate_limit_entities.erase(rate_limit_entity_t{entity_type,entity});
-
-    return true;
-
+    // Check if a AND rule exists for the given entity
+    std::unordered_map<std::pair<rate_limit_entity_t, rate_limit_entity_t>, rate_limit_rule_t*>::iterator it;
+    while((it = std::find_if(rate_limit_entities_and.begin(), rate_limit_entities_and.end(), 
+        [entity_type, entity](const std::pair<std::pair<rate_limit_entity_t, rate_limit_entity_t>, rate_limit_rule_t*> &p) {
+            if(entity_type == RateLimitedEntityType::api_key) {
+                return p.first.first.entity_id == entity;
+            }
+            else if(entity_type == RateLimitedEntityType::ip) {
+                return p.first.second.entity_id == entity;
+            }
+            return false;
+        })) != rate_limit_entities_and.end()) {
+        // Remove the rule from the rule store
+        rule_store.erase(it->second->id);
+        // Remove the rule from the entity rate limits map
+        rate_limit_entities_and.erase(it);
+        found_rule = true;
+    }
+    return found_rule;
 }
 
 void RateLimitManager::temp_ban_entity(const rate_limit_entity_t& entity, const int64_t number_of_hours) {
@@ -37,92 +54,137 @@ void RateLimitManager::temp_ban_entity(const rate_limit_entity_t& entity, const 
 bool RateLimitManager::is_rate_limited(const std::vector<rate_limit_entity_t> &entities) {
     // lock mutex
     std::shared_lock lock(rate_limit_mutex);
-    // Check if any of the entities has rule
-    for(const auto &entity : entities) {
 
-        auto entity_rule = rate_limit_entities.find(entity);
-        auto wildcard_rule = rate_limit_entities.find(rate_limit_entity_t{entity.entity_type, ".*"});
-
-        if (entity_rule == rate_limit_entities.end() && wildcard_rule == rate_limit_entities.end()) {
-            continue;
+    rate_limit_entity_t api_key_entity, ip_entity;
+    // Find the api_key and ip entities 
+    for(auto &entity : entities) {
+        if(entity.entity_type == RateLimitedEntityType::api_key) {
+            api_key_entity = entity;
         }
-        const auto& rule =  entity_rule != rate_limit_entities.end() ? *(entity_rule->second) : *(wildcard_rule->second);
-        if (rule.action == RateLimitAction::block) {
-            return true;
-        }
-        else if(rule.action == RateLimitAction::allow) {
-            return false;
-        }
-        else if(throttled_entities.count(entity) > 0) {
-            // Check if ban duration is not over
-            if (throttled_entities.at(entity).throttling_to > get_current_time()) {
-                return true;
-            }
-            // Remove ban from DB store
-            std::string ban_key = std::string(BANS_PREFIX) + "_" + std::to_string(throttled_entities.at(entity).status_id);
-            store->remove(ban_key);
-            // Remove ban
-            throttled_entities.erase(entity);
-            // Reset request counts
-            auto& request_counts = rate_limit_request_counts.lookup(entity);
-            request_counts.reset();
-            // Check if throttle rule still exists
-            if (rule.action == RateLimitAction::throttle) {
-                // Increase because of this request
-                request_counts.current_requests_count_minute++;
-                request_counts.current_requests_count_hour++;
-            }
-            continue;
-        }
-        else {
-            if(!rate_limit_request_counts.contains(entity)){
-                rate_limit_request_counts.insert(entity, request_counter_t{});
-            }
-            auto& request_counts = rate_limit_request_counts.lookup(entity);
-            // Check if last reset time was more than 1 minute ago
-            if (request_counts.last_reset_time_minute <= get_current_time() - 60) {
-                request_counts.previous_requests_count_minute = request_counts.current_requests_count_minute;
-                request_counts.current_requests_count_minute = 0;
-                if(request_counts.last_reset_time_minute <= get_current_time() - 120) {
-                    request_counts.previous_requests_count_minute = 0;
-                }
-                request_counts.last_reset_time_minute = get_current_time();
-            }
-            // Check if last reset time was more than 1 hour ago
-            if (request_counts.last_reset_time_hour <= get_current_time() - 3600) {
-                request_counts.previous_requests_count_hour = request_counts.current_requests_count_hour;
-                request_counts.current_requests_count_hour = 0;
-                if(request_counts.last_reset_time_hour <= get_current_time() - 7200) {
-                    request_counts.previous_requests_count_hour = 0;
-                }
-                request_counts.last_reset_time_hour = get_current_time();
-            }
-            // Check if request count is over the limit
-            auto current_rate_for_minute = (60 - (get_current_time() - request_counts.last_reset_time_minute)) / 60  * request_counts.previous_requests_count_minute;
-            current_rate_for_minute += request_counts.current_requests_count_minute;
-            if(rule.max_requests.minute_threshold >= 0 && current_rate_for_minute >= rule.max_requests.minute_threshold) {
-                bool auto_ban_is_enabled = (rule.auto_ban_threshold_num > 0 && rule.auto_ban_num_hours > 0);
-                if(auto_ban_is_enabled) {
-                    if(get_current_time() - request_counts.last_threshold_exceed_time >= 60) {
-                        request_counts.threshold_exceed_count_minute++;
-                        request_counts.last_threshold_exceed_time = get_current_time();
-                    }
-                    if(request_counts.threshold_exceed_count_minute > rule.auto_ban_threshold_num) {
-                        temp_ban_entity_unsecure(entity, rule.auto_ban_num_hours);
-                    }
-                } 
-                return true;
-            }
-            auto current_rate_for_hour = (3600 - (get_current_time() - request_counts.last_reset_time_hour)) / 3600  * request_counts.previous_requests_count_hour;
-            current_rate_for_hour += request_counts.current_requests_count_hour;
-            if(rule.max_requests.hour_threshold >= 0 && current_rate_for_hour >= rule.max_requests.hour_threshold) {
-                return true;
-            }
-            // Increment request counts
-            request_counts.current_requests_count_minute++;
-            request_counts.current_requests_count_hour++;
+        else if(entity.entity_type == RateLimitedEntityType::ip) {
+            ip_entity = entity;
         }
     }
+    // Check if a AND rule exists for the given entities
+    auto and_rule = rate_limit_entities_and.find(std::make_pair(api_key_entity, ip_entity));
+    // Pointer to the rule with the highest priority
+    rate_limit_rule_t *rule = nullptr;
+    bool is_and = false;
+
+    if (and_rule != rate_limit_entities_and.end()) {
+        if (rule == nullptr || and_rule->second->priority > rule->priority) {
+            rule = &(*and_rule->second);
+            is_and = true;
+        }
+    }
+    // Get the rule with the highest priority
+    for(auto &entity : entities) {
+        auto entity_rule = rate_limit_entities.find(entity);
+        auto wildcard_rule = rate_limit_entities.find(rate_limit_entity_t{entity.entity_type, ".*"});
+        // Pick the rule with the highest priority between entitiy_rule, wildcard_rule and and_rule
+        if (entity_rule != rate_limit_entities.end()) {
+            if (rule == nullptr || entity_rule->second->priority > rule->priority) {
+                rule = &(*entity_rule->second);
+                is_and = rule->is_and;
+            }
+        }
+        if (wildcard_rule != rate_limit_entities.end()) {
+            if (rule == nullptr || wildcard_rule->second->priority > rule->priority) {
+                rule = &(*wildcard_rule->second);
+                is_and = rule->is_and;
+            }
+        }
+    }
+    // If no rule was found, return false
+    if (rule == nullptr) {
+        return false;
+    }
+    
+    const auto& throttled_entity_it = (is_and ? throttled_entities[ip_entity].find(rate_limit_entity_t{RateLimitedEntityType::api_key, ".*"}) : throttled_entities[ip_entity].find(api_key_entity));
+
+    if (rule->action == RateLimitAction::block) {
+        return true;
+    }
+    else if(rule->action == RateLimitAction::allow) {
+        return false;
+    }
+
+    // Check if the entities are already throttled
+    if(throttled_entities.count(ip_entity) > 0 && throttled_entity_it != throttled_entities[ip_entity].end()) {
+        auto& throttled_entity = throttled_entity_it->second;
+
+        // Check if ban duration is not over                                              
+        if (throttled_entity.throttling_to > get_current_time()) {
+            return true;
+        }
+        // Remove ban from DB store
+        std::string ban_key = std::string(BANS_PREFIX) + "_" + std::to_string(throttled_entity.status_id);
+        store->remove(ban_key);
+        // Remove ban
+        throttled_entities[ip_entity].erase(throttled_entity_it);
+        if(throttled_entities[ip_entity].empty()) {
+            throttled_entities.erase(ip_entity);
+        }
+        // Reset request counts
+        auto& request_counts = is_and ? rate_limit_request_counts_and.lookup(std::make_pair(api_key_entity, ip_entity)) : rate_limit_request_counts.lookup(ip_entity);
+        request_counts.reset();
+
+        // Increase because of this request
+        request_counts.current_requests_count_minute++;
+        request_counts.current_requests_count_hour++;
+        return false;
+    }
+
+    if(!is_and && !rate_limit_request_counts.contains(ip_entity)){
+        rate_limit_request_counts.insert(ip_entity, request_counter_t{});
+    } else if(is_and && !rate_limit_request_counts_and.contains(std::make_pair(api_key_entity, ip_entity))){
+        rate_limit_request_counts_and.insert(std::make_pair(api_key_entity, ip_entity), request_counter_t{});
+    }
+    
+    auto& request_counts = is_and ? rate_limit_request_counts_and.lookup(std::make_pair(api_key_entity, ip_entity)) : rate_limit_request_counts.lookup(ip_entity);
+    // Check if last reset time was more than 1 minute ago
+    if (request_counts.last_reset_time_minute <= get_current_time() - 60) {
+        request_counts.previous_requests_count_minute = request_counts.current_requests_count_minute;
+        request_counts.current_requests_count_minute = 0;
+        if(request_counts.last_reset_time_minute <= get_current_time() - 120) {
+            request_counts.previous_requests_count_minute = 0;
+        }
+        request_counts.last_reset_time_minute = get_current_time();
+    }
+    // Check if last reset time was more than 1 hour ago
+    if (request_counts.last_reset_time_hour <= get_current_time() - 3600) {
+        request_counts.previous_requests_count_hour = request_counts.current_requests_count_hour;
+        request_counts.current_requests_count_hour = 0;
+        if(request_counts.last_reset_time_hour <= get_current_time() - 7200) {
+            request_counts.previous_requests_count_hour = 0;
+        }
+        request_counts.last_reset_time_hour = get_current_time();
+    }
+    // Check if request count is over the limit
+    auto current_rate_for_minute = (60 - (get_current_time() - request_counts.last_reset_time_minute)) / 60  * request_counts.previous_requests_count_minute;
+    current_rate_for_minute += request_counts.current_requests_count_minute;
+    if(rule->max_requests.minute_threshold >= 0 && current_rate_for_minute >= rule->max_requests.minute_threshold) {
+        bool auto_ban_is_enabled = (rule->auto_ban_threshold_num > 0 && rule->auto_ban_num_hours > 0);
+        if(auto_ban_is_enabled) {
+            if(get_current_time() - request_counts.last_threshold_exceed_time >= 60) {
+                request_counts.threshold_exceed_count_minute++;
+                request_counts.last_threshold_exceed_time = get_current_time();
+            }
+            if(request_counts.threshold_exceed_count_minute > rule->auto_ban_threshold_num) {
+                temp_ban_entity_unsecure(ip_entity, rule->auto_ban_num_hours, is_and ? &api_key_entity : nullptr);
+            }
+        } 
+        return true;
+    }
+    auto current_rate_for_hour = (3600 - (get_current_time() - request_counts.last_reset_time_hour)) / 3600  * request_counts.previous_requests_count_hour;
+    current_rate_for_hour += request_counts.current_requests_count_hour;
+    if(rule->max_requests.hour_threshold >= 0 && current_rate_for_hour >= rule->max_requests.hour_threshold) {
+        return true;
+    }
+    // Increment request counts
+    request_counts.current_requests_count_minute++;
+    request_counts.current_requests_count_hour++;
+
     return false;
 }
 
@@ -136,7 +198,7 @@ Option<nlohmann::json> RateLimitManager::find_rule_by_id(const uint64_t id) {
 }
 
 bool RateLimitManager::delete_rule_by_id(const uint64_t id) {
-    std::shared_lock lock(rate_limit_mutex);
+    std::unique_lock lock(rate_limit_mutex);
     const std::string rule_store_key = get_rule_key(id);
     bool deleted = store->remove(rule_store_key);
     if(!deleted) {
@@ -148,8 +210,26 @@ bool RateLimitManager::delete_rule_by_id(const uint64_t id) {
         // Remove rule from rule store
         rule_store.erase(id);
         // Remove rule from rate limit rule pointer
-        for(const auto& entity : rule.entity_ids) {
-            rate_limit_entities.erase(rate_limit_entity_t{rule.entity_type,entity});
+        if(!rule.is_and) {
+            for(const auto& entity : rule.entities) {
+                rate_limit_entities.erase(entity);
+            }
+        } else {
+            std::vector<rate_limit_entity_t> ip_entities, api_key_entities;
+            for(const auto& entity : rule.entities) {
+                if(entity.entity_type == RateLimitedEntityType::ip) {
+                    ip_entities.push_back(entity);
+                } else {
+                    api_key_entities.push_back(entity);
+                }
+            }
+
+            // Delete all combinations of ip and api key entities from AND store
+            for(const auto& ip_entity : ip_entities) {
+                for(const auto& api_key_entity : api_key_entities) {
+                    rate_limit_entities_and.erase(std::make_pair(api_key_entity, ip_entity));
+                }
+            }
         }
         return true;
     }
@@ -168,20 +248,20 @@ const std::vector<rate_limit_rule_t> RateLimitManager::get_all_rules() {
     return rules;
 }
 
-const std::vector<rate_limit_status_t> RateLimitManager::get_banned_entities(const RateLimitedEntityType entity_type) {
+const std::vector<rate_limit_status_t> RateLimitManager::get_banned_entities() {
     std::shared_lock lock(rate_limit_mutex);
 
     std::vector <rate_limit_status_t> banned_entities;
     for (auto& element: throttled_entities) {
-        if (element.second.entity_type == entity_type) {
-            banned_entities.push_back(element.second);
+        for (auto& entity: element.second) {
+            banned_entities.push_back(entity.second);
         }
     }
     // Get permanent bans
     for (auto& element: rule_store) {
-        if (element.second.action == RateLimitAction::block && element.second.entity_type == entity_type) {
-            for (auto& entity : element.second.entity_ids) {
-                banned_entities.push_back(rate_limit_status_t{last_ban_id, 0, 0, entity, entity_type});
+        if (element.second.action == RateLimitAction::block) {
+            for (auto& entity: element.second.entities) {
+                    banned_entities.push_back(rate_limit_status_t{last_ban_id, 0, 0, entity});
             }
         }
     }
@@ -192,6 +272,8 @@ void RateLimitManager::clear_all() {
     std::shared_lock lock(rate_limit_mutex);
     rate_limit_request_counts.clear();
     rate_limit_entities.clear();
+    rate_limit_entities_and.clear();
+    rate_limit_request_counts_and.clear();
     throttled_entities.clear();
     rule_store.clear();
     last_rule_id = 0;
@@ -199,20 +281,24 @@ void RateLimitManager::clear_all() {
     base_timestamp = 0;
 }
 
-void RateLimitManager::temp_ban_entity_unsecure(const rate_limit_entity_t& entity, const int64_t number_of_hours) {
+void RateLimitManager::temp_ban_entity_unsecure(const rate_limit_entity_t& entity, const int64_t number_of_hours, const rate_limit_entity_t* and_entity) {
     // Check if entity is already banned
-    if (throttled_entities.count(entity) > 0) {
+    if (throttled_entities.find(entity) != throttled_entities.end() && throttled_entities[entity].find(and_entity != nullptr ? *and_entity : rate_limit_entity_t{RateLimitedEntityType::api_key, ".*"}) != throttled_entities[entity].end()) {
         return;
     }
     auto now = get_current_time();
     // Add entity to throttled_entities for the given number of days
-    rate_limit_status_t status{last_ban_id, now, now + (number_of_hours * 60 * 60), entity.entity_id, entity.entity_type};
+    rate_limit_status_t status(last_ban_id, now, now + (number_of_hours * 60 * 60), entity, and_entity);
     std::string ban_key = get_ban_key(last_ban_id);
     bool inserted = store->insert(ban_key, status.to_json().dump());
     if(!inserted) {
         LOG(INFO) << "Failed to insert ban for entity " << entity.entity_id;
     }
-    throttled_entities.insert({entity, rate_limit_status_t{last_ban_id, now, now + (number_of_hours * 60 * 60), entity.entity_id, entity.entity_type}});
+    if(and_entity != nullptr) {
+        throttled_entities[entity][*and_entity] = status;
+    } else {
+        throttled_entities[entity][rate_limit_entity_t{RateLimitedEntityType::api_key, ".*"}] = status;
+    }
     last_ban_id++;
     store->increment(std::string(BANS_NEXT_ID), 1);
     if(rate_limit_request_counts.contains(entity)){
@@ -236,11 +322,19 @@ const nlohmann::json rate_limit_rule_t::to_json() const {
         nlohmann::json rule;
         rule["id"] = id;
         rule["action"] = magic_enum::enum_name(action);
-        rule["entity_type"] = magic_enum::enum_name(entity_type);
-        if(entity_type == RateLimitedEntityType::ip) {
-            rule["ip_addresses"] = entity_ids;
-        } else {
-            rule["api_keys"] = entity_ids;
+        rule["priority"] = priority;
+        for(const auto& entity : entities) {
+            if(entity.entity_type == RateLimitedEntityType::ip) {
+                if(!rule.contains("ip_addresses")) {
+                    rule["ip_addresses"] = nlohmann::json::array();
+                }
+                rule["ip_addresses"].push_back(entity.entity_id);
+            } else  {
+                if(!rule.contains("api_keys")) {
+                    rule["api_keys"] = nlohmann::json::array();
+                }
+                rule["api_keys"].push_back(entity.entity_id);
+            }
         }
         if(max_requests.minute_threshold >= 0) {
             rule["max_requests_1m"] = max_requests.minute_threshold;
@@ -261,8 +355,13 @@ const nlohmann::json rate_limit_status_t::to_json() const {
     nlohmann::json status;
     status["throttling_from"] = throttling_from;
     status["throttling_to"] = throttling_to;
-    status["value"] = value;
-    status["entity_type"] = magic_enum::enum_name(entity_type);
+    status["value"] = entity.entity_id;
+    status["entity_type"] = magic_enum::enum_name(entity.entity_type);
+    if(is_and) {
+        status["and_entity"] = nlohmann::json::object();
+        status["and_entity"]["value"] = and_entity.entity_id;
+        status["and_entity"]["entity_type"] = magic_enum::enum_name(and_entity.entity_type);
+    }
     status["id"] = status_id;
     return status;
 }
@@ -271,8 +370,13 @@ void rate_limit_status_t::parse_json(const nlohmann::json &json) {
 
     throttling_from = json["throttling_from"];
     throttling_to = json["throttling_to"];
-    value = json["value"];
-    entity_type = magic_enum::enum_cast<RateLimitedEntityType>(json["entity_type"].get<std::string>()).value();
+    entity.entity_id = json["value"];
+    entity.entity_type = magic_enum::enum_cast<RateLimitedEntityType>(json["entity_type"].get<std::string>()).value();
+    if(json.contains("and_entity")) {
+        is_and = true;
+        and_entity.entity_id = json["and_entity"]["value"];
+        and_entity.entity_type = magic_enum::enum_cast<RateLimitedEntityType>(json["and_entity"]["entity_type"].get<std::string>()).value();
+    }
     status_id = json["id"];
 }
 
@@ -303,7 +407,6 @@ Option<nlohmann::json> RateLimitManager::add_rule(const nlohmann::json &rule_jso
 
     rate_limit_rule_t parsed_rule = parse_rule(rule_json);
     parsed_rule.id = last_rule_id++;
-
     const std::string rule_store_key = get_rule_key(parsed_rule.id);
     bool inserted = store->insert(rule_store_key, parsed_rule.to_json().dump());
     if(!inserted) {
@@ -334,15 +437,14 @@ Option<nlohmann::json> RateLimitManager::edit_rule(const uint64_t id, const nloh
 
     rate_limit_rule_t parsed_rule = parse_rule(rule_json);
     parsed_rule.id = id;
+    lock.unlock();
+    // Delete rule from rate limit rule pointer
+    delete_rule_by_id(id);
+    lock.lock();
     const std::string rule_store_key = get_rule_key(parsed_rule.id);
     bool inserted = store->insert(rule_store_key, parsed_rule.to_json().dump());
     if(!inserted) {
         return Option<nlohmann::json>(500, "Failed to update rule in the DB store");
-    }
-    auto old_rule = rule_store.at(id);
-    // Remove rule from rate limit rule pointer
-    for(const auto &entity : old_rule.entity_ids) {
-        rate_limit_entities.erase(rate_limit_entity_t{old_rule.entity_type,entity});
     }
     // unlock mutex before inserting rule to rule store
     lock.unlock();
@@ -359,13 +461,13 @@ Option<bool> RateLimitManager::is_valid_rule(const nlohmann::json &rule_json) {
         return Option<bool>(400, "Parameter `action` is required.");
     }
     if (rule_json["action"] == "allow") {
-        if ((rule_json.count("ip_addresses") == 0 && rule_json.count("api_keys") == 0) || (rule_json.count("ip_addresses") > 0 && rule_json.count("api_keys") > 0)) {
-            return Option<bool>(400, "Either `ip_addresses` or `api_keys` is required.");
+        if ((rule_json.count("ip_addresses") == 0 && rule_json.count("api_keys") == 0)) {
+            return Option<bool>(400, "`ip_addresses` and/or `api_keys` is required.");
         }
         return Option<bool>(true);
     } else if (rule_json["action"] == "block") {
-        if ((rule_json.count("ip_addresses") == 0 && rule_json.count("api_keys") == 0) || (rule_json.count("ip_addresses") > 0 && rule_json.count("api_keys") > 0)) {
-            return Option<bool>(400, "Either `ip_addresses` or `api_keys` is required.");
+        if ((rule_json.count("ip_addresses") == 0 && rule_json.count("api_keys") == 0)) {
+            return Option<bool>(400, "`ip_addresses` and/or `api_keys` is required.");
         }
         return Option<bool>(true);
     } else if (rule_json["action"] == "throttle") {
@@ -378,8 +480,8 @@ Option<bool> RateLimitManager::is_valid_rule(const nlohmann::json &rule_json) {
         if (rule_json.count("max_requests_1h") > 0 && rule_json["max_requests_1h"].is_number_integer() == false) {
             return Option<bool>(400, "Parameter `max_requests_1h` must be an integer.");
         }
-        if ((rule_json.count("ip_addresses") == 0 && rule_json.count("api_keys") == 0) || (rule_json.count("ip_addresses") > 0 && rule_json.count("api_keys") > 0)) {
-            return Option<bool>(400, "Either `ip_addresses` or `api_keys` is required.");
+        if ((rule_json.count("ip_addresses") == 0 && rule_json.count("api_keys") == 0)) {
+            return Option<bool>(400, "`ip_addresses` and/or `api_keys` is required.");
         }
         if(rule_json.count("ip_addresses") > 0 && !rule_json["ip_addresses"].is_array() && !rule_json["ip_addresses"][0].is_string()) {
             return Option<bool>(400, "Parameter `ip_addresses` must be an array of strings.");
@@ -411,15 +513,13 @@ rate_limit_rule_t RateLimitManager::parse_rule(const nlohmann::json &rule_json)
     rate_limit_rule_t new_rule;
     new_rule.action = magic_enum::enum_cast<RateLimitAction>(rule_json["action"].get<std::string>()).value();
     if(rule_json.count("ip_addresses") > 0) {
-        new_rule.entity_type = RateLimitedEntityType::ip;
-        for(const auto& ip: rule_json["ip_addresses"]) {
-            new_rule.entity_ids.push_back(ip);
+        for(const auto& ip_address: rule_json["ip_addresses"]) {
+            new_rule.entities.push_back(rate_limit_entity_t{RateLimitedEntityType::ip, ip_address});
         }
     }
     if(rule_json.count("api_keys") > 0) {
-        new_rule.entity_type = RateLimitedEntityType::api_key;
         for(const auto& api_key: rule_json["api_keys"]) {
-            new_rule.entity_ids.push_back(api_key);
+            new_rule.entities.push_back(rate_limit_entity_t{RateLimitedEntityType::api_key, api_key});
         }
     }
     if(rule_json.count("max_requests_1m") > 0) {
@@ -432,17 +532,83 @@ rate_limit_rule_t RateLimitManager::parse_rule(const nlohmann::json &rule_json)
         new_rule.auto_ban_threshold_num = rule_json["auto_ban_threshold_num"];
         new_rule.auto_ban_num_hours = rule_json["auto_ban_num_hours"];
     }
-
-    return std::move(new_rule);
+    if(rule_json.count("priority") > 0) {
+        new_rule.priority = rule_json["priority"];
+    }
+    new_rule.is_and = rule_json.count("ip_addresses") > 0 && rule_json.count("api_keys") > 0 && (std::find_if(new_rule.entities.begin(), new_rule.entities.end(), [](const rate_limit_entity_t &entity) {
+        return entity.entity_id == ".*";
+    }) == new_rule.entities.end());
+    return new_rule;
 }
 
 
-void RateLimitManager::insert_rule(const rate_limit_rule_t &rule) {
+void RateLimitManager::insert_rule(rate_limit_rule_t &rule) {
     std::unique_lock lock(rate_limit_mutex);
 
     rule_store[rule.id] = rule;
-    for(const auto &entity : rule.entity_ids) {
-        rate_limit_entities.insert({rate_limit_entity_t{rule.entity_type,entity}, &rule_store.at(rule.id)});
+    if(!rule.is_and) {
+        // Check if the rule has both IP and API key entities
+        bool has_both = std::find_if(rule.entities.begin(), rule.entities.end(), [](const rate_limit_entity_t &entity) {
+            return entity.entity_type == RateLimitedEntityType::ip;
+        }) != rule.entities.end() && std::find_if(rule.entities.begin(), rule.entities.end(), [](const rate_limit_entity_t &entity) {
+            return entity.entity_type == RateLimitedEntityType::api_key;
+        }) != rule.entities.end();
+        if(has_both) {
+            // Edge case: If the rule has any wildcard entity, we need to add it by an IP wildcard entity
+            auto is_wildcard_ip = std::find_if(rule.entities.begin(), rule.entities.end(), [](const rate_limit_entity_t &entity) {
+                return entity.entity_type == RateLimitedEntityType::ip && entity.entity_id == ".*";
+            }) != rule.entities.end();
+
+            auto is_wildcard_api_key = std::find_if(rule.entities.begin(), rule.entities.end(), [](const rate_limit_entity_t &entity) {
+                return entity.entity_type == RateLimitedEntityType::api_key && entity.entity_id == ".*";
+            }) != rule.entities.end();
+
+            // Edge Case: If the rule has both wildcard entities, we count it as an IP wildcard entity
+            if(is_wildcard_ip && is_wildcard_api_key) {
+                rate_limit_entities.insert({rate_limit_entity_t{RateLimitedEntityType::ip, ".*"}, &rule_store.at(rule.id)});
+            }
+            // Edge Case: If the rule has an IP wildcard entity, but not an API key wildcard entity, we need to remove all IP entities from the rule
+            else if(is_wildcard_ip) {
+                for(const auto &entity : rule.entities) {
+                    if(entity.entity_type == RateLimitedEntityType::api_key) {
+                        rate_limit_entities.insert({entity, &rule_store.at(rule.id)});
+                    }
+                }
+            }
+            // Edge Case: If the rule has an API key wildcard entity, but not an IP wildcard entity, we need to remove all API key entities from the rule
+            else if(is_wildcard_api_key) {
+                for(const auto &entity : rule.entities) {
+                    if(entity.entity_type == RateLimitedEntityType::ip) {
+                        rate_limit_entities.insert({entity, &rule_store.at(rule.id)});
+                    }
+                }
+            }
+        }
+        else {
+            if(std::find_if(rule.entities.begin(), rule.entities.end(), [](const rate_limit_entity_t &entity) {
+                return entity.entity_type == RateLimitedEntityType::ip;
+            }) == rule.entities.end()) {
+                rule_store[rule.id].is_and = true;
+            }
+            for(const auto &entity : rule.entities) {
+                rate_limit_entities.insert({entity, &rule_store.at(rule.id)});
+            }
+        }
+    } else {
+        std::vector<rate_limit_entity_t> ip_entities, api_key_entities;
+        for(const auto &entity : rule.entities) {
+            if(entity.entity_type == RateLimitedEntityType::ip) {
+                ip_entities.push_back(entity);
+            } else {
+                api_key_entities.push_back(entity);
+            }
+        }
+        // Add all combinations of ip and api key entities to AND store
+        for(const auto &ip_entity : ip_entities) {
+            for(const auto &api_key_entity : api_key_entities) {
+                rate_limit_entities_and.insert({std::make_pair(api_key_entity, ip_entity), &rule_store.at(rule.id)});
+            }
+        }
     }
 }
 
@@ -456,7 +622,6 @@ Option<bool> RateLimitManager::init(Store* store) {
 
     // Set store
     this->store = store;
-
     // Load rules from database
     std::string last_rule_id_str;
     StoreStatus last_rule_id_status = store->get(std::string(RULES_NEXT_ID), last_rule_id_str);
@@ -505,7 +670,6 @@ Option<bool> RateLimitManager::init(Store* store) {
     }
     else if(last_ban_id_status == StoreStatus::FOUND) {
         last_ban_id = StringUtils::deserialize_uint32_t(last_ban_id_str);
-        LOG(INFO) << "Last ban id: " << last_ban_id;
     }
     else {
         LOG(INFO) << "No bans found in database.";
@@ -519,7 +683,11 @@ Option<bool> RateLimitManager::init(Store* store) {
         nlohmann::json ban_json = nlohmann::json::parse(ban_json_str);
         rate_limit_status_t ban_status;
         ban_status.parse_json(ban_json);
-        throttled_entities.insert({rate_limit_entity_t{ban_status.entity_type, ban_status.value}, ban_status});
+        if(ban_status.is_and) {
+            throttled_entities[ban_status.entity][ban_status.and_entity] = ban_status;
+        } else {
+            throttled_entities[ban_status.entity][rate_limit_entity_t{RateLimitedEntityType::api_key, ".*"}] = ban_status;
+        }
     }
     LOG(INFO) << "Loaded " << rule_store.size() << " rate limit rules.";
     LOG(INFO) << "Loaded " << throttled_entities.size() << " rate limit bans.";
@@ -547,26 +715,29 @@ const nlohmann::json RateLimitManager::get_all_throttled_entities_json() {
     std::shared_lock lock(rate_limit_mutex);
 
     nlohmann::json throttled_entities_array = nlohmann::json::object();
+    for(const auto& entity_map : throttled_entities) {
+        for(const auto& entity : entity_map.second) {
+            if(entity.second.throttling_to <= get_current_time()) {
+                store->remove(get_ban_key(entity.second.status_id));
+                throttled_entities.erase(entity.first);
+                if(throttled_entities[entity.first].empty()) {
+                    throttled_entities.erase(entity.first);
+                }
+            }
+            auto entity_json = entity.second.to_json();
 
-    for(const auto& entity : throttled_entities) {
-        if(entity.second.throttling_to <= get_current_time()) {
-            store->remove(get_ban_key(entity.second.status_id));
-            throttled_entities.erase(entity.first);
-        }
-        auto entity_json = entity.second.to_json();
-
-        if(entity.second.entity_type == RateLimitedEntityType::api_key) {
-            entity_json["api_key"] = entity_json["value"];
-        } else {
             entity_json["ip_address"] = entity_json["value"];
+
+            if(entity.second.is_and) {
+                entity_json["api_key"] = entity.second.and_entity.entity_id;
+            }
+
+            entity_json.erase("value");
+            entity_json.erase("entity_type");
+            entity_json.erase("and_entity");
+            throttled_entities_array["active"].push_back(entity_json);
         }
-
-        entity_json.erase("value");
-        entity_json.erase("entity_type");
-        throttled_entities_array["active"].push_back(entity_json);
     }
-
-    LOG(INFO) << "Returning " << throttled_entities.size() << " throttled entities.";
     return throttled_entities_array;
 }
 
@@ -583,7 +754,14 @@ const Option<nlohmann::json> RateLimitManager::delete_throttle_by_id(const uint6
     nlohmann::json ban_json = nlohmann::json::parse(ban_json_str);
     rate_limit_status_t ban_status;
     ban_status.parse_json(ban_json);
-    throttled_entities.erase(rate_limit_entity_t{ban_status.entity_type, ban_status.value});
+    if(ban_status.is_and) {
+        throttled_entities[ban_status.entity].erase(ban_status.and_entity);
+    } else {
+        throttled_entities[ban_status.entity].erase(rate_limit_entity_t{RateLimitedEntityType::api_key, ".*"});
+    }
+    if(throttled_entities[ban_status.entity].empty()) {
+        throttled_entities.erase(ban_status.entity);
+    }
     const auto removed = store->remove(get_ban_key(id));
 
     if(!removed) {

--- a/src/typesense_server_utils.cpp
+++ b/src/typesense_server_utils.cpp
@@ -445,8 +445,13 @@ int run_server(const Config & config, const std::string & version, void (*master
     collectionManager.init(&store, &app_thread_pool, config.get_max_memory_ratio(),
                            config.get_api_key(), quit_raft_service, batch_indexer);
     
-    RateLimitManager* rateLimitManager = RateLimitManager::getInstance();
-    rateLimitManager->set_store(&meta_store);
+  
+    RateLimitManager *rateLimitManager = RateLimitManager::getInstance();
+    auto rate_limit_manager_init = rateLimitManager->init(&meta_store);
+
+    if(!rate_limit_manager_init.ok()) {
+        LOG(ERROR) << "Failed to initialize rate limit manager: " << rate_limit_manager_init.error();
+    }
 
     // first we start the peering service
     ReplicationState replication_state(server, batch_indexer, &store,

--- a/src/typesense_server_utils.cpp
+++ b/src/typesense_server_utils.cpp
@@ -445,15 +445,10 @@ int run_server(const Config & config, const std::string & version, void (*master
     collectionManager.init(&store, &app_thread_pool, config.get_max_memory_ratio(),
                            config.get_api_key(), quit_raft_service, batch_indexer);
     
-    RateLimitManager *rateLimitManager = RateLimitManager::getInstance();
-    auto rate_limit_manager_init = rateLimitManager->init(&store);
-
-    if(!rate_limit_manager_init.ok()) {
-        LOG(INFO) << "Failed to initialize rate limit manager: " << rate_limit_manager_init.error();
-    }
+    RateLimitManager* rateLimitManager = RateLimitManager::getInstance();
+    rateLimitManager->set_store(&meta_store);
 
     // first we start the peering service
-
     ReplicationState replication_state(server, batch_indexer, &store,
                                        &app_thread_pool, server->get_message_dispatcher(),
                                        ssl_enabled,

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -536,3 +536,18 @@ TEST_F(CoreAPIUtilsTest, ExportWithFilter) {
     ASSERT_TRUE(done);
     ASSERT_EQ('}', export_state.res_body->back());
 }
+
+TEST_F(CoreAPIUtilsTest, TestGetEntitiesValid) {
+    auto parsed_metadata_op = get_entities("4:test0.0.0.0");
+
+    ASSERT_TRUE(parsed_metadata_op.ok());
+    ASSERT_EQ("test", parsed_metadata_op.get().first);
+    ASSERT_EQ("0.0.0.0", parsed_metadata_op.get().second);
+}
+
+TEST_F(CoreAPIUtilsTest, TestGetEntitiesInvalid) {
+    auto parsed_metadata_op = get_entities("4:test");
+
+    ASSERT_FALSE(parsed_metadata_op.ok());
+    ASSERT_EQ("Invalid metadata", parsed_metadata_op.error());
+}

--- a/test/ratelimit_test.cpp
+++ b/test/ratelimit_test.cpp
@@ -467,6 +467,11 @@ TEST_F(RateLimitManagerTest, TestAutoBannedEntitiesList) {
     auto throttled_entities = manager->get_all_throttled_entities_json();
     EXPECT_EQ(throttled_entities.size(), 1);
     EXPECT_EQ(throttled_entities["active"][0]["api_key"], "test");
+
+    manager->delete_throttle_by_id(throttled_entities["active"][0]["id"]);
+
+    throttled_entities = manager->get_all_throttled_entities_json();
+    EXPECT_EQ(throttled_entities.size(), 0);
 }
 
 TEST_F(RateLimitManagerTest, TestMultiSearchRateLimit) {

--- a/test/ratelimit_test.cpp
+++ b/test/ratelimit_test.cpp
@@ -54,8 +54,10 @@ TEST_F(RateLimitManagerTest, TestAddRateLimitApiKey) {
         {"max_requests_1m", 10},
         {"max_requests_1h", 100},
         {"auto_ban_threshold_num", 10},
-        {"auto_ban_num_days", 1}
+        {"auto_ban_num_hours", 1}
     });
+
+    LOG(INFO) << res.error();
 
 
     EXPECT_EQ(manager->get_all_rules().size(), 1);
@@ -68,7 +70,7 @@ TEST_F(RateLimitManagerTest, TestAddRateLimitIp) {
         {"max_requests_1m", 10},
         {"max_requests_1h", 100},
         {"auto_ban_threshold_num", 10},
-        {"auto_ban_num_days", 1}
+        {"auto_ban_num_hours", 1}
     });
 
     EXPECT_EQ(manager->get_all_rules().size(), 1);
@@ -81,7 +83,7 @@ TEST_F(RateLimitManagerTest, TestRemoveRateLimitApiKey) {
         {"max_requests_1m", 10},
         {"max_requests_1h", 100},
         {"auto_ban_threshold_num", 10},
-        {"auto_ban_num_days", 1}
+        {"auto_ban_num_hours", 1}
     });
     EXPECT_EQ(manager->get_all_rules().size(), 1);
     manager->remove_rule_entity(RateLimitedEntityType::api_key, "test");
@@ -95,7 +97,7 @@ TEST_F(RateLimitManagerTest, TestRemoveRateLimitIp) {
         {"max_requests_1m", 10},
         {"max_requests_1h", 100},
         {"auto_ban_threshold_num", 10},
-        {"auto_ban_num_days", 1}
+        {"auto_ban_num_hours", 1}
     });
     EXPECT_EQ(manager->get_all_rules().size(), 1);
     manager->remove_rule_entity(RateLimitedEntityType::ip, "0.0.0.1");
@@ -117,7 +119,7 @@ TEST_F(RateLimitManagerTest, TestGetTrackedIps) {
         {"max_requests_1m", 10},
         {"max_requests_1h", 100},
         {"auto_ban_threshold_num", 10},
-        {"auto_ban_num_days", 1}
+        {"auto_ban_num_hours", 1}
     });
     auto entities = manager->get_all_rules();
     bool found = entities[0].action == RateLimitAction::throttle && entities[0].max_requests.minute_threshold == 10 && entities[0].max_requests.hour_threshold == 100;
@@ -132,7 +134,7 @@ TEST_F(RateLimitManagerTest, TestGetTrackedApiKeys) {
         {"max_requests_1m", 10},
         {"max_requests_1h", 100},
         {"auto_ban_threshold_num", 10},
-        {"auto_ban_num_days", 1}
+        {"auto_ban_num_hours", 1}
     });
     auto entities = manager->get_all_rules();
     bool found = entities[0].action == RateLimitAction::throttle && entities[0].max_requests.minute_threshold == 10 && entities[0].max_requests.hour_threshold == 100;
@@ -359,7 +361,7 @@ TEST_F(RateLimitManagerTest, TestAutoBan) {
         {"max_requests_1m", 5},
         {"max_requests_1h", -1},
         {"auto_ban_threshold_num", 2},
-        {"auto_ban_num_days", 1}
+        {"auto_ban_num_hours", 1}
     });
     EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
     EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
@@ -374,7 +376,7 @@ TEST_F(RateLimitManagerTest, TestAutoBan) {
     EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
     EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
     EXPECT_TRUE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
-    this->changeBaseTimestamp(60*60*24);
+    this->changeBaseTimestamp(60*60);
     EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}})); 
 }
 
@@ -446,7 +448,7 @@ TEST_F(RateLimitManagerTest, TestAutoBannedEntitiesList) {
         {"max_requests_1m", 5},
         {"max_requests_1h", -1},
         {"auto_ban_threshold_num", 1},
-        {"auto_ban_num_days", 3}
+        {"auto_ban_num_hours", 3}
     });
     EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
     EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));

--- a/test/ratelimit_test.cpp
+++ b/test/ratelimit_test.cpp
@@ -37,8 +37,7 @@ protected:
         system(("rm -rf "+state_dir_path+" && mkdir -p "+state_dir_path).c_str());
 
         store = new Store(state_dir_path);
-        manager->set_store(store);
-        manager->init();
+        manager->init(store);
     }
 
     virtual void TearDown() {
@@ -485,7 +484,7 @@ TEST_F(RateLimitManagerTest, TestMultiSearchRateLimit) {
     search["q"] = "bmw";
     body["searches"] = nlohmann::json::array({search, search, search, search, search, search});
     req->embedded_params_vec.resize(6);
-    req->metadata = "test 0.0.0.0";
+    req->metadata = "4:test0.0.0.0";
     req->body = body.dump();
 
     post_multi_search(req, res);

--- a/test/ratelimit_test.cpp
+++ b/test/ratelimit_test.cpp
@@ -474,20 +474,16 @@ TEST_F(RateLimitManagerTest, TestMultiSearchRateLimit) {
         {"max_requests_60s", 3},
         {"max_requests_1h", -1}
     });
-
-
     std::shared_ptr<http_req> req = std::make_shared<http_req>();
     std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
 
     nlohmann::json search,body;
+    
     search["collection"] = "cars";
     search["query_by"] = "brand";
     search["q"] = "bmw";
-    for(int i=0;i<6;i) {
-        body["searches"].push_back(search);
-        req->embedded_params_vec.push_back(nlohmann::json::object());
-    }
-
+    body["searches"] = nlohmann::json::array({search, search, search, search, search, search});
+    req->embedded_params_vec.resize(6);
     req->metadata = "test 0.0.0.0";
     req->body = body.dump();
 

--- a/test/ratelimit_test.cpp
+++ b/test/ratelimit_test.cpp
@@ -51,7 +51,7 @@ TEST_F(RateLimitManagerTest, TestAddRateLimitApiKey) {
     auto res = manager->add_rule({
         {"action", "throttle"},
         {"api_keys", nlohmann::json::array({"test"})},
-        {"max_requests_60s", 10},
+        {"max_requests_1m", 10},
         {"max_requests_1h", 100},
         {"auto_ban_threshold_num", 10},
         {"auto_ban_num_days", 1}
@@ -65,7 +65,7 @@ TEST_F(RateLimitManagerTest, TestAddRateLimitIp) {
     auto res = manager->add_rule({
         {"action", "throttle"},
         {"ip_addresses", nlohmann::json::array({"0.0.0.1"})},
-        {"max_requests_60s", 10},
+        {"max_requests_1m", 10},
         {"max_requests_1h", 100},
         {"auto_ban_threshold_num", 10},
         {"auto_ban_num_days", 1}
@@ -78,7 +78,7 @@ TEST_F(RateLimitManagerTest, TestRemoveRateLimitApiKey) {
     manager->add_rule({
         {"action", "throttle"},
         {"api_keys", nlohmann::json::array({"test"})},
-        {"max_requests_60s", 10},
+        {"max_requests_1m", 10},
         {"max_requests_1h", 100},
         {"auto_ban_threshold_num", 10},
         {"auto_ban_num_days", 1}
@@ -92,7 +92,7 @@ TEST_F(RateLimitManagerTest, TestRemoveRateLimitIp) {
     manager->add_rule({
         {"action", "throttle"},
         {"ip_addresses", nlohmann::json::array({"0.0.0.1"})},
-        {"max_requests_60s", 10},
+        {"max_requests_1m", 10},
         {"max_requests_1h", 100},
         {"auto_ban_threshold_num", 10},
         {"auto_ban_num_days", 1}
@@ -114,7 +114,7 @@ TEST_F(RateLimitManagerTest, TestGetTrackedIps) {
     manager->add_rule({
         {"action", "throttle"},
         {"ip_addresses", nlohmann::json::array({"0.0.0.1"})},
-        {"max_requests_60s", 10},
+        {"max_requests_1m", 10},
         {"max_requests_1h", 100},
         {"auto_ban_threshold_num", 10},
         {"auto_ban_num_days", 1}
@@ -129,7 +129,7 @@ TEST_F(RateLimitManagerTest, TestGetTrackedApiKeys) {
     manager->add_rule({
         {"action", "throttle"},
         {"api_keys", nlohmann::json::array({"test"})},
-        {"max_requests_60s", 10},
+        {"max_requests_1m", 10},
         {"max_requests_1h", 100},
         {"auto_ban_threshold_num", 10},
         {"auto_ban_num_days", 1}
@@ -177,7 +177,7 @@ TEST_F(RateLimitManagerTest, TestIsBannedIpTemp) {
     manager->add_rule({
         {"action", "throttle"},
         {"ip_addresses", nlohmann::json::array({"0.0.0.1"})},
-        {"max_requests_60s", 1},
+        {"max_requests_1m", 1},
         {"max_requests_1h", 1}
     });
     EXPECT_TRUE(manager->get_all_rules().size() == 1);
@@ -200,7 +200,7 @@ TEST_F(RateLimitManagerTest, TestIsBannedAPIKeyTemp) {
     manager->add_rule({
         {"action", "throttle"},
         {"api_keys", nlohmann::json::array({"test"})},
-        {"max_requests_60s", 1},
+        {"max_requests_1m", 1},
         {"max_requests_1h", 1}
     });
     EXPECT_TRUE(manager->get_all_rules().size() == 1);
@@ -230,7 +230,7 @@ TEST_F(RateLimitManagerTest, TestThrottleAPIKey) {
     manager->add_rule({
         {"action", "throttle"},
         {"api_keys", nlohmann::json::array({"test"})},
-        {"max_requests_60s", 1},
+        {"max_requests_1m", 1},
         {"max_requests_1h", 1}
     });
     EXPECT_TRUE(manager->get_all_rules().size() == 1);
@@ -242,7 +242,7 @@ TEST_F(RateLimitManagerTest, TestDeleteRuleByID) {
     manager->add_rule({
         {"action", "throttle"},
         {"api_keys", nlohmann::json::array({"test"})},
-        {"max_requests_60s", 1},
+        {"max_requests_1m", 1},
         {"max_requests_1h", 1}
     });
     EXPECT_TRUE(manager->get_all_rules().size() == 1);
@@ -255,7 +255,7 @@ TEST_F(RateLimitManagerTest, TestMinuteRateLimitAPIKey) {
     manager->add_rule({
         {"action", "throttle"},
         {"api_keys", nlohmann::json::array({"test"})},
-        {"max_requests_60s", 5},
+        {"max_requests_1m", 5},
         {"max_requests_1h", -1}
     });
     EXPECT_TRUE(manager->get_all_rules().size() == 1);
@@ -271,7 +271,7 @@ TEST_F(RateLimitManagerTest, TestHourRateLimitAPIKey) {
     manager->add_rule({
         {"action", "throttle"},
         {"api_keys", nlohmann::json::array({"test"})},
-        {"max_requests_60s", -1},
+        {"max_requests_1m", -1},
         {"max_requests_1h", 5}
     });
     EXPECT_TRUE(manager->get_all_rules().size() == 1);
@@ -287,7 +287,7 @@ TEST_F(RateLimitManagerTest, TestMinuteRateLimitIp) {
     manager->add_rule({
         {"action", "throttle"},
         {"ip_addresses", nlohmann::json::array({"0.0.0.1"})},
-        {"max_requests_60s", 5},
+        {"max_requests_1m", 5},
         {"max_requests_1h", -1}
     });
     EXPECT_TRUE(manager->get_all_rules().size() == 1);
@@ -303,7 +303,7 @@ TEST_F(RateLimitManagerTest, TestHourRateLimitIp) {
     manager->add_rule({
         {"action", "throttle"},
         {"ip_addresses", nlohmann::json::array({"0.0.0.1"})},
-        {"max_requests_60s", -1},
+        {"max_requests_1m", -1},
         {"max_requests_1h", 5}
     });
     EXPECT_TRUE(manager->get_all_rules().size() == 1);
@@ -319,13 +319,13 @@ TEST_F(RateLimitManagerTest, TestGetAllRules) {
     manager->add_rule({
         {"action", "throttle"},
         {"ip_addresses", nlohmann::json::array({"0.0.0.1"})},
-        {"max_requests_60s", -1},
+        {"max_requests_1m", -1},
         {"max_requests_1h", 5}
     });
     manager->add_rule({
         {"action", "throttle"},
         {"api_keys", nlohmann::json::array({"test"})},
-        {"max_requests_60s", 5},
+        {"max_requests_1m", 5},
         {"max_requests_1h", -1}
     });
     EXPECT_TRUE(manager->get_all_rules().size() == 2);
@@ -340,7 +340,7 @@ TEST_F(RateLimitManagerTest, TestGetAllRulesJSON) {
     manager->add_rule({
         {"action", "throttle"},
         {"api_keys", nlohmann::json::array({"test"})},
-        {"max_requests_60s", 5},
+        {"max_requests_1m", 5},
         {"max_requests_1h", -1}
     });
     nlohmann::json rules = manager->get_all_rules_json();
@@ -356,7 +356,7 @@ TEST_F(RateLimitManagerTest, TestAutoBan) {
     manager->add_rule({
         {"action", "throttle"},
         {"api_keys", nlohmann::json::array({"test"})},
-        {"max_requests_60s", 5},
+        {"max_requests_1m", 5},
         {"max_requests_1h", -1},
         {"auto_ban_threshold_num", 2},
         {"auto_ban_num_days", 1}
@@ -383,7 +383,7 @@ TEST_F(RateLimitManagerTest, TestWildcard) {
     manager->add_rule({
         {"action", "throttle"},
         {"api_keys", nlohmann::json::array({".*"})},
-        {"max_requests_60s", 5},
+        {"max_requests_1m", 5},
         {"max_requests_1h", -1}
     });
     EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
@@ -404,13 +404,13 @@ TEST_F(RateLimitManagerTest, TestCorrectOrderofRules) {
     manager->add_rule({
         {"action", "throttle"},
         {"api_keys", nlohmann::json::array({".*"})},
-        {"max_requests_60s", 2},
+        {"max_requests_1m", 2},
         {"max_requests_1h", -1}
     });
     manager->add_rule({
         {"action", "throttle"},
         {"api_keys", nlohmann::json::array({"test"})},
-        {"max_requests_60s", 5},
+        {"max_requests_1m", 5},
         {"max_requests_1h", -1}
     });
     manager->add_rule({
@@ -443,7 +443,7 @@ TEST_F(RateLimitManagerTest, TestAutoBannedEntitiesList) {
     manager->add_rule({
         {"action", "throttle"},
         {"api_keys", nlohmann::json::array({"test"})},
-        {"max_requests_60s", 5},
+        {"max_requests_1m", 5},
         {"max_requests_1h", -1},
         {"auto_ban_threshold_num", 1},
         {"auto_ban_num_days", 3}
@@ -471,7 +471,7 @@ TEST_F(RateLimitManagerTest, TestMultiSearchRateLimit) {
     manager->add_rule({
         {"action", "throttle"},
         {"api_keys", nlohmann::json::array({".*"})},
-        {"max_requests_60s", 3},
+        {"max_requests_1m", 3},
         {"max_requests_1h", -1}
     });
     std::shared_ptr<http_req> req = std::make_shared<http_req>();

--- a/test/ratelimit_test.cpp
+++ b/test/ratelimit_test.cpp
@@ -37,7 +37,8 @@ protected:
         system(("rm -rf "+state_dir_path+" && mkdir -p "+state_dir_path).c_str());
 
         store = new Store(state_dir_path);
-        manager->init(store);
+        manager->set_store(store);
+        manager->init();
     }
 
     virtual void TearDown() {

--- a/test/ratelimit_test.cpp
+++ b/test/ratelimit_test.cpp
@@ -3,6 +3,7 @@
 #include <thread>
 #include "ratelimit_manager.h"
 #include "logger.h"
+#include "core_api.h"
 
 // Google test for RateLimitManager
 class RateLimitManagerTest : public ::testing::Test
@@ -436,4 +437,62 @@ TEST_F(RateLimitManagerTest, TestCorrectOrderofRules) {
     EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test2"}}));
     EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test2"}}));
     EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test2"}}));
+}
+
+TEST_F(RateLimitManagerTest, TestAutoBannedEntitiesList) {
+    manager->add_rule({
+        {"action", "throttle"},
+        {"api_keys", nlohmann::json::array({"test"})},
+        {"max_requests_60s", 5},
+        {"max_requests_1h", -1},
+        {"auto_ban_threshold_num", 1},
+        {"auto_ban_num_days", 3}
+    });
+    EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
+    EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
+    EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
+    EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
+    EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
+    EXPECT_TRUE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
+    this->changeBaseTimestamp(120);
+    EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
+    EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
+    EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
+    EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
+    EXPECT_FALSE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
+    EXPECT_TRUE(manager->is_rate_limited({{RateLimitedEntityType::api_key, "test"}}));
+
+    auto throttled_entities = manager->get_all_throttled_entities_json();
+    EXPECT_EQ(throttled_entities.size(), 1);
+    EXPECT_EQ(throttled_entities["active"][0]["api_key"], "test");
+}
+
+TEST_F(RateLimitManagerTest, TestMultiSearchRateLimit) {
+    manager->add_rule({
+        {"action", "throttle"},
+        {"api_keys", nlohmann::json::array({".*"})},
+        {"max_requests_60s", 3},
+        {"max_requests_1h", -1}
+    });
+
+
+    std::shared_ptr<http_req> req = std::make_shared<http_req>();
+    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
+
+    nlohmann::json search,body;
+    search["collection"] = "cars";
+    search["query_by"] = "brand";
+    search["q"] = "bmw";
+    for(int i=0;i<6;i) {
+        body["searches"].push_back(search);
+        req->embedded_params_vec.push_back(nlohmann::json::object());
+    }
+
+    req->metadata = "test 0.0.0.0";
+    req->body = body.dump();
+
+    post_multi_search(req, res);
+
+    EXPECT_EQ(res->status_code, 429);
+    EXPECT_EQ(res->body, "{\"message\": \"Rate limit exceeded.\"}");
 }


### PR DESCRIPTION
List of changes:

1.Added a more meaningful response for delete operation of rules (returns ID of the deleted rule as requested)
2./limits/active endpoint is active now.
3. You can delete auto bans with DELETE request to /limits/active/:id endpoint
4. Resolved hanging issue for /limits/:id endpoint with invalid inputs.
5./multi_search endpoint now increases request counts as size of searches array.
6.Encountered and fixed a logic error on calculation of how many times user exceeded minute threshold so far.
7.Added unit test for those cases.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
