### PR TITLE
support alias in `include_fields`

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -395,7 +395,8 @@ public:
                                   const tsl::htrie_set<char>& exclude_names, const std::string& parent_name = "",
                                   size_t depth = 0,
                                   const std::map<std::string, reference_filter_result_t>& reference_filter_results = {},
-                                  Collection *const collection = nullptr, const uint32_t& seq_id = 0);
+                                  Collection *const collection = nullptr, const uint32_t& seq_id = 0,
+                                  const std::vector<std::string>& ref_include_fields_vec = {});
 
     const Index* _get_index() const;
 
@@ -494,7 +495,8 @@ public:
                                   const size_t remote_embedding_timeout_ms = 30000,
                                   const size_t remote_embedding_num_tries = 2,
                                   const std::string& stopwords_set="",
-                                  const std::vector<std::string>& facet_return_parent = {}) const;
+                                  const std::vector<std::string>& facet_return_parent = {},
+                                  const std::vector<std::string>& ref_include_fields_vec = {}) const;
 
     Option<bool> get_filter_ids(const std::string & filter_query, filter_result_t& filter_result) const;
 

--- a/include/collection.h
+++ b/include/collection.h
@@ -386,6 +386,7 @@ public:
 
     static Option<bool> add_reference_fields(nlohmann::json& doc,
                                              Collection *const ref_collection,
+                                             const std::string& alias,
                                              const reference_filter_result_t& references,
                                              const tsl::htrie_set<char>& ref_include_fields_full,
                                              const tsl::htrie_set<char>& ref_exclude_fields_full,
@@ -396,7 +397,7 @@ public:
                                   size_t depth = 0,
                                   const std::map<std::string, reference_filter_result_t>& reference_filter_results = {},
                                   Collection *const collection = nullptr, const uint32_t& seq_id = 0,
-                                  const std::vector<std::string>& ref_include_fields_vec = {});
+                                  const std::vector<ref_include_fields>& ref_include_fields_vec = {});
 
     const Index* _get_index() const;
 
@@ -496,7 +497,7 @@ public:
                                   const size_t remote_embedding_num_tries = 2,
                                   const std::string& stopwords_set="",
                                   const std::vector<std::string>& facet_return_parent = {},
-                                  const std::vector<std::string>& ref_include_fields_vec = {}) const;
+                                  const std::vector<ref_include_fields>& ref_include_fields_vec = {}) const;
 
     Option<bool> get_filter_ids(const std::string & filter_query, filter_result_t& filter_result) const;
 

--- a/include/field.h
+++ b/include/field.h
@@ -487,6 +487,11 @@ namespace sort_field_const {
     static const std::string vector_distance = "_vector_distance";
 }
 
