### PR TITLE
add resource error response in /health end-point

### DIFF
--- a/include/cached_resource_stat.h
+++ b/include/cached_resource_stat.h
@@ -5,6 +5,13 @@
 #include <sys/statvfs.h>
 
 class cached_resource_stat_t {
+public:
+    enum resource_check_t {
+        OK,
+        OUT_OF_DISK,
+        OUT_OF_MEMORY
+    };
+
 private:
     const static size_t REFRESH_INTERVAL_SECS = 5;
     uint64_t disk_total_bytes = 0;
@@ -18,27 +25,17 @@ private:
 
     uint64_t last_checked_ts = 0;
 
-    static constexpr const char* out_of_memory_str = "OUT_OF_MEMORY";
-    static constexpr const char* out_of_disk_str = "OUT_OF_DISK";
-
-    std::string out_of_resource_error="";
+    resource_check_t resource_error;
 
     cached_resource_stat_t() = default;
 
     ~cached_resource_stat_t() = default;
 
 public:
-
     static cached_resource_stat_t& get_instance() {
         static cached_resource_stat_t instance;
         return instance;
     }
-
-    enum resource_check_t {
-        OK,
-        OUT_OF_DISK,
-        OUT_OF_MEMORY
-    };
 
     // On Mac, we will only check for disk usage
     resource_check_t has_enough_resources(const std::string& data_dir_path,

--- a/include/cached_resource_stat.h
+++ b/include/cached_resource_stat.h
@@ -18,6 +18,11 @@ private:
 
     uint64_t last_checked_ts = 0;
 
+    static constexpr const char* out_of_memory_str = "OUT_OF_MEMORY";
+    static constexpr const char* out_of_disk_str = "OUT_OF_DISK";
+
+    std::string out_of_resource_error="";
+
     cached_resource_stat_t() = default;
 
     ~cached_resource_stat_t() = default;
@@ -39,4 +44,6 @@ public:
     resource_check_t has_enough_resources(const std::string& data_dir_path,
                                           const int disk_used_max_percentage,
                                           const int memory_used_max_percentage);
+
+    const std::string get_out_of_resource_error() const;
 };

--- a/include/cached_resource_stat.h
+++ b/include/cached_resource_stat.h
@@ -42,5 +42,5 @@ public:
                                           const int disk_used_max_percentage,
                                           const int memory_used_max_percentage);
 
-    const std::string get_out_of_resource_error() const;
+    const resource_check_t get_out_of_resource_error() const;
 };

--- a/src/cached_resource_stat.cpp
+++ b/src/cached_resource_stat.cpp
@@ -1,7 +1,6 @@
 #include "cached_resource_stat.h"
 #include <fstream>
 #include "logger.h"
