### PR TITLE
Filter scoring

### DIFF
--- a/include/field.h
+++ b/include/field.h
@@ -496,12 +496,14 @@ struct sort_by {
     };
 
     struct eval_t {
-        filter_node_t* filter_tree_root = nullptr;
-        uint32_t* ids = nullptr;
-        uint32_t  size = 0;
+        filter_node_t* filter_trees = nullptr;
+        std::vector<uint32_t*> eval_ids_vec;
+        std::vector<uint32_t> eval_ids_count_vec;
+        std::vector<int64_t> scores;
     };
 
     std::string name;
+    std::vector<std::string> eval_expressions;
     std::string order;
 
     // for text_match score bucketing
@@ -523,6 +525,13 @@ struct sort_by {
 
     }
 
+    sort_by(std::vector<std::string> eval_expressions, std::vector<int64_t> scores, std::string  order):
+            eval_expressions(std::move(eval_expressions)), order(std::move(order)), text_match_buckets(0), geopoint(0), exclude_radius(0),
+            geo_precision(0), missing_values(normal) {
+        name = sort_field_const::eval;
+        eval.scores = std::move(scores);
+    }
+
     sort_by(const std::string &name, const std::string &order, uint32_t text_match_buckets, int64_t geopoint,
             uint32_t exclude_radius, uint32_t geo_precision) :
             name(name), order(order), text_match_buckets(text_match_buckets),
