### PR TITLE
Nested Join.

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -446,7 +446,7 @@ public:
                                            const tsl::htrie_set<char>& ref_include_fields_full,
                                            const tsl::htrie_set<char>& ref_exclude_fields_full,
                                            const std::string& error_prefix, const bool& is_reference_array,
-                                           const bool& nest_ref_doc);
+                                           const ref_include::strategy_enum& strategy);
 
     static Option<bool> prune_doc(nlohmann::json& doc, const tsl::htrie_set<char>& include_names,
                                   const tsl::htrie_set<char>& exclude_names, const std::string& parent_name = "",

--- a/include/collection.h
+++ b/include/collection.h
@@ -438,22 +438,23 @@ public:
 
     static void remove_reference_helper_fields(nlohmann::json& document);
 
-    static Option<bool> include_references(nlohmann::json& doc,
-                                           const std::string& ref_collection_name,
-                                           Collection *const ref_collection,
-                                           const std::string& alias,
-                                           const reference_filter_result_t& references,
-                                           const tsl::htrie_set<char>& ref_include_fields_full,
-                                           const tsl::htrie_set<char>& ref_exclude_fields_full,
-                                           const std::string& error_prefix, const bool& is_reference_array,
-                                           const ref_include::strategy_enum& strategy);
+    static Option<bool> prune_ref_doc(nlohmann::json& doc,
+                                      const reference_filter_result_t& references,
+                                      const tsl::htrie_set<char>& ref_include_fields_full,
+                                      const tsl::htrie_set<char>& ref_exclude_fields_full,
+                                      const bool& is_reference_array,
+                                      const ref_include_exclude_fields& ref_include_exclude);
+
+    static Option<bool> include_references(nlohmann::json& doc, const uint32_t& seq_id, Collection *const collection,
+                                           const std::map<std::string, reference_filter_result_t>& reference_filter_results,
+                                           const std::vector<ref_include_exclude_fields>& ref_include_exclude_fields_vec);
 
     static Option<bool> prune_doc(nlohmann::json& doc, const tsl::htrie_set<char>& include_names,
                                   const tsl::htrie_set<char>& exclude_names, const std::string& parent_name = "",
                                   size_t depth = 0,
                                   const std::map<std::string, reference_filter_result_t>& reference_filter_results = {},
                                   Collection *const collection = nullptr, const uint32_t& seq_id = 0,
-                                  const std::vector<ref_include_fields>& ref_include_fields_vec = {});
+                                  const std::vector<ref_include_exclude_fields>& ref_include_exclude_fields_vec = {});
 
     const Index* _get_index() const;
 
@@ -558,7 +559,7 @@ public:
                                   const size_t remote_embedding_num_tries = 2,
                                   const std::string& stopwords_set="",
                                   const std::vector<std::string>& facet_return_parent = {},
-                                  const std::vector<ref_include_fields>& ref_include_fields_vec = {},
+                                  const std::vector<ref_include_exclude_fields>& ref_include_exclude_fields_vec = {},
                                   const std::string& drop_tokens_mode = "right_to_left",
                                   const bool prioritize_num_matching_fields = true,
                                   const bool group_missing_values = true,

--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -113,6 +113,15 @@ public:
     CollectionManager(CollectionManager const&) = delete;
     void operator=(CollectionManager const&) = delete;
 
+    struct ref_include_collection_names_t {
+        std::set<std::string> collection_names;
+        ref_include_collection_names_t* nested_include = nullptr;
+
+        ~ref_include_collection_names_t() {
+            delete nested_include;
+        }
+    };
+
     static Collection* init_collection(const nlohmann::json & collection_meta,
                                        const uint32_t collection_next_seq_id,
                                        Store* store,
@@ -210,7 +219,12 @@ public:
     Option<bool> delete_preset(const std::string & preset_name);
 
     static void _get_reference_collection_names(const std::string& filter_query,
-                                                std::set<std::string>& reference_collection_names);
+                                                ref_include_collection_names_t*& reference_collection_names);
+
+    // Separate out the reference includes into `ref_include_fields_vec`.
+    static void _initialize_ref_include_fields_vec(const std::string& filter_query,
+                                                   std::vector<std::string>& include_fields_vec,
+                                                   std::vector<ref_include_fields>& ref_include_fields_vec);
 
     void add_referenced_in_backlog(const std::string& collection_name, reference_pair&& pair);
 

--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -221,10 +221,11 @@ public:
     static void _get_reference_collection_names(const std::string& filter_query,
                                                 ref_include_collection_names_t*& reference_collection_names);
 
-    // Separate out the reference includes into `ref_include_fields_vec`.
-    static Option<bool> _initialize_ref_include_fields_vec(const std::string& filter_query,
-                                                           std::vector<std::string>& include_fields_vec,
-                                                           std::vector<ref_include_fields>& ref_include_fields_vec);
+    // Separate out the reference includes and excludes into `ref_include_exclude_fields_vec`.
+    static Option<bool> _initialize_ref_include_exclude_fields_vec(const std::string& filter_query,
+                                                                   std::vector<std::string>& include_fields_vec,
+                                                                   std::vector<std::string>& exclude_fields_vec,
+                                                                   std::vector<ref_include_exclude_fields>& ref_include_exclude_fields_vec);
 
     void add_referenced_in_backlog(const std::string& collection_name, reference_pair&& pair);
 

--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -222,9 +222,9 @@ public:
                                                 ref_include_collection_names_t*& reference_collection_names);
 
     // Separate out the reference includes into `ref_include_fields_vec`.
-    static void _initialize_ref_include_fields_vec(const std::string& filter_query,
-                                                   std::vector<std::string>& include_fields_vec,
-                                                   std::vector<ref_include_fields>& ref_include_fields_vec);
+    static Option<bool> _initialize_ref_include_fields_vec(const std::string& filter_query,
+                                                           std::vector<std::string>& include_fields_vec,
+                                                           std::vector<ref_include_fields>& ref_include_fields_vec);
 
     void add_referenced_in_backlog(const std::string& collection_name, reference_pair&& pair);
 

--- a/include/field.h
+++ b/include/field.h
@@ -518,7 +518,10 @@ struct ref_include_fields {
     std::string collection_name;
     std::string fields;
     std::string alias;
-    bool nest_ref_doc = false;
+    bool nest_ref_doc = true;
+
+    // In case we have nested join.
+    std::vector<ref_include_fields> nested_join_includes;
 };
 
 struct hnsw_index_t;

--- a/include/field.h
+++ b/include/field.h
@@ -530,14 +530,15 @@ namespace ref_include {
     }
 }
 
-struct ref_include_fields {
+struct ref_include_exclude_fields {
     std::string collection_name;
-    std::string fields;
+    std::string include_fields;
+    std::string exclude_fields;
     std::string alias;
     ref_include::strategy_enum strategy = ref_include::nest;
 
     // In case we have nested join.
-    std::vector<ref_include_fields> nested_join_includes = {};
+    std::vector<ref_include_exclude_fields> nested_join_includes = {};
 };
 
 struct hnsw_index_t;

--- a/include/field.h
+++ b/include/field.h
@@ -510,18 +510,34 @@ namespace sort_field_const {
 }
 
 namespace ref_include {
-    static const std::string merge = "merge";
-    static const std::string nest = "nest";
+    static const std::string merge_string = "merge";
+    static const std::string nest_string = "nest";
+    static const std::string nest_array_string = "nest_array";
+
+    enum strategy_enum {merge = 0, nest, nest_array};
+
+    static Option<strategy_enum> string_to_enum(const std::string& strategy) {
+        if (strategy == merge_string) {
+            return Option<strategy_enum>(merge);
+        } else if (strategy == nest_string) {
+            return Option<strategy_enum>(nest);
+        } else if (strategy == nest_array_string) {
+            return Option<strategy_enum>(nest_array);
+        }
+
+        return Option<strategy_enum>(400, "Unknown include strategy `" + strategy + "`. "
+                                           "Valid options are `merge`, `nest`, `nest_array`.");
+    }
 }
 
 struct ref_include_fields {
     std::string collection_name;
     std::string fields;
     std::string alias;
-    bool nest_ref_doc = true;
+    ref_include::strategy_enum strategy = ref_include::nest;
 
     // In case we have nested join.
-    std::vector<ref_include_fields> nested_join_includes;
+    std::vector<ref_include_fields> nested_join_includes = {};
 };
 
 struct hnsw_index_t;

--- a/include/index.h
+++ b/include/index.h
@@ -786,11 +786,14 @@ public:
                                         filter_result_t& filter_result,
                                         const std::string& collection_name = "") const;
 
-
     Option<bool> do_reference_filtering_with_lock(filter_node_t* const filter_tree_root,
                                                   filter_result_t& filter_result,
-                                                  const std::string& collection_name,
+                                                  const std::string& ref_collection_name,
                                                   const std::string& reference_helper_field_name) const;
+
+    Option<filter_result_t> do_filtering_with_reference_ids(const std::string& reference_helper_field_name,
+                                                            const std::string& ref_collection_name,
+                                                            filter_result_t&& ref_filter_result) const;
 
     void refresh_schemas(const std::vector<field>& new_fields, const std::vector<field>& del_fields);
 

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -334,11 +334,11 @@ struct StringUtils {
 
     static Option<bool> tokenize_filter_query(const std::string& filter_query, std::queue<std::string>& tokens);
 
-    static Option<bool> split_include_fields(const std::string& include_fields, std::vector<std::string>& tokens);
+    static Option<bool> split_include_exclude_fields(const std::string& include_exclude_fields,
+                                                     std::vector<std::string>& tokens);
 
     static size_t get_occurence_count(const std::string& str, char symbol);
 
-    static Option<bool> split_reference_include_fields(const std::string& include_fields,
-                                                       size_t& index,
-                                                       std::string& token);
+    static Option<bool> split_reference_include_exclude_fields(const std::string& include_fields,
+                                                               size_t& index, std::string& token);
 };

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -337,4 +337,8 @@ struct StringUtils {
     static Option<bool> split_include_fields(const std::string& include_fields, std::vector<std::string>& tokens);
 
     static size_t get_occurence_count(const std::string& str, char symbol);
+
+    static Option<bool> split_reference_include_fields(const std::string& include_fields,
+                                                       size_t& index,
+                                                       std::string& token);
 };

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -951,6 +951,10 @@ void CollectionManager::_get_reference_collection_names(const std::string& filte
                     reference_collection_names.clear();
                     return;
                 }
