### PR TITLE
Fix extracting field names for two embedding fields with same prefix

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -1044,6 +1044,10 @@ Option<bool> Collection::extract_field_name(const std::string& field_name,
             continue;
         }
 
+        if(!exact_key_match && text_embedding) {
+            continue;
+        }
+
         if (exact_primitive_match || is_wildcard || text_embedding ||
             // field_name prefix must be followed by a "." to indicate an object search
             (enable_nested_fields && kv.key().size() > field_name.size() && kv.key()[field_name.size()] == '.')) {


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
