### PR TITLE
Add support for open-text-embeddings

### DIFF
--- a/include/text_embedder_remote.h
+++ b/include/text_embedder_remote.h
@@ -110,3 +110,15 @@ class GCPEmbedder : public RemoteEmbedder {
 };
 
 
+class OTEEmbedder : public RemoteEmbedder {
+    private: 
+        std::string url;
+    public:
+        OTEEmbedder(const std::string& url);
+        static Option<bool> is_model_valid(const nlohmann::json& model_config, size_t& num_dims);
+        embedding_res_t Embed(const std::string& text, const size_t remote_embedder_timeout_ms = 30000, const size_t remote_embedding_num_tries = 2) override;
+        std::vector<embedding_res_t> batch_embed(const std::vector<std::string>& inputs, const size_t remote_embedding_batch_size = 200,
+                                                 const size_t remote_embedding_timeout_ms = 60000, const size_t remote_embedding_num_tries = 2) override;
+        nlohmann::json get_error_json(const nlohmann::json& req_body, long res_code, const std::string& res_body) override;
+        static std::string get_model_key(const nlohmann::json& model_config);
+};

--- a/src/embedder_manager.cpp
+++ b/src/embedder_manager.cpp
@@ -48,6 +48,11 @@ Option<bool> EmbedderManager::validate_and_init_remote_model(const nlohmann::jso
         if(!op.ok()) {
             return op;
         }
+    } else if(model_namespace == "open-text-embeddings") {
+        auto op = OTEEmbedder::is_model_valid(model_config, num_dims);
+        if(!op.ok()) {
+            return op;
+        }
     } else {
         return Option<bool>(400, "Invalid model namespace");
     }
@@ -510,5 +515,5 @@ const std::string EmbedderManager::get_model_namespace(const std::string& model_
 
 bool EmbedderManager::is_remote_model(const std::string& model_name) {
     auto model_namespace = get_namespace(model_name);
-    return model_namespace.ok() && (model_namespace.get() == "openai" || model_namespace.get() == "google" || model_namespace.get() == "gcp");
+    return model_namespace.ok() && (model_namespace.get() == "openai" || model_namespace.get() == "google" || model_namespace.get() == "gcp") || model_namespace.get() == "open-text-embeddings";
 }

--- a/src/text_embedder.cpp
+++ b/src/text_embedder.cpp
@@ -85,6 +85,10 @@ TextEmbedder::TextEmbedder(const nlohmann::json& model_config, size_t num_dims, 
         auto client_secret = model_config["client_secret"].get<std::string>();
 
         remote_embedder_ = std::make_unique<GCPEmbedder>(project_id, model_name, access_token, refresh_token, client_id, client_secret);
+    } else if(model_namespace == "open-text-embeddings") {
+        auto url = model_config["url"].get<std::string>();
+        
+        remote_embedder_ = std::make_unique<OTEEmbedder>(url);
     }
 
     num_dim = num_dims;


### PR DESCRIPTION
## Usage

```json
{
    "name": "test",
    "fields": [
        {
            "name": "text",
            "type": "string"
        }, 
        {
            "name": "vec",
            "type": "float[]",
            "embed": {
                "from": [
                    "text"
                ],
                "model_config": {
                    "model_name": "open-text-embeddings/intfloat/e5-small-v2",
                    "url": "http://localhost:8000"
                }
            }
        }
    ]
}
```