### PR TITLE
Remove double quotes to prevent bad escaping in JSON response for infix search

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2636,7 +2636,7 @@ Option<bool> Index::search_infix(const std::string& query, const std::string& fi
 
     if(infix_maps_it == infix_index.end()) {
         return Option<bool>(400, "Could not find `" + field_name + "` in the infix index. Make sure to enable infix "
-                                                                   "search by specifying `\"infix\": true` in the schema.");
+                                                                   "search by specifying `infix: true` in the schema.");
     }
 
     auto infix_sets = infix_maps_it->second;

--- a/test/collection_infix_search_test.cpp
+++ b/test/collection_infix_search_test.cpp
@@ -57,7 +57,7 @@ TEST_F(CollectionInfixSearchTest, InfixBasics) {
                                  4, {always});
     ASSERT_FALSE(response.ok());
     ASSERT_EQ("Could not find `non_infix` in the infix index."
-              " Make sure to enable infix search by specifying `\"infix\": true` in the schema.", response.error());
+              " Make sure to enable infix search by specifying `infix: true` in the schema.", response.error());
 
     auto results = coll1->search("100037",
                                  {"title"}, "", {}, {}, {0}, 3, 1, FREQUENCY, {true}, 5,


### PR DESCRIPTION
Context: https://github.com/typesense/typesense/issues/1753#issuecomment-2130247713