### PR TITLE
Allow a field inside an object to have `reference`.

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -356,7 +356,6 @@ public:
     static constexpr const char* COLLECTION_SYMBOLS_TO_INDEX = "symbols_to_index";
     static constexpr const char* COLLECTION_SEPARATORS = "token_separators";
 
-    static constexpr const char* REFERENCE_HELPER_FIELD_SUFFIX = "_sequence_id";
     // methods
 
     Collection() = delete;

--- a/include/collection.h
+++ b/include/collection.h
@@ -147,6 +147,10 @@ private:
     /// collection_name -> field_name
     spp::sparse_hash_map<std::string, std::string> referenced_in;
 
+    /// Reference helper fields that are part of an object. The reference doc of these fields will be included in the
+    /// object rather than in the document.
+    tsl::htrie_set<char> object_reference_helper_fields;
+
     // Keep index as the last field since it is initialized in the constructor via init_index(). Add a new field before it.
     Index* index;
 
@@ -208,7 +212,9 @@ private:
                                           const std::string& fallback_field_type,
                                           bool is_update,
                                           std::vector<field>& new_fields,
-                                          bool enable_nested_fields);
+                                          bool enable_nested_fields,
+                                          const spp::sparse_hash_map<std::string, reference_pair>& reference_fields,
+                                          tsl::htrie_set<char>& object_reference_helper_fields);
 
     static bool facet_count_compare(const facet_count_t& a, const facet_count_t& b) {
         return std::tie(a.count, a.fhash) > std::tie(b.count, b.fhash);
@@ -397,9 +403,13 @@ public:
 
     tsl::htrie_map<char, field> get_embedding_fields_unsafe();
 
+    tsl::htrie_set<char> get_object_reference_helper_fields();
+
     std::string get_default_sorting_field();
 
-    Option<bool> add_reference_helper_fields(nlohmann::json& document);
+    static Option<bool> add_reference_helper_fields(nlohmann::json& document, const tsl::htrie_map<char, field>& schema,
+                                                    const spp::sparse_hash_map<std::string, reference_pair>& reference_fields,
+                                                    tsl::htrie_set<char>& object_reference_helper_fields);
 
     Option<doc_seq_id_t> to_doc(const std::string& json_str, nlohmann::json& document,
                                 const index_operation_t& operation,

--- a/include/collection.h
+++ b/include/collection.h
@@ -320,9 +320,12 @@ private:
 
     Option<std::string> get_referenced_in_field(const std::string& collection_name) const;
 
-    Option<bool> get_related_ids(const std::string& ref_collection_name, const uint32_t& seq_id,
+    Option<bool> get_related_ids(const std::string& ref_field_name, const uint32_t& seq_id,
                                  std::vector<uint32_t>& result) const;
 
+    Option<bool> get_object_array_related_id(const std::string& ref_field_name,
+                                             const uint32_t& seq_id, const uint32_t& object_index,
+                                             uint32_t& result) const;
 
     void remove_embedding_field(const std::string& field_name);
 
@@ -430,15 +433,15 @@ public:
 
     static void remove_reference_helper_fields(nlohmann::json& document);
 
-    static Option<bool> add_reference_fields(nlohmann::json& doc,
-                                             const std::string& ref_collection_name,
-                                             Collection *const ref_collection,
-                                             const std::string& alias,
-                                             const reference_filter_result_t& references,
-                                             const tsl::htrie_set<char>& ref_include_fields_full,
-                                             const tsl::htrie_set<char>& ref_exclude_fields_full,
-                                             const std::string& error_prefix, const bool& is_reference_array,
-                                             const bool& nest_ref_doc);
+    static Option<bool> include_references(nlohmann::json& doc,
+                                           const std::string& ref_collection_name,
+                                           Collection *const ref_collection,
+                                           const std::string& alias,
+                                           const reference_filter_result_t& references,
+                                           const tsl::htrie_set<char>& ref_include_fields_full,
+                                           const tsl::htrie_set<char>& ref_exclude_fields_full,
+                                           const std::string& error_prefix, const bool& is_reference_array,
+                                           const bool& nest_ref_doc);
 
     static Option<bool> prune_doc(nlohmann::json& doc, const tsl::htrie_set<char>& include_names,
                                   const tsl::htrie_set<char>& exclude_names, const std::string& parent_name = "",

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -335,11 +335,11 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
     if (!field_json[fields::reference].get<std::string>().empty()) {
         // Add a reference helper field in the schema. It stores the doc id of the document it references to reduce the
         // computation while searching.
-        the_fields.emplace_back(
-                field(field_json[fields::name].get<std::string>() + fields::REFERENCE_HELPER_FIELD_SUFFIX,
-                      field_types::is_array(field_json[fields::type].get<std::string>()) ? field_types::INT64_ARRAY : field_types::INT64,
-                      false, field_json[fields::optional], true)
-        );
+        auto f = field(field_json[fields::name].get<std::string>() + fields::REFERENCE_HELPER_FIELD_SUFFIX,
+                       field_types::is_array(field_json[fields::type].get<std::string>()) ? field_types::INT64_ARRAY : field_types::INT64,
+                       false, field_json[fields::optional], true);
+        f.nested = field_json[fields::nested];
+        the_fields.emplace_back(std::move(f));
     }
 
     return Option<bool>(true);

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -314,6 +314,14 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
         if (tokens.size() < 2) {
             return Option<bool>(400, "Invalid reference `" + field_json[fields::reference].get<std::string>()  + "`.");
         }
+
+        tokens.clear();
+        StringUtils::split(field_json[fields::name].get<std::string>(), tokens, ".");
+
+        if (tokens.size() > 2) {
+            return Option<bool>(400, "`" + field_json[fields::name].get<std::string>() + "` field cannot have a reference."
+                                        " Only the top-level field of an object is allowed.");
+        }
     }
 
     the_fields.emplace_back(

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -359,10 +359,10 @@ Option<uint32_t> validator_t::coerce_int64_t(const DIRTY_VALUES& dirty_values, c
         item = std::atoll(item.get<std::string>().c_str());
     }
 
-    else if(is_array) {
-        if(!a_field.nested || !a_field.is_reference_helper || item.size() != 2 ||
-            !item.at(0).is_number() || !item.at(1).is_number()) {
-            return Option<>(400, "Expected `" + field_name + "` to be an object array reference helper field.");
+    else if(is_array && a_field.nested && a_field.is_reference_helper) {
+        if(item.size() != 2 || !item.at(0).is_number() || !item.at(1).is_number()) {
+            return Option<>(400, "`" + field_name + "` object array reference helper field has wrong value `"
+                                    + item.dump() + "`.");
         }
     }
 

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -359,6 +359,13 @@ Option<uint32_t> validator_t::coerce_int64_t(const DIRTY_VALUES& dirty_values, c
         item = std::atoll(item.get<std::string>().c_str());
     }
 
+    else if(is_array) {
+        if(!a_field.nested || !a_field.is_reference_helper || item.size() != 2 ||
+            !item.at(0).is_number() || !item.at(1).is_number()) {
+            return Option<>(400, "Expected `" + field_name + "` to be an object array reference helper field.");
+        }
+    }
+
     else {
         if(dirty_values == DIRTY_VALUES::COERCE_OR_DROP) {
             if(!a_field.optional) {

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -92,6 +92,21 @@ TEST_F(CollectionJoinTest, SchemaReferenceField) {
             R"({
                 "name": "Customers",
                 "fields": [
+                    {"name": "Object.object.field", "type": "string", "reference": "Products.product_id"},
+                    {"name": "customer_name", "type": "string"},
+                    {"name": "product_price", "type": "float"}
+                ]
+            })"_json;
+
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_FALSE(collection_create_op.ok());
+    ASSERT_EQ("`Object.object.field` field cannot have a reference. Only the top-level field of an object is allowed.",
+              collection_create_op.error());
+
+    schema_json =
+            R"({
+                "name": "Customers",
+                "fields": [
                     {"name": "product_id", "type": "string", "reference": "Products.product_id"},
                     {"name": "customer_name", "type": "string"},
                     {"name": "product_price", "type": "float"}
@@ -442,7 +457,14 @@ TEST_F(CollectionJoinTest, IndexDocumentHavingReferenceField) {
                     {"name": "ref_geopoint_field", "type": "geopoint", "optional": true, "reference": "coll1.geopoint_field"},
                     {"name": "ref_geopoint_array_field", "type": "geopoint[]", "optional": true, "reference": "coll1.geopoint_array_field"},
                     {"name": "ref_object_field", "type": "object", "optional": true, "reference": "coll1.object_field"},
-                    {"name": "ref_object_array_field", "type": "object[]", "optional": true, "reference": "coll1.object_array_field"}
+                    {"name": "ref_object_array_field", "type": "object[]", "optional": true, "reference": "coll1.object_array_field"},
+                    {"name": "non_indexed_object.ref_field", "type": "string", "optional": true, "reference": "coll1.string_field"},
+                    {"name": "object.ref_field", "type": "string", "optional": true, "reference": "coll1.string_field"},
+                    {"name": "object.ref_array_field", "type": "string[]", "optional": true, "reference": "coll1.string_array_field"},
+                    {"name": "object", "type": "object", "optional": true},
+                    {"name": "object_array.ref_field", "type": "string", "optional": true, "reference": "coll1.string_field"},
+                    {"name": "object_array.ref_array_field", "type": "string[]", "optional": true, "reference": "coll1.string_array_field"},
+                    {"name": "object_array", "type": "object[]", "optional": true}
                 ]
             })"_json;
     auto temp_json = schema_json;
@@ -498,7 +520,7 @@ TEST_F(CollectionJoinTest, IndexDocumentHavingReferenceField) {
     ASSERT_EQ("ref_string_field_sequence_id", doc[".ref"][0]);
 
     doc_json = R"({
-                    "ref_string_array_field": ["a", "d"]
+                    "ref_string_array_field": ["foo"]
                 })"_json;
     add_doc_op = coll2->add(doc_json.dump());
     ASSERT_TRUE(add_doc_op.ok());
@@ -800,6 +822,151 @@ TEST_F(CollectionJoinTest, IndexDocumentHavingReferenceField) {
     ASSERT_EQ(1, doc.count("ref_int64_array_field_sequence_id"));
     ASSERT_EQ(1, doc["ref_int64_array_field_sequence_id"].size());
     ASSERT_EQ(6, doc["ref_int64_array_field_sequence_id"][0]);
+
+    // reference field inside object/object[]
+    doc_json = R"({
+                    "non_indexed_object": {
+                        "ref_field": "foo"
+                    }
+                })"_json;
+    add_doc_op = coll2->add(doc_json.dump());
+    ASSERT_FALSE(add_doc_op.ok());
+    ASSERT_EQ("Could not find `non_indexed_object` object/object[] field in the schema.", add_doc_op.error());
+
+    doc_json = R"({
+                    "object": {
+                        "ref_field": 1
+                    }
+                })"_json;
+    add_doc_op = coll2->add(doc_json.dump());
+    ASSERT_FALSE(add_doc_op.ok());
+    ASSERT_EQ("Field `object.ref_field` must have `string` value.", add_doc_op.error());
+
+    doc_json = R"({
+                    "object": {
+                        "ref_array_field": [1]
+                    }
+                })"_json;
+    add_doc_op = coll2->add(doc_json.dump());
+    ASSERT_FALSE(add_doc_op.ok());
+    ASSERT_EQ("Field `object.ref_array_field` must only have `string` values.", add_doc_op.error());
+
+    doc_json = R"({
+                    "object_array": [
+                        {
+                            "ref_field": 1
+                        }
+                    ]
+                })"_json;
+    add_doc_op = coll2->add(doc_json.dump());
+    ASSERT_FALSE(add_doc_op.ok());
+    ASSERT_EQ("Field `object_array.ref_field` must have `string` value.", add_doc_op.error());
+
+    doc_json = R"({
+                    "object_array": [
+                        {
+                            "ref_field": "foo"
+                        }
+                    ]
+                })"_json;
+    add_doc_op = coll2->add(doc_json.dump());
+    ASSERT_FALSE(add_doc_op.ok());
+    ASSERT_EQ("Reference document having `string_field:= foo` not found in the collection `coll1`.", add_doc_op.error());
+
+    doc_json = R"({
+                    "object_array": [
+                        {
+                            "ref_field": "a"
+                        }
+                    ]
+                })"_json;
+    add_doc_op = coll2->add(doc_json.dump());
+    ASSERT_FALSE(add_doc_op.ok());
+    ASSERT_EQ("Field `object_array.ref_field` has an incorrect type."
+              " Hint: field inside an array of objects must be an array type as well.", add_doc_op.error());
+
+    doc_json = R"({
+                    "object_array": [
+                        {
+                            "ref_array_field": "foo"
+                        }
+                    ]
+                })"_json;
+    add_doc_op = coll2->add(doc_json.dump());
+    ASSERT_FALSE(add_doc_op.ok());
+    ASSERT_EQ("Reference document having `string_array_field:= foo` not found in the collection `coll1`.", add_doc_op.error());
+
+    collectionManager.drop_collection("coll2");
+    temp_json = schema_json;
+    collection_create_op = collectionManager.create_collection(temp_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    coll2 = collection_create_op.get();
+
+    doc_json = R"({
+                    "object": {
+                        "ref_field": "d"
+                    }
+                })"_json;
+    add_doc_op = coll2->add(doc_json.dump());
+    ASSERT_TRUE(add_doc_op.ok());
+
+    doc = coll2->get("0").get();
+    ASSERT_EQ(1, doc.count("object.ref_field_sequence_id"));
+    ASSERT_EQ(1, doc["object.ref_field_sequence_id"]);
+    ASSERT_EQ(1, doc.count(".ref"));
+    ASSERT_EQ(1, doc[".ref"].size());
+    ASSERT_EQ("object.ref_field_sequence_id", doc[".ref"][0]);
+    ASSERT_EQ(1, coll2->get_object_reference_helper_fields().count("object.ref_field_sequence_id"));
+
+    doc_json = R"({
+                    "object": {
+                        "ref_array_field": ["foo"]
+                    }
+                })"_json;
+    add_doc_op = coll2->add(doc_json.dump());
+    ASSERT_TRUE(add_doc_op.ok());
+
+    doc = coll2->get("1").get();
+    ASSERT_EQ(1, doc.count("object.ref_array_field_sequence_id"));
+    ASSERT_EQ(0, doc["object.ref_array_field_sequence_id"].size());
+    ASSERT_EQ(1, doc.count(".ref"));
+    ASSERT_EQ(1, doc[".ref"].size());
+    ASSERT_EQ("object.ref_array_field_sequence_id", doc[".ref"][0]);
+
+    doc_json = R"({
+                    "object": {
+                        "ref_array_field": ["b", "foo"]
+                    }
+                })"_json;
+    add_doc_op = coll2->add(doc_json.dump());
+    ASSERT_TRUE(add_doc_op.ok());
+
+    doc = coll2->get("2").get();
+    ASSERT_EQ(1, doc.count("object.ref_array_field_sequence_id"));
+    ASSERT_EQ(1, doc["object.ref_array_field_sequence_id"].size());
+    ASSERT_EQ(0, doc["object.ref_array_field_sequence_id"][0]);
+
+    doc_json = R"({
+                    "object_array": [
+                        {
+                            "ref_array_field": "c"
+                        },
+                        {
+                            "ref_array_field": "e"
+                        }
+                    ]
+                })"_json;
+    add_doc_op = coll2->add(doc_json.dump());
+    ASSERT_TRUE(add_doc_op.ok());
+
+    doc = coll2->get("3").get();
+    ASSERT_EQ(1, doc.count("object_array.ref_array_field_sequence_id"));
+    ASSERT_EQ(2, doc["object_array.ref_array_field_sequence_id"].size());
+    ASSERT_EQ(0, doc["object_array.ref_array_field_sequence_id"][0]);
+    ASSERT_EQ(1, doc["object_array.ref_array_field_sequence_id"][1]);
+    ASSERT_EQ(1, doc.count(".ref"));
+    ASSERT_EQ(1, doc[".ref"].size());
+    ASSERT_EQ("object_array.ref_array_field_sequence_id", doc[".ref"][0]);
 
     // float/float[] reference fields
     doc_json = R"({
