### PR TITLE
fix: conversation_history check

### DIFF
--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -920,7 +920,7 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
         nlohmann::json conversation_history = nlohmann::json::array();
         conversation_history.push_back(formatted_question_op.get());
         conversation_history.push_back(formatted_answer_op.get());
-        std::string conversation_id = conversation_history ? orig_req_params["conversation_id"] : "";
+        std::string conversation_id = conversation_history.size() > 0 ? orig_req_params["conversation_id"] : "";
 
         auto add_conversation_op = ConversationManager::get_instance().add_conversation(conversation_history, conversation_model["conversation_collection"], conversation_id);
         if(!add_conversation_op.ok()) {


### PR DESCRIPTION
## Change Summary
Fixed `conversation_history` existence check, the reason for the endless answer of `/multi_search?conversation=true` request.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
