### PR TITLE
Exact prefix value filter.

### DIFF
--- a/include/filter_result_iterator.h
+++ b/include/filter_result_iterator.h
@@ -280,6 +280,10 @@ private:
     /// Sample filter: [>10, !15].
     std::unordered_set<uint32_t> numerical_not_iterator_index;
 
+    /// String filter can specify prefix value match.
+    /// Sample filter: [Chris P*].
+    std::unordered_set<uint32_t> string_prefix_filter_index;
+
     bool delete_filter_node = false;
 
     std::unique_ptr<filter_result_iterator_timeout_info> timeout_info;

--- a/include/posting_list.h
+++ b/include/posting_list.h
@@ -203,9 +203,18 @@ public:
 
     static bool is_single_token_verbatim_match(const posting_list_t::iterator_t& it, bool field_is_array);
 
+    static bool is_single_token_prefix_match(const posting_list_t::iterator_t& it, bool field_is_array);
+
+    static void get_prefix_matches(std::vector<iterator_t>& its, const bool field_is_array,
+                                   const uint32_t* ids, const uint32_t num_ids,
+                                   uint32_t*& prefix_ids, size_t& num_prefix_ids);
+
     static void get_exact_matches(std::vector<iterator_t>& its, bool field_is_array,
                                   const uint32_t* ids, const uint32_t num_ids,
                                   uint32_t*& exact_ids, size_t& num_exact_ids);
+
+    static bool has_prefix_match(std::vector<posting_list_t::iterator_t>& posting_list_iterators,
+                                 const bool field_is_array);
 
     static bool has_exact_match(std::vector<posting_list_t::iterator_t>& posting_list_iterators,
                                   const bool field_is_array);

--- a/src/posting_list.cpp
+++ b/src/posting_list.cpp
@@ -1139,6 +1139,140 @@ void posting_list_t::get_prefix_matches(std::vector<iterator_t>& its, const bool
                 prefix_ids[prefix_id_index++] = id;
             }
         }