-#include "magic_enum.hpp"
 
 cached_resource_stat_t::resource_check_t
 cached_resource_stat_t::has_enough_resources(const std::string& data_dir_path,
@@ -101,6 +100,6 @@ cached_resource_stat_t::has_enough_resources(const std::string& data_dir_path,
     return cached_resource_stat_t::OK;
 }
 
-const std::string cached_resource_stat_t::get_out_of_resource_error() const {
-    return std::string(magic_enum::enum_name(resource_error));
+const cached_resource_stat_t::resource_check_t cached_resource_stat_t::get_out_of_resource_error() const {
+    return resource_error;
 }

--- a/src/cached_resource_stat.cpp
+++ b/src/cached_resource_stat.cpp
@@ -1,6 +1,7 @@
 #include "cached_resource_stat.h"
 #include <fstream>
 #include "logger.h"
+#include "magic_enum.hpp"
 
 cached_resource_stat_t::resource_check_t
 cached_resource_stat_t::has_enough_resources(const std::string& data_dir_path,
@@ -66,7 +67,7 @@ cached_resource_stat_t::has_enough_resources(const std::string& data_dir_path,
         LOG(INFO) << "disk_total_bytes: " << disk_total_bytes << ", disk_used_bytes: " << disk_used_bytes
                   << ", disk_used_percentage: " << disk_used_percentage;
 
-        out_of_resource_error = out_of_disk_str;
+        resource_error = cached_resource_stat_t::OUT_OF_DISK;
         return cached_resource_stat_t::OUT_OF_DISK;
     }
 
@@ -79,7 +80,7 @@ cached_resource_stat_t::has_enough_resources(const std::string& data_dir_path,
     uint64_t all_memory_used = (memory_total_bytes - memory_available_bytes) + (swap_total_bytes - swap_free_bytes);
 
     if(all_memory_used >= memory_total_bytes) {
-        out_of_resource_error = out_of_memory_str;
+        resource_error = cached_resource_stat_t::OUT_OF_MEMORY;
         return cached_resource_stat_t::OUT_OF_MEMORY;
     }
 
@@ -92,13 +93,14 @@ cached_resource_stat_t::has_enough_resources(const std::string& data_dir_path,
         LOG(INFO) << "memory_total: " << memory_total_bytes << ", memory_available: " << memory_available_bytes
                   << ", all_memory_used: " << all_memory_used << ", free_mem: " << free_mem
                   << ", memory_free_min: " << memory_free_min_bytes;
-        out_of_resource_error = out_of_memory_str;
+        resource_error = cached_resource_stat_t::OUT_OF_MEMORY;
         return cached_resource_stat_t::OUT_OF_MEMORY;
     }
 
+    resource_error = cached_resource_stat_t::OK;
     return cached_resource_stat_t::OK;
 }
 
 const std::string cached_resource_stat_t::get_out_of_resource_error() const {
-    return out_of_resource_error;
+    return std::string(magic_enum::enum_name(resource_error));
 }

--- a/src/cached_resource_stat.cpp
+++ b/src/cached_resource_stat.cpp
@@ -65,6 +65,8 @@ cached_resource_stat_t::has_enough_resources(const std::string& data_dir_path,
     if(disk_used_percentage > disk_used_max_percentage) {
         LOG(INFO) << "disk_total_bytes: " << disk_total_bytes << ", disk_used_bytes: " << disk_used_bytes
                   << ", disk_used_percentage: " << disk_used_percentage;
+
+        out_of_resource_error = out_of_disk_str;
         return cached_resource_stat_t::OUT_OF_DISK;
     }
 
@@ -77,6 +79,7 @@ cached_resource_stat_t::has_enough_resources(const std::string& data_dir_path,
     uint64_t all_memory_used = (memory_total_bytes - memory_available_bytes) + (swap_total_bytes - swap_free_bytes);
 
     if(all_memory_used >= memory_total_bytes) {
+        out_of_resource_error = out_of_memory_str;
         return cached_resource_stat_t::OUT_OF_MEMORY;
     }
 
@@ -89,8 +92,13 @@ cached_resource_stat_t::has_enough_resources(const std::string& data_dir_path,
         LOG(INFO) << "memory_total: " << memory_total_bytes << ", memory_available: " << memory_available_bytes
                   << ", all_memory_used: " << all_memory_used << ", free_mem: " << free_mem
                   << ", memory_free_min: " << memory_free_min_bytes;
+        out_of_resource_error = out_of_memory_str;
         return cached_resource_stat_t::OUT_OF_MEMORY;
     }
 
     return cached_resource_stat_t::OK;
+}
+
+const std::string cached_resource_stat_t::get_out_of_resource_error() const {
+    return out_of_resource_error;
 }

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -289,6 +289,10 @@ bool get_health(const std::shared_ptr<http_req>& req, const std::shared_ptr<http
     nlohmann::json result;
     bool alive = server->is_alive();
     result["ok"] = alive;
+    const auto resource_error = cached_resource_stat_t::get_instance().get_out_of_resource_error();
+    if(!resource_error.empty()) {
+        result["resource_error"] = resource_error;
+    }
 
     if(alive) {
         res->set_body(200, result.dump());

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -289,7 +289,11 @@ bool get_health(const std::shared_ptr<http_req>& req, const std::shared_ptr<http
     nlohmann::json result;
     bool alive = server->is_alive();
     result["ok"] = alive;
-    result["resource_error"] = cached_resource_stat_t::get_instance().get_out_of_resource_error();
+
+    auto resource_error = cached_resource_stat_t::get_instance().get_out_of_resource_error();
+    if (resource_error != cached_resource_stat_t::resource_check_t::OK) {
+        result["resource_error"] = std::string(magic_enum::enum_name(resource_error));
+    }
 
     if(alive) {
         res->set_body(200, result.dump());

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -289,10 +289,7 @@ bool get_health(const std::shared_ptr<http_req>& req, const std::shared_ptr<http
     nlohmann::json result;
     bool alive = server->is_alive();
     result["ok"] = alive;
-    const auto resource_error = cached_resource_stat_t::get_instance().get_out_of_resource_error();
-    if(!resource_error.empty()) {
-        result["resource_error"] = resource_error;
-    }
+    result["resource_error"] = cached_resource_stat_t::get_instance().get_out_of_resource_error();
 
     if(alive) {
         res->set_body(200, result.dump());


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- add `resource_error` response in /health end-point in case of out_of_memory or out_of_disk resource errors
## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
