### PR TITLE
facilitate to add metadata while creating collection

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -372,6 +372,8 @@ public:
     static constexpr const char* COLLECTION_SEPARATORS = "token_separators";
     static constexpr const char* COLLECTION_VOICE_QUERY_MODEL = "voice_query_model";
 
+    static constexpr const char* COLLECTION_METADATA = "metadata";
+
     // methods
 
     Collection() = delete;

--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -170,7 +170,7 @@ public:
                                           const std::vector<std::string>& symbols_to_index = {},
                                           const std::vector<std::string>& token_separators = {},
                                           const bool enable_nested_fields = false, std::shared_ptr<VQModel> model = nullptr,
-                                          const nlohmann::json& metadata = nullptr);
+                                          const nlohmann::json& metadata = {});
 
     locked_resource_view_t<Collection> get_collection(const std::string & collection_name) const;
 

--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -169,7 +169,8 @@ public:
                                           const std::string& fallback_field_type = "",
                                           const std::vector<std::string>& symbols_to_index = {},
                                           const std::vector<std::string>& token_separators = {},
-                                          const bool enable_nested_fields = false, std::shared_ptr<VQModel> model = nullptr);
+                                          const bool enable_nested_fields = false, std::shared_ptr<VQModel> model = nullptr,
+                                          const nlohmann::json& metadata = nullptr);
 
     locked_resource_view_t<Collection> get_collection(const std::string & collection_name) const;
 

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -487,7 +487,6 @@ Option<Collection*> CollectionManager::create_collection(const std::string& name
     }
 
     if(!metadata.is_null()) {
-        collection_meta[Collection::COLLECTION_METADATA] = nlohmann::json::object();
         collection_meta[Collection::COLLECTION_METADATA] = metadata;
     }
 
@@ -1957,8 +1956,8 @@ Option<Collection*> CollectionManager::create_collection(nlohmann::json& req_jso
 
     nlohmann::json metadata = nullptr;
     if(req_json.count("metadata") != 0) {
-        if(req_json["metadata"].empty() || !req_json["metadata"].is_object()) {
-            return Option<Collection *>(400, "The `metadata` value should be non empty object.");
+        if(!req_json["metadata"].is_object()) {
+            return Option<Collection *>(400, "The `metadata` value should be an object.");
         }
         metadata = req_json["metadata"];
     }

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -486,7 +486,7 @@ Option<Collection*> CollectionManager::create_collection(const std::string& name
         collection_meta[Collection::COLLECTION_VOICE_QUERY_MODEL]["model_name"] = model->get_model_name();
     }
 
-    if(!metadata.is_null()) {
+    if(!metadata.empty()) {
         collection_meta[Collection::COLLECTION_METADATA] = metadata;
     }
 
@@ -1874,6 +1874,7 @@ Option<Collection*> CollectionManager::create_collection(nlohmann::json& req_jso
     const char* TOKEN_SEPARATORS = "token_separators";
     const char* ENABLE_NESTED_FIELDS = "enable_nested_fields";
     const char* DEFAULT_SORTING_FIELD = "default_sorting_field";
+    const char* METADATA = "metadata";
 
     // validate presence of mandatory fields
 
@@ -1954,12 +1955,12 @@ Option<Collection*> CollectionManager::create_collection(nlohmann::json& req_jso
                      "`name`, `type` and optionally, `facet` properties.");
     }
 
-    nlohmann::json metadata = nullptr;
-    if(req_json.count("metadata") != 0) {
-        if(!req_json["metadata"].is_object()) {
+    if(req_json.count(METADATA) != 0) {
+        if(!req_json[METADATA].is_object()) {
             return Option<Collection *>(400, "The `metadata` value should be an object.");
         }
-        metadata = req_json["metadata"];
+    } else {
+        req_json[METADATA] = {};
     }
 
     const std::string& default_sorting_field = req_json[DEFAULT_SORTING_FIELD].get<std::string>();
@@ -2012,7 +2013,7 @@ Option<Collection*> CollectionManager::create_collection(nlohmann::json& req_jso
                                                                 req_json[SYMBOLS_TO_INDEX],
                                                                 req_json[TOKEN_SEPARATORS],
                                                                 req_json[ENABLE_NESTED_FIELDS],
-                                                                model, metadata);
+                                                                model, req_json[METADATA]);
 }
 
 Option<bool> CollectionManager::load_collection(const nlohmann::json &collection_meta,

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -1742,12 +1742,12 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
           {"name": "value.g", "type": "int32", "optional": false, "facet": true },
           {"name": "value.b", "type": "int32", "optional": false, "facet": true }
         ],
-        "metadata": {}
+        "metadata": "abc"
     })"_json;
 
     auto op = collectionManager.create_collection(schema1);
     ASSERT_FALSE(op.ok());
-    ASSERT_EQ("The `metadata` value should be non empty object.", op.error());
+    ASSERT_EQ("The `metadata` value should be an object.", op.error());
 
     nlohmann::json schema2 = R"({
         "name": "collection_meta",


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- adding ability to store metadata while creating collection
- adding test

## Add metadata while creating collection
To add any metadata while creating collection, just need to add `metadata` field in collection schema like below,
```curl
 curl -k "http://localhost:8108/collections" -X POST -H "Content-Type: application/json"       -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -d '{
            "name": "hnstories",
            "enable_nested_fields": true,
            "fields": [
              {"name": "title", "type": "string", "facet":true },
              {"name": "points", "type": "int32" }
            ],
            "metadata":{
             "batch_job":325,
             "indexed_from":"2023-04-20T00:00:00.000Z"
          }'
```
here metadata field should be `object` type only.
metadata will be stored to disk along with collection schema.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
