### PR TITLE
Fix infix search + filtering regression

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -813,8 +813,8 @@ public:
                                  const std::vector<size_t>& geopoint_indices,
                                  const std::string& collection_name = "") const;
 
-    void search_infix(const std::string& query, const std::string& field_name, std::vector<uint32_t>& ids,
-                      size_t max_extra_prefix, size_t max_extra_suffix) const;
+    Option<bool> search_infix(const std::string& query, const std::string& field_name, std::vector<uint32_t>& ids,
+                              size_t max_extra_prefix, size_t max_extra_suffix) const;
 
     void curate_filtered_ids(const std::set<uint32_t>& curated_ids,
                              const uint32_t* exclude_token_ids, size_t exclude_token_ids_size, uint32_t*& filter_ids,

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -5128,6 +5128,7 @@ Option<bool> Index::do_infix_search(const size_t num_search_fields, const std::v
                     }
 
                     filtered_infix_ids = std::move(result);
+                    filter_result_iterator->reset();
                 }
 
                 bool field_is_array = search_schema.at(the_fields[field_id].name).is_array();

--- a/test/collection_infix_search_test.cpp
+++ b/test/collection_infix_search_test.cpp
@@ -194,8 +194,8 @@ TEST_F(CollectionInfixSearchTest, InfixWithFiltering) {
             R"({
                 "name": "Foods",
                 "fields": [
-                    {"name": "title", "type": "string"},
-                    {"name": "summary", "type": "string"},
+                    {"name": "title", "type": "string", "infix": true},
+                    {"name": "summary", "type": "string", "infix": true},
                     {"name": "rating", "type": "int32"}
                 ]
             })"_json;


### PR DESCRIPTION
## Change Summary
* Fixes issue with infix search where `filter_by` was not filtering the results.
* Adds an error response when trying to do infix search without enabling it first.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
