### PR TITLE
adding popularity score

### DIFF
--- a/include/analytics_manager.h
+++ b/include/analytics_manager.h
@@ -46,6 +46,11 @@ struct click_event_t {
     }
 };
 
+struct popular_clicks_t {
+    std::string counter_field;
+    std::map<std::string, uint64_t> docid_counts;
+};
+
 struct query_hits_count_t {
     std::string query;
     uint64_t timestamp;
@@ -137,6 +142,9 @@ private:
     // suggestion collection => nohits queries
     std::unordered_map<std::string, QueryAnalytics*> nohits_queries;
 
+    // collection => popular clicks
+    std::unordered_map<std::string, popular_clicks_t> popular_clicks;
+
     //query collection => click events
     std::unordered_map<std::string, std::vector<click_event_t>> query_collection_click_events;
 
@@ -163,6 +171,7 @@ public:
     static constexpr const char* QUERY_HITS_COUNT = "$QH";
     static constexpr const char* POPULAR_QUERIES_TYPE = "popular_queries";
     static constexpr const char* NOHITS_QUERIES_TYPE = "nohits_queries";
+    static constexpr const char* POPULAR_CLICKS_TYPE = "popular_clicks";
 
     static AnalyticsManager& get_instance() {
         static AnalyticsManager instance;
@@ -200,7 +209,11 @@ public:
 
     void persist_query_hits_click_events(ReplicationState *raft_server, uint64_t prev_persistence_s);
 
+    void persist_popular_clicks(ReplicationState *raft_server, uint64_t prev_persistence_s);
+
     nlohmann::json get_click_events();
+
+    std::unordered_map<std::string, popular_clicks_t> get_popular_clicks();
 
     Option<bool> write_events_to_store(nlohmann::json& event_jsons);
 

--- a/include/collection.h
+++ b/include/collection.h
@@ -396,6 +396,8 @@ public:
 
     std::vector<field> get_fields();
 
+    bool contains_field(const std::string&);
+
     std::unordered_map<std::string, field> get_dynamic_fields();
 
     tsl::htrie_map<char, field> get_schema();

--- a/src/analytics_manager.cpp
+++ b/src/analytics_manager.cpp
@@ -113,9 +113,13 @@ Option<bool> AnalyticsManager::create_queries_index(nlohmann::json &payload, boo
             return Option<bool>(400, "There's already another configuration for this destination collection.");
         }
 
-        auto coll_schema = CollectionManager::get_instance().get_collection(suggestion_collection)->get_schema();
-        if(coll_schema.find(counter_field) == coll_schema.end()) {
-            return Option<bool>(404, "counter_field not found in destination collection.");
+        auto coll = CollectionManager::get_instance().get_collection(suggestion_collection).get();
+        if(coll != nullptr) {
+            if (!coll->contains_field(counter_field)) {
+                return Option<bool>(404, "counter_field `" + counter_field + "` not found in destination collection.");
+            }
+        } else {
+            return Option<bool>(404, "Collection `" + suggestion_collection + "` not found.");
         }
     }
 

--- a/src/analytics_manager.cpp
+++ b/src/analytics_manager.cpp
@@ -43,7 +43,8 @@ Option<bool> AnalyticsManager::create_rule(nlohmann::json& payload, bool upsert,
         return Option<bool>(400, "Bad or missing params.");
     }
 
-    if(payload["type"] == POPULAR_QUERIES_TYPE || payload["type"] == NOHITS_QUERIES_TYPE) {
+    if(payload["type"] == POPULAR_QUERIES_TYPE || payload["type"] == NOHITS_QUERIES_TYPE
+            || payload["type"] == POPULAR_CLICKS_TYPE) {
         return create_queries_index(payload, upsert, write_to_disk);
     }
 
@@ -84,6 +85,15 @@ Option<bool> AnalyticsManager::create_queries_index(nlohmann::json &payload, boo
         return Option<bool>(400, "Must contain a valid destination collection.");
     }
 
+    std::string counter_field;
+
+    if(params["destination"].contains("counter_field")) {
+        if (!params["destination"]["counter_field"].is_string()) {
+            return Option<bool>(400, "Must contain a valid counter_field.");
+        }
+        counter_field = params["destination"]["counter_field"].get<std::string>();
+    }
+
     const std::string& suggestion_collection = params["destination"]["collection"].get<std::string>();
     suggestion_config_t suggestion_config;
     suggestion_config.name = suggestion_config_name;
@@ -97,6 +107,15 @@ Option<bool> AnalyticsManager::create_queries_index(nlohmann::json &payload, boo
     } else if(payload["type"] == NOHITS_QUERIES_TYPE) {
         if (!upsert && nohits_queries.count(suggestion_collection) != 0) {
             return Option<bool>(400, "There's already another configuration for this destination collection.");
+        }
+    } else if(payload["type"] == POPULAR_CLICKS_TYPE) {
+        if (!upsert && popular_clicks.count(suggestion_collection) != 0) {
+            return Option<bool>(400, "There's already another configuration for this destination collection.");
+        }
+
+        auto coll_schema = CollectionManager::get_instance().get_collection(suggestion_collection)->get_schema();
+        if(coll_schema.find(counter_field) == coll_schema.end()) {
+            return Option<bool>(404, "counter_field not found in destination collection.");
         }
     }
 
@@ -131,6 +150,8 @@ Option<bool> AnalyticsManager::create_queries_index(nlohmann::json &payload, boo
     } else if(payload["type"] == NOHITS_QUERIES_TYPE) {
         QueryAnalytics *noresultsQueries = new QueryAnalytics(limit);
         nohits_queries.emplace(suggestion_collection, noresultsQueries);
+    } else if(payload["type"] == POPULAR_CLICKS_TYPE) {
+        popular_clicks.emplace(suggestion_collection, popular_clicks_t{counter_field, {}});
     }
 
     if(write_to_disk) {
@@ -278,6 +299,13 @@ Option<bool> AnalyticsManager::add_click_event(const std::string &query_collecti
         click_event_t click_event(query, now_ts_useconds, user_id, doc_id, position);
         click_events_vec.emplace_back(click_event);
 
+        auto popular_clicks_it = popular_clicks.find(query_collection);
+        if(popular_clicks_it != popular_clicks.end()) {
+            popular_clicks_it->second.docid_counts[doc_id]++;
+        } else {
+            LOG(ERROR) << "collection " << query_collection << " not found in analytics rule.";
+        }
+
         return Option<bool>(true);
     }
 
@@ -346,6 +374,7 @@ void AnalyticsManager::run(ReplicationState* raft_server) {
         checkEventsExpiry();
         persist_query_events(raft_server, prev_persistence_s);
         persist_query_hits_click_events(raft_server, prev_persistence_s);
+        persist_popular_clicks(raft_server, prev_persistence_s);
 
         prev_persistence_s = std::chrono::duration_cast<std::chrono::seconds>(
                 std::chrono::system_clock::now().time_since_epoch()).count();
@@ -508,6 +537,41 @@ void AnalyticsManager::persist_query_hits_click_events(ReplicationState *raft_se
     }
 }
 
+void AnalyticsManager::persist_popular_clicks(ReplicationState *raft_server, uint64_t prev_persistence_s) {
+    auto send_http_response = [&](const std::string& import_payload, const std::string& collection) {
+        if (import_payload.empty()) {
+            return;
+        }
+
+        std::string leader_url = raft_server->get_leader_url();
+        if (!leader_url.empty()) {
+            const std::string &base_url = leader_url + "collections/" + collection;
+            std::string res;
+
+            const std::string &update_url = base_url + "/documents/import?action=update";
+            std::map<std::string, std::string> res_headers;
+            long status_code = HttpClient::post_response(update_url, import_payload,
+                                                         res, res_headers, {}, 10 * 1000, true);
+
+            if (status_code != 200) {
+                LOG(ERROR) << "Error while sending popular_clicks events to leader. "
+                           << "Status code: " << status_code << ", response: " << res;
+            }
+        }
+    };
+
+    for(const auto& popular_clicks_it : popular_clicks) {
+        auto coll = popular_clicks_it.first;
+        nlohmann::json doc;
+        auto counter_field = popular_clicks_it.second.counter_field;
+        for(const auto& popular_click : popular_clicks_it.second.docid_counts) {
+            doc["id"] = popular_click.first;
+            doc[counter_field] = popular_click.second;
+            send_http_response(doc, coll);
+        }
+    }
+}
+
 void AnalyticsManager::stop() {
     quit = true;
     cv.notify_all();
@@ -542,6 +606,11 @@ std::unordered_map<std::string, QueryAnalytics*> AnalyticsManager::get_popular_q
 std::unordered_map<std::string, QueryAnalytics*> AnalyticsManager::get_nohits_queries() {
     std::unique_lock lk(mutex);
     return nohits_queries;
+}
+
+std::unordered_map<std::string, popular_clicks_t> AnalyticsManager::get_popular_clicks() {
+    std::unique_lock lk(mutex);
+    return popular_clicks;
 }
 
 nlohmann::json AnalyticsManager::get_click_events() {

--- a/src/analytics_manager.cpp
+++ b/src/analytics_manager.cpp
@@ -543,10 +543,6 @@ void AnalyticsManager::persist_query_hits_click_events(ReplicationState *raft_se
 
 void AnalyticsManager::persist_popular_clicks(ReplicationState *raft_server, uint64_t prev_persistence_s) {
     auto send_http_response = [&](const std::string& import_payload, const std::string& collection) {
-        if (import_payload.empty()) {
-            return;
-        }
-
         std::string leader_url = raft_server->get_leader_url();
         if (!leader_url.empty()) {
             const std::string &base_url = leader_url + "collections/" + collection;
@@ -571,7 +567,7 @@ void AnalyticsManager::persist_popular_clicks(ReplicationState *raft_server, uin
         for(const auto& popular_click : popular_clicks_it.second.docid_counts) {
             doc["id"] = popular_click.first;
             doc[counter_field] = popular_click.second;
-            send_http_response(doc, coll);
+            send_http_response(doc.dump(), coll);
         }
     }
 }

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -4336,6 +4336,11 @@ std::vector<field> Collection::get_fields() {
     return fields;
 }
 
+bool Collection::contains_field(const std::string &field) {
+    std::shared_lock lock(mutex);
+    return search_schema.find(field) != search_schema.end();
+}
+
 std::unordered_map<std::string, field> Collection::get_dynamic_fields() {
     std::shared_lock lock(mutex);
     return dynamic_fields;


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
### Popularity Score
 Typesense supports feature of popularity score with analytics.

Assume we have a collection `products` with following schema,
```json
       {
            "name": "products",
            "fields": [
                {"name": "title", "type": "string"},
                {"name": "popularity", "type": "int32"}
            ]
        }
```
And we import following records,
```json
{"id": "0", "title": "Cool trousers", "popularity": 0}
{"id": "1", "title": "Funky trousers", "popularity": 0}
{"id": "2", "title": "Casual shorts", "popularity": 0}
{"id": "3", "title": "Trendy shorts", "popularity": 0}
{"id": "4", "title": "Formal pants", "popularity": 0}
```
Now we have to create analytics rule for aggregation of popularity score like below,
```curl
curl -k "http://localhost:8108/analytics/rules" \
      -X POST \
      -H "Content-Type: application/json" \
      -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
      -d '{
        "name": "product_popularity_rule",
        "type": "popular_clicks",
        "params": {
            "source": {
                "collections": ["products"]
            },
            "destination": {
                "collection": "products", 
                "counter_field": "popularity"
            }
        }
      }'
```
Here we have to provide valid collection name in `source` and `destination` params. 
Additionally destination collection should have the provided `counter_field` which will be updated.

Let's assume someone searches with query `trousers` and clicks on `Funky trousers`.
So accordingly click event will be sent to end-point like below,
 ```curl
curl "http://localhost:8108/analytics/click_events" -X POST -H "Content-Type: application/json" -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -d '{
                          "type": "query_click",
                          "data": {
                                  "q": "trousers",
                                  "collection": "products",
                                  "doc_id": "1",
                                  "position": 3,
             		          "user_id": "12"
                                  }
                      }' 
 ```

Similarly for other click event can be sent ,
```curl
curl "http://localhost:8108/analytics/click_events" -X POST -H "Content-Type: application/json" -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -d '{
                          "type": "query_click",
                          "data": {
                                  "q": "shorts",
                                  "collection": "products",
                                  "doc_id": "3",
                                  "position": 3,
             		          "user_id": "12"
                                  }
                      }' 
```
On `analytics-flush-interval` this events will be aggregated to the destination collection's `counter_field`.

With wildcard search, we can see the documents will be having updated count in `popularity`.
```json
{"facet_counts":[],"found":5,"hits":[{"document":{"id":"3","popularity":1,"title":"Trendy shorts"},"highlight":{},"highlights":[]},{"document":{"id":"1","popularity":1,"title":"Funky trousers"},"highlight":{},"highlights":[]},{"document":{"id":"4","popularity":0,"title":"Formal pants"},"highlight":{},"highlights":[]},{"document":{"id":"2","popularity":0,"title":"Casual shorts"},"highlight":{},"highlights":[]},{"document":{"id":"0","popularity":0,"title":"Cool trousers"},"highlight":{},"highlights":[]}],"out_of":5,"page":1,"request_params":{"collection_name":"products","per_page":10,"q":"*"},"search_cutoff":false,"search_time_ms":0}
```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
