### PR TITLE
Include reference document by merging or nesting.

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -400,12 +400,14 @@ public:
     static void remove_flat_fields(nlohmann::json& document);
 
     static Option<bool> add_reference_fields(nlohmann::json& doc,
+                                             const std::string& ref_collection_name,
                                              Collection *const ref_collection,
                                              const std::string& alias,
                                              const reference_filter_result_t& references,
                                              const tsl::htrie_set<char>& ref_include_fields_full,
                                              const tsl::htrie_set<char>& ref_exclude_fields_full,
-                                             const std::string& error_prefix, const bool& is_reference_array);
+                                             const std::string& error_prefix, const bool& is_reference_array,
+                                             const bool& nest_ref_doc);
 
     static Option<bool> prune_doc(nlohmann::json& doc, const tsl::htrie_set<char>& include_names,
                                   const tsl::htrie_set<char>& exclude_names, const std::string& parent_name = "",

--- a/include/collection.h
+++ b/include/collection.h
@@ -267,7 +267,8 @@ private:
                                            std::vector<std::string>& processed_search_fields,
                                            bool extract_only_string_fields,
                                            bool enable_nested_fields,
-                                           const bool handle_wildcard = true);
+                                           const bool handle_wildcard = true,
+                                           const bool& include_id = false);
 
     bool is_nested_array(const nlohmann::json& obj, std::vector<std::string> path_parts, size_t part_i) const;
 

--- a/include/field.h
+++ b/include/field.h
@@ -496,9 +496,16 @@ namespace sort_field_const {
     static const std::string vector_query = "_vector_query";
 }
 
