### PR TITLE
Remove limit of 10 filter values to compute filter iterator.

### DIFF
--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -985,11 +985,6 @@ void filter_result_iterator_t::init() {
 
             seq_ids = std::vector<uint32_t>(id_lists.size(), UINT32_MAX);
 
-            if (a_filter.values.size() > 10) {
-                compute_iterators();
-                return;
-            }
-
             if (a_filter.apply_not_equals) {
                 auto const& num_ids = index->seq_ids->num_ids();
                 approx_filter_ids_length = approx_filter_ids_length >= num_ids ? num_ids : (num_ids - approx_filter_ids_length);
@@ -1111,11 +1106,6 @@ void filter_result_iterator_t::init() {
             }
 
             seq_ids = std::vector<uint32_t>(id_lists.size(), UINT32_MAX);
-
-            if (a_filter.values.size() > 10) {
-                compute_iterators();
-                return;
-            }
 
             if (a_filter.apply_not_equals) {
                 auto const& num_ids = index->seq_ids->num_ids();
@@ -1509,11 +1499,6 @@ void filter_result_iterator_t::init() {
 
             // Multiple filter values get OR.
             approx_filter_ids_length += approx_filter_value_match;
-        }
-
-        if (a_filter.values.size() > 10) {
-            compute_iterators();
-            return;
         }
 
         if (a_filter.apply_not_equals) {

--- a/test/filter_test.cpp
+++ b/test/filter_test.cpp
@@ -464,25 +464,6 @@ TEST_F(FilterTest, FilterTreeIterator) {
     delete filter_tree_root;
 
     filter_tree_root = nullptr;
-    filter_op = filter::parse_filter_query("tags: [gold, gold, gold, gold, gold, gold, gold, gold, gold, gold, gold]",
-                                                            coll->get_schema(), store, doc_id_prefix,
-                                           filter_tree_root);
-    ASSERT_TRUE(filter_op.ok());
-
-    auto iter_string_multi_value_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
-    ASSERT_TRUE(iter_string_multi_value_test_2.init_status().ok());
-    ASSERT_TRUE(iter_string_multi_value_test_2._get_is_filter_result_initialized());
-
-    expected = {0, 2, 4};
-    for (auto const& i : expected) {
-        ASSERT_EQ(filter_result_iterator_t::valid, iter_string_multi_value_test_2.validity);
-        ASSERT_EQ(i, iter_string_multi_value_test_2.seq_id);
-        iter_string_multi_value_test_2.next();
-    }
-    ASSERT_EQ(filter_result_iterator_t::invalid, iter_string_multi_value_test_2.validity);
-    delete filter_tree_root;
-
-    filter_tree_root = nullptr;
     filter_op = filter::parse_filter_query("tags:= bronze", coll->get_schema(), store, doc_id_prefix,
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());


### PR DESCRIPTION
## Change Summary
The limit of less than 25K matches to compute the filter iterator is sufficient. #1720

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