@@ -2592,6 +2759,132 @@ TEST_F(CollectionJoinTest, FilterByReferenceArrayField) {
     ASSERT_EQ("Grunge", res_obj["hits"][2]["document"]["name"].get<std::string>());
     ASSERT_EQ(1, res_obj["hits"][2]["document"]["song.title"].size());
     ASSERT_EQ("Corduroy", res_obj["hits"][2]["document"]["song.title"][0]);
+}
+
+TEST_F(CollectionJoinTest, FilterByObjectReferenceField) {
+    auto schema_json =
+            R"({
+                "name": "Portions",
+                "fields": [
+                    {"name": "portion_id", "type": "string"},
+                    {"name": "quantity", "type": "int32"},
+                    {"name": "unit", "type": "string"}
+                ]
+            })"_json;
+    std::vector<nlohmann::json> documents = {
+            R"({
+                "portion_id": "portion_a",
+                "quantity": 500,
+                "unit": "g"
+            })"_json,
+            R"({
+                "portion_id": "portion_b",
+                "quantity": 1,
+                "unit": "lt"
+            })"_json,
+            R"({
+                "portion_id": "portion_c",
+                "quantity": 500,
+                "unit": "ml"
+            })"_json
+    };
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    for (auto const &json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    schema_json =
+            R"({
+                "name": "Foods",
+                "fields": [
+                    {"name": "name", "type": "string"},
+                    {"name": "portions", "type": "object[]"},
+                    {"name": "portions.portion_id", "type": "string[]", "reference": "Portions.portion_id"}
+                ],
+                "enable_nested_fields": true
+            })"_json;
+    documents = {
+            R"({
+                "name": "Bread",
+                "portions": [
+                    {
+                        "portion_id": "portion_a",
+                        "count": 10
+                    }
+                ]
+            })"_json,
+            R"({
+                "name": "Milk",
+                "portions": [
+                    {
+                        "portion_id": "portion_b",
+                        "count": 3
+                    },
+                    {
+                        "portion_id": "portion_c",
+                        "count": 1
+                    }
+                ]
+            })"_json
+    };
+
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    for (auto const &json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    std::map<std::string, std::string> req_params = {
+            {"collection", "Foods"},
+            {"q", "*"},
+            {"include_fields", "$Portions(*:merge)"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op_bool = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op_bool.ok());
+
+    auto res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, res_obj["found"].get<size_t>());
+    ASSERT_EQ(2, res_obj["hits"].size());
+    ASSERT_EQ(3, res_obj["hits"][0]["document"].size());
+    ASSERT_EQ(1, res_obj["hits"][0]["document"].count("name"));
+
+    ASSERT_EQ("Milk", res_obj["hits"][0]["document"]["name"]);
+    ASSERT_EQ(1, res_obj["hits"][0]["document"].count("portions"));
+    ASSERT_EQ(2, res_obj["hits"][0]["document"]["portions"].size());
+    ASSERT_EQ(5, res_obj["hits"][0]["document"]["portions"][0].size());
+    ASSERT_EQ("portion_b", res_obj["hits"][0]["document"]["portions"][0].at("portion_id"));
+    ASSERT_EQ(1 , res_obj["hits"][0]["document"]["portions"][0].at("quantity"));
+    ASSERT_EQ("lt", res_obj["hits"][0]["document"]["portions"][0].at("unit"));
+    ASSERT_EQ(3 , res_obj["hits"][0]["document"]["portions"][0].at("count"));
+    ASSERT_EQ(5, res_obj["hits"][0]["document"]["portions"][1].size());
+    ASSERT_EQ("portion_c", res_obj["hits"][0]["document"]["portions"][1].at("portion_id"));
+    ASSERT_EQ(500 , res_obj["hits"][0]["document"]["portions"][1].at("quantity"));
+    ASSERT_EQ("ml", res_obj["hits"][0]["document"]["portions"][1].at("unit"));
+    ASSERT_EQ(1 , res_obj["hits"][0]["document"]["portions"][1].at("count"));
+
+    ASSERT_EQ("Bread", res_obj["hits"][1]["document"]["name"]);
+    ASSERT_EQ(1, res_obj["hits"][1]["document"].count("portions"));
+    ASSERT_EQ(1, res_obj["hits"][1]["document"]["portions"].size());
+    ASSERT_EQ(5, res_obj["hits"][1]["document"]["portions"][0].size());
+    ASSERT_EQ("portion_a", res_obj["hits"][1]["document"]["portions"][0].at("portion_id"));
+    ASSERT_EQ(500 , res_obj["hits"][1]["document"]["portions"][0].at("quantity"));
+    ASSERT_EQ("g", res_obj["hits"][1]["document"]["portions"][0].at("unit"));
+    ASSERT_EQ(10 , res_obj["hits"][1]["document"]["portions"][0].at("count"));
 }
 
 TEST_F(CollectionJoinTest, CascadeDeletion) {


### PR DESCRIPTION
## Change Summary
Adds the ability to have a `reference` field inside an object. If we have an object `order` in the document and it has a reference to a `product`, the following schema can be specified:
```json
{
  "name": "Coll",
  "fields": [
    {"name": "order", "type": "object"},
    {"name": "order.product_id", "type": "string", "reference": "Products.id"}
  ]
}
```
If we had an array of objects instead with each object containing a reference, the type of the reference field would be array as well
```json
{
  "name": "Coll",
  "fields": [
    {"name": "order", "type": "object[]"},
    {"name": "order.product_id", "type": "string[]", "reference": "Products.id"}
  ]
}
```
The referenced document of an object is included inside the object itself instead of in the document.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