+
+                // Need to process the filter expression inside parenthesis in case of nested join.
+                auto sub_filter_query = filter_query.substr(open_paren_pos + 1, i - open_paren_pos - 2);
+                _get_reference_collection_names(sub_filter_query, reference_collection_names);
             } else {
                 while (i + 1 < size && filter_query[++i] != ':');
                 if (i >= size) {

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1049,6 +1049,7 @@ Option<bool> parse_nested_include(const std::string& include_field_exp,
         }
         StringUtils::trim(ref_fields);
 
+        index = closing_parenthesis_pos;
         auto as_pos = include_field_exp.find(" as ", index);
         comma_pos = include_field_exp.find(',', index);
         if (as_pos != std::string::npos && as_pos < comma_pos) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1801,37 +1801,160 @@ Option<bool> Index::do_filtering_with_lock(filter_node_t* const filter_tree_root
         return filter_init_op;
     }
 
-    filter_result.count = filter_result_iterator.to_filter_id_array(filter_result.docs);
+    if (filter_result_iterator.reference.empty()) {
+        filter_result.count = filter_result_iterator.to_filter_id_array(filter_result.docs);
+        return Option(true);
+    }
 
+    filter_result_iterator.compute_result();
+    if (filter_result_iterator.approx_filter_ids_length == 0) {
+        return Option(true);
+    }
+
+    uint32_t count = filter_result_iterator.approx_filter_ids_length, dummy;
+    auto ref_filter_result = new filter_result_t();
+    std::unique_ptr<filter_result_t> ref_filter_result_guard(ref_filter_result);
+    filter_result_iterator.get_n_ids(count, dummy, nullptr, 0, ref_filter_result);
+
+    if (filter_result_iterator.validity == filter_result_iterator_t::timed_out) {
+        return Option<bool>(true);
+    }
+
+    filter_result = std::move(*ref_filter_result);
     return Option(true);
+}
+
+void aggregate_nested_references(single_filter_result_t *const reference_result,
+                                 reference_filter_result_t& ref_filter_result) {
+    // Add reference doc id in result.
+    auto temp_docs = new uint32_t[ref_filter_result.count + 1];
+    std::copy(ref_filter_result.docs, ref_filter_result.docs + ref_filter_result.count, temp_docs);
+    temp_docs[ref_filter_result.count] = reference_result->seq_id;
+
+    delete[] ref_filter_result.docs;
+    ref_filter_result.docs = temp_docs;
+    ref_filter_result.count++;
+    ref_filter_result.is_reference_array_field = false;
+
+    // Add references of the reference doc id in result.
+    auto& references = ref_filter_result.coll_to_references;
+    auto temp_references = new std::map<std::string, reference_filter_result_t>[ref_filter_result.count] {};
+    for (uint32_t i = 0; i < ref_filter_result.count - 1; i++) {
+        temp_references[i] = std::move(references[i]);
+    }
+    temp_references[ref_filter_result.count - 1] = std::move(reference_result->reference_filter_results);
+
+    delete[] references;
+    references = temp_references;
 }
 
 Option<bool> Index::do_reference_filtering_with_lock(filter_node_t* const filter_tree_root,
                                                      filter_result_t& filter_result,
-                                                     const std::string& collection_name,
+                                                     const std::string& ref_collection_name,
                                                      const std::string& reference_helper_field_name) const {
     std::shared_lock lock(mutex);
 
-    auto filter_result_iterator = filter_result_iterator_t(collection_name, this, filter_tree_root,
-                                                           search_begin_us, search_stop_us);
-    auto filter_init_op = filter_result_iterator.init_status();
+    auto ref_filter_result_iterator = filter_result_iterator_t(ref_collection_name, this, filter_tree_root,
+                                                               search_begin_us, search_stop_us);
+    auto filter_init_op = ref_filter_result_iterator.init_status();
     if (!filter_init_op.ok()) {
         return filter_init_op;
     }
 
-    uint32_t* reference_docs = nullptr;
-    uint32_t count = filter_result_iterator.to_filter_id_array(reference_docs);
-    std::unique_ptr<uint32_t[]> docs_guard(reference_docs);
-
-    if (count == 0) {
+    ref_filter_result_iterator.compute_result();
+    if (ref_filter_result_iterator.approx_filter_ids_length == 0) {
         return Option(true);
     }
 
-    if (search_schema.at(reference_helper_field_name).is_singular()) {
+    uint32_t count = ref_filter_result_iterator.approx_filter_ids_length, dummy;
+    auto ref_filter_result = new filter_result_t();
+    std::unique_ptr<filter_result_t> ref_filter_result_guard(ref_filter_result);
+    ref_filter_result_iterator.get_n_ids(count, dummy, nullptr, 0, ref_filter_result);
+
+    if (ref_filter_result_iterator.validity == filter_result_iterator_t::timed_out) {
+        return Option<bool>(true);
+    }
+
+    uint32_t* reference_docs = ref_filter_result->docs;
+    ref_filter_result->docs = nullptr;
+    std::unique_ptr<uint32_t[]> docs_guard(reference_docs);
+
+    auto const is_nested_join = !ref_filter_result_iterator.reference.empty();
+    if (search_schema.at(reference_helper_field_name).is_singular()) { // Only one reference per doc.
+        if (sort_index.count(reference_helper_field_name) == 0) {
+            return Option<bool>(400, "`" + reference_helper_field_name + "` is not present in sort index.");
+        }
+        auto const& ref_index = *sort_index.at(reference_helper_field_name);
+
+        if (is_nested_join) {
+            // In case of nested join, we need to collect all the doc ids from the reference ids along with their references.
+            std::vector<std::pair<uint32_t, single_filter_result_t*>> id_pairs;
+            std::unordered_set<uint32_t> unique_doc_ids;
+
+            for (uint32_t i = 0; i < count; i++) {
+                auto& reference_doc_id = reference_docs[i];
+                auto reference_doc_references = std::move(ref_filter_result->coll_to_references[i]);
+                if (ref_index.count(reference_doc_id) == 0) { // Reference field might be optional.
+                    continue;
+                }
+                auto doc_id = ref_index.at(reference_doc_id);
+
+                id_pairs.emplace_back(std::make_pair(doc_id, new single_filter_result_t(reference_doc_id,
+                                                                                        std::move(reference_doc_references),
+                                                                                        false)));
+                unique_doc_ids.insert(doc_id);
+            }
+
+            if (id_pairs.empty()) {
+                return Option(true);
+            }
+
+            std::sort(id_pairs.begin(), id_pairs.end(), [](auto const& left, auto const& right) {
+                return left.first < right.first;
+            });
+
+            filter_result.count = unique_doc_ids.size();
+            filter_result.docs = new uint32_t[unique_doc_ids.size()];
+            filter_result.coll_to_references = new std::map<std::string, reference_filter_result_t>[unique_doc_ids.size()] {};
+
+            reference_filter_result_t previous_doc_references;
+            for (uint32_t i = 0, previous_doc = id_pairs[0].first + 1, result_index = 0; i < id_pairs.size(); i++) {
+                auto const& current_doc = id_pairs[i].first;
+                auto& reference_result = id_pairs[i].second;
+
+                if (current_doc != previous_doc) {
+                    filter_result.docs[result_index] = current_doc;
+                    if (result_index > 0) {
+                        std::map<std::string, reference_filter_result_t> references;
+                        references[ref_collection_name] = std::move(previous_doc_references);
+                        filter_result.coll_to_references[result_index - 1] = std::move(references);
+                    }
+
+                    result_index++;
+                    previous_doc = current_doc;
+                    aggregate_nested_references(reference_result, previous_doc_references);
+                } else {
+                    aggregate_nested_references(reference_result, previous_doc_references);
+                }
+            }
+
+            if (previous_doc_references.count != 0) {
+                std::map<std::string, reference_filter_result_t> references;
+                references[ref_collection_name] = std::move(previous_doc_references);
+                filter_result.coll_to_references[filter_result.count - 1] = std::move(references);
+            }
+
+            for (auto &item: id_pairs) {
+                delete item.second;
+            }
+
+            return Option(true);
+        }
+
         // Collect all the doc ids from the reference ids.
         std::vector<std::pair<uint32_t, uint32_t>> id_pairs;
         std::unordered_set<uint32_t> unique_doc_ids;
-        auto const& ref_index = *sort_index.at(reference_helper_field_name);
+
         for (uint32_t i = 0; i < count; i++) {
             auto& reference_doc_id = reference_docs[i];
             if (ref_index.count(reference_doc_id) == 0) { // Reference field might be optional.
@@ -1839,8 +1962,12 @@ Option<bool> Index::do_reference_filtering_with_lock(filter_node_t* const filter
             }
             auto doc_id = ref_index.at(reference_doc_id);
 
-            id_pairs.emplace_back(std::pair(doc_id, reference_doc_id));
+            id_pairs.emplace_back(std::make_pair(doc_id, reference_doc_id));
             unique_doc_ids.insert(doc_id);
+        }
+
+        if (id_pairs.empty()) {
+            return Option(true);
         }
 
         std::sort(id_pairs.begin(), id_pairs.end(), [](auto const& left, auto const& right) {
@@ -1861,9 +1988,11 @@ Option<bool> Index::do_reference_filtering_with_lock(filter_node_t* const filter
                 if (result_index > 0) {
                     auto& reference_result = filter_result.coll_to_references[result_index - 1];
 
-                    auto r = reference_filter_result_t(previous_doc_references.size(), new uint32_t[previous_doc_references.size()]);
+                    auto r = reference_filter_result_t(previous_doc_references.size(),
+                                                       new uint32_t[previous_doc_references.size()],
+                                                       false);
                     std::copy(previous_doc_references.begin(), previous_doc_references.end(), r.docs);
-                    reference_result[collection_name] = std::move(r);
+                    reference_result[ref_collection_name] = std::move(r);
 
                     previous_doc_references.clear();
                 }
@@ -1879,39 +2008,315 @@ Option<bool> Index::do_reference_filtering_with_lock(filter_node_t* const filter
         if (!previous_doc_references.empty()) {
             auto& reference_result = filter_result.coll_to_references[filter_result.count - 1];
 
-            auto r = reference_filter_result_t(previous_doc_references.size(), new uint32_t[previous_doc_references.size()]);
+            auto r = reference_filter_result_t(previous_doc_references.size(),
+                                               new uint32_t[previous_doc_references.size()],
+                                               false);
             std::copy(previous_doc_references.begin(), previous_doc_references.end(), r.docs);
-            reference_result[collection_name] = std::move(r);
+            reference_result[ref_collection_name] = std::move(r);
         }
 
         return Option(true);
     }
 
-    size_t ids_len = 0;
-    uint32_t *ids = nullptr;
+    // Multiple references per doc.
+    if (reference_index.count(reference_helper_field_name) == 0) {
+        return Option<bool>(400, "`" + reference_helper_field_name + "` is not present in reference index.");
+    }
     auto& ref_index = *reference_index.at(reference_helper_field_name);
+
+    if (is_nested_join) {
+        // In case of nested join, we need to collect all the doc ids from the reference ids along with their references.
+        std::vector<std::pair<uint32_t, single_filter_result_t*>> id_pairs;
+        std::unordered_set<uint32_t> unique_doc_ids;
+
+        for (uint32_t i = 0; i < count; i++) {
+            auto& reference_doc_id = reference_docs[i];
+            auto reference_doc_references = std::move(ref_filter_result->coll_to_references[i]);
+            size_t doc_ids_len = 0;
+            uint32_t* doc_ids = nullptr;
+
+            ref_index.search(EQUALS, reference_doc_id, &doc_ids, doc_ids_len);
+
+            for (size_t j = 0; j < doc_ids_len; j++) {
+                auto doc_id = doc_ids[j];
+                auto reference_doc_references_copy = reference_doc_references;
+                id_pairs.emplace_back(std::make_pair(doc_id, new single_filter_result_t(reference_doc_id,
+                                                                                        std::move(reference_doc_references_copy),
+                                                                                        false)));
+                unique_doc_ids.insert(doc_id);
+            }
+            delete[] doc_ids;
+        }
+
+        if (id_pairs.empty()) {
+            return Option(true);
+        }
+
+        std::sort(id_pairs.begin(), id_pairs.end(), [](auto const& left, auto const& right) {
+            return left.first < right.first;
+        });
+
+        filter_result.count = unique_doc_ids.size();
+        filter_result.docs = new uint32_t[unique_doc_ids.size()];
+        filter_result.coll_to_references = new std::map<std::string, reference_filter_result_t>[unique_doc_ids.size()] {};
+
+        reference_filter_result_t previous_doc_references;
+        for (uint32_t i = 0, previous_doc = id_pairs[0].first + 1, result_index = 0; i < id_pairs.size(); i++) {
+            auto const& current_doc = id_pairs[i].first;
+            auto& reference_result = id_pairs[i].second;
+
+            if (current_doc != previous_doc) {
+                filter_result.docs[result_index] = current_doc;
+                if (result_index > 0) {
+                    std::map<std::string, reference_filter_result_t> references;
+                    references[ref_collection_name] = std::move(previous_doc_references);
+                    filter_result.coll_to_references[result_index - 1] = std::move(references);
+                }
+
+                result_index++;
+                previous_doc = current_doc;
+                aggregate_nested_references(reference_result, previous_doc_references);
+            } else {
+                aggregate_nested_references(reference_result, previous_doc_references);
+            }
+        }
+
+        if (previous_doc_references.count != 0) {
+            std::map<std::string, reference_filter_result_t> references;
+            references[ref_collection_name] = std::move(previous_doc_references);
+            filter_result.coll_to_references[filter_result.count - 1] = std::move(references);
+        }
+
+        for (auto &item: id_pairs) {
+            delete item.second;
+        }
+
+        return Option<bool>(true);
+    }
+
+    std::vector<std::pair<uint32_t, uint32_t>> id_pairs;
+    std::unordered_set<uint32_t> unique_doc_ids;
+
     for (uint32_t i = 0; i < count; i++) {
         auto& reference_doc_id = reference_docs[i];
-        ref_index.search(EQUALS, reference_doc_id, &ids, ids_len);
+        size_t doc_ids_len = 0;
+        uint32_t* doc_ids = nullptr;
+
+        ref_index.search(EQUALS, reference_doc_id, &doc_ids, doc_ids_len);
+
+        for (size_t j = 0; j < doc_ids_len; j++) {
+            auto doc_id = doc_ids[j];
+            id_pairs.emplace_back(std::make_pair(doc_id, reference_doc_id));
+            unique_doc_ids.insert(doc_id);
+        }
+        delete[] doc_ids;
     }
 
-    filter_result.count = ids_len;
-    filter_result.docs = new uint32_t[ids_len];
-    filter_result.coll_to_references = new std::map<std::string, reference_filter_result_t>[ids_len] {};
-
-    auto& num_index = *numerical_index.at(reference_helper_field_name);
-    for (size_t i = 0; i < ids_len; i++) {
-        filter_result.docs[i] = ids[i];
-
-        reference_filter_result_t reference_result;
-        size_t len = 0;
-        num_index.search(EQUALS, ids[i], &reference_result.docs, len);
-        reference_result.count = len;
-        filter_result.coll_to_references[i][collection_name] = std::move(reference_result);
+    if (id_pairs.empty()) {
+        return Option(true);
     }
 
-    delete [] ids;
+    std::sort(id_pairs.begin(), id_pairs.end(), [](auto const& left, auto const& right) {
+        return left.first < right.first;
+    });
+
+    filter_result.count = unique_doc_ids.size();
+    filter_result.docs = new uint32_t[unique_doc_ids.size()];
+    filter_result.coll_to_references = new std::map<std::string, reference_filter_result_t>[unique_doc_ids.size()] {};
+
+    std::vector<uint32_t> previous_doc_references;
+    for (uint32_t i = 0, previous_doc = id_pairs[0].first + 1, result_index = 0; i < id_pairs.size(); i++) {
+        auto const& current_doc = id_pairs[i].first;
+        auto const& reference_doc_id = id_pairs[i].second;
+
+        if (current_doc != previous_doc) {
+            filter_result.docs[result_index] = current_doc;
+            if (result_index > 0) {
+                auto& reference_result = filter_result.coll_to_references[result_index - 1];
+
+                auto r = reference_filter_result_t(previous_doc_references.size(), new uint32_t[previous_doc_references.size()]);
+                std::copy(previous_doc_references.begin(), previous_doc_references.end(), r.docs);
+                reference_result[ref_collection_name] = std::move(r);
+
+                previous_doc_references.clear();
+            }
+
+            result_index++;
+            previous_doc = current_doc;
+            previous_doc_references.push_back(reference_doc_id);
+        } else {
+            previous_doc_references.push_back(reference_doc_id);
+        }
+    }
+
+    if (!previous_doc_references.empty()) {
+        auto& reference_result = filter_result.coll_to_references[filter_result.count - 1];
+
+        auto r = reference_filter_result_t(previous_doc_references.size(), new uint32_t[previous_doc_references.size()]);
+        std::copy(previous_doc_references.begin(), previous_doc_references.end(), r.docs);
+        reference_result[ref_collection_name] = std::move(r);
+    }
+
     return Option(true);
+}
+
+Option<filter_result_t> Index::do_filtering_with_reference_ids(const std::string& reference_helper_field_name,
+                                                               const std::string& ref_collection_name,
+                                                               filter_result_t&& ref_filter_result) const {
+    filter_result_t filter_result;
+    auto const& count = ref_filter_result.count;
+    auto const& reference_docs = ref_filter_result.docs;
+    auto const is_nested_join = ref_filter_result.coll_to_references != nullptr;
+
+    if (count == 0) {
+        return Option<filter_result_t>(filter_result);
+    }
+
+    if (numerical_index.count(reference_helper_field_name) == 0) {
+        return Option<filter_result_t>(400, "`" + reference_helper_field_name + "` is not present in index.");
+    }
+    auto num_tree = numerical_index.at(reference_helper_field_name);
+
+    if (is_nested_join) {
+        // In case of nested join, we need to collect all the doc ids from the reference ids along with their references.
+        std::vector<std::pair<uint32_t, single_filter_result_t*>> id_pairs;
+        std::unordered_set<uint32_t> unique_doc_ids;
+
+        for (uint32_t i = 0; i < count; i++) {
+            auto& reference_doc_id = reference_docs[i];
+            auto reference_doc_references = std::move(ref_filter_result.coll_to_references[i]);
+            size_t doc_ids_len = 0;
+            uint32_t* doc_ids = nullptr;
+
+            num_tree->search(NUM_COMPARATOR::EQUALS, reference_doc_id, &doc_ids, doc_ids_len);
+
+            for (size_t j = 0; j < doc_ids_len; j++) {
+                auto doc_id = doc_ids[j];
+                auto reference_doc_references_copy = reference_doc_references;
+                id_pairs.emplace_back(std::make_pair(doc_id, new single_filter_result_t(reference_doc_id,
+                                                                                        std::move(reference_doc_references_copy),
+                                                                                        false)));
+                unique_doc_ids.insert(doc_id);
+            }
+
+            delete[] doc_ids;
+        }
+
+        if (id_pairs.empty()) {
+            return Option(filter_result);
+        }
+
+        std::sort(id_pairs.begin(), id_pairs.end(), [](auto const& left, auto const& right) {
+            return left.first < right.first;
+        });
+
+        filter_result.count = unique_doc_ids.size();
+        filter_result.docs = new uint32_t[unique_doc_ids.size()];
+        filter_result.coll_to_references = new std::map<std::string, reference_filter_result_t>[unique_doc_ids.size()] {};
+
+        reference_filter_result_t previous_doc_references;
+        for (uint32_t i = 0, previous_doc = id_pairs[0].first + 1, result_index = 0; i < id_pairs.size(); i++) {
+            auto const& current_doc = id_pairs[i].first;
+            auto& reference_result = id_pairs[i].second;
+
+            if (current_doc != previous_doc) {
+                filter_result.docs[result_index] = current_doc;
+                if (result_index > 0) {
+                    std::map<std::string, reference_filter_result_t> references;
+                    references[ref_collection_name] = std::move(previous_doc_references);
+                    filter_result.coll_to_references[result_index - 1] = std::move(references);
+                }
+
+                result_index++;
+                previous_doc = current_doc;
+                aggregate_nested_references(reference_result, previous_doc_references);
+            } else {
+                aggregate_nested_references(reference_result, previous_doc_references);
+            }
+        }
+
+        if (previous_doc_references.count != 0) {
+            std::map<std::string, reference_filter_result_t> references;
+            references[ref_collection_name] = std::move(previous_doc_references);
+            filter_result.coll_to_references[filter_result.count - 1] = std::move(references);
+        }
+
+        for (auto &item: id_pairs) {
+            delete item.second;
+        }
+
+        return Option<filter_result_t>(filter_result);
+    }
+
+    // Collect all the doc ids from the reference ids.
+    std::vector<std::pair<uint32_t, uint32_t>> id_pairs;
+    std::unordered_set<uint32_t> unique_doc_ids;
+
+    for (uint32_t i = 0; i < count; i++) {
+        auto& reference_doc_id = reference_docs[i];
+        size_t doc_ids_len = 0;
+        uint32_t* doc_ids = nullptr;
+
+        num_tree->search(NUM_COMPARATOR::EQUALS, reference_doc_id, &doc_ids, doc_ids_len);
+
+        for (size_t j = 0; j < doc_ids_len; j++) {
+            auto doc_id = doc_ids[j];
+            id_pairs.emplace_back(std::make_pair(doc_id, reference_doc_id));
+            unique_doc_ids.insert(doc_id);
+        }
+        delete[] doc_ids;
+    }
+
+    if (id_pairs.empty()) {
+        return Option(filter_result);
+    }
+
+    std::sort(id_pairs.begin(), id_pairs.end(), [](auto const& left, auto const& right) {
+        return left.first < right.first;
+    });
+
+    filter_result.count = unique_doc_ids.size();
+    filter_result.docs = new uint32_t[unique_doc_ids.size()];
+    filter_result.coll_to_references = new std::map<std::string, reference_filter_result_t>[unique_doc_ids.size()] {};
+
+    std::vector<uint32_t> previous_doc_references;
+    for (uint32_t i = 0, previous_doc = id_pairs[0].first + 1, result_index = 0; i < id_pairs.size(); i++) {
+        auto const& current_doc = id_pairs[i].first;
+        auto const& reference_doc_id = id_pairs[i].second;
+
+        if (current_doc != previous_doc) {
+            filter_result.docs[result_index] = current_doc;
+            if (result_index > 0) {
+                auto& reference_result = filter_result.coll_to_references[result_index - 1];
+
+                auto r = reference_filter_result_t(previous_doc_references.size(),
+                                                   new uint32_t[previous_doc_references.size()],
+                                                   false);
+                std::copy(previous_doc_references.begin(), previous_doc_references.end(), r.docs);
+                reference_result[ref_collection_name] = std::move(r);
+
+                previous_doc_references.clear();
+            }
+
+            result_index++;
+            previous_doc = current_doc;
+            previous_doc_references.push_back(reference_doc_id);
+        } else {
+            previous_doc_references.push_back(reference_doc_id);
+        }
+    }
+
+    if (!previous_doc_references.empty()) {
+        auto& reference_result = filter_result.coll_to_references[filter_result.count - 1];
+
+        auto r = reference_filter_result_t(previous_doc_references.size(),
+                                           new uint32_t[previous_doc_references.size()],
+                                           false);
+        std::copy(previous_doc_references.begin(), previous_doc_references.end(), r.docs);
+        reference_result[ref_collection_name] = std::move(r);
+    }
+
+    return Option<filter_result_t>(filter_result);
 }
 
 Option<bool> Index::run_search(search_args* search_params, const std::string& collection_name,

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -492,49 +492,87 @@ Option<bool> StringUtils::tokenize_filter_query(const std::string& filter_query,
     return Option<bool>(true);
 }
 
+Option<bool> StringUtils::split_reference_include_fields(const std::string& include_fields,
+                                                         size_t& index,
+                                                         std::string& token) {
+    auto ref_include_error = Option<bool>(400, "Invalid reference in include_fields, expected `$CollectionName(fieldA, ...)`.");
+    auto const& size = include_fields.size();
+    size_t start_index = index;
+    while(++index < size && include_fields[index] != '(') {}
+
+    if (index >= size) {
+        return ref_include_error;
+    }
+
+    // In case of nested join, the reference include field could have parenthesis inside it.
+    int parenthesis_count = 1;
+    while (++index < size && parenthesis_count > 0) {
+        if (include_fields[index] == '(') {
+            parenthesis_count++;
+        } else if (include_fields[index] == ')') {
+            parenthesis_count--;
+        }
+    }
+
+    if (parenthesis_count != 0) {
+        return ref_include_error;
+    }
+
+    // In case of nested reference include, we might end up with one of the following scenarios:
+    // $ref_include( $nested_ref_include(foo :merge)as nest ) as ref
+    //                                                   ...^
+    // $ref_include( $nested_ref_include(foo :merge)as nest, bar ) as ref
+    //                                                  ...^
+    // $ref_include( $nested_ref_include(foo :merge)as nest :merge ) as ref
+    //                                                   ...^
+    auto closing_parenthesis_pos = include_fields.find(')', index);
+    auto comma_pos = include_fields.find(',', index);
+    auto colon_pos = include_fields.find(':', index);
+    auto alias_start_pos = include_fields.find(" as ", index);
+    auto alias_end_pos = std::min(std::min(closing_parenthesis_pos, comma_pos), colon_pos);
+    std::string alias;
+    if (alias_start_pos != std::string::npos && alias_start_pos < alias_end_pos) {
+        alias = include_fields.substr(alias_start_pos, alias_end_pos - alias_start_pos);
+    }
+
+    token = include_fields.substr(start_index, index - start_index) + " " + trim(alias);
+    trim(token);
+
+    index = alias_end_pos;
+    return Option<bool>(true);
+}
+
 Option<bool> StringUtils::split_include_fields(const std::string& include_fields, std::vector<std::string>& tokens) {
-    size_t start = 0, end = 0, size = include_fields.size();
-    std::string include_field;
-
-    while (true) {
-        auto range_pos = include_fields.find('$', start);
-        auto comma_pos = include_fields.find(',', start);
-
-        if (range_pos == std::string::npos && comma_pos == std::string::npos) {
-            if (start < size - 1) {
-                include_field = include_fields.substr(start, size - start);
-                include_field = trim(include_field);
-                if (!include_field.empty()) {
-                    tokens.push_back(include_field);
-                }
+    std::string token;
+    auto const& size = include_fields.size();
+    for (size_t i = 0; i < size;) {
+        auto c = include_fields[i];
+        if (c == ' ') {
+            i++;
+            continue;
+        } else if (c == '$') { // Reference include
+            std::string ref_include_token;
+            auto split_op = split_reference_include_fields(include_fields, i, ref_include_token);
+            if (!split_op.ok()) {
+                return split_op;
             }
+
+            tokens.push_back(ref_include_token);
+            continue;
+        }
+
+        auto comma_pos = include_fields.find(',', i);
+        token = include_fields.substr(i, (comma_pos == std::string::npos ? size : comma_pos) - i);
+        trim(token);
+        if (!token.empty()) {
+            tokens.push_back(token);
+        }
+
+        if (comma_pos == std::string::npos) {
             break;
-        } else if (range_pos < comma_pos) {
-            end = include_fields.find(')', range_pos);
-            if (end == std::string::npos || end < include_fields.find('(', range_pos)) {
-                return Option<bool>(400, "Invalid reference in include_fields, expected `$CollectionName(fieldA, ...)`.");
-            }
-
-            include_field = include_fields.substr(range_pos, (end - range_pos) + 1);
-
-            comma_pos = include_fields.find(',', end);
-            auto as_pos = include_fields.find(" as ", end);
-            if (as_pos != std::string::npos && as_pos < comma_pos) {
-                auto alias = include_fields.substr(as_pos, (comma_pos - as_pos));
-                end += alias.size() + 1;
-                include_field += (" " + trim(alias));
-            }
-        } else {
-            end = comma_pos;
-            include_field = include_fields.substr(start, end - start);
         }
-
-        include_field = trim(include_field);
-        if (!include_field.empty()) {
-            tokens.push_back(include_field);
-        }
-
-        start = end + 1;
+        i = comma_pos + 1;
+        token.clear();
     }
 
     return Option<bool>(true);

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -1827,6 +1827,559 @@ TEST_F(CollectionJoinTest, FilterByNReferences) {
     collectionManager.drop_collection("Links");
 }
 
+TEST_F(CollectionJoinTest, FilterByNestedReferences) {
+    auto schema_json =
+            R"({
+                "name": "Coll_A",
+                "fields": [
+                    {"name": "title", "type": "string"}
+                ]
+            })"_json;
+    std::vector<nlohmann::json> documents = {
+            R"({
+                "title": "coll_a_0"
+            })"_json,
+            R"({
+                "title": "coll_a_1"
+            })"_json
+    };
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    for (auto const &json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+    schema_json =
+            R"({
+                "name": "Coll_B",
+                "fields": [
+                    {"name": "title", "type": "string"},
+                    {"name": "ref_coll_a", "type": "string", "reference": "Coll_A.id"}
+                ]
+            })"_json;
+    documents = {
+            R"({
+                "title": "coll_b_0",
+                "ref_coll_a": "1"
+            })"_json,
+            R"({
+                "title": "coll_b_1",
+                "ref_coll_a": "0"
+            })"_json,
+            R"({
+                "title": "coll_b_2",
+                "ref_coll_a": "0"
+            })"_json
+    };
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    for (auto const &json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+    schema_json =
+            R"({
+                "name": "Coll_C",
+                "fields": [
+                    {"name": "title", "type": "string"},
+                    {"name": "ref_coll_b", "type": "string[]", "reference": "Coll_B.id"}
+                ]
+            })"_json;
+    documents = {
+            R"({
+                "title": "coll_c_0",
+                "ref_coll_b": ["0"]
+            })"_json,
+            R"({
+                "title": "coll_c_1",
+                "ref_coll_b": ["1"]
+            })"_json,
+            R"({
+                "title": "coll_c_2",
+                "ref_coll_b": ["0", "1"]
+            })"_json,
+            R"({
+                "title": "coll_c_3",
+                "ref_coll_b": ["2"]
+            })"_json
+    };
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    for (auto const &json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    std::map<std::string, std::string> req_params = {
+            {"collection", "Coll_A"},
+            {"q", "*"},
+            {"filter_by", "$Coll_B($Coll_C(id: [1, 3]))"},
+            {"include_fields", "title, $Coll_B(title, $Coll_C(title))"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    nlohmann::json res_obj = nlohmann::json::parse(json_res);
+    //              coll_b_1 <- coll_c_1
+    // coll_a_0  <
+    //             coll_b_2 <- coll_c_3
+    ASSERT_EQ(1, res_obj["found"].get<size_t>());
+    ASSERT_EQ(1, res_obj["hits"].size());
+    ASSERT_EQ(2, res_obj["hits"][0]["document"].size());
+    ASSERT_EQ("coll_a_0", res_obj["hits"][0]["document"]["title"]);
+    ASSERT_EQ(2, res_obj["hits"][0]["document"]["Coll_B"].size());
+    ASSERT_EQ("coll_b_1", res_obj["hits"][0]["document"]["Coll_B"][0]["title"]);
+    ASSERT_EQ(1, res_obj["hits"][0]["document"]["Coll_B"][0]["Coll_C"].size());
+    ASSERT_EQ("coll_c_1", res_obj["hits"][0]["document"]["Coll_B"][0]["Coll_C"][0]["title"]);
+    ASSERT_EQ("coll_b_2", res_obj["hits"][0]["document"]["Coll_B"][1]["title"]);
+    ASSERT_EQ(1, res_obj["hits"][0]["document"]["Coll_B"][1]["Coll_C"].size());
+    ASSERT_EQ("coll_c_3", res_obj["hits"][0]["document"]["Coll_B"][1]["Coll_C"][0]["title"]);
+
+    req_params = {
+            {"collection", "Coll_A"},
+            {"q", "*"},
+            {"filter_by", "$Coll_B($Coll_C(id: != 0))"},
+            {"include_fields", "title, $Coll_B(title, $Coll_C(title):nest_array)"}
+    };
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    res_obj = nlohmann::json::parse(json_res);
+    // coll_a_1 <- coll_b_0 <- coll_c_2
+    //
+    //             coll_b_1 <- coll_c_1, coll_c_2
+    // coll_a_0  <
+    //             coll_b_2 <- coll_c_3
+    ASSERT_EQ(2, res_obj["found"].get<size_t>());
+    ASSERT_EQ(2, res_obj["hits"].size());
+    ASSERT_EQ(2, res_obj["hits"][0]["document"].size());
+    ASSERT_EQ("coll_a_1", res_obj["hits"][0]["document"]["title"]);
+    ASSERT_EQ(1, res_obj["hits"][0]["document"]["Coll_B"].size());
+    ASSERT_EQ("coll_b_0", res_obj["hits"][0]["document"]["Coll_B"][0]["title"]);
+    ASSERT_EQ(1, res_obj["hits"][0]["document"]["Coll_B"][0]["Coll_C"].size());
+    ASSERT_EQ("coll_c_2", res_obj["hits"][0]["document"]["Coll_B"][0]["Coll_C"][0]["title"]);
+
+    ASSERT_EQ("coll_a_0", res_obj["hits"][1]["document"]["title"]);
+    ASSERT_EQ(2, res_obj["hits"][1]["document"]["Coll_B"].size());
+    ASSERT_EQ("coll_b_1", res_obj["hits"][1]["document"]["Coll_B"][0]["title"]);
+    ASSERT_EQ(2, res_obj["hits"][1]["document"]["Coll_B"][0]["Coll_C"].size());
+    ASSERT_EQ("coll_c_1", res_obj["hits"][1]["document"]["Coll_B"][0]["Coll_C"][0]["title"]);
+    ASSERT_EQ("coll_c_2", res_obj["hits"][1]["document"]["Coll_B"][0]["Coll_C"][1]["title"]);
+    ASSERT_EQ("coll_b_2", res_obj["hits"][1]["document"]["Coll_B"][1]["title"]);
+    ASSERT_EQ(1, res_obj["hits"][1]["document"]["Coll_B"][1]["Coll_C"].size());
+    ASSERT_EQ("coll_c_3", res_obj["hits"][1]["document"]["Coll_B"][1]["Coll_C"][0]["title"]);
+
+    req_params = {
+            {"collection", "Coll_C"},
+            {"q", "*"},
+            {"filter_by", "$Coll_B($Coll_A(id: 0))"},
+            {"include_fields", "title, $Coll_B(title, $Coll_A(title))"}
+    };
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    res_obj = nlohmann::json::parse(json_res);
+    // coll_c_3 -> coll_b_2 -> coll_a_0
+    //
+    // coll_c_2 -> coll_b_1 -> coll_a_0
+    //
+    // coll_c_1 -> coll_b_1 -> coll_a_0
+    ASSERT_EQ(3, res_obj["found"].get<size_t>());
+    ASSERT_EQ(3, res_obj["hits"].size());
+    ASSERT_EQ(2, res_obj["hits"][0]["document"].size());
+    ASSERT_EQ("coll_c_3", res_obj["hits"][0]["document"]["title"]);
+    ASSERT_EQ(2, res_obj["hits"][0]["document"]["Coll_B"].size());
+    ASSERT_EQ("coll_b_2", res_obj["hits"][0]["document"]["Coll_B"]["title"]);
+    ASSERT_EQ(1, res_obj["hits"][0]["document"]["Coll_B"]["Coll_A"].size());
+    ASSERT_EQ("coll_a_0", res_obj["hits"][0]["document"]["Coll_B"]["Coll_A"]["title"]);
+
+    ASSERT_EQ(2, res_obj["hits"][1]["document"].size());
+    ASSERT_EQ("coll_c_2", res_obj["hits"][1]["document"]["title"]);
+    ASSERT_EQ(2, res_obj["hits"][1]["document"]["Coll_B"].size());
+    ASSERT_EQ("coll_b_1", res_obj["hits"][1]["document"]["Coll_B"]["title"]);
+    ASSERT_EQ(1, res_obj["hits"][1]["document"]["Coll_B"]["Coll_A"].size());
+    ASSERT_EQ("coll_a_0", res_obj["hits"][1]["document"]["Coll_B"]["Coll_A"]["title"]);
+
+    ASSERT_EQ(2, res_obj["hits"][2]["document"].size());
+    ASSERT_EQ("coll_c_1", res_obj["hits"][2]["document"]["title"]);
+    ASSERT_EQ(2, res_obj["hits"][2]["document"]["Coll_B"].size());
+    ASSERT_EQ("coll_b_1", res_obj["hits"][2]["document"]["Coll_B"]["title"]);
+    ASSERT_EQ(1, res_obj["hits"][2]["document"]["Coll_B"]["Coll_A"].size());
+    ASSERT_EQ("coll_a_0", res_obj["hits"][2]["document"]["Coll_B"]["Coll_A"]["title"]);
+
+    schema_json =
+            R"({
+                "name": "Coll_D",
+                "fields": [
+                    {"name": "title", "type": "string"},
+                    {"name": "ref_coll_c", "type": "string[]", "reference": "Coll_C.id"}
+                ]
+            })"_json;
+    documents = {
+            R"({
+                "title": "coll_d_0",
+                "ref_coll_c": []
+            })"_json,
+            R"({
+                "title": "coll_d_1",
+                "ref_coll_c": ["1", "3"]
+            })"_json,
+            R"({
+                "title": "coll_d_2",
+                "ref_coll_c": ["2", "3"]
+            })"_json,
+    };
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    for (auto const &json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    req_params = {
+            {"collection", "Coll_B"},
+            {"q", "*"},
+            {"filter_by", "$Coll_C($Coll_D(id: *))"},
+            {"include_fields", "title, $Coll_C(title, $Coll_D(title:nest_array):nest_array)"}
+    };
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    res_obj = nlohmann::json::parse(json_res);
+    // coll_b_2 <- coll_c_3 <- coll_d_1, coll_d_2
+    //
+    //             coll_c_1 <- coll_d_1
+    // coll_b_1  <
+    //             coll_c_2 <- coll_d_2
+    //
+    // coll_b_0 <- coll_c_2 <- coll_d_2
+    ASSERT_EQ(3, res_obj["found"].get<size_t>());
+    ASSERT_EQ(3, res_obj["hits"].size());
+    ASSERT_EQ(2, res_obj["hits"][0]["document"].size());
+    ASSERT_EQ("coll_b_2", res_obj["hits"][0]["document"]["title"]);
+    ASSERT_EQ(1, res_obj["hits"][0]["document"]["Coll_C"].size());
+    ASSERT_EQ("coll_c_3", res_obj["hits"][0]["document"]["Coll_C"][0]["title"]);
+    ASSERT_EQ(2, res_obj["hits"][0]["document"]["Coll_C"][0]["Coll_D"].size());
+    ASSERT_EQ("coll_d_1", res_obj["hits"][0]["document"]["Coll_C"][0]["Coll_D"][0]["title"]);
+    ASSERT_EQ("coll_d_2", res_obj["hits"][0]["document"]["Coll_C"][0]["Coll_D"][1]["title"]);
+
+    ASSERT_EQ(2, res_obj["hits"][1]["document"].size());
+    ASSERT_EQ("coll_b_1", res_obj["hits"][1]["document"]["title"]);
+    ASSERT_EQ(2, res_obj["hits"][1]["document"]["Coll_C"].size());
+    ASSERT_EQ("coll_c_1", res_obj["hits"][1]["document"]["Coll_C"][0]["title"]);
+    ASSERT_EQ(1, res_obj["hits"][1]["document"]["Coll_C"][0]["Coll_D"].size());
+    ASSERT_EQ("coll_d_1", res_obj["hits"][1]["document"]["Coll_C"][0]["Coll_D"][0]["title"]);
+    ASSERT_EQ("coll_c_2", res_obj["hits"][1]["document"]["Coll_C"][1]["title"]);
+    ASSERT_EQ(1, res_obj["hits"][1]["document"]["Coll_C"][1]["Coll_D"].size());
+    ASSERT_EQ("coll_d_2", res_obj["hits"][1]["document"]["Coll_C"][1]["Coll_D"][0]["title"]);
+
+    ASSERT_EQ(2, res_obj["hits"][2]["document"].size());
+    ASSERT_EQ("coll_b_0", res_obj["hits"][2]["document"]["title"]);
+    ASSERT_EQ(1, res_obj["hits"][2]["document"]["Coll_C"].size());
+    ASSERT_EQ("coll_c_2", res_obj["hits"][2]["document"]["Coll_C"][0]["title"]);
+    ASSERT_EQ(1, res_obj["hits"][2]["document"]["Coll_C"][0]["Coll_D"].size());
+    ASSERT_EQ("coll_d_2", res_obj["hits"][2]["document"]["Coll_C"][0]["Coll_D"][0]["title"]);
+
+    req_params = {
+            {"collection", "Coll_D"},
+            {"q", "*"},
+            {"filter_by", "$Coll_C($Coll_B(id: [0, 1]))"},
+            {"include_fields", "title, $Coll_C(title, $Coll_B(title:nest_array):nest_array)"}
+    };
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    res_obj = nlohmann::json::parse(json_res);
+    LOG(INFO) << res_obj.dump();
+    // coll_d_2 -> coll_c_2 -> coll_b_0, coll_b_1
+    //
+    // coll_d_1 -> coll_c_1 -> coll_b_1
+    ASSERT_EQ(2, res_obj["found"].get<size_t>());
+    ASSERT_EQ(2, res_obj["hits"].size());
+    ASSERT_EQ(2, res_obj["hits"][0]["document"].size());
+    ASSERT_EQ("coll_d_2", res_obj["hits"][0]["document"]["title"]);
+    ASSERT_EQ(1, res_obj["hits"][0]["document"]["Coll_C"].size());
+    ASSERT_EQ("coll_c_2", res_obj["hits"][0]["document"]["Coll_C"][0]["title"]);
+    ASSERT_EQ(2, res_obj["hits"][0]["document"]["Coll_C"][0]["Coll_B"].size());
+    ASSERT_EQ("coll_b_0", res_obj["hits"][0]["document"]["Coll_C"][0]["Coll_B"][0]["title"]);
+    ASSERT_EQ("coll_b_1", res_obj["hits"][0]["document"]["Coll_C"][0]["Coll_B"][1]["title"]);
+
+    ASSERT_EQ(2, res_obj["hits"][1]["document"].size());
+    ASSERT_EQ("coll_d_1", res_obj["hits"][1]["document"]["title"]);
+    ASSERT_EQ(1, res_obj["hits"][1]["document"]["Coll_C"].size());
+    ASSERT_EQ("coll_c_1", res_obj["hits"][1]["document"]["Coll_C"][0]["title"]);
+    ASSERT_EQ(1, res_obj["hits"][1]["document"]["Coll_C"][0]["Coll_B"].size());
+    ASSERT_EQ("coll_b_1", res_obj["hits"][1]["document"]["Coll_C"][0]["Coll_B"][0]["title"]);
+
+    schema_json =
+            R"({
+                "name": "products",
+                "fields": [
+                    {"name": "title", "type": "string"}
+                ]
+            })"_json;
+    documents = {
+            R"({
+                "title": "shampoo"
+            })"_json,
+            R"({
+                "title": "soap"
+            })"_json
+    };
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    for (auto const &json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    schema_json =
+            R"({
+                "name": "product_variants",
+                "fields": [
+                    {"name": "title", "type": "string"},
+                    {"name": "product_id", "type": "string", "reference": "products.id"}
+                ]
+            })"_json;
+    documents = {
+            R"({
+                "title": "panteen",
+                "product_id": "0"
+            })"_json,
+            R"({
+                "title": "loreal",
+                "product_id": "0"
+            })"_json,
+            R"({
+                "title": "pears",
+                "product_id": "1"
+            })"_json,
+            R"({
+                "title": "lifebuoy",
+                "product_id": "1"
+            })"_json
+    };
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    for (auto const &json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    schema_json =
+            R"({
+                "name": "retailers",
+                "fields": [
+                    {"name": "title", "type": "string"},
+                    {"name": "location", "type": "geopoint"}
+                ]
+            })"_json;
+    documents = {
+            R"({
+                "title": "retailer 1",
+                "location": [48.872576479306765, 2.332291112241466]
+            })"_json,
+            R"({
+                "title": "retailer 2",
+                "location": [48.888286721920934, 2.342340862419206]
+            })"_json,
+            R"({
+                "title": "retailer 3",
+                "location": [48.87538726829884, 2.296113163780903]
+            })"_json
+    };
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    for (auto const &json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    schema_json =
+            R"({
+                "name": "inventory",
+                "fields": [
+                    {"name": "qty", "type": "int32"},
+                    {"name": "retailer_id", "type": "string", "reference": "retailers.id"},
+                    {"name": "product_variant_id", "type": "string", "reference": "product_variants.id"}
+                ]
+            })"_json;
+    documents = {
+            R"({
+                "qty": "1",
+                "retailer_id": "0",
+                "product_variant_id": "0"
+            })"_json,
+            R"({
+                "qty": "2",
+                "retailer_id": "0",
+                "product_variant_id": "1"
+            })"_json,
+            R"({
+                "qty": "3",
+                "retailer_id": "0",
+                "product_variant_id": "2"
+            })"_json,
+            R"({
+                "qty": "4",
+                "retailer_id": "0",
+                "product_variant_id": "3"
+            })"_json,
+            R"({
+                "qty": "5",
+                "retailer_id": "1",
+                "product_variant_id": "0"
+            })"_json,
+            R"({
+                "qty": "6",
+                "retailer_id": "1",
+                "product_variant_id": "1"
+            })"_json,
+            R"({
+                "qty": "7",
+                "retailer_id": "1",
+                "product_variant_id": "2"
+            })"_json,
+            R"({
+                "qty": "8",
+                "retailer_id": "1",
+                "product_variant_id": "3"
+            })"_json,
+            R"({
+                "qty": "9",
+                "retailer_id": "2",
+                "product_variant_id": "0"
+            })"_json,
+            R"({
+                "qty": "10",
+                "retailer_id": "2",
+                "product_variant_id": "1"
+            })"_json,
+            R"({
+                "qty": "11",
+                "retailer_id": "2",
+                "product_variant_id": "2"
+            })"_json,
+            R"({
+                "qty": "12",
+                "retailer_id": "2",
+                "product_variant_id": "3"
+            })"_json,
+    };
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    for (auto const &json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    req_params = {
+            {"collection", "products"},
+            {"q", "*"},
+            {"filter_by", "$product_variants($inventory($retailers(location:(48.87538726829884, 2.296113163780903,1 km))))"},
+            {"include_fields", "$product_variants(id,$inventory(qty,sku,$retailers(id,title)))"}
+    };
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, res_obj["found"].get<size_t>());
+    ASSERT_EQ(2, res_obj["hits"].size());
+    ASSERT_EQ("1", res_obj["hits"][0]["document"]["id"]);
+    ASSERT_EQ("soap", res_obj["hits"][0]["document"]["title"]);
+    ASSERT_EQ(2, res_obj["hits"][0]["document"]["product_variants"].size());
+
+    ASSERT_EQ("2", res_obj["hits"][0]["document"]["product_variants"][0]["id"]);
+    ASSERT_EQ(2, res_obj["hits"][0]["document"]["product_variants"][0]["inventory"].size());
+    ASSERT_EQ(11, res_obj["hits"][0]["document"]["product_variants"][0]["inventory"]["qty"]);
+    ASSERT_EQ(2, res_obj["hits"][0]["document"]["product_variants"][0]["inventory"]["retailers"].size());
+    ASSERT_EQ("2", res_obj["hits"][0]["document"]["product_variants"][0]["inventory"]["retailers"]["id"]);
+    ASSERT_EQ("retailer 3", res_obj["hits"][0]["document"]["product_variants"][0]["inventory"]["retailers"]["title"]);
+
+    ASSERT_EQ("3", res_obj["hits"][0]["document"]["product_variants"][1]["id"]);
+    ASSERT_EQ(2, res_obj["hits"][0]["document"]["product_variants"][1]["inventory"].size());
+    ASSERT_EQ(12, res_obj["hits"][0]["document"]["product_variants"][1]["inventory"]["qty"]);
+    ASSERT_EQ(2, res_obj["hits"][0]["document"]["product_variants"][1]["inventory"]["retailers"].size());
+    ASSERT_EQ("2", res_obj["hits"][0]["document"]["product_variants"][1]["inventory"]["retailers"]["id"]);
+    ASSERT_EQ("retailer 3", res_obj["hits"][0]["document"]["product_variants"][1]["inventory"]["retailers"]["title"]);
+
+    ASSERT_EQ("0", res_obj["hits"][1]["document"]["id"]);
+    ASSERT_EQ("shampoo", res_obj["hits"][1]["document"]["title"]);
+    ASSERT_EQ(2, res_obj["hits"][1]["document"]["product_variants"].size());
+
+    ASSERT_EQ("0", res_obj["hits"][1]["document"]["product_variants"][0]["id"]);
+    ASSERT_EQ(2, res_obj["hits"][1]["document"]["product_variants"][0]["inventory"].size());
+    ASSERT_EQ(9, res_obj["hits"][1]["document"]["product_variants"][0]["inventory"]["qty"]);
+    ASSERT_EQ(2, res_obj["hits"][1]["document"]["product_variants"][0]["inventory"]["retailers"].size());
+    ASSERT_EQ("2", res_obj["hits"][1]["document"]["product_variants"][0]["inventory"]["retailers"]["id"]);
+    ASSERT_EQ("retailer 3", res_obj["hits"][1]["document"]["product_variants"][0]["inventory"]["retailers"]["title"]);
+
+    ASSERT_EQ("1", res_obj["hits"][1]["document"]["product_variants"][1]["id"]);
+    ASSERT_EQ(2, res_obj["hits"][1]["document"]["product_variants"][1]["inventory"].size());
+    ASSERT_EQ(10, res_obj["hits"][1]["document"]["product_variants"][1]["inventory"]["qty"]);
+    ASSERT_EQ(2, res_obj["hits"][1]["document"]["product_variants"][1]["inventory"]["retailers"].size());
+    ASSERT_EQ("2", res_obj["hits"][1]["document"]["product_variants"][1]["inventory"]["retailers"]["id"]);
+    ASSERT_EQ("retailer 3", res_obj["hits"][1]["document"]["product_variants"][1]["inventory"]["retailers"]["title"]);
+
+    req_params = {
+            {"collection", "products"},
+            {"q", "*"},
+            {"filter_by", "$product_variants($inventory($retailers(id: [0, 1]) && qty: [4..5]))"},
+            {"include_fields", "$product_variants(id,$inventory(qty,sku,$retailers(id,title)))"},
+            {"exclude_fields", "$product_variants($inventory($retailers(id)))"}
+    };
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, res_obj["found"].get<size_t>());
+    ASSERT_EQ(2, res_obj["hits"].size());
+    ASSERT_EQ("1", res_obj["hits"][0]["document"]["id"]);
+    ASSERT_EQ("soap", res_obj["hits"][0]["document"]["title"]);
+    ASSERT_EQ("3", res_obj["hits"][0]["document"]["product_variants"]["id"]);
+    ASSERT_EQ(2, res_obj["hits"][0]["document"]["product_variants"]["inventory"].size());
+    ASSERT_EQ(4, res_obj["hits"][0]["document"]["product_variants"]["inventory"]["qty"]);
+    ASSERT_EQ(1, res_obj["hits"][0]["document"]["product_variants"]["inventory"]["retailers"].size());
+    ASSERT_EQ("retailer 1", res_obj["hits"][0]["document"]["product_variants"]["inventory"]["retailers"]["title"]);
+
+    ASSERT_EQ("0", res_obj["hits"][1]["document"]["id"]);
+    ASSERT_EQ("shampoo", res_obj["hits"][1]["document"]["title"]);
+    ASSERT_EQ("0", res_obj["hits"][1]["document"]["product_variants"]["id"]);
+    ASSERT_EQ(2, res_obj["hits"][1]["document"]["product_variants"]["inventory"].size());
+    ASSERT_EQ(5, res_obj["hits"][1]["document"]["product_variants"]["inventory"]["qty"]);
+    ASSERT_EQ(1, res_obj["hits"][1]["document"]["product_variants"]["inventory"]["retailers"].size());
+    ASSERT_EQ("retailer 2", res_obj["hits"][1]["document"]["product_variants"]["inventory"]["retailers"]["title"]);
+}
+
 TEST_F(CollectionJoinTest, IncludeExcludeFieldsByReference) {
     auto schema_json =
             R"({
@@ -1926,12 +2479,14 @@ TEST_F(CollectionJoinTest, IncludeExcludeFieldsByReference) {
 
     auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
     ASSERT_FALSE(search_op.ok());
-    ASSERT_EQ("Invalid reference in include_fields, expected `$CollectionName(fieldA, ...)`.", search_op.error());
+    ASSERT_EQ("Invalid reference `$foo.bar` in include_fields/exclude_fields, expected `$CollectionName(fieldA, ...)`.",
+              search_op.error());
 
     req_params["include_fields"] = "$foo(bar";
     search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
     ASSERT_FALSE(search_op.ok());
-    ASSERT_EQ("Invalid reference in include_fields, expected `$CollectionName(fieldA, ...)`.", search_op.error());
+    ASSERT_EQ("Invalid reference `$foo(bar` in include_fields/exclude_fields, expected `$CollectionName(fieldA, ...)`.",
+              search_op.error());
 
     req_params["include_fields"] = "$foo(bar)";
     search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -1970,6 +1970,34 @@ TEST_F(CollectionJoinTest, IncludeExcludeFieldsByReference) {
             {"q", "*"},
             {"query_by", "product_name"},
             {"filter_by", "$Customers(customer_id:=customer_a && product_price:<100)"},
+            {"include_fields", "*, $Customers(*:nest_array) as Customers"}
+    };
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, res_obj["found"].get<size_t>());
+    ASSERT_EQ(1, res_obj["hits"].size());
+    // No fields are mentioned in `include_fields`, should include all fields of Products and Customers by default.
+    ASSERT_EQ(7, res_obj["hits"][0]["document"].size());
+    ASSERT_EQ(1, res_obj["hits"][0]["document"].count("id"));
+    ASSERT_EQ(1, res_obj["hits"][0]["document"].count("product_id"));
+    ASSERT_EQ(1, res_obj["hits"][0]["document"].count("product_name"));
+    ASSERT_EQ(1, res_obj["hits"][0]["document"].count("product_description"));
+    ASSERT_EQ(1, res_obj["hits"][0]["document"].count("embedding"));
+    ASSERT_EQ(1, res_obj["hits"][0]["document"].count("rating"));
+    // In nest_array strategy we return the referenced docs in an array.
+    ASSERT_EQ(1, res_obj["hits"][0]["document"]["Customers"].size());
+    ASSERT_EQ(1, res_obj["hits"][0]["document"]["Customers"][0].count("customer_id"));
+    ASSERT_EQ(1, res_obj["hits"][0]["document"]["Customers"][0].count("customer_name"));
+    ASSERT_EQ(1, res_obj["hits"][0]["document"]["Customers"][0].count("id"));
+    ASSERT_EQ(1, res_obj["hits"][0]["document"]["Customers"][0].count("product_id"));
+    ASSERT_EQ(1, res_obj["hits"][0]["document"]["Customers"][0].count("product_price"));
+
+    req_params = {
+            {"collection", "Products"},
+            {"q", "*"},
+            {"query_by", "product_name"},
+            {"filter_by", "$Customers(customer_id:=customer_a && product_price:<100)"},
             {"include_fields", "*, $Customers(*:merge) as Customers"}
     };
     search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -1425,6 +1425,15 @@ TEST_F(CollectionManagerTest, GetReferenceCollectionNames) {
         ASSERT_EQ(1, reference_collection_names.count(item));
     }
     reference_collection_names.clear();
+
+    filter_query = "$product_variants( $inventory($retailers(location:(33.865,-118.375,100 km))))";
+    result = {"product_variants", "inventory", "retailers"};
+    CollectionManager::_get_reference_collection_names(filter_query, reference_collection_names);
+    ASSERT_EQ(3, reference_collection_names.size());
+    for (const auto &item: result) {
+        ASSERT_EQ(1, reference_collection_names.count(item));
+    }
+    reference_collection_names.clear();
 }
 
 TEST_F(CollectionManagerTest, ReferencedInBacklog) {

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -1464,94 +1464,127 @@ TEST_F(CollectionManagerTest, InitializeRefIncludeFields) {
     std::string filter_query = "";
     std::vector<std::string> include_fields_vec;
     std::vector<ref_include_fields> ref_include_fields_vec;
-    CollectionManager::_initialize_ref_include_fields_vec(filter_query, include_fields_vec, ref_include_fields_vec);
+    auto initialize_op = CollectionManager::_initialize_ref_include_fields_vec(filter_query, include_fields_vec,
+                                                                               ref_include_fields_vec);
+    ASSERT_TRUE(initialize_op.ok());
     ASSERT_TRUE(ref_include_fields_vec.empty());
 
     filter_query = "$foo(bar:baz)";
-    CollectionManager::_initialize_ref_include_fields_vec(filter_query, include_fields_vec, ref_include_fields_vec);
+    initialize_op = CollectionManager::_initialize_ref_include_fields_vec(filter_query, include_fields_vec,
+                                                                               ref_include_fields_vec);
+    ASSERT_TRUE(initialize_op.ok());
     ASSERT_EQ(1, ref_include_fields_vec.size());
     ASSERT_EQ("foo", ref_include_fields_vec[0].collection_name);
     ASSERT_TRUE(ref_include_fields_vec[0].fields.empty());
     ASSERT_TRUE(ref_include_fields_vec[0].alias.empty());
-    ASSERT_TRUE(ref_include_fields_vec[0].nest_ref_doc);
+    ASSERT_EQ(ref_include::nest, ref_include_fields_vec[0].strategy);
     ASSERT_TRUE(ref_include_fields_vec[0].nested_join_includes.empty());
     ref_include_fields_vec.clear();
 
+    filter_query = "";
+    include_fields_vec = {"$Customers(product_price: foo) as customers"};
+    initialize_op = CollectionManager::_initialize_ref_include_fields_vec(filter_query, include_fields_vec,
+                                                                               ref_include_fields_vec);
+    ASSERT_FALSE(initialize_op.ok());
+    ASSERT_EQ("Error parsing `$Customers(product_price: foo) as customers`: Unknown include strategy `foo`. "
+              "Valid options are `merge`, `nest`, `nest_array`.", initialize_op.error());
+
     filter_query = "$Customers(customer_id:=customer_a && (product_price:>100 && product_price:<200))";
     include_fields_vec = {"$Customers(product_price: merge) as customers"};
-    CollectionManager::_initialize_ref_include_fields_vec(filter_query, include_fields_vec, ref_include_fields_vec);
+    initialize_op = CollectionManager::_initialize_ref_include_fields_vec(filter_query, include_fields_vec,
+                                                                          ref_include_fields_vec);
+    ASSERT_TRUE(initialize_op.ok());
     ASSERT_EQ(1, ref_include_fields_vec.size());
     ASSERT_EQ("Customers", ref_include_fields_vec[0].collection_name);
     ASSERT_EQ("product_price", ref_include_fields_vec[0].fields);
     ASSERT_EQ("customers.", ref_include_fields_vec[0].alias);
-    ASSERT_FALSE(ref_include_fields_vec[0].nest_ref_doc);
+    ASSERT_EQ(ref_include::merge, ref_include_fields_vec[0].strategy);
+    ASSERT_TRUE(ref_include_fields_vec[0].nested_join_includes.empty());
+    ref_include_fields_vec.clear();
+
+    filter_query = "$Customers(customer_id:=customer_a && (product_price:>100 && product_price:<200))";
+    include_fields_vec = {"$Customers(product_price: nest_array) as customers"};
+    initialize_op = CollectionManager::_initialize_ref_include_fields_vec(filter_query, include_fields_vec,
+                                                                          ref_include_fields_vec);
+    ASSERT_TRUE(initialize_op.ok());
+    ASSERT_EQ(1, ref_include_fields_vec.size());
+    ASSERT_EQ("Customers", ref_include_fields_vec[0].collection_name);
+    ASSERT_EQ("product_price", ref_include_fields_vec[0].fields);
+    ASSERT_EQ("customers", ref_include_fields_vec[0].alias);
+    ASSERT_EQ(ref_include::nest_array, ref_include_fields_vec[0].strategy);
     ASSERT_TRUE(ref_include_fields_vec[0].nested_join_includes.empty());
     ref_include_fields_vec.clear();
 
     filter_query = "$product_variants( $inventory($retailers(location:(33.865,-118.375,100 km))))";
     include_fields_vec = {"$product_variants(title, $inventory(qty:merge) as inventory: nest) as variants"};
-    CollectionManager::_initialize_ref_include_fields_vec(filter_query, include_fields_vec, ref_include_fields_vec);
+    initialize_op = CollectionManager::_initialize_ref_include_fields_vec(filter_query, include_fields_vec,
+                                                                          ref_include_fields_vec);
+    ASSERT_TRUE(initialize_op.ok());
     ASSERT_EQ(1, ref_include_fields_vec.size());
     ASSERT_EQ("product_variants", ref_include_fields_vec[0].collection_name);
     ASSERT_EQ("title,", ref_include_fields_vec[0].fields);
     ASSERT_EQ("variants", ref_include_fields_vec[0].alias);
-    ASSERT_TRUE(ref_include_fields_vec[0].nest_ref_doc);
+    ASSERT_EQ(ref_include::nest, ref_include_fields_vec[0].strategy);
 
     auto nested_join_includes = ref_include_fields_vec[0].nested_join_includes;
     ASSERT_EQ("inventory", nested_join_includes[0].collection_name);
     ASSERT_EQ("qty", nested_join_includes[0].fields);
     ASSERT_EQ("inventory.", nested_join_includes[0].alias);
-    ASSERT_FALSE(nested_join_includes[0].nest_ref_doc);
+    ASSERT_EQ(ref_include::merge, nested_join_includes[0].strategy);
 
     nested_join_includes = ref_include_fields_vec[0].nested_join_includes[0].nested_join_includes;
     ASSERT_EQ("retailers", nested_join_includes[0].collection_name);
     ASSERT_TRUE(nested_join_includes[0].fields.empty());
     ASSERT_TRUE(nested_join_includes[0].alias.empty());
-    ASSERT_TRUE(nested_join_includes[0].nest_ref_doc);
+    ASSERT_EQ(ref_include::nest, ref_include_fields_vec[0].strategy);
     ref_include_fields_vec.clear();
 
     filter_query = "$product_variants( $inventory(id:*) && $retailers(location:(33.865,-118.375,100 km)))";
     include_fields_vec = {"$product_variants(title, $inventory(qty:merge) as inventory,"
                             " $retailers(title): merge) as variants"};
-    CollectionManager::_initialize_ref_include_fields_vec(filter_query, include_fields_vec, ref_include_fields_vec);
+    initialize_op = CollectionManager::_initialize_ref_include_fields_vec(filter_query, include_fields_vec,
+                                                                          ref_include_fields_vec);
+    ASSERT_TRUE(initialize_op.ok());
     ASSERT_EQ(1, ref_include_fields_vec.size());
     ASSERT_EQ("product_variants", ref_include_fields_vec[0].collection_name);
     ASSERT_EQ("title,", ref_include_fields_vec[0].fields);
     ASSERT_EQ("variants.", ref_include_fields_vec[0].alias);
-    ASSERT_FALSE(ref_include_fields_vec[0].nest_ref_doc);
+    ASSERT_EQ(ref_include::merge, ref_include_fields_vec[0].strategy);
 
     nested_join_includes = ref_include_fields_vec[0].nested_join_includes;
     ASSERT_EQ("inventory", nested_join_includes[0].collection_name);
     ASSERT_EQ("qty", nested_join_includes[0].fields);
     ASSERT_EQ("inventory.", nested_join_includes[0].alias);
-    ASSERT_FALSE(nested_join_includes[0].nest_ref_doc);
+    ASSERT_EQ(ref_include::merge, nested_join_includes[0].strategy);
 
     ASSERT_EQ("retailers", nested_join_includes[1].collection_name);
     ASSERT_EQ("title", nested_join_includes[1].fields);
     ASSERT_TRUE(nested_join_includes[1].alias.empty());
-    ASSERT_TRUE(nested_join_includes[1].nest_ref_doc);
+    ASSERT_EQ(ref_include::nest, nested_join_includes[1].strategy);
     ref_include_fields_vec.clear();
 
     filter_query = "$product_variants( $inventory(id:*) && $retailers(location:(33.865,-118.375,100 km)))";
     include_fields_vec = {"$product_variants(title, $inventory(qty:merge) as inventory, description,"
                             " $retailers(title), foo: merge) as variants"};
-    CollectionManager::_initialize_ref_include_fields_vec(filter_query, include_fields_vec, ref_include_fields_vec);
+    initialize_op = CollectionManager::_initialize_ref_include_fields_vec(filter_query, include_fields_vec,
+                                                                          ref_include_fields_vec);
+    ASSERT_TRUE(initialize_op.ok());
     ASSERT_EQ(1, ref_include_fields_vec.size());
     ASSERT_EQ("product_variants", ref_include_fields_vec[0].collection_name);
     ASSERT_EQ("title, description, foo", ref_include_fields_vec[0].fields);
     ASSERT_EQ("variants.", ref_include_fields_vec[0].alias);
-    ASSERT_FALSE(ref_include_fields_vec[0].nest_ref_doc);
+    ASSERT_EQ(ref_include::merge, ref_include_fields_vec[0].strategy);
 
     nested_join_includes = ref_include_fields_vec[0].nested_join_includes;
     ASSERT_EQ("inventory", nested_join_includes[0].collection_name);
     ASSERT_EQ("qty", nested_join_includes[0].fields);
     ASSERT_EQ("inventory.", nested_join_includes[0].alias);
-    ASSERT_FALSE(nested_join_includes[0].nest_ref_doc);
+    ASSERT_EQ(ref_include::merge, nested_join_includes[0].strategy);
 
     ASSERT_EQ("retailers", nested_join_includes[1].collection_name);
     ASSERT_EQ("title", nested_join_includes[1].fields);
     ASSERT_TRUE(nested_join_includes[1].alias.empty());
-    ASSERT_TRUE(nested_join_includes[1].nest_ref_doc);
+    ASSERT_EQ(ref_include::nest, nested_join_includes[1].strategy);
     ref_include_fields_vec.clear();
 }
 

--- a/test/string_utils_test.cpp
+++ b/test/string_utils_test.cpp
@@ -398,9 +398,9 @@ TEST(StringUtilsTest, TokenizeFilterQuery) {
     tokenizeTestHelper(filter_query, tokenList);
 }
 
-void splitIncludeTestHelper(const std::string& include_fields, const std::vector<std::string>& expected) {
+void splitIncludeExcludeTestHelper(const std::string& include_exclude_fields, const std::vector<std::string>& expected) {
     std::vector<std::string> output;
-    auto tokenize_op = StringUtils::split_include_fields(include_fields, output);
+    auto tokenize_op = StringUtils::split_include_exclude_fields(include_exclude_fields, output);
     ASSERT_TRUE(tokenize_op.ok());
     ASSERT_EQ(expected.size(), output.size());
     for (auto i = 0; i < output.size(); i++) {
@@ -408,51 +408,73 @@ void splitIncludeTestHelper(const std::string& include_fields, const std::vector
     }
 }
 
-TEST(StringUtilsTest, SplitIncludeFields) {
+TEST(StringUtilsTest, SplitIncludeExcludeFields) {
     std::string include_fields;
     std::vector<std::string> tokens;
 
     include_fields = " id, title , count ";
     tokens = {"id", "title", "count"};
-    splitIncludeTestHelper(include_fields, tokens);
+    splitIncludeExcludeTestHelper(include_fields, tokens);
 
     include_fields = "id, $Collection(title, pref*),count";
     tokens = {"id", "$Collection(title, pref*)", "count"};
-    splitIncludeTestHelper(include_fields, tokens);
+    splitIncludeExcludeTestHelper(include_fields, tokens);
 
     include_fields = "id, $Collection(title, pref*), count, ";
     tokens = {"id", "$Collection(title, pref*)", "count"};
-    splitIncludeTestHelper(include_fields, tokens);
+    splitIncludeExcludeTestHelper(include_fields, tokens);
 
     include_fields = "$Collection(title, pref*) as coll";
     tokens = {"$Collection(title, pref*) as coll"};
-    splitIncludeTestHelper(include_fields, tokens);
+    splitIncludeExcludeTestHelper(include_fields, tokens);
 
     include_fields = "id, $Collection(title, pref*)  as coll , count, ";
     tokens = {"id", "$Collection(title, pref*) as coll", "count"};
-    splitIncludeTestHelper(include_fields, tokens);
+    splitIncludeExcludeTestHelper(include_fields, tokens);
 
     include_fields = "$Collection(title, pref*: merge) as coll";
     tokens = {"$Collection(title, pref*: merge) as coll"};
-    splitIncludeTestHelper(include_fields, tokens);
+    splitIncludeExcludeTestHelper(include_fields, tokens);
 
     include_fields = "$product_variants(id,$inventory(qty,sku,$retailer(id,title: merge) as retailer_info))  as variants";
     tokens = {"$product_variants(id,$inventory(qty,sku,$retailer(id,title: merge) as retailer_info)) as variants"};
-    splitIncludeTestHelper(include_fields, tokens);
+    splitIncludeExcludeTestHelper(include_fields, tokens);
+
+    std::string exclude_fields = " id, title, $Collection(title), count,";
+    tokens = {"id", "title", "$Collection(title)", "count"};
+    splitIncludeExcludeTestHelper(exclude_fields, tokens);
+
+    exclude_fields = " id, title , count, $Collection(title), $product_variants(id,$inventory(qty,sku,$retailer(id,title)))";
+    tokens = {"id", "title", "count", "$Collection(title)", "$product_variants(id,$inventory(qty,sku,$retailer(id,title)))"};
+    splitIncludeExcludeTestHelper(exclude_fields, tokens);
 }
 
-TEST(StringUtilsTest, SplitReferenceIncludeFields) {
+TEST(StringUtilsTest, SplitReferenceIncludeExcludeFields) {
     std::string include_fields = "$retailer(id,title: merge) as retailer_info:merge)  as variants, foo", token;
     size_t index = 0;
-    auto tokenize_op = StringUtils::split_reference_include_fields(include_fields, index, token);
+    auto tokenize_op = StringUtils::split_reference_include_exclude_fields(include_fields, index, token);
     ASSERT_TRUE(tokenize_op.ok());
     ASSERT_EQ("$retailer(id,title: merge) as retailer_info", token);
     ASSERT_EQ(":merge)  as variants, foo", include_fields.substr(index));
 
     include_fields = "$inventory(qty,sku,$retailer(id,title: merge) as retailer_info)  as inventory)  as variants, foo";
     index = 0;
-    tokenize_op = StringUtils::split_reference_include_fields(include_fields, index, token);
+    tokenize_op = StringUtils::split_reference_include_exclude_fields(include_fields, index, token);
     ASSERT_TRUE(tokenize_op.ok());
     ASSERT_EQ("$inventory(qty,sku,$retailer(id,title: merge) as retailer_info) as inventory", token);
     ASSERT_EQ(")  as variants, foo", include_fields.substr(index));
+
+    std::string exclude_fields = "$Collection(title), $product_variants(id,$inventory(qty,sku,$retailer(id,title)))";
+    index = 0;
+    tokenize_op = StringUtils::split_reference_include_exclude_fields(exclude_fields, index, token);
+    ASSERT_TRUE(tokenize_op.ok());
+    ASSERT_EQ("$Collection(title)", token);
+    ASSERT_EQ(", $product_variants(id,$inventory(qty,sku,$retailer(id,title)))", exclude_fields.substr(index));
+
+    exclude_fields = "$inventory(qty,sku,$retailer(id,title)), foo)";
+    index = 0;
+    tokenize_op = StringUtils::split_reference_include_exclude_fields(exclude_fields, index, token);
+    ASSERT_TRUE(tokenize_op.ok());
+    ASSERT_EQ("$inventory(qty,sku,$retailer(id,title))", token);
+    ASSERT_EQ(", foo)", exclude_fields.substr(index));
 }


### PR DESCRIPTION
## Change Summary
* Adds `nest_array` include strategy. Syntax for reference include:
 `$<reference_collection_name>( <field_names> : <include_strategy>)  as <alias>`

If the following is the document of the collection being searched,
```json
{
  "foo": 1
}
```
and this is the reference document,
```json
{
  "bar": 2,
  "baz": 3
}
```
with `nest_array` strategy, the resulting document will be:
```json
{
  "foo": 1,
  "alias": [
    {
      "bar": 2,
      "baz": 3
    }
  ]
}
```

* Adds the ability to include/exclude fields of a collection in nested join. If we have the following collections:
```json
{
  "name": "Coll_A",
  "fields": [
    { "name": "id", "type": "string" }
  ]
}
```
```json
{
  "name": "Coll_B",
  "fields": [
    { "name": "id", "type": "string" },
    { "name": "Coll_A_reference", "type": "string", "reference": "Coll_A.id" }
  ]
}
```
```json
{
  "name": "Coll_C",
  "fields": [
    { "name": "id", "type": "string" },
    {  "name": "Coll_B_reference", "type": "string", "reference": "Coll_B.id" }
  ]
}
```
and we search on `Coll_A` and join on `Coll_B` that further joins on `Coll_C` like:

```
collection: Coll_A
q: *
filter_by: $Coll_B( $Coll_C( id: * ) )
```
to include the referenced document fields, we can nest the collections similar to the `filter_by` following the syntax:
`$ref_collection_name(field_1, field_2, $nested_ref_coll(nested_field_1: nested_include_strategy) as nested_ref_alias: include_strategy) as ref_alias`. For example:
```
include_fields: $Coll_B(id, $Coll_C(id) as C) as B
```
the response would be:
```json
{
  "id": "Coll_A_1",
  "B": {
    "id": "Coll_B_1",
    "C": {
      "id": "Coll_C_1"
    }
  }
}
```
The default include strategy is `nest`. To merge the `Coll_C` document in `Coll_B`, following can be specified
```
include_fields: $Coll_B(id, $Coll_C(id :merge) as C :nest) as B
```
the response would be:
```json
{
  "id": "Coll_A_1",
  "B": {
    "id": "Coll_B_1",
    "C.id": "Coll_C_1"
  }
}
```
Similarly, to exclude the fields the following syntax is used:
`$ref_collection_name(field_1, field_2, $nested_ref_coll(nested_field_1))`. For example:
```
exclude_fields: $Coll_B(id, $Coll_C(id))
```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