@@ -535,6 +544,7 @@ struct sort_by {
         if (&other == this)
             return;
         name = other.name;
+        eval_expressions = other.eval_expressions;
         order = other.order;
         text_match_buckets = other.text_match_buckets;
         geopoint = other.geopoint;
@@ -547,6 +557,7 @@ struct sort_by {
 
     sort_by& operator=(const sort_by& other) {
         name = other.name;
+        eval_expressions = other.eval_expressions;
         order = other.order;
         text_match_buckets = other.text_match_buckets;
         geopoint = other.geopoint;

--- a/include/filter.h
+++ b/include/filter.h
@@ -67,7 +67,9 @@ struct filter_node_t {
     filter_node_t* left = nullptr;
     filter_node_t* right = nullptr;
 
-    filter_node_t(filter filter_exp)
+    filter_node_t() = default;
+
+    explicit filter_node_t(filter filter_exp)
             : filter_exp(std::move(filter_exp)),
               isOperator(false),
               left(nullptr),
@@ -84,5 +86,26 @@ struct filter_node_t {
     ~filter_node_t() {
         delete left;
         delete right;
+    }
+
+    filter_node_t& operator=(filter_node_t&& obj) noexcept {
+        if (&obj == this) {
+            return *this;
+        }
+
+        if (obj.isOperator) {
+            isOperator = true;
+            filter_operator = obj.filter_operator;
+            left = obj.left;
+            right = obj.right;
+
+            obj.left = nullptr;
+            obj.right = nullptr;
+        } else {
+            isOperator = false;
+            filter_exp = obj.filter_exp;
+        }
+
+        return *this;
     }
 };

--- a/include/filter_result_iterator.h
+++ b/include/filter_result_iterator.h
@@ -210,6 +210,8 @@ public:
     /// iterator reaching it's end. (is_valid would be false in both these cases)
     uint32_t approx_filter_ids_length = 0;
 
+    filter_result_iterator_t() = default;
+
     explicit filter_result_iterator_t(uint32_t* ids, const uint32_t& ids_count);
 
     explicit filter_result_iterator_t(const std::string collection_name,

--- a/include/index.h
+++ b/include/index.h
@@ -957,7 +957,7 @@ public:
                                      std::array<spp::sparse_hash_map<uint32_t, int64_t>*, 3> field_values,
                                      const std::vector<size_t>& geopoint_indices, uint32_t seq_id,
                                      const std::map<basic_string<char>, reference_filter_result_t>& references,
-                                     size_t filter_index,
+                                     std::vector<uint32_t>& filter_indexes,
                                      int64_t max_field_match_score,
                                      int64_t* scores,
                                      int64_t& match_score_index, float vector_distance = 0,

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -1596,9 +1596,10 @@ filter_result_iterator_t::~filter_result_iterator_t() {
     delete right_it;
 }
 
-filter_result_iterator_t &filter_result_iterator_t::operator=(filter_result_iterator_t &&obj) noexcept {
-    if (&obj == this)
+filter_result_iterator_t& filter_result_iterator_t::operator=(filter_result_iterator_t&& obj) noexcept {
+    if (&obj == this) {
         return *this;
+    }
 
     // In case the filter was on string field.
     for(auto expanded_plist: expanded_plists) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2478,7 +2478,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                 }
             }
 
-            std::vector<uint32_t> nearest_ids;
+            std::vector<uint32_t> nearest_ids, filter_indexes;
 
             for (auto& dist_result : dist_results) {
                 auto& seq_id = dist_result.second.seq_id;
@@ -2507,8 +2507,9 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                 int64_t match_score_index = -1;
 
                 auto compute_sort_scores_op = compute_sort_scores(sort_fields_std, sort_order, field_values,
-                                                                  geopoint_indices, seq_id, references, 0, 0, scores,
-                                                                  match_score_index, vec_dist_score, collection_name);
+                                                                  geopoint_indices, seq_id, references, filter_indexes,
+                                                                  0, scores, match_score_index, vec_dist_score,
+                                                                  collection_name);
                 if (!compute_sort_scores_op.ok()) {
                     return compute_sort_scores_op;
                 }
@@ -2847,7 +2848,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                     result->scores[result->match_score_index] = float_to_int64_t((1.0 / (i + 1)) * TEXT_MATCH_WEIGHT);
                 }
 
-                std::vector<uint32_t> vec_search_ids;  // list of IDs found only in vector search
+                std::vector<uint32_t> vec_search_ids, filter_indexes;  // list of IDs found only in vector search
 
                 for(size_t res_index = 0; res_index < vec_results.size(); res_index++) {
                     auto& vec_result = vec_results[res_index];
@@ -2888,7 +2889,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                         int64_t scores[3] = {0};
 
                         auto compute_sort_scores_op = compute_sort_scores(sort_fields_std, sort_order, field_values,
-                                                                          geopoint_indices, seq_id, references, 0,
+                                                                          geopoint_indices, seq_id, references, filter_indexes,
                                                                           match_score, scores, match_score_index,
                                                                           vec_result.second, collection_name);
                         if (!compute_sort_scores_op.ok()) {
@@ -2909,7 +2910,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                         int64_t match_score_index = -1;
 
                         auto compute_sort_scores_op = compute_sort_scores(sort_fields_std, sort_order, field_values,
-                                                                          geopoint_indices, seq_id, references, 0,
+                                                                          geopoint_indices, seq_id, references, filter_indexes,
                                                                           match_score, scores, match_score_index,
                                                                           vec_result.second, collection_name);
                         if (!compute_sort_scores_op.ok()) {
@@ -3807,8 +3808,7 @@ Option<bool> Index::search_across_fields(const std::vector<token_t>& query_token
         token_its.push_back(std::move(token_fields));
     }
 
-    std::vector<uint32_t> result_ids;
-    size_t filter_index = 0;
+    std::vector<uint32_t> result_ids, filter_indexes;
     Option<bool> status(true);
 
     or_iterator_t::intersect(token_its, istate,
@@ -3905,7 +3905,7 @@ Option<bool> Index::search_across_fields(const std::vector<token_t>& query_token
         int64_t match_score_index = -1;
 
         auto compute_sort_scores_op = compute_sort_scores(sort_fields, sort_order, field_values, geopoint_indices,
-                                                          seq_id, references, filter_index, best_field_match_score,
+                                                          seq_id, references, filter_indexes, best_field_match_score,
                                                           scores, match_score_index, 0, collection_name);
         if (!compute_sort_scores_op.ok()) {
             status = Option<bool>(compute_sort_scores_op.code(), compute_sort_scores_op.error());
@@ -4013,7 +4013,7 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
                                         std::array<spp::sparse_hash_map<uint32_t, int64_t>*, 3> field_values,
                                         const std::vector<size_t>& geopoint_indices,
                                         uint32_t seq_id, const std::map<basic_string<char>, reference_filter_result_t>& references,
-                                        size_t filter_index, int64_t max_field_match_score, int64_t* scores,
+                                        std::vector<uint32_t>& filter_indexes, int64_t max_field_match_score, int64_t* scores,
                                         int64_t& match_score_index, float vector_distance,
                                         const std::string& collection_name) const {
 
@@ -4189,22 +4189,32 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
                 }
             }
         } else if(field_values[0] == &eval_sentinel_value) {
-            // Returns iterator to the first element that is >= to value or last if no such element is found.
-            bool found = false;
-            if (filter_index == 0 || filter_index < sort_fields[0].eval.size) {
-                size_t found_index = std::lower_bound(sort_fields[0].eval.ids + filter_index,
-                                                      sort_fields[0].eval.ids + sort_fields[0].eval.size, seq_id) -
-                                     sort_fields[0].eval.ids;
-
-                if (found_index != sort_fields[0].eval.size && sort_fields[0].eval.ids[found_index] == seq_id) {
-                    filter_index = found_index + 1;
-                    found = true;
-                }
-
-                filter_index = found_index;
+            auto const& count = sort_fields[0].eval_expressions.size();
+            if (filter_indexes.empty()) {
+                filter_indexes = std::vector<uint32_t>(count, 0);
             }
 
-            scores[0] = int64_t(found);
+            bool found = false;
+            uint32_t index = 0;
+            auto const& eval = sort_fields[0].eval;
+            for (; index < count; index++) {
+                auto& filter_index = filter_indexes[index];
+                auto const& eval_ids = eval.eval_ids_vec[index];
+                auto const& eval_ids_count = eval.eval_ids_count_vec[index];
+                if (filter_index == 0 || filter_index < eval_ids_count) {
+                    // Returns iterator to the first element that is >= to value or last if no such element is found.
+                    filter_index = std::lower_bound(eval_ids + filter_index, eval_ids + eval_ids_count, seq_id) -
+                                                            eval_ids;
+
+                    if (filter_index < eval_ids_count && eval_ids[filter_index] == seq_id) {
+                        filter_index++;
+                        found = true;
+                        break;
+                    }
+                }
+            }
+
+            scores[0] = found ? eval.scores[index] : 0;
         } else if(field_values[0] == &vector_distance_sentinel_value) {
             scores[0] = float_to_int64_t(vector_distance);
         } else {
@@ -4342,22 +4352,32 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
                 }
             }
         } else if(field_values[1] == &eval_sentinel_value) {
-            // Returns iterator to the first element that is >= to value or last if no such element is found.
-            bool found = false;
-            if (filter_index == 0 || filter_index < sort_fields[1].eval.size) {
-                size_t found_index = std::lower_bound(sort_fields[1].eval.ids + filter_index,
-                                                      sort_fields[1].eval.ids + sort_fields[1].eval.size, seq_id) -
-                                     sort_fields[1].eval.ids;
-
-                if (found_index != sort_fields[1].eval.size && sort_fields[1].eval.ids[found_index] == seq_id) {
-                    filter_index = found_index + 1;
-                    found = true;
-                }
-
-                filter_index = found_index;
+            auto const& count = sort_fields[1].eval_expressions.size();
+            if (filter_indexes.empty()) {
+                filter_indexes = std::vector<uint32_t>(count, 0);
             }
 
-            scores[1] = int64_t(found);
+            bool found = false;
+            uint32_t index = 0;
+            auto const& eval = sort_fields[1].eval;
+            for (; index < count; index++) {
+                auto& filter_index = filter_indexes[index];
+                auto const& eval_ids = eval.eval_ids_vec[index];
+                auto const& eval_ids_count = eval.eval_ids_count_vec[index];
+                if (filter_index == 0 || filter_index < eval_ids_count) {
+                    // Returns iterator to the first element that is >= to value or last if no such element is found.
+                    filter_index = std::lower_bound(eval_ids + filter_index, eval_ids + eval_ids_count, seq_id) -
+                                   eval_ids;
+
+                    if (filter_index < eval_ids_count && eval_ids[filter_index] == seq_id) {
+                        filter_index++;
+                        found = true;
+                        break;
+                    }
+                }
+            }
+
+            scores[1] = found ? eval.scores[index] : 0;
         }  else if(field_values[1] == &vector_distance_sentinel_value) {
             scores[1] = float_to_int64_t(vector_distance);
         } else {
@@ -4491,22 +4511,32 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
                 }
             }
         } else if(field_values[2] == &eval_sentinel_value) {
-            // Returns iterator to the first element that is >= to value or last if no such element is found.
-            bool found = false;
-            if (filter_index == 0 || filter_index < sort_fields[2].eval.size) {
-                size_t found_index = std::lower_bound(sort_fields[2].eval.ids + filter_index,
-                                                      sort_fields[2].eval.ids + sort_fields[2].eval.size, seq_id) -
-                                     sort_fields[2].eval.ids;
-
-                if (found_index != sort_fields[2].eval.size && sort_fields[2].eval.ids[found_index] == seq_id) {
-                    filter_index = found_index + 1;
-                    found = true;
-                }
-
-                filter_index = found_index;
+            auto const& count = sort_fields[2].eval_expressions.size();
+            if (filter_indexes.empty()) {
+                filter_indexes = std::vector<uint32_t>(count, 0);
             }
 
-            scores[2] = int64_t(found);
+            bool found = false;
+            uint32_t index = 0;
+            auto const& eval = sort_fields[2].eval;
+            for (; index < count; index++) {
+                auto& filter_index = filter_indexes[index];
+                auto const& eval_ids = eval.eval_ids_vec[index];
+                auto const& eval_ids_count = eval.eval_ids_count_vec[index];
+                if (filter_index == 0 || filter_index < eval_ids_count) {
+                    // Returns iterator to the first element that is >= to value or last if no such element is found.
+                    filter_index = std::lower_bound(eval_ids + filter_index, eval_ids + eval_ids_count, seq_id) -
+                                   eval_ids;
+
+                    if (filter_index < eval_ids_count && eval_ids[filter_index] == seq_id) {
+                        filter_index++;
+                        found = true;
+                        break;
+                    }
+                }
+            }
+
+            scores[2] = found ? eval.scores[index] : 0;
         } else if(field_values[2] == &vector_distance_sentinel_value) {
             scores[2] = float_to_int64_t(vector_distance);
         } else {
@@ -4654,7 +4684,7 @@ Option<bool> Index::do_phrase_search(const size_t num_search_fields, const std::
     all_result_ids_len = filter_result_iterator->to_filter_id_array(all_result_ids);
     filter_result_iterator->reset();
 
-    size_t filter_index = 0;
+    std::vector<uint32_t> filter_indexes;
     // populate topster
     for(size_t i = 0; i < std::min<size_t>(10000, all_result_ids_len); i++) {
         auto seq_id = filter_result_iterator->seq_id;
@@ -4666,7 +4696,7 @@ Option<bool> Index::do_phrase_search(const size_t num_search_fields, const std::
         int64_t match_score_index = -1;
 
         auto compute_sort_scores_op = compute_sort_scores(sort_fields, sort_order, field_values, geopoint_indices,
-                                                          seq_id, references, filter_index, match_score, scores,
+                                                          seq_id, references, filter_indexes, match_score, scores,
                                                           match_score_index, 0, collection_name);
         if (!compute_sort_scores_op.ok()) {
             return compute_sort_scores_op;
@@ -4810,7 +4840,7 @@ Option<bool> Index::do_infix_search(const size_t num_search_fields, const std::v
                 }
 
                 bool field_is_array = search_schema.at(the_fields[field_id].name).is_array();
-                size_t filter_index = 0;
+                std::vector<uint32_t> filter_indexes;
 
                 for(size_t i = 0; i < raw_infix_ids_length; i++) {
                     auto seq_id = raw_infix_ids[i];
@@ -4828,7 +4858,7 @@ Option<bool> Index::do_infix_search(const size_t num_search_fields, const std::v
 
                     auto compute_sort_scores_op = compute_sort_scores(sort_fields, sort_order, field_values,
                                                                       geopoint_indices, seq_id, references,
-                                                                      filter_index, 100, scores, match_score_index,
+                                                                      filter_indexes, 100, scores, match_score_index,
                                                                       0, collection_name);
                     if (!compute_sort_scores_op.ok()) {
                         return compute_sort_scores_op;
@@ -5196,7 +5226,7 @@ Option<bool> Index::search_wildcard(filter_node_t const* const& filter_tree_root
             search_stop_us = parent_search_stop_ms;
             search_cutoff = parent_search_cutoff;
 
-            size_t filter_index = 0;
+            std::vector<uint32_t> filter_indexes;
 
             for(size_t i = 0; i < batch_result->count; i++) {
                 const uint32_t seq_id = batch_result->docs[i];
@@ -5214,7 +5244,7 @@ Option<bool> Index::search_wildcard(filter_node_t const* const& filter_tree_root
                 int64_t match_score_index = -1;
 
                 auto compute_sort_scores_op = compute_sort_scores(sort_fields, sort_order, field_values, geopoint_indices,
-                                                                  seq_id, references, filter_index, 100, scores,
+                                                                  seq_id, references, filter_indexes, 100, scores,
                                                                   match_score_index, 0, collection_name);
                 if (!compute_sort_scores_op.ok()) {
                     compute_sort_score_status = new Option<bool>(compute_sort_scores_op.code(), compute_sort_scores_op.error());
@@ -5325,12 +5355,20 @@ void Index::populate_sort_mapping(int* sort_order, std::vector<size_t>& geopoint
             field_values[i] = &seq_id_sentinel_value;
         } else if (sort_fields_std[i].name == sort_field_const::eval) {
             field_values[i] = &eval_sentinel_value;
-            auto filter_result_iterator = filter_result_iterator_t("", this, sort_fields_std[i].eval.filter_tree_root);
-            auto filter_init_op = filter_result_iterator.init_status();
-            if (!filter_init_op.ok()) {
-                return;
+            auto& eval_exp = sort_fields_std[i].eval;
+            auto count = sort_fields_std[i].eval_expressions.size();
+            for (uint32_t j = 0; j < count; j++) {
+                auto filter_result_iterator = filter_result_iterator_t("", this, &eval_exp.filter_trees[j]);
+                auto filter_init_op = filter_result_iterator.init_status();
+                if (!filter_init_op.ok()) {
+                    return;
+                }
+                uint32_t* eval_ids = nullptr;
+                auto eval_ids_count = filter_result_iterator.to_filter_id_array(eval_ids);
+
+                eval_exp.eval_ids_vec.push_back(eval_ids);
+                eval_exp.eval_ids_count_vec.push_back(eval_ids_count);
             }
-            sort_fields_std[i].eval.size = filter_result_iterator.to_filter_id_array(sort_fields_std[i].eval.ids);
         } else if(sort_fields_std[i].name == sort_field_const::vector_distance) {
             field_values[i] = &vector_distance_sentinel_value;
         } else if (search_schema.count(sort_fields_std[i].name) != 0 && search_schema.at(sort_fields_std[i].name).sort) {

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -1177,10 +1177,26 @@ TEST_F(CollectionManagerTest, ParseSortByClause) {
     sort_fields.clear();
     sort_by_parsed = CollectionManager::parse_sort_by_str("_eval(brand:nike && foo:bar):DESC,points:desc ", sort_fields);
     ASSERT_TRUE(sort_by_parsed);
-    ASSERT_EQ("_eval(brand:nike && foo:bar)", sort_fields[0].name);
+    ASSERT_EQ("_eval", sort_fields[0].name);
+    ASSERT_FALSE(sort_fields[0].eval_expressions.empty());
+    ASSERT_EQ("brand:nike && foo:bar", sort_fields[0].eval_expressions[0]);
+    ASSERT_EQ(1, sort_fields[0].eval.scores.size());
+    ASSERT_EQ(1, sort_fields[0].eval.scores[0]);
     ASSERT_EQ("DESC", sort_fields[0].order);
     ASSERT_EQ("points", sort_fields[1].name);
     ASSERT_EQ("DESC", sort_fields[1].order);
+
+    sort_fields.clear();
+    sort_by_parsed = CollectionManager::parse_sort_by_str("_eval([(brand:nike || brand:air):3, (brand:adidas):2]):DESC", sort_fields);
+    ASSERT_TRUE(sort_by_parsed);
+    ASSERT_EQ("_eval", sort_fields[0].name);
+    ASSERT_EQ(2, sort_fields[0].eval_expressions.size());
+    ASSERT_EQ("brand:nike || brand:air", sort_fields[0].eval_expressions[0]);
+    ASSERT_EQ("brand:adidas", sort_fields[0].eval_expressions[1]);
+    ASSERT_EQ(2, sort_fields[0].eval.scores.size());
+    ASSERT_EQ(3, sort_fields[0].eval.scores[0]);
+    ASSERT_EQ(2, sort_fields[0].eval.scores[1]);
+    ASSERT_EQ("DESC", sort_fields[0].order);
 
     sort_fields.clear();
     sort_by_parsed = CollectionManager::parse_sort_by_str("points:desc,loc(24.56,10.45):ASC,"


### PR DESCRIPTION
## Change Summary
Allow the following syntax in `sort_by`
```
_eval([ (<exp_1>):<score_1>, (<exp_2>):<score_2> ]):<sort_order>
```
to provide custom scores to the records matching a filter expression. For example, if we have a shoe catalog and we want to rank all the `Nike` shoes above the `Adidas` shoes, we can send:
```
sort_by: _eval([ (brand:Nike):3, (brand:Adidas):2 ]):desc
```
There can be as many expressions as needed in the `_eval` and each of those expressions can be as complex as standard `filter_by` expression.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