+    } else {
+
+        if (!field_is_array) {
+            for (size_t i = 0; i < num_ids; i++) {
+                uint32_t id = ids[i];
+                bool is_match = true;
+
+                for (int j = its.size()-1; j >= 0; j--) {
+                    posting_list_t::iterator_t& it = its[j];
+                    it.skip_to(id);
+
+                    block_t* curr_block = it.block();
+                    uint32_t curr_index = it.index();
+
+                    if (curr_block == nullptr || curr_index == UINT32_MAX) {
+                        is_match = false;
+                        break;
+                    }
+
+                    uint32_t* offsets = it.offsets;
+
+                    uint32_t start_offset_index = it.offset_index[curr_index];
+                    uint32_t end_offset_index = (curr_index == curr_block->size() - 1) ?
+                                                curr_block->offsets.getLength() :
+                                                it.offset_index[curr_index + 1];
+
+                    // looping handles duplicate query tokens, e.g. "hip hip hurray hurray"
+                    while (start_offset_index < end_offset_index) {
+                        uint32_t offset = offsets[start_offset_index];
+                        start_offset_index++;
+
+                        if (offset == (j + 1)) {
+                            // we have found a matching index, no need to look further for this token
+                            is_match = true;
+                            break;
+                        }
+
+                        if (offset > (j + 1)) {
+                            is_match = false;
+                            break;
+                        }
+                    }
+
+                    if (!is_match) {
+                        break;
+                    }
+                }
+
+                if (is_match) {
+                    prefix_ids[prefix_id_index++] = id;
+                }
+            }
+        }
+
+        else {
+            // field is an array
+
+            struct token_index_meta_t {
+                std::bitset<32> token_index;
+            };
+
+            for (size_t i = 0; i < num_ids; i++) {
+                uint32_t id = ids[i];
+
+                std::map<size_t, token_index_meta_t> array_index_to_token_index;
+                bool premature_exit = false;
+
+                for (int j = its.size()-1; j >= 0; j--) {
+                    posting_list_t::iterator_t& it = its[j];
+
+                    it.skip_to(id);
+
+                    block_t* curr_block = it.block();
+                    uint32_t curr_index = it.index();
+
+                    if (curr_block == nullptr || curr_index == UINT32_MAX) {
+                        premature_exit = true;
+                        break;
+                    }
+
+                    uint32_t* offsets = it.offsets;
+                    uint32_t start_offset_index = it.offset_index[curr_index];
+                    uint32_t end_offset_index = (curr_index == curr_block->size() - 1) ?
+                                                curr_block->offsets.getLength() :
+                                                it.offset_index[curr_index + 1];
+
+                    int prev_pos = -1;
+                    bool found_matching_index = false;
+                    size_t num_matching_index = 0;
+
+                    while (start_offset_index < end_offset_index) {
+                        int pos = offsets[start_offset_index];
+                        start_offset_index++;
+
+                        if (pos == prev_pos) {  // indicates end of array index
+                            size_t array_index = (size_t) offsets[start_offset_index];
+
+                            if (found_matching_index) {
+                                array_index_to_token_index[array_index].token_index.set(j+1);
+                            }
+
+                            start_offset_index++;  // skip current value which is the array index or flag for last index
+                            prev_pos = -1;
+                            found_matching_index = false;
+                            continue;
+                        }
+
+                        if (pos == (j + 1)) {
+                            // we have found a matching index
+                            found_matching_index = true;
+                            num_matching_index++;
+                        }
+
+                        prev_pos = pos;
+                    }
+
+                    if (num_matching_index == 0) {
+                        // not even a single matching index found: can never be an exact match
+                        premature_exit = true;
+                        break;
+                    }
+                }
+
+                if (!premature_exit) {
+                    // iterate array index to token index to check if atleast 1 array position contains all tokens
+                    for (auto& kv: array_index_to_token_index) {
+                        if (kv.second.token_index.count() == its.size()) {
+                            prefix_ids[prefix_id_index++] = id;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
     }
 
     num_prefix_ids = prefix_id_index;
@@ -1327,11 +1461,119 @@ void posting_list_t::get_exact_matches(std::vector<iterator_t>& its, const bool 
 
 bool posting_list_t::has_prefix_match(std::vector<posting_list_t::iterator_t>& posting_list_iterators,
                                       const bool field_is_array) {
+    if (posting_list_iterators.empty()) {
+        return false;
+    }
+
     if (posting_list_iterators.size() == 1) {
         return is_single_token_prefix_match(posting_list_iterators[0], field_is_array);
     }
 
-    return false;
+    if (!field_is_array) {
+        for (uint32_t i = 0; i < posting_list_iterators.size(); i++) {
+            posting_list_t::iterator_t& it = posting_list_iterators[i];
+
+            block_t* curr_block = it.block();
+            uint32_t curr_index = it.index();
+
+            if (curr_block == nullptr || curr_index == UINT32_MAX) {
+                return false;
+            }
+
+            uint32_t* offsets = it.offsets;
+
+            uint32_t start_offset_index = it.offset_index[curr_index];
+            uint32_t end_offset_index = (curr_index == curr_block->size() - 1) ?
+                                        curr_block->offsets.getLength() :
+                                        it.offset_index[curr_index + 1];
+
+            // looping handles duplicate query tokens, e.g. "hip hip hurray hurray"
+            while (start_offset_index < end_offset_index) {
+                uint32_t offset = offsets[start_offset_index];
+                start_offset_index++;
+
+                if (offset == (i + 1)) {
+                    // we have found a matching index, no need to look further for this token.
+                    break;
+                }
+
+                if (offset > (i + 1)) {
+                    return false;
+                }
+            }
+        }
+    }
+
+    else {
+        // field is an array
+
+        struct token_index_meta_t {
+            std::bitset<32> token_index;
+        };
+
+        std::map<size_t, token_index_meta_t> array_index_to_token_index;
+
+        for (int i = posting_list_iterators.size() - 1; i >= 0; i--) {
+            posting_list_t::iterator_t& it = posting_list_iterators[i];
+
+            block_t* curr_block = it.block();
+            uint32_t curr_index = it.index();
+
+            if (curr_block == nullptr || curr_index == UINT32_MAX) {
+                return false;
+            }
+
+            uint32_t* offsets = it.offsets;
+            uint32_t start_offset_index = it.offset_index[curr_index];
+            uint32_t end_offset_index = (curr_index == curr_block->size() - 1) ?
+                                        curr_block->offsets.getLength() :
+                                        it.offset_index[curr_index + 1];
+
+            int prev_pos = -1;
+            bool found_matching_index = false;
+            size_t num_matching_index = 0;
+
+            while (start_offset_index < end_offset_index) {
+                int pos = offsets[start_offset_index];
+                start_offset_index++;
+
+                if (pos == prev_pos) {  // indicates end of array index
+                    size_t array_index = (size_t) offsets[start_offset_index];
+
+                    if (found_matching_index) {
+                        array_index_to_token_index[array_index].token_index.set(i + 1);
+                    }
+
+                    start_offset_index++;  // skip current value which is the array index or flag for last index
+                    prev_pos = -1;
+                    found_matching_index = false;
+                    continue;
+                }
+
+                if (pos == (i + 1)) {
+                    // we have found a matching index
+                    found_matching_index = true;
+                    num_matching_index++;
+                }
+
+                prev_pos = pos;
+            }
+
+            if (num_matching_index == 0) {
+                // not even a single matching index found: can never be an exact match
+                return false;
+            }
+        }
+
+        // iterate array index to token index to check if atleast 1 array position contains all tokens
+        for (auto& kv: array_index_to_token_index) {
+            if (kv.second.token_index.count() == posting_list_iterators.size()) {
+                return true;
+            }
+        }
+    }
+
+    return true;
 }
 
 bool posting_list_t::has_exact_match(std::vector<posting_list_t::iterator_t>& posting_list_iterators,

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -2563,6 +2563,103 @@ TEST_F(CollectionFilteringTest, PrefixFilterOnTextFields) {
         std::string id = ids.at(i);
         ASSERT_EQ(id, result_id);
     }
+
+    auto schema_json =
+            R"({
+                "name": "Names",
+                "fields": [
+                    {"name": "name", "type": "string"}
+                ]
+            })"_json;
+    std::vector<nlohmann::json> documents = {
+            R"({
+                "name": "Steve Jobs"
+            })"_json,
+            R"({
+                "name": "Adam Stator"
+            })"_json,
+    };
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    for (auto const &json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    std::map<std::string, std::string> req_params = {
+            {"collection", "Names"},
+            {"q", "*"},
+            {"query_by", "name"},
+            {"filter_by", "name:= S*"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    auto res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, res_obj["found"].get<size_t>());
+    ASSERT_EQ(1, res_obj["hits"].size());
+    ASSERT_EQ("Steve Jobs", res_obj["hits"][0]["document"].at("name"));
+
+    req_params = {
+            {"collection", "Names"},
+            {"q", "*"},
+            {"query_by", "name"},
+            {"filter_by", "name: S*"}
+    };
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, res_obj["found"].get<size_t>());
+    ASSERT_EQ(2, res_obj["hits"].size());
+    ASSERT_EQ("Adam Stator", res_obj["hits"][0]["document"].at("name"));
+    ASSERT_EQ("Steve Jobs", res_obj["hits"][1]["document"].at("name"));
+
+    auto doc = R"({
+                "name": "Storm"
+            })"_json;
+    auto add_op = collection_create_op.get()->add(doc.dump());
+    ASSERT_TRUE(add_op.ok());
+
+    req_params = {
+            {"collection", "Names"},
+            {"q", "s"},
+            {"query_by", "name"},
+            {"filter_by", "name:= St*"}
+    };
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, res_obj["found"].get<size_t>());
+    ASSERT_EQ(2, res_obj["hits"].size());
+    ASSERT_EQ("Storm", res_obj["hits"][0]["document"].at("name"));
+    ASSERT_EQ("Steve Jobs", res_obj["hits"][1]["document"].at("name"));
+
+    req_params = {
+            {"collection", "Names"},
+            {"q", "s"},
+            {"query_by", "name"},
+            {"filter_by", "name: St*"}
+    };
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(3, res_obj["found"].get<size_t>());
+    ASSERT_EQ(3, res_obj["hits"].size());
+    ASSERT_EQ("Storm", res_obj["hits"][0]["document"].at("name"));
+    ASSERT_EQ("Adam Stator", res_obj["hits"][1]["document"].at("name"));
+    ASSERT_EQ("Steve Jobs", res_obj["hits"][2]["document"].at("name"));
 }
 
 TEST_F(CollectionFilteringTest, FilterOnStemmedField) {


### PR DESCRIPTION
## Change Summary
Prefix filter with exact operator `:=` should match values starting with that prefix. For example, given `"filter_by: name:= S*"` we should match "Steve Jobs" but NOT "Adam Stator"

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
