### PR TITLE
Reference array field.

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -351,6 +351,8 @@ public:
 
     uint32_t get_next_seq_id();
 
+    Option<uint32_t> doc_id_to_seq_id_with_lock(const std::string & doc_id) const;
+
     Option<uint32_t> doc_id_to_seq_id(const std::string & doc_id) const;
 
     std::vector<std::string> get_facet_fields();

--- a/include/collection.h
+++ b/include/collection.h
@@ -287,7 +287,10 @@ private:
                                                  tsl::htrie_set<char>& include_fields_full,
                                                  tsl::htrie_set<char>& exclude_fields_full) const;
 
-    Option<uint32_t> get_reference_doc_id(const std::string& ref_collection_name, const uint32_t& seq_id) const;
+    Option<std::string> get_referenced_in_field(const std::string& collection_name) const;
+
+    Option<bool> get_related_ids(const std::string& ref_collection_name, const uint32_t& seq_id,
+                                 std::vector<uint32_t>& result) const;
 
     static void hide_credential(nlohmann::json& json, const std::string& credential_name);
 
@@ -319,8 +322,6 @@ public:
 
     static constexpr const char* COLLECTION_SYMBOLS_TO_INDEX = "symbols_to_index";
     static constexpr const char* COLLECTION_SEPARATORS = "token_separators";
-
-    static constexpr const char* REFERENCE_HELPER_FIELD_SUFFIX = "_sequence_id";
 
     // methods
 
@@ -398,7 +399,7 @@ public:
                                              const reference_filter_result_t& references,
                                              const tsl::htrie_set<char>& ref_include_fields_full,
                                              const tsl::htrie_set<char>& ref_exclude_fields_full,
-                                             const std::string& error_prefix);
+                                             const std::string& error_prefix, const bool& is_reference_array);
 
     static Option<bool> prune_doc(nlohmann::json& doc, const tsl::htrie_set<char>& include_names,
                                   const tsl::htrie_set<char>& exclude_names, const std::string& parent_name = "",
@@ -614,9 +615,12 @@ public:
 
     void add_referenced_in(const std::string& collection_name, const std::string& field_name);
 
-    Option<std::string> get_reference_field(const std::string& collection_name) const;
+    Option<std::string> get_referenced_in_field_with_lock(const std::string& collection_name) const;
 
-    Option<uint32_t> get_sort_indexed_field_value(const std::string& field_name, const uint32_t& seq_id) const;
+    Option<bool> get_related_ids_with_lock(const std::string& field_name, const uint32_t& seq_id,
+                                           std::vector<uint32_t>& result) const;
+
+    Option<uint32_t> get_sort_index_value_with_lock(const std::string& field_name, const uint32_t& seq_id) const;
 
     friend class filter_result_iterator_t;
 };

