### PR TITLE
Install Curl for health check support

### DIFF
--- a/docker/deployment.Dockerfile
+++ b/docker/deployment.Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:20.04
 
-RUN apt-get -y update && apt-get -y install ca-certificates curl
+RUN apt-get -y update && apt-get -y install ca-certificates netcat
 
 RUN mkdir -p /opt
 COPY typesense-server /opt
 RUN chmod +x /opt/typesense-server
 
 EXPOSE 8108
-HEALTHCHECK curl -f http://localhost:8108/health
+HEALTHCHECK CMD ["nc", "-z", "127.0.0.1", "8108"]
 
 ENTRYPOINT ["/opt/typesense-server"]

--- a/docker/deployment.Dockerfile
+++ b/docker/deployment.Dockerfile
@@ -1,9 +1,12 @@
 FROM ubuntu:20.04
 
-RUN apt-get -y update && apt-get -y install ca-certificates
+RUN apt-get -y update && apt-get -y install ca-certificates curl
 
 RUN mkdir -p /opt
 COPY typesense-server /opt
 RUN chmod +x /opt/typesense-server
+
 EXPOSE 8108
+HEALTHCHECK curl -f http://localhost:8108/health
+
 ENTRYPOINT ["/opt/typesense-server"]


### PR DESCRIPTION
## Change Summary
If you can install curl in the deployment image this will allow docker to monitor the health of the container:

```
healthcheck:
    test: [ "CMD", "curl", "-f", "http://localhost:8108/health" ]
    interval: 30s
    timeout: 5s
    retries: 1
    start_period: 30s
```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
