### PR TITLE
Geosearch sorting with precision fix.

### DIFF
--- a/include/field.h
+++ b/include/field.h
@@ -595,6 +595,7 @@ struct sort_by {
     int64_t geopoint;
     uint32_t exclude_radius;
     uint32_t geo_precision;
+    std::string unit;
 
     missing_values_t missing_values;
     eval_t eval;
@@ -631,6 +632,7 @@ struct sort_by {
         geopoint = other.geopoint;
         exclude_radius = other.exclude_radius;
         geo_precision = other.geo_precision;
+        unit = other.unit;
         missing_values = other.missing_values;
         eval = other.eval;
         reference_collection_name = other.reference_collection_name;
@@ -645,6 +647,7 @@ struct sort_by {
         geopoint = other.geopoint;
         exclude_radius = other.exclude_radius;
         geo_precision = other.geo_precision;
+        unit = other.unit;
         missing_values = other.missing_values;
         eval = other.eval;
         reference_collection_name = other.reference_collection_name;

--- a/include/index.h
+++ b/include/index.h
@@ -1045,6 +1045,9 @@ public:
     void repair_hnsw_index();
 
     void aggregate_facet(const size_t group_limit, facet& this_facet, facet& acc_facet) const;
+
+    float get_distance(const string& geo_field_name, const uint32_t& seq_id,
+                       const S2LatLng& reference_lat_lng, const std::string& unit) const;
 };
 
 template<class T>

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -2791,12 +2791,14 @@ Option<nlohmann::json> Collection::search(std::string raw_query,
 
             for(size_t sort_field_index = 0; sort_field_index < sort_fields_std.size(); sort_field_index++) {
                 const auto& sort_field = sort_fields_std[sort_field_index];
-                if(sort_field.geopoint != 0) {
+                if(sort_field.geopoint != 0 && sort_field.geo_precision != 0) {
                     S2LatLng reference_lat_lng;
                     GeoPoint::unpack_lat_lng(sort_field.geopoint, reference_lat_lng);
 
                     geo_distances[sort_field.name] = index->get_distance(sort_field.name, field_order_kv->key,
                                                                          reference_lat_lng, sort_field.unit);
+                } else if(sort_field.geopoint != 0) {
+                    geo_distances[sort_field.name] = std::abs(field_order_kv->scores[sort_field_index]);
                 }
             }
 

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -1510,6 +1510,7 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
                         if(unit != "km" && unit != "mi") {
                             return Option<bool>(400, "Sort field's parameter unit must be either `km` or `mi`.");
                         }
+                        sort_field_std.unit = unit;
 
                         std::vector<std::string> dist_values;
                         StringUtils::split(param_parts[1], dist_values, unit);
@@ -2791,7 +2792,11 @@ Option<nlohmann::json> Collection::search(std::string raw_query,
             for(size_t sort_field_index = 0; sort_field_index < sort_fields_std.size(); sort_field_index++) {
                 const auto& sort_field = sort_fields_std[sort_field_index];
                 if(sort_field.geopoint != 0) {
-                    geo_distances[sort_field.name] = std::abs(field_order_kv->scores[sort_field_index]);
+                    S2LatLng reference_lat_lng;
+                    GeoPoint::unpack_lat_lng(sort_field.geopoint, reference_lat_lng);
+
+                    geo_distances[sort_field.name] = index->get_distance(sort_field.name, field_order_kv->key,
+                                                                         reference_lat_lng, sort_field.unit);
                 }
             }
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -7635,6 +7635,8 @@ Option<uint32_t> Index::get_sort_index_value_with_lock(const std::string& collec
 
 float Index::get_distance(const string& geo_field_name, const uint32_t& seq_id,
                           const S2LatLng& reference_lat_lng, const std::string& unit) const {
+    std::unique_lock lock(mutex);
+
     int64_t distance = 0;
     if (sort_index.count(geo_field_name) != 0) {
         auto& geo_index = sort_index.at(geo_field_name);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -7633,6 +7633,50 @@ Option<uint32_t> Index::get_sort_index_value_with_lock(const std::string& collec
     return Option<uint32_t>(sort_index.at(field_name)->at(seq_id));
 }
 
+float Index::get_distance(const string& geo_field_name, const uint32_t& seq_id,
+                          const S2LatLng& reference_lat_lng, const std::string& unit) const {
+    int64_t distance = 0;
+    if (sort_index.count(geo_field_name) != 0) {
+        auto& geo_index = sort_index.at(geo_field_name);
+
+        auto it = geo_index->find(seq_id);
+        if (it != geo_index->end()) {
+            int64_t packed_latlng = it->second;
+            S2LatLng s2_lat_lng;
+            GeoPoint::unpack_lat_lng(packed_latlng, s2_lat_lng);
+            distance = GeoPoint::distance(s2_lat_lng, reference_lat_lng);
+        }
+    } else {
+        // indicates geo point array
+        auto field_it = geo_array_index.at(geo_field_name);
+        auto it = field_it->find(seq_id);
+
+        if (it != field_it->end()) {
+            int64_t* latlngs = it->second;
+            for (size_t li = 0; li < latlngs[0]; li++) {
+                S2LatLng s2_lat_lng;
+                int64_t packed_latlng = latlngs[li + 1];
+                GeoPoint::unpack_lat_lng(packed_latlng, s2_lat_lng);
+                int64_t this_dist = GeoPoint::distance(s2_lat_lng, reference_lat_lng);
+                if (this_dist < distance) {
+                    distance = this_dist;
+                }
+            }
+        }
+    }
+
+    double dist = distance;
+    if (unit == "km") {
+        dist = dist * 0.001;
+    } else if (unit == "mi") {
+        dist =  dist * 0.00062137;
+    } else {
+        return 0;
+    }
+
+    return std::round(dist * 1000.0) / 1000.0;
+}
+
 /*
 // https://stackoverflow.com/questions/924171/geo-fencing-point-inside-outside-polygon
 // NOTE: polygon and point should have been transformed with `transform_for_180th_meridian`

--- a/test/collection_sorting_test.cpp
+++ b/test/collection_sorting_test.cpp
@@ -945,9 +945,12 @@ TEST_F(CollectionSortingTest, GeoPointSortingWithPrecision) {
     std::vector<std::string> expected_ids = {
         "6", "2", "1", "0", "3", "4", "7", "5"
     };
+    std::vector<uint32_t> geo_distance_meters = {900,900,900,900,1800,2700,3600,3600};
 
     for (size_t i = 0; i < expected_ids.size(); i++) {
-        ASSERT_STREQ(expected_ids[i].c_str(), results["hits"][i]["document"]["id"].get<std::string>().c_str());
+        auto const& hit = results["hits"][i];
+        ASSERT_EQ(expected_ids[i], hit["document"]["id"]);
+        ASSERT_EQ(geo_distance_meters[i], hit["geo_distance_meters"]["loc"]);
     }
 
     // badly formatted precision

--- a/test/collection_sorting_test.cpp
+++ b/test/collection_sorting_test.cpp
@@ -945,12 +945,12 @@ TEST_F(CollectionSortingTest, GeoPointSortingWithPrecision) {
     std::vector<std::string> expected_ids = {
         "6", "2", "1", "0", "3", "4", "7", "5"
     };
-    std::vector<uint32_t> geo_distance_meters = {900,900,900,900,1800,2700,3600,3600};
+    std::vector<float> geo_distance_meters = {0.726,0.461,0.46,0.467,1.786,2.007,3.556,3.299};
 
     for (size_t i = 0; i < expected_ids.size(); i++) {
         auto const& hit = results["hits"][i];
         ASSERT_EQ(expected_ids[i], hit["document"]["id"]);
-        ASSERT_EQ(geo_distance_meters[i], hit["geo_distance_meters"]["loc"]);
+        ASSERT_FLOAT_EQ(geo_distance_meters[i], hit["geo_distance_meters"]["loc"]);
     }
 
     // badly formatted precision


### PR DESCRIPTION
## Change Summary
Return real distances in the same unit when [precision](https://typesense.org/docs/26.0/api/geosearch.html#precision) is specified.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