--- a/include/field.h
+++ b/include/field.h
@@ -66,6 +66,8 @@ namespace fields {
     static const std::string query_prefix = "query_prefix";
     static const std::string api_key = "api_key";
     static const std::string model_config = "model_config";
+
+    static const std::string REFERENCE_HELPER_FIELD_SUFFIX = "_sequence_id";
 }
 
 enum vector_distance_type_t {
@@ -100,6 +102,8 @@ struct field {
 
     bool range_index;
 
+    bool is_reference_helper = false;
+
     field() {}
 
     field(const std::string &name, const std::string &type, const bool facet, const bool optional = false,
@@ -111,6 +115,9 @@ struct field {
             embed(embed), range_index(range_index) {
 
         set_computed_defaults(sort, infix);
+
+        auto const suffix = std::string(fields::REFERENCE_HELPER_FIELD_SUFFIX);
+        is_reference_helper = name.size() > suffix.size() && name.substr(name.size() - suffix.size()) == suffix;
     }
 
     void set_computed_defaults(int sort, int infix) {

--- a/include/field.h
+++ b/include/field.h
@@ -35,6 +35,10 @@ namespace field_types {
     static bool is_string_or_array(const std::string& type_def) {
         return type_def == "string*";
     }
+
+    static bool is_array(const std::string& type_def) {
+        return type_def.size() > 2 && type_def[type_def.size() - 2] == '[' &&  type_def[type_def.size() - 1] == ']';
+    }
 }
 
 namespace fields {

--- a/include/index.h
+++ b/include/index.h
@@ -343,6 +343,10 @@ private:
 
     spp::sparse_hash_map<std::string, num_tree_t*> numerical_index;
 
+    // reference_helper_field => (seq_id => ref_seq_ids)
+    // Only used when the reference field is an array type otherwise sort_index is used.
+    spp::sparse_hash_map<std::string, num_tree_t*> reference_index;
+
     spp::sparse_hash_map<std::string, NumericTrie*> range_index;
 
     spp::sparse_hash_map<std::string, NumericTrie*> geo_range_index;
@@ -779,8 +783,6 @@ public:
 
     int64_t reference_string_sort_score(const std::string& field_name, const uint32_t& seq_id) const;
 
-    Option<uint32_t> get_sort_indexed_field_value(const std::string& field_name, const uint32_t& seq_id) const;
-
     static void remove_matched_tokens(std::vector<std::string>& tokens, const std::set<std::string>& rule_token_set) ;
 
     void compute_facet_infos(const std::vector<facet>& facets, facet_query_t& facet_query,
@@ -1000,7 +1002,12 @@ public:
     Option<bool> seq_ids_outside_top_k(const std::string& field_name, size_t k,
                                        std::vector<uint32_t>& outside_seq_ids);
 
-    Option<uint32_t> get_reference_doc_id_with_lock(const std::string& reference_helper_field_name,
+    Option<bool> get_related_ids(const std::string& collection_name,
+                                 const std::string& reference_helper_field_name,
+                                 const uint32_t& seq_id, std::vector<uint32_t>& result) const;
+
+    Option<uint32_t> get_sort_index_value_with_lock(const std::string& collection_name,
+                                                    const std::string& field_name,
                                                     const uint32_t& seq_id) const;
 
     friend class filter_result_iterator_t;

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -12,6 +12,7 @@
 #include <regex>
 #include <list>
 #include <posting.h>
+#include <timsort.hpp>
 #include "validator.h"
 #include "topster.h"
 #include "logger.h"
@@ -91,6 +92,7 @@ Option<bool> Collection::add_reference_helper_fields(nlohmann::json& document) {
         if (reference_field_name == "id") {
             auto id_field_type_error_op =  Option<bool>(400, "Field `" + field_name + "` must have string value.");
             if (document[field_name].is_array()) {
+                document[field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX] = nlohmann::json::array();
                 for (const auto &item: document[field_name].items()) {
                     if (!item.value().is_string()) {
                         return id_field_type_error_op;
@@ -104,7 +106,7 @@ Option<bool> Collection::add_reference_helper_fields(nlohmann::json& document) {
                                                  reference_collection_name + "`." );
                     }
 
-                    document[field_name + REFERENCE_HELPER_FIELD_SUFFIX] += ref_doc_id_op.get();
+                    document[field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX] += ref_doc_id_op.get();
                 }
             } else if (document[field_name].is_string()) {
                 auto id = document[field_name].get<std::string>();
@@ -115,7 +117,7 @@ Option<bool> Collection::add_reference_helper_fields(nlohmann::json& document) {
                                              reference_collection_name + "`." );
                 }
 
-                document[field_name + REFERENCE_HELPER_FIELD_SUFFIX] = ref_doc_id_op.get();
+                document[field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX] = ref_doc_id_op.get();
             } else {
                 return id_field_type_error_op;
             }
@@ -185,13 +187,9 @@ Option<bool> Collection::add_reference_helper_fields(nlohmann::json& document) {
         }
 
         if (document[field_name].is_array()) {
-            if (filter_result.count == 0) {
-                return  Option<bool>(400, "No reference document matching `" + filter_query + "` found in the collection `"
-                                          + reference_collection_name + "`.");
-            }
-
+            document[field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX] = nlohmann::json::array();
             for (uint32_t i = 0; i < filter_result.count; i++) {
-                document[field_name + REFERENCE_HELPER_FIELD_SUFFIX] += filter_result.docs[i];
+                document[field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX] += filter_result.docs[i];
             }
         } else {
             if (filter_result.count != 1) {
@@ -203,7 +201,7 @@ Option<bool> Collection::add_reference_helper_fields(nlohmann::json& document) {
                                           reference_collection_name + "`.");
             }
 
-            document[field_name + REFERENCE_HELPER_FIELD_SUFFIX] = filter_result.docs[0];
+            document[field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX] = filter_result.docs[0];
         }
     }
 
@@ -3132,8 +3130,9 @@ Option<bool> Collection::get_filter_ids(const std::string& filter_query, filter_
     return index->do_filtering_with_lock(filter_tree_root, filter_result, name);
 }
 
-Option<uint32_t> Collection::get_reference_doc_id(const std::string& ref_field_name, const uint32_t& seq_id) const {
-    return index->get_reference_doc_id_with_lock(ref_field_name, seq_id);
+Option<bool> Collection::get_related_ids(const std::string& ref_field_name, const uint32_t& seq_id,
+                                               std::vector<uint32_t>& result) const {
+    return index->get_related_ids(name, ref_field_name, seq_id, result);
 }
 
 Option<bool> Collection::get_reference_filter_ids(const std::string & filter_query,
@@ -4533,9 +4532,9 @@ Option<bool> Collection::add_reference_fields(nlohmann::json& doc,
                                               const reference_filter_result_t& references,
                                               const tsl::htrie_set<char>& ref_include_fields_full,
                                               const tsl::htrie_set<char>& ref_exclude_fields_full,
-                                              const std::string& error_prefix) {
+                                              const std::string& error_prefix, const bool& is_reference_array) {
     // One-to-one relation.
-    if (references.count == 1) {
+    if (!is_reference_array && references.count == 1) {
         auto ref_doc_seq_id = references.docs[0];
 
         nlohmann::json ref_doc;
@@ -4744,54 +4743,74 @@ Option<bool> Collection::prune_doc(nlohmann::json& doc,
 
         Option<bool> add_reference_fields_op = Option<bool>(true);
         if (has_filter_reference) {
-            add_reference_fields_op = add_reference_fields(doc, ref_collection.get(), ref_include.alias,
-                                                           reference_filter_results.at(ref_collection_name),
-                                                           ref_include_fields_full, ref_exclude_fields_full,
-                                                           error_prefix);
-        } else if (doc_has_reference) {
-            auto get_reference_field_op = ref_collection->get_reference_field(collection->name);
+            auto get_reference_field_op = collection->get_referenced_in_field(ref_collection_name);
             if (!get_reference_field_op.ok()) {
                 continue;
             }
             auto const& field_name = get_reference_field_op.get();
-            auto get_reference_doc_id_op = collection->get_reference_doc_id(field_name, seq_id);
-            if (!get_reference_doc_id_op.ok()) {
+            if (ref_collection->search_schema.count(field_name) == 0) {
+                continue;
+            }
+            add_reference_fields_op = add_reference_fields(doc, ref_collection.get(), ref_include.alias,
+                                                           reference_filter_results.at(ref_collection_name),
+                                                           ref_include_fields_full, ref_exclude_fields_full, error_prefix,
+                                                           ref_collection->get_schema().at(field_name).is_array());
+        } else if (doc_has_reference) {
+            auto get_reference_field_op = ref_collection->get_referenced_in_field_with_lock(collection->name);
+            if (!get_reference_field_op.ok()) {
+                continue;
+            }
+            auto const& field_name = get_reference_field_op.get();
+            if (collection->search_schema.count(field_name) == 0) {
                 continue;
             }
 
-            reference_filter_result_t r{1, new uint32[1]{get_reference_doc_id_op.get()}};
-            add_reference_fields_op = add_reference_fields(doc, ref_collection.get(), ref_include.alias, r,
-                                                           ref_include_fields_full, ref_exclude_fields_full,
-                                                           error_prefix);
+            reference_filter_result_t result;
+            std::vector<uint32_t> ids;
+            auto get_references_op = collection->get_related_ids(field_name, seq_id, ids);
+            if (!get_references_op.ok()) {
+                continue;
+            }
+            result.count = ids.size();
+            result.docs = &ids[0];
+
+            add_reference_fields_op = add_reference_fields(doc, ref_collection.get(), ref_include.alias, result,
+                                                           ref_include_fields_full, ref_exclude_fields_full, error_prefix,
+                                                           collection->search_schema.at(field_name).is_array());
+            result.docs = nullptr;
         } else if (joined_coll_has_reference) {
             auto joined_collection = cm.get_collection(joined_coll_having_reference);
             if (joined_collection == nullptr) {
                 continue;
             }
 
-            auto reference_field_name_op = ref_collection->get_reference_field(joined_coll_having_reference);
-            if (!reference_field_name_op.ok()) {
+            auto reference_field_name_op = ref_collection->get_referenced_in_field_with_lock(joined_coll_having_reference);
+            if (!reference_field_name_op.ok() || joined_collection->get_schema().count(reference_field_name_op.get()) == 0) {
                 continue;
             }
 
             auto const& reference_field_name = reference_field_name_op.get();
             auto const& reference_filter_result = reference_filter_results.at(joined_coll_having_reference);
             auto const& count = reference_filter_result.count;
-            reference_filter_result_t r{count, new uint32[count]};
-
+            std::vector<uint32_t> ids;
+            ids.reserve(count);
             for (uint32_t i = 0; i < count; i++) {
-                auto op = joined_collection->get_sort_indexed_field_value(reference_field_name,
-                                                                          reference_filter_result.docs[i]);
-                if (!op.ok()) {
-                    return Option<bool>(op.code(), error_prefix + op.error());
-                }
-
-                r.docs[i] = op.get();
+                joined_collection->get_related_ids_with_lock(reference_field_name, reference_filter_result.docs[i], ids);
+            }
+            if (ids.empty()) {
+                continue;
             }
 
-            add_reference_fields_op = add_reference_fields(doc, ref_collection.get(), ref_include.alias, r,
-                                                           ref_include_fields_full, ref_exclude_fields_full,
-                                                           error_prefix);
+            gfx::timsort(ids.begin(), ids.end());
+            ids.erase(unique(ids.begin(), ids.end()), ids.end());
+
+            reference_filter_result_t result;
+            result.count = ids.size();
+            result.docs = &ids[0];
+            add_reference_fields_op = add_reference_fields(doc, ref_collection.get(), ref_include.alias, result,
+                                                           ref_include_fields_full, ref_exclude_fields_full, error_prefix,
+                                                           joined_collection->get_schema().at(reference_field_name).is_array());
+            result.docs = nullptr;
         }
 
         if (!add_reference_fields_op.ok()) {
@@ -5345,11 +5364,11 @@ Index* Collection::init_index() {
             auto ref_coll = collectionManager.get_collection(ref_coll_name);
             if (ref_coll != nullptr) {
                 // Passing reference helper field helps perform operation on doc_id instead of field value.
-                ref_coll->add_referenced_in(name, field.name + REFERENCE_HELPER_FIELD_SUFFIX);
+                ref_coll->add_referenced_in(name, field.name + fields::REFERENCE_HELPER_FIELD_SUFFIX);
             } else {
                 // Reference collection has not been created yet.
                 collectionManager.add_referenced_in_backlog(ref_coll_name,
-                                                            reference_pair{name, field.name + REFERENCE_HELPER_FIELD_SUFFIX});
+                                                            reference_pair{name, field.name + fields::REFERENCE_HELPER_FIELD_SUFFIX});
             }
         }
     }
@@ -5804,9 +5823,12 @@ void Collection::add_referenced_in(const std::string& collection_name, const std
     referenced_in.emplace(collection_name, field_name);
 }
 
-Option<std::string> Collection::get_reference_field(const std::string& collection_name) const {
+Option<std::string> Collection::get_referenced_in_field_with_lock(const std::string& collection_name) const {
     std::shared_lock lock(mutex);
+    return get_referenced_in_field(collection_name);
+}
 
+Option<std::string> Collection::get_referenced_in_field(const std::string& collection_name) const {
     if (referenced_in.count(collection_name) == 0) {
         return Option<std::string>(400, "Could not find any field in `" + name + "` referencing the collection `"
                                         + collection_name + "`.");
@@ -5815,9 +5837,16 @@ Option<std::string> Collection::get_reference_field(const std::string& collectio
     return Option<std::string>(referenced_in.at(collection_name));
 }
 
-Option<uint32_t> Collection::get_sort_indexed_field_value(const std::string& field_name, const uint32_t& seq_id) const {
+Option<bool> Collection::get_related_ids_with_lock(const std::string& field_name, const uint32_t& seq_id,
+                                                   std::vector<uint32_t>& result) const {
     std::shared_lock lock(mutex);
-    return index->get_sort_indexed_field_value(field_name, seq_id);
+    return index->get_related_ids(name, field_name, seq_id, result);
+}
+
+Option<uint32_t> Collection::get_sort_index_value_with_lock(const std::string& field_name,
+                                                            const uint32_t& seq_id) const {
+    std::shared_lock lock(mutex);
+    return index->get_sort_index_value_with_lock(name, field_name, seq_id);
 }
 
 void Collection::remove_embedding_field(const std::string& field_name) {

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -263,7 +263,7 @@ Option<bool> CollectionManager::load(const size_t collection_batch_size, const s
                     if (referenced_ins.count(ref_coll_name) == 0) {
                         referenced_ins[ref_coll_name] = {};
                     }
-                    auto const field_name = item.first + Collection::REFERENCE_HELPER_FIELD_SUFFIX;
+                    auto const field_name = item.first + fields::REFERENCE_HELPER_FIELD_SUFFIX;
                     referenced_ins.at(ref_coll_name).insert(reference_pair{collection_name, field_name});
                 }
             }

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -328,7 +328,7 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
         // Add a reference helper field in the schema. It stores the doc id of the document it references to reduce the
         // computation while searching.
         the_fields.emplace_back(
-                field(field_json[fields::name].get<std::string>() + Collection::REFERENCE_HELPER_FIELD_SUFFIX,
+                field(field_json[fields::name].get<std::string>() + fields::REFERENCE_HELPER_FIELD_SUFFIX,
                       field_types::is_array(field_json[fields::type].get<std::string>()) ? field_types::INT64_ARRAY : field_types::INT64,
                       false, field_json[fields::optional], true)
         );

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -329,7 +329,8 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
         // computation while searching.
         the_fields.emplace_back(
                 field(field_json[fields::name].get<std::string>() + Collection::REFERENCE_HELPER_FIELD_SUFFIX,
-                      "int64", false, field_json[fields::optional], true)
+                      field_types::is_array(field_json[fields::type].get<std::string>()) ? field_types::INT64_ARRAY : field_types::INT64,
+                      false, field_json[fields::optional], true)
         );
     }
 

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -647,7 +647,7 @@ void filter_result_iterator_t::init() {
                 return;
             }
 
-            auto get_reference_field_op = ref_collection->get_reference_field(collection_name);
+            auto get_reference_field_op = ref_collection->get_referenced_in_field_with_lock(collection_name);
             if (!get_reference_field_op.ok()) {
                 status = Option<bool>(get_reference_field_op.code(), get_reference_field_op.error());
                 is_valid = false;

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -1436,11 +1436,11 @@ TEST_F(CollectionManagerTest, ReferencedInBacklog) {
     referenced_ins_backlog = collectionManager._get_referenced_in_backlog();
     ASSERT_EQ(0, referenced_ins_backlog.count("Products"));
 
-    auto get_reference_field_op = create_op.get()->get_reference_field("collection1");
+    auto get_reference_field_op = create_op.get()->get_referenced_in_field_with_lock("collection1");
     ASSERT_TRUE(get_reference_field_op.ok());
     ASSERT_EQ("product_id_sequence_id", get_reference_field_op.get());
 
-    get_reference_field_op = create_op.get()->get_reference_field("foo");
+    get_reference_field_op = create_op.get()->get_referenced_in_field_with_lock("foo");
     ASSERT_FALSE(get_reference_field_op.ok());
     ASSERT_EQ("Could not find any field in `Products` referencing the collection `foo`.", get_reference_field_op.error());
 }


### PR DESCRIPTION
## Change Summary
* Implements the ability to have a `reference` in an array-type field(`int32[]`, `int64[]` and `string[]`) to lift the requirement of creating a junction collection in a scenario like:

```json
"name": "songs",
"fields": [
    { "name": "id", "type": "string" },
    { "name": "title", "type": "string" },
    { "name": "genres", "type": "string[]", "facet": true}
]

"name": "genres",
"fields": [
    { "name": "id", "type": "string" },
    { "name": "name", "type": "string" }
]
```
In the `songs` collection, `genres` field contains a list of genre ids. Instead of having a junction collection that would relate a song to a genre like:
```json
"name": "song_genre_relation",
"fields": [
    { "name": "song_id", "type": "string", "reference": "songs.id" },
    { "name": "genre_id", "type": "string", "reference": "genres.id" }
]
```
`reference` can now be specified in the `genres` field
```json
{ "name": "genres", "type": "string[]", "facet": true, "reference": "genres.id"}
```
The following request will include the related genre names of a song
```bash
curl 'http://localhost:8108/multi_search' -X POST -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -d '
  {"searches":[{
                "collection":"songs",
                "q":"*",
                "include_fields": "$genres(name) as genre",
                "exclude_fields": "genres_sequence_id"
}]}'
``` 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
