### PR TITLE
pagination for collections GET

### DIFF
--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -136,7 +136,7 @@ public:
 
     void add_to_collections(Collection* collection);
 
-    std::vector<Collection*> get_collections() const;
+    Option<std::vector<Collection*>> get_collections(uint32_t limit = 0, uint32_t offset = 0) const;
 
     std::vector<std::string> get_collection_names() const;
 
@@ -176,7 +176,7 @@ public:
 
     locked_resource_view_t<Collection> get_collection_with_id(uint32_t collection_id) const;
 
-    nlohmann::json get_collection_summaries() const;
+    Option<nlohmann::json> get_collection_summaries(uint32_t limit = 0 , uint32_t offset = 0) const;
 
     Option<nlohmann::json> drop_collection(const std::string& collection_name,
                                            const bool remove_from_store = true,

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -588,11 +588,7 @@ Option<std::vector<Collection*>> CollectionManager::get_collections(uint32_t lim
 
     auto collections_end = collections.end();
 
-    if(limit > 0 && (limit != collections.size() || (offset + limit != collections.size()))) {
-        if((limit > collections.size()) || (offset + limit > collections.size())) {
-            return Option<std::vector<Collection*>>(400, "Invalid limit param.");
-        }
-
+    if(limit > 0 && (offset + limit < collections.size())) {
         collections_end = collections_it;
         std::advance(collections_end, limit);
     }

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -598,10 +598,12 @@ Option<std::vector<Collection*>> CollectionManager::get_collections(uint32_t lim
     }
 
 
-    std::sort(std::begin(collection_vec), std::end(collection_vec),
-              [] (Collection* lhs, Collection* rhs) {
-                  return lhs->get_collection_id()  > rhs->get_collection_id();
-              });
+    if(offset == 0 && limit == 0) { //dont sort for paginated requests
+        std::sort(std::begin(collection_vec), std::end(collection_vec),
+                  [](Collection *lhs, Collection *rhs) {
+                      return lhs->get_collection_id() > rhs->get_collection_id();
+                  });
+    }
 
     return Option<std::vector<Collection*>>(collection_vec);
 }

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -184,8 +184,8 @@ bool get_collections(const std::shared_ptr<http_req>& req, const std::shared_ptr
 
     uint32_t offset = 0, limit = 0;
     if(req->params.count("offset") != 0) {
-        auto offset_str = req->params["offset"];
-        if(offset_str.find_first_not_of("0123456789") != std::string::npos) {
+        const auto &offset_str = req->params["offset"];
+        if(!StringUtils::is_uint32_t(offset_str)) {
             res->set(400, "Offset param should be unsigned integer.");
             return false;
         }
@@ -193,8 +193,8 @@ bool get_collections(const std::shared_ptr<http_req>& req, const std::shared_ptr
     }
 
     if(req->params.count("limit") != 0) {
-        auto limit_str = req->params["limit"];
-        if(limit_str.find_first_not_of("0123456789") != std::string::npos) {
+        const auto &limit_str = req->params["limit"];
+        if(!StringUtils::is_uint32_t(limit_str)) {
             res->set(400, "Limit param should be unsigned integer.");
             return false;
         }
@@ -204,6 +204,7 @@ bool get_collections(const std::shared_ptr<http_req>& req, const std::shared_ptr
     auto collections_summaries_op = collectionManager.get_collection_summaries(limit, offset);
     if(!collections_summaries_op.ok()) {
         res->set(collections_summaries_op.code(), collections_summaries_op.error());
+        return false;
     }
 
     nlohmann::json json_response = collections_summaries_op.get();

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -182,22 +182,13 @@ index_operation_t get_index_operation(const std::string& action) {
 bool get_collections(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     CollectionManager & collectionManager = CollectionManager::get_instance();
 
-    nlohmann::json req_json;
-    try {
-        req_json = nlohmann::json::parse(req->body);
-    } catch(const std::exception& e) {
-        //LOG(ERROR) << "JSON error: " << e.what();
-        res->set_400("Bad JSON.");
-        return false;
-    }
-
     uint32_t offset = 0, limit = 0;
-    if(req_json.contains("offset")) {
-        offset = req_json["offset"].get<size_t >();
+    if(req->params.count("offset") != 0) {
+        offset = std::stoi(req->params["offset"]);
     }
 
-    if(req_json.contains("limit")) {
-        limit = req_json["limit"].get<size_t>();
+    if(req->params.count("limit") != 0) {
+        limit = std::stoi(req->params["limit"]);
     }
 
     auto collections_summaries_op = collectionManager.get_collection_summaries(limit, offset);

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -184,11 +184,21 @@ bool get_collections(const std::shared_ptr<http_req>& req, const std::shared_ptr
 
     uint32_t offset = 0, limit = 0;
     if(req->params.count("offset") != 0) {
-        offset = std::stoi(req->params["offset"]);
+        auto offset_str = req->params["offset"];
+        if(offset_str.find_first_not_of("0123456789") != std::string::npos) {
+            res->set(400, "Offset param should be unsigned integer.");
+            return false;
+        }
+        offset = std::stoi(offset_str);
     }
 
     if(req->params.count("limit") != 0) {
-        limit = std::stoi(req->params["limit"]);
+        auto limit_str = req->params["limit"];
+        if(limit_str.find_first_not_of("0123456789") != std::string::npos) {
+            res->set(400, "Limit param should be unsigned integer.");
+            return false;
+        }
+        limit = std::stoi(limit_str);
     }
 
     auto collections_summaries_op = collectionManager.get_collection_summaries(limit, offset);

--- a/src/main/typesense_server.cpp
+++ b/src/main/typesense_server.cpp
@@ -50,6 +50,7 @@ void master_server_routes() {
     server->post("/collections", post_create_collection);
     server->patch("/collections/:collection", patch_update_collection);
     server->get("/collections", get_collections);
+    server->get("/collections/:offset/:limit", get_collections);
     server->del("/collections/:collection", del_drop_collection);
     server->get("/collections/:collection", get_collection_summary);
 

--- a/src/main/typesense_server.cpp
+++ b/src/main/typesense_server.cpp
@@ -50,7 +50,6 @@ void master_server_routes() {
     server->post("/collections", post_create_collection);
     server->patch("/collections/:collection", patch_update_collection);
     server->get("/collections", get_collections);
-    server->get("/collections/:offset/:limit", get_collections);
     server->del("/collections/:collection", del_drop_collection);
     server->get("/collections/:collection", get_collection_summary);
 

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -301,7 +301,7 @@ TEST_F(CollectionManagerTest, ParallelCollectionCreation) {
 
     int64_t prev_id = INT32_MAX;
 
-    for(auto coll: collectionManager.get_collections()) {
+    for(auto coll: collectionManager.get_collections().get()) {
         // collections are sorted by ID, in descending order
         ASSERT_TRUE(coll->get_collection_id() < prev_id);
         prev_id = coll->get_collection_id();
@@ -355,7 +355,7 @@ TEST_F(CollectionManagerTest, ShouldInitCollection) {
 }
 
 TEST_F(CollectionManagerTest, GetAllCollections) {
-    std::vector<Collection*> collection_vec = collectionManager.get_collections();
+    std::vector<Collection*> collection_vec = collectionManager.get_collections().get();
     ASSERT_EQ(1, collection_vec.size());
     ASSERT_STREQ("collection1", collection_vec[0]->get_name().c_str());
 
@@ -369,7 +369,7 @@ TEST_F(CollectionManagerTest, GetAllCollections) {
     })"_json;
 
     collectionManager.create_collection(new_schema);
-    collection_vec = collectionManager.get_collections();
+    collection_vec = collectionManager.get_collections().get();
     ASSERT_EQ(2, collection_vec.size());
 
     // most recently created collection first
@@ -1104,7 +1104,7 @@ TEST_F(CollectionManagerTest, Symlinking) {
     ASSERT_TRUE(drop_op.ok());
 
     // try to list collections now
-    nlohmann::json summaries = cmanager.get_collection_summaries();
+    nlohmann::json summaries = cmanager.get_collection_summaries().get();
     ASSERT_EQ(0, summaries.size());
 
     // remap alias to another non-existing collection
@@ -1172,7 +1172,7 @@ TEST_F(CollectionManagerTest, LoadMultipleCollections) {
         cmanager.create_collection("collection" + std::to_string(i), 4, schema, "points").get();
     }
 
-    ASSERT_EQ(100, cmanager.get_collections().size());
+    ASSERT_EQ(100, cmanager.get_collections().get().size());
 
     cmanager.dispose();
     delete new_store;
@@ -1181,7 +1181,7 @@ TEST_F(CollectionManagerTest, LoadMultipleCollections) {
     cmanager.init(new_store, 1.0, "auth_key", quit);
     cmanager.load(8, 1000);
 
-    ASSERT_EQ(100, cmanager.get_collections().size());
+    ASSERT_EQ(100, cmanager.get_collections().get().size());
 
     for(size_t i = 0; i < 100; i++) {
         collectionManager.drop_collection("collection" + std::to_string(i));
@@ -1907,4 +1907,83 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
     expected_meta_json["created_at"] = actual_json["created_at"];
 
     ASSERT_EQ(expected_meta_json.dump(), actual_json.dump());
+}
+
+TEST_F(CollectionManagerTest, CollectionPagination) {
+    //remove all collections first
+    auto collections = collectionManager.get_collections().get();
+    for(auto collection : collections) {
+        collectionManager.drop_collection(collection->get_name());
+    }
+
+    //create few collections
+    std::vector<std::thread> threads;
+    for(size_t i = 0; i < 5; i++) {
+        threads.emplace_back([i, &collectionManager = collectionManager]() {
+            nlohmann::json coll_json = R"({
+                "name": "cp",
+                "fields": [
+                    {"name": "title", "type": "string"}
+                ]
+            })"_json;
+            coll_json["name"] = coll_json["name"].get<std::string>() + std::to_string(i+1);
+            auto coll_op = collectionManager.create_collection(coll_json);
+            ASSERT_TRUE(coll_op.ok());
+        });
+    }
+
+    for(auto& thread : threads){
+        thread.join();
+    }
+
+    uint32_t limit = 0, offset = 0;
+
+    //limit collections by 2
+    limit=2;
+    auto collection_op = collectionManager.get_collections(limit);
+    auto collections_vec = collection_op.get();
+
+    ASSERT_EQ("cp5", collections_vec[0]->get_name());
+    ASSERT_EQ("cp2", collections_vec[1]->get_name());
+
+    //get 2 collection from offset 3
+    offset=3;
+    collection_op = collectionManager.get_collections(limit, offset);
+    collections_vec = collection_op.get();
+
+    ASSERT_EQ("cp4", collections_vec[0]->get_name());
+    ASSERT_EQ("cp1", collections_vec[1]->get_name());
+
+    //get all collection except first
+    offset=1; limit=0;
+    collection_op = collectionManager.get_collections(limit, offset);
+    collections_vec = collection_op.get();
+
+    ASSERT_EQ("cp5", collections_vec[0]->get_name());
+    ASSERT_EQ("cp4", collections_vec[1]->get_name());
+    ASSERT_EQ("cp3", collections_vec[2]->get_name());
+    ASSERT_EQ("cp1", collections_vec[3]->get_name());
+
+    //get last collection
+    offset=4, limit=1;
+    collection_op = collectionManager.get_collections(limit, offset);
+    collections_vec = collection_op.get();
+
+    ASSERT_EQ("cp4", collections_vec[0]->get_name());
+
+    //invalid offset and limit
+    offset=6; limit=0;
+    collection_op = collectionManager.get_collections(limit, offset);
+    ASSERT_FALSE(collection_op.ok());
+    ASSERT_EQ("Invalid offset param.", collection_op.error());
+
+    offset=0; limit=8;
+    collection_op = collectionManager.get_collections(limit, offset);
+    ASSERT_FALSE(collection_op.ok());
+    ASSERT_EQ("Invalid limit param.", collection_op.error());
+
+    offset=3; limit=4;
+    collection_op = collectionManager.get_collections(limit, offset);
+    ASSERT_FALSE(collection_op.ok());
+    ASSERT_EQ("Invalid limit param.", collection_op.error());
 }

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -1936,16 +1936,16 @@ TEST_F(CollectionManagerTest, CollectionPagination) {
     auto collection_op = collectionManager.get_collections(limit);
     auto collections_vec = collection_op.get();
     ASSERT_EQ(2, collections_vec.size());
-    ASSERT_EQ("cp5", collections_vec[0]->get_name());
-    ASSERT_EQ("cp2", collections_vec[1]->get_name());
+    ASSERT_EQ("cp2", collections_vec[0]->get_name());
+    ASSERT_EQ("cp5", collections_vec[1]->get_name());
 
     //get 2 collection from offset 3
     offset=3;
     collection_op = collectionManager.get_collections(limit, offset);
     collections_vec = collection_op.get();
     ASSERT_EQ(2, collections_vec.size());
-    ASSERT_EQ("cp4", collections_vec[0]->get_name());
-    ASSERT_EQ("cp1", collections_vec[1]->get_name());
+    ASSERT_EQ("cp1", collections_vec[0]->get_name());
+    ASSERT_EQ("cp4", collections_vec[1]->get_name());
 
     //get all collection except first
     offset=1; limit=0;
@@ -1953,9 +1953,9 @@ TEST_F(CollectionManagerTest, CollectionPagination) {
     collections_vec = collection_op.get();
     ASSERT_EQ(4, collections_vec.size());
     ASSERT_EQ("cp5", collections_vec[0]->get_name());
-    ASSERT_EQ("cp4", collections_vec[1]->get_name());
-    ASSERT_EQ("cp3", collections_vec[2]->get_name());
-    ASSERT_EQ("cp1", collections_vec[3]->get_name());
+    ASSERT_EQ("cp3", collections_vec[1]->get_name());
+    ASSERT_EQ("cp1", collections_vec[2]->get_name());
+    ASSERT_EQ("cp4", collections_vec[3]->get_name());
 
     //get last collection
     offset=4, limit=1;
@@ -1969,18 +1969,18 @@ TEST_F(CollectionManagerTest, CollectionPagination) {
     collection_op = collectionManager.get_collections(limit, offset);
     collections_vec = collection_op.get();
     ASSERT_EQ(5, collections_vec.size());
-    ASSERT_EQ("cp5", collections_vec[0]->get_name());
-    ASSERT_EQ("cp4", collections_vec[1]->get_name());
+    ASSERT_EQ("cp2", collections_vec[0]->get_name());
+    ASSERT_EQ("cp5", collections_vec[1]->get_name());
     ASSERT_EQ("cp3", collections_vec[2]->get_name());
-    ASSERT_EQ("cp2", collections_vec[3]->get_name());
-    ASSERT_EQ("cp1", collections_vec[4]->get_name());
+    ASSERT_EQ("cp1", collections_vec[3]->get_name());
+    ASSERT_EQ("cp4", collections_vec[4]->get_name());
 
     offset=3; limit=4;
     collection_op = collectionManager.get_collections(limit, offset);
     collections_vec = collection_op.get();
     ASSERT_EQ(2, collections_vec.size());
-    ASSERT_EQ("cp4", collections_vec[0]->get_name());
-    ASSERT_EQ("cp1", collections_vec[1]->get_name());
+    ASSERT_EQ("cp1", collections_vec[0]->get_name());
+    ASSERT_EQ("cp4", collections_vec[1]->get_name());
 
     //invalid offset
     offset=6; limit=0;


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
# Pagination with collections GET
One can use `limit` and `offset` params with GET request to restrict returned collections in paginated manner.
 
- `limit` param is non-zero unsigned integer which restricts the number of collections from offset 
- `offset` is unsigned integer param which sets the offset from where you want to get collections from disk

Below is a simple use case how to use GET request with `limit` and `offset` params
```curl
curl "http://localhost:8108/collections?offset=1&limit=3" -X GET -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}"
```
above curl request will return 3 collections from offset 1.
If there are 4 collections on disk then it'll return all collections except the first one on disk.

- Similarly one can get the last collection on disk using `offset=3` and `limit=1`.
- Out of 4 collections on disk, `offset=1` and `limit=2` will return the middle two collections leaving first and last.

#### passing `offset` greater than total collections on disk throws error `Invalid offset param.`
#### If there are lesser collections than given `limit` value then all collection from `offset` will be returned.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
