### PR TITLE
fix: log events to stdout instead of stderr

### DIFF
--- a/docker/development-arm.Dockerfile
+++ b/docker/development-arm.Dockerfile
@@ -60,10 +60,10 @@ RUN tar -C /opt -xf /opt/leveldb-1.22.tar.gz
 RUN mkdir -p /opt/leveldb-1.22/build && cd /opt/leveldb-1.22/build && cmake -DCMAKE_BUILD_TYPE=Release .. && \
     cmake --build . && make install && rm -rf /usr/local/lib/*.so*
 
-ADD https://github.com/google/glog/archive/0a2e593.tar.gz /opt/glog-0a2e593.tar.gz
-RUN tar -C /opt -xf /opt/glog-0a2e593.tar.gz
-RUN mkdir -p /opt/glog-0a2e5931bd5ff22fd3bf8999eb8ce776f159cda6/bld && \
-    cd /opt/glog-0a2e5931bd5ff22fd3bf8999eb8ce776f159cda6/bld && \
+ADD https://github.com/google/glog/archive/b33e3ba.tar.gz /opt/glog-b33e3ba.tar.gz
+RUN tar -C /opt -xf /opt/glog-b33e3ba.tar.gz
+RUN mkdir -p /opt/glog-b33e3bad4c46c8a6345525fd822af355e5ef9446/bld && \
+    cd /opt/glog-b33e3bad4c46c8a6345525fd822af355e5ef9446/bld && \
     cmake -DBUILD_TESTING=0 -DWITH_GFLAGS=ON -DWITH_TLS=OFF -DWITH_UNWIND=OFF .. && \
     cmake --build . && make install && rm -rf /usr/local/lib/*.so*
 

--- a/docker/development.Dockerfile
+++ b/docker/development.Dockerfile
@@ -62,10 +62,10 @@ RUN tar -C /opt -xf /opt/leveldb-1.22.tar.gz
 RUN mkdir -p /opt/leveldb-1.22/build && cd /opt/leveldb-1.22/build && cmake -DCMAKE_BUILD_TYPE=Release .. && \
     cmake --build . && make install && rm -rf /usr/local/lib/*.so*
 
-ADD https://github.com/google/glog/archive/0a2e593.tar.gz /opt/glog-0a2e593.tar.gz
-RUN tar -C /opt -xf /opt/glog-0a2e593.tar.gz
-RUN mkdir -p /opt/glog-0a2e5931bd5ff22fd3bf8999eb8ce776f159cda6/bld && \
-    cd /opt/glog-0a2e5931bd5ff22fd3bf8999eb8ce776f159cda6/bld && \
+ADD https://github.com/google/glog/archive/b33e3ba.tar.gz /opt/glog-b33e3ba.tar.gz
+RUN tar -C /opt -xf /opt/glog-b33e3ba.tar.gz
+RUN mkdir -p /opt/glog-b33e3bad4c46c8a6345525fd822af355e5ef9446/bld && \
+    cd /opt/glog-b33e3bad4c46c8a6345525fd822af355e5ef9446/bld && \
     cmake -DBUILD_TESTING=0 -DWITH_GFLAGS=ON -DWITH_TLS=OFF -DWITH_UNWIND=OFF .. && \
     cmake --build . && make install && rm -rf /usr/local/lib/*.so*
 

--- a/src/typesense_server_utils.cpp
+++ b/src/typesense_server_utils.cpp
@@ -121,7 +121,7 @@ int init_root_logger(Config & config, const std::string & server_version) {
 
     if(log_dir.empty()) {
         // use console logger if log dir is not specified
-        FLAGS_logtostderr = true;
+        FLAGS_logtostdout = true;
     } else {
         if(!directory_exists(log_dir)) {
             std::cerr << "Typesense failed to start. " << "Log directory " << log_dir << " does not exist.";


### PR DESCRIPTION
Signed-off-by: William Albertus Dembo <29192168+walbertus@users.noreply.github.com>

## Change Summary
Events log should be outputted to stdout instead of stderr. It was impossible before due to GLOG limitations. The new version already supports logging to stdout.
This PR will close #351 

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
