### PR TITLE
remove expired API keys when specified

### DIFF
--- a/include/auth_manager.h
+++ b/include/auth_manager.h
@@ -17,6 +17,7 @@ struct api_key_t {
     std::vector<std::string> actions;
     std::vector<std::string> collections;
     uint64_t expires_at;
+    bool autodelete;
 
     static constexpr const size_t PREFIX_LEN = 4;
     static constexpr const uint64_t FAR_FUTURE_TIMESTAMP = 64723363199;  // year 4020
@@ -26,8 +27,9 @@ struct api_key_t {
     }
 
     api_key_t(const std::string &value, const std::string &description, const std::vector<std::string> &actions,
-              const std::vector<std::string> &collections, uint64_t expires_at) :
-            value(value), description(description), actions(actions), collections(collections), expires_at(expires_at) {
+              const std::vector<std::string> &collections, uint64_t expires_at, bool autodel=false) :
+            value(value), description(description), actions(actions), collections(collections), expires_at(expires_at),
+            autodelete(autodel) {
 
     }
 
@@ -45,6 +47,7 @@ struct api_key_t {
         description = key_obj["description"].get<std::string>();
         actions = key_obj["actions"].get<std::vector<std::string>>();
         collections = key_obj["collections"].get<std::vector<std::string>>();
+        autodelete = key_obj["autodelete"].get<bool>();
 
         // handle optional fields
 
@@ -67,6 +70,7 @@ struct api_key_t {
         obj["actions"] = actions;
         obj["collections"] = collections;
         obj["expires_at"] = expires_at;
+        obj["autodelete"] = autodelete;
 
         return obj;
     }
@@ -119,6 +123,7 @@ private:
 
     static bool regexp_match(const std::string& value, const std::string& regexp);
 
+    void remove_expired_keys();
 public:
 
     static const size_t GENERATED_KEY_LEN = 32;
@@ -144,4 +149,6 @@ public:
     static bool add_item_to_params(std::map<std::string, std::string> &req_params,
                                    const nlohmann::detail::iteration_proxy_value<nlohmann::json::iterator>& item,
                                    bool overwrite);
+
+    void do_housekeeping();
 };

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -1787,6 +1787,10 @@ bool post_create_key(const std::shared_ptr<http_req>& req, const std::shared_ptr
         req_json["expires_at"] = api_key_t::FAR_FUTURE_TIMESTAMP;
     }
 
+    if(req_json.count("autodelete") == 0) {
+        req_json["autodelete"] = false;
+    }
+
     const std::string &rand_key = (req_json.count("value") != 0) ?
             req_json["value"].get<std::string>() : req->metadata;
 
@@ -1795,7 +1799,8 @@ bool post_create_key(const std::shared_ptr<http_req>& req, const std::shared_ptr
         req_json["description"].get<std::string>(),
         req_json["actions"].get<std::vector<std::string>>(),
         req_json["collections"].get<std::vector<std::string>>(),
-        req_json["expires_at"].get<uint64_t>()
+        req_json["expires_at"].get<uint64_t>(),
+        req_json["autodelete"].get<bool>()
     );
 
     const Option<api_key_t>& api_key_op = auth_manager.create_key(api_key);

--- a/src/housekeeper.cpp
+++ b/src/housekeeper.cpp
@@ -48,6 +48,9 @@ void HouseKeeper::run() {
                 LOG(INFO) << "Ran housekeeping for " << coll_names.size() << " collections.";
             }
 
+            //do housekeeping for authmanager
+            CollectionManager::get_instance().getAuthManager().do_housekeeping();
+
             prev_hnsw_repair_s = std::chrono::duration_cast<std::chrono::seconds>(
                     std::chrono::system_clock::now().time_since_epoch()).count();
         }


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- delete expired API keys when specified `autodelete=true` on creation
- add test

### Create keys with autodelete
To create keys which gets auto deleted after expiry, additional parameter `autodelete` needs to passed while creation of key like below,
```curl
curl 'http://localhost:8108/keys' \
    -X POST \
    -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
    -H 'Content-Type: application/json' \
    -d '{"description":"Admin key.","actions": ["*"], "collections": ["*"], "expires_at":1704807756, "autodelete":true}'
``` 
Keys will be auto deleted on expiry when explicitly specified only.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