+struct ref_include_fields {
+    std::string expression;
+    std::string alias;
+};
+
 struct sort_by {
     enum missing_values_t {
         first,

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -9,6 +9,7 @@
 #include "logger.h"
 #include "magic_enum.hpp"
 #include "stopwords_manager.h"
+#include "field.h"
 
 constexpr const size_t CollectionManager::DEFAULT_NUM_MEMORY_SHARDS;
 
@@ -838,35 +839,42 @@ void CollectionManager::_get_reference_collection_names(const std::string& filte
 
 // Separate out the reference includes into `ref_include_fields_vec`.
 void initialize_ref_include_fields_vec(const std::string& filter_query, std::vector<std::string>& include_fields_vec,
-                                       std::vector<std::string>& ref_include_fields_vec) {
+                                       std::vector<ref_include_fields>& ref_include_fields_vec) {
     std::set<std::string> reference_collection_names;
     CollectionManager::_get_reference_collection_names(filter_query, reference_collection_names);
 
     std::vector<std::string> result_include_fields_vec;
     auto wildcard_include_all = true;
-    for (auto include_field: include_fields_vec) {
-        if (include_field[0] != '$') {
-            if (include_field == "*") {
+    for (auto include_field_exp: include_fields_vec) {
+        if (include_field_exp[0] != '$') {
+            if (include_field_exp == "*") {
                 continue;
             }
 
             wildcard_include_all = false;
-            result_include_fields_vec.emplace_back(include_field);
+            result_include_fields_vec.emplace_back(include_field_exp);
             continue;
         }
 
-        auto open_paren_pos = include_field.find('(');
+        auto as_pos = include_field_exp.find(" as ");
+        auto ref_include = include_field_exp.substr(0, as_pos),
+                alias = (as_pos == std::string::npos) ? "" :
+                        include_field_exp.substr(as_pos + 4, include_field_exp.size() - (as_pos + 4));
+
+        // For an alias `foo`, we need append `foo.` to all the top level keys of reference doc.
+        ref_include_fields_vec.emplace_back(ref_include_fields{ref_include, alias.empty() ? alias :
+                                                                                StringUtils::trim(alias) + "."});
+
+        auto open_paren_pos = include_field_exp.find('(');
         if (open_paren_pos == std::string::npos) {
             continue;
         }
 
-        auto reference_collection_name = include_field.substr(1, open_paren_pos - 1);
+        auto reference_collection_name = include_field_exp.substr(1, open_paren_pos - 1);
         StringUtils::trim(reference_collection_name);
         if (reference_collection_name.empty()) {
             continue;
         }
-
-        ref_include_fields_vec.emplace_back(include_field);
 
         // Referenced collection in filter_query is already mentioned in ref_include_fields.
         reference_collection_names.erase(reference_collection_name);
@@ -874,7 +882,7 @@ void initialize_ref_include_fields_vec(const std::string& filter_query, std::vec
 
     // Get all the fields of the referenced collection in the filter but not mentioned in include_fields.
     for (const auto &reference_collection_name: reference_collection_names) {
-        ref_include_fields_vec.emplace_back("$" + reference_collection_name + "(*)");
+        ref_include_fields_vec.emplace_back(ref_include_fields{"$" + reference_collection_name + "(*)", ""});
     }
 
     // Since no field of the collection is mentioned in include_fields, get all the fields.
@@ -1048,7 +1056,7 @@ Option<bool> CollectionManager::do_search(std::map<std::string, std::string>& re
 
     std::vector<std::string> include_fields_vec;
     std::vector<std::string> exclude_fields_vec;
-    std::vector<std::string> ref_include_fields_vec;
+    std::vector<ref_include_fields> ref_include_fields_vec;
     spp::sparse_hash_set<std::string> include_fields;
     spp::sparse_hash_set<std::string> exclude_fields;
 

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -516,6 +516,14 @@ Option<bool> StringUtils::split_include_fields(const std::string& include_fields
             }
 
             include_field = include_fields.substr(range_pos, (end - range_pos) + 1);
+
+            comma_pos = include_fields.find(',', end);
+            auto as_pos = include_fields.find(" as ", end);
+            if (as_pos != std::string::npos && as_pos < comma_pos) {
+                auto alias = include_fields.substr(as_pos, (comma_pos - as_pos));
+                end += alias.size() + 1;
+                include_field += (" " + trim(alias));
+            }
         } else {
             end = comma_pos;
             include_field = include_fields.substr(start, end - start);

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -1167,7 +1167,8 @@ TEST_F(CollectionJoinTest, IncludeExcludeFieldsByReference) {
     ASSERT_EQ(1, res_obj["found"].get<size_t>());
     ASSERT_EQ(1, res_obj["hits"].size());
     // No fields are mentioned in `include_fields`, should include all fields of Products and Customers by default.
-    ASSERT_EQ(8, res_obj["hits"][0]["document"].size());
+    ASSERT_EQ(9, res_obj["hits"][0]["document"].size());
+    ASSERT_EQ(1, res_obj["hits"][0]["document"].count("id"));
     ASSERT_EQ(1, res_obj["hits"][0]["document"].count("product_id"));
     ASSERT_EQ(1, res_obj["hits"][0]["document"].count("product_name"));
     ASSERT_EQ(1, res_obj["hits"][0]["document"].count("product_description"));
@@ -1191,7 +1192,8 @@ TEST_F(CollectionJoinTest, IncludeExcludeFieldsByReference) {
     ASSERT_EQ(1, res_obj["found"].get<size_t>());
     ASSERT_EQ(1, res_obj["hits"].size());
     // No fields of Products collection are mentioned in `include_fields`, should include all of its fields by default.
-    ASSERT_EQ(4, res_obj["hits"][0]["document"].size());
+    ASSERT_EQ(5, res_obj["hits"][0]["document"].size());
+    ASSERT_EQ(1, res_obj["hits"][0]["document"].count("id"));
     ASSERT_EQ(1, res_obj["hits"][0]["document"].count("product_id"));
     ASSERT_EQ(1, res_obj["hits"][0]["document"].count("product_name"));
     ASSERT_EQ(1, res_obj["hits"][0]["document"].count("product_description"));
@@ -1210,7 +1212,7 @@ TEST_F(CollectionJoinTest, IncludeExcludeFieldsByReference) {
     res_obj = nlohmann::json::parse(json_res);
     ASSERT_EQ(1, res_obj["found"].get<size_t>());
     ASSERT_EQ(1, res_obj["hits"].size());
-    ASSERT_EQ(5, res_obj["hits"][0]["document"].size());
+    ASSERT_EQ(6, res_obj["hits"][0]["document"].size());
     ASSERT_EQ(1, res_obj["hits"][0]["document"].count("product_price"));
     ASSERT_EQ(73.5, res_obj["hits"][0]["document"].at("product_price"));
 
@@ -1227,7 +1229,7 @@ TEST_F(CollectionJoinTest, IncludeExcludeFieldsByReference) {
     res_obj = nlohmann::json::parse(json_res);
     ASSERT_EQ(1, res_obj["found"].get<size_t>());
     ASSERT_EQ(1, res_obj["hits"].size());
-    ASSERT_EQ(6, res_obj["hits"][0]["document"].size());
+    ASSERT_EQ(7, res_obj["hits"][0]["document"].size());
     ASSERT_EQ(1, res_obj["hits"][0]["document"].count("product_price"));
     ASSERT_EQ(73.5, res_obj["hits"][0]["document"].at("product_price"));
     ASSERT_EQ(1, res_obj["hits"][0]["document"].count("customer_id"));
@@ -1246,8 +1248,8 @@ TEST_F(CollectionJoinTest, IncludeExcludeFieldsByReference) {
     res_obj = nlohmann::json::parse(json_res);
     ASSERT_EQ(1, res_obj["found"].get<size_t>());
     ASSERT_EQ(1, res_obj["hits"].size());
-    // 4 fields in Products document and 2 fields from Customers document
-    ASSERT_EQ(6, res_obj["hits"][0]["document"].size());
+    // 5 fields in Products document and 2 fields from Customers document
+    ASSERT_EQ(7, res_obj["hits"][0]["document"].size());
 
     req_params = {
             {"collection", "Products"},
@@ -1262,8 +1264,9 @@ TEST_F(CollectionJoinTest, IncludeExcludeFieldsByReference) {
     res_obj = nlohmann::json::parse(json_res);
     ASSERT_EQ(1, res_obj["found"].get<size_t>());
     ASSERT_EQ(1, res_obj["hits"].size());
-    // 4 fields in Products document and 2 fields from Customers document
-    ASSERT_EQ(6, res_obj["hits"][0]["document"].size());
+    // 5 fields in Products document and 2 fields from Customers document
+    ASSERT_EQ(7, res_obj["hits"][0]["document"].size());
+    ASSERT_EQ(1, res_obj["hits"][0]["document"].count("product_price"));
     ASSERT_EQ(1, res_obj["hits"][0]["document"].count("product_id_sequence_id"));
 
     req_params = {
@@ -1280,8 +1283,8 @@ TEST_F(CollectionJoinTest, IncludeExcludeFieldsByReference) {
     res_obj = nlohmann::json::parse(json_res);
     ASSERT_EQ(1, res_obj["found"].get<size_t>());
     ASSERT_EQ(1, res_obj["hits"].size());
-    // 4 fields in Products document and 1 fields from Customers document
-    ASSERT_EQ(5, res_obj["hits"][0]["document"].size());
+    // 5 fields in Products document and 1 fields from Customers document
+    ASSERT_EQ(6, res_obj["hits"][0]["document"].size());
     ASSERT_EQ(1, res_obj["hits"][0]["document"].count("product_id"));
     ASSERT_EQ(1, res_obj["hits"][0]["document"].count("product_name"));
     ASSERT_EQ(1, res_obj["hits"][0]["document"].count("product_description"));

--- a/test/collection_specific_test.cpp
+++ b/test/collection_specific_test.cpp
@@ -2879,6 +2879,36 @@ TEST_F(CollectionSpecificTest, NonIndexField) {
     ASSERT_EQ(1, results["hits"].size());
     ASSERT_EQ(1, coll1->_get_index()->_get_search_index().size());
 
+    std::map<std::string, std::string> req_params = {
+            {"collection", "coll1"},
+            {"q", "*"},
+            {"include_fields", "*, "}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+
+    results = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ(3, results["hits"][0].at("document").size());
+    ASSERT_EQ(1, results["hits"][0].at("document").count("description"));
+
+    req_params = {
+            {"collection", "coll1"},
+            {"q", "*"},
+            {"include_fields", "*, title"}  // Adding a field name overrides include all wildcard
+    };
+
+    collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+
+    results = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ(1, results["hits"][0].at("document").size());
+    ASSERT_EQ(1, results["hits"][0].at("document").count("title"));
+
     collectionManager.drop_collection("coll1");
 }
 

--- a/test/string_utils_test.cpp
+++ b/test/string_utils_test.cpp
@@ -419,4 +419,12 @@ TEST(StringUtilsTest, SplitIncludeFields) {
     include_fields = "id, $Collection(title, pref*), count, ";
     tokens = {"id", "$Collection(title, pref*)", "count"};
     splitIncludeTestHelper(include_fields, tokens);
+
+    include_fields = "$Collection(title, pref*) as coll";
+    tokens = {"$Collection(title, pref*) as coll"};
+    splitIncludeTestHelper(include_fields, tokens);
+
+    include_fields = "id, $Collection(title, pref*)  as coll , count, ";
+    tokens = {"id", "$Collection(title, pref*) as coll", "count"};
+    splitIncludeTestHelper(include_fields, tokens);
 }


### PR DESCRIPTION
* Support `as` to specify an alias for reference doc's fields.
* Fix reference `include_fields` returning flattened fields.
* Fix `"include_fields": "*, "` only including indexed fields in the response.

## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