+namespace ref_include {
+    static const std::string merge = "merge";
+    static const std::string nest = "nest";
+}
+
 struct ref_include_fields {
-    std::string expression;
+    std::string collection_name;
+    std::string fields;
     std::string alias;
+    bool nest_ref_doc = false;
 };
 
 struct hnsw_index_t;

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -4440,12 +4440,14 @@ void Collection::remove_flat_fields(nlohmann::json& document) {
 }
 
 Option<bool> Collection::add_reference_fields(nlohmann::json& doc,
+                                              const std::string& ref_collection_name,
                                               Collection *const ref_collection,
                                               const std::string& alias,
                                               const reference_filter_result_t& references,
                                               const tsl::htrie_set<char>& ref_include_fields_full,
                                               const tsl::htrie_set<char>& ref_exclude_fields_full,
-                                              const std::string& error_prefix, const bool& is_reference_array) {
+                                              const std::string& error_prefix, const bool& is_reference_array,
+                                              const bool& nest_ref_doc) {
     // One-to-one relation.
     if (!is_reference_array && references.count == 1) {
         auto ref_doc_seq_id = references.docs[0];
@@ -4463,15 +4465,19 @@ Option<bool> Collection::add_reference_fields(nlohmann::json& doc,
             return Option<bool>(prune_op.code(), error_prefix + prune_op.error());
         }
 
-        if (!alias.empty()) {
-            auto temp_doc = ref_doc;
-            ref_doc.clear();
-            for (const auto &item: temp_doc.items()) {
-                ref_doc[alias + item.key()] = item.value();
+        if (nest_ref_doc && !ref_doc.empty()) {
+            auto field_name = alias.empty() ? ref_collection_name : alias;
+            doc[field_name] = ref_doc;
+        } else {
+            if (!alias.empty()) {
+                auto temp_doc = ref_doc;
+                ref_doc.clear();
+                for (const auto &item: temp_doc.items()) {
+                    ref_doc[alias + item.key()] = item.value();
+                }
             }
+            doc.update(ref_doc);
         }
-
-        doc.update(ref_doc);
         return Option<bool>(true);
     }
 
@@ -4492,17 +4498,21 @@ Option<bool> Collection::add_reference_fields(nlohmann::json& doc,
             return Option<bool>(prune_op.code(), error_prefix + prune_op.error());
         }
 
-        if (!alias.empty()) {
-            auto temp_doc = ref_doc;
-            ref_doc.clear();
-            for (const auto &item: temp_doc.items()) {
-                ref_doc[alias + item.key()] = item.value();
+        if (nest_ref_doc && !ref_doc.empty()) {
+            auto field_name = alias.empty() ? ref_collection_name : alias;
+            doc[field_name] += ref_doc;
+        } else {
+            if (!alias.empty()) {
+                auto temp_doc = ref_doc;
+                ref_doc.clear();
+                for (const auto &item: temp_doc.items()) {
+                    ref_doc[alias + item.key()] = item.value();
+                }
             }
-        }
-
-        for (auto ref_doc_it = ref_doc.begin(); ref_doc_it != ref_doc.end(); ref_doc_it++) {
-            // Add the values of ref_doc as JSON array into doc.
-            doc[ref_doc_it.key()] += ref_doc_it.value();
+            for (auto ref_doc_it = ref_doc.begin(); ref_doc_it != ref_doc.end(); ref_doc_it++) {
+                // Add the values of ref_doc as JSON array into doc.
+                doc[ref_doc_it.key()] += ref_doc_it.value();
+            }
         }
     }
 
@@ -4592,11 +4602,7 @@ Option<bool> Collection::prune_doc(nlohmann::json& doc,
     }
 
     for (auto const& ref_include: ref_includes) {
-        auto const& ref = ref_include.expression;
-        size_t parenthesis_index = ref.find('(');
-
-        auto ref_collection_name = ref.substr(1, parenthesis_index - 1);
-        auto reference_fields = ref.substr(parenthesis_index + 1, ref.size() - parenthesis_index - 2);
+        auto const& ref_collection_name = ref_include.collection_name;
 
         auto& cm = CollectionManager::get_instance();
         auto ref_collection = cm.get_collection(ref_collection_name);
@@ -4631,12 +4637,12 @@ Option<bool> Collection::prune_doc(nlohmann::json& doc,
         }
 
         std::vector<std::string> ref_include_fields_vec, ref_exclude_fields_vec;
-        StringUtils::split(reference_fields, ref_include_fields_vec, ",");
+        StringUtils::split(ref_include.fields, ref_include_fields_vec, ",");
         auto exclude_reference_it = exclude_names.equal_prefix_range("$" + ref_collection_name);
         if (exclude_reference_it.first != exclude_reference_it.second) {
             auto ref_exclude = exclude_reference_it.first.key();
-            parenthesis_index = ref_exclude.find('(');
-            reference_fields = ref_exclude.substr(parenthesis_index + 1, ref_exclude.size() - parenthesis_index - 2);
+            auto parenthesis_index = ref_exclude.find('(');
+            auto reference_fields = ref_exclude.substr(parenthesis_index + 1, ref_exclude.size() - parenthesis_index - 2);
             StringUtils::split(reference_fields, ref_exclude_fields_vec, ",");
         }
 
@@ -4664,10 +4670,12 @@ Option<bool> Collection::prune_doc(nlohmann::json& doc,
             if (ref_collection->search_schema.count(field_name) == 0) {
                 continue;
             }
-            add_reference_fields_op = add_reference_fields(doc, ref_collection.get(), ref_include.alias,
+            add_reference_fields_op = add_reference_fields(doc, ref_include.collection_name,
+                                                           ref_collection.get(), ref_include.alias,
                                                            reference_filter_results.at(ref_collection_name),
                                                            ref_include_fields_full, ref_exclude_fields_full, error_prefix,
-                                                           ref_collection->get_schema().at(field_name).is_array());
+                                                           ref_collection->get_schema().at(field_name).is_array(),
+                                                           ref_include.nest_ref_doc);
         } else if (doc_has_reference) {
             auto get_reference_field_op = ref_collection->get_referenced_in_field_with_lock(collection->name);
             if (!get_reference_field_op.ok()) {
@@ -4687,9 +4695,11 @@ Option<bool> Collection::prune_doc(nlohmann::json& doc,
             result.count = ids.size();
             result.docs = &ids[0];
 
-            add_reference_fields_op = add_reference_fields(doc, ref_collection.get(), ref_include.alias, result,
+            add_reference_fields_op = add_reference_fields(doc, ref_include.collection_name,
+                                                           ref_collection.get(), ref_include.alias, result,
                                                            ref_include_fields_full, ref_exclude_fields_full, error_prefix,
-                                                           collection->search_schema.at(field_name).is_array());
+                                                           collection->search_schema.at(field_name).is_array(),
+                                                           ref_include.nest_ref_doc);
             result.docs = nullptr;
         } else if (joined_coll_has_reference) {
             auto joined_collection = cm.get_collection(joined_coll_having_reference);
@@ -4720,9 +4730,11 @@ Option<bool> Collection::prune_doc(nlohmann::json& doc,
             reference_filter_result_t result;
             result.count = ids.size();
             result.docs = &ids[0];
-            add_reference_fields_op = add_reference_fields(doc, ref_collection.get(), ref_include.alias, result,
+            add_reference_fields_op = add_reference_fields(doc, ref_include.collection_name,
+                                                           ref_collection.get(), ref_include.alias, result,
                                                            ref_include_fields_full, ref_exclude_fields_full, error_prefix,
-                                                           joined_collection->get_schema().at(reference_field_name).is_array());
+                                                           joined_collection->get_schema().at(reference_field_name).is_array(),
+                                                           ref_include.nest_ref_doc);
             result.docs = nullptr;
         }
 

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -4465,9 +4465,13 @@ Option<bool> Collection::add_reference_fields(nlohmann::json& doc,
             return Option<bool>(prune_op.code(), error_prefix + prune_op.error());
         }
 
-        if (nest_ref_doc && !ref_doc.empty()) {
-            auto field_name = alias.empty() ? ref_collection_name : alias;
-            doc[field_name] = ref_doc;
+        if (ref_doc.empty()) {
+            return Option<bool>(true);
+        }
+
+        if (nest_ref_doc) {
+            auto key = alias.empty() ? ref_collection_name : alias;
+            doc[key] = ref_doc;
         } else {
             if (!alias.empty()) {
                 auto temp_doc = ref_doc;
@@ -4498,7 +4502,11 @@ Option<bool> Collection::add_reference_fields(nlohmann::json& doc,
             return Option<bool>(prune_op.code(), error_prefix + prune_op.error());
         }
 
-        if (nest_ref_doc && !ref_doc.empty()) {
+        if (ref_doc.empty()) {
+            continue;
+        }
+
+        if (nest_ref_doc) {
             auto key = alias.empty() ? ref_collection_name : alias;
             if (doc.contains(key) && !doc[key].is_array()) {
                 return Option<bool>(400, "Could not include the reference document of `" + ref_collection_name +

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -2079,6 +2079,30 @@ TEST_F(CollectionJoinTest, IncludeExcludeFieldsByReference) {
 
     // Add alias using `as`
     req_params = {
+            {"collection", "Products"},
+            {"q", "soap"},
+            {"query_by", "product_name"},
+            {"filter_by", "$Customers(id:*)"},
+            {"include_fields", "id, $Customers(id :merge)"}
+    };
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_FALSE(search_op.ok());
+    ASSERT_EQ("Could not include the value of `id` key of the reference document of `Customers` collection."
+              " Expected `id` to be an array. Try adding an alias.", search_op.error());
+
+    req_params = {
+            {"collection", "Products"},
+            {"q", "soap"},
+            {"query_by", "product_name"},
+            {"filter_by", "$Customers(id:*)"},
+            {"include_fields", "id, $Customers(id :nest) as id"}
+    };
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_FALSE(search_op.ok());
+    ASSERT_EQ("Could not include the reference document of `Customers` collection."
+              " Expected `id` to be an array. Try renaming the alias.", search_op.error());
+
+    req_params = {
             {"collection", "Customers"},
             {"q", "Joe"},
             {"query_by", "customer_name"},


### PR DESCRIPTION
## Change Summary
Adds the ability to choose between `merge` and `nest` reference include strategies. Syntax for reference include:
 `$<reference_collection_name>( <field_names> : <include_strategy>)  as <alias>`

If the following is the document of the collection being searched,
```json
{
  "foo": 1
}
```
and this is the reference document,
```json
{
  "bar": 2,
  "baz": 3
}
```
with `merge` strategy, the resulting document will be:
```json
{
  "foo": 1,
  "bar": 2,
  "baz": 3
}
```
with `nest` strategy, the resulting document will be:
```json
{
  "foo": 1,
  "alias": {
    "bar": 2,
    "baz": 3
  }
}
```




## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
