### PR TITLE
add flag to enable/disable auto-aggregation of search queries

### DIFF
--- a/include/query_analytics.h
+++ b/include/query_analytics.h
@@ -25,7 +25,7 @@ private:
     const size_t max_query_length = 1024;
 
     bool expand_query = false;
-
+    bool auto_aggregation_enabled;
     // counts aggregated within the current node
     tsl::htrie_map<char, uint32_t> local_counts;
     std::shared_mutex lmutex;
@@ -35,7 +35,7 @@ private:
 
 public:
 
-    QueryAnalytics(size_t k);
+    QueryAnalytics(size_t k, bool enable_auto_aggregation = true);
 
     void add(const std::string& value, const std::string& expanded_key,
              const bool live_query, const std::string& user_id, uint64_t now_ts_us = 0);
@@ -53,4 +53,6 @@ public:
     tsl::htrie_map<char, uint32_t> get_local_counts();
 
     void set_expand_query(bool expand_query);
+
+    bool is_auto_aggregation_enabled() const;
 };

--- a/src/event_manager.cpp
+++ b/src/event_manager.cpp
@@ -23,30 +23,29 @@ Option<bool> EventManager::add_event(const nlohmann::json& event, const std::str
     if(event_type_val.is_string()) {
         const std::string& event_type = event_type_val.get<std::string>();
         if(event_type == AnalyticsManager::CLICK_EVENT || event_type == AnalyticsManager::CONVERSION_EVENT
-            || event_type == AnalyticsManager::VISIT_EVENT || event_type == AnalyticsManager::CUSTOM_EVENT
-            || event_type == AnalyticsManager::SEARCH_EVENT) {
+           || event_type == AnalyticsManager::VISIT_EVENT || event_type == AnalyticsManager::CUSTOM_EVENT
+           || event_type == AnalyticsManager::SEARCH_EVENT) {
 
-            if (!event.contains(EVENT_DATA)) {
+            if(!event.contains(EVENT_DATA)) {
                 return Option<bool>(404, "key `data` not found.");
             }
 
-            const auto &event_data_val = event[EVENT_DATA];
+            const auto& event_data_val = event[EVENT_DATA];
 
-            if (!event.contains(EVENT_NAME)) {
+            if(!event.contains(EVENT_NAME)) {
                 return Option<bool>(404, "key `name` not found.");
             }
-            const auto &event_name = event[EVENT_NAME];
-            if (!event_data_val.is_object()) {
+            const auto& event_name = event[EVENT_NAME];
+            if(!event_data_val.is_object()) {
                 return Option<bool>(500, "event_data_val is not object.");
             }
 
             if(event_type != AnalyticsManager::CUSTOM_EVENT) {
-                if ((event_type == AnalyticsManager::SEARCH_EVENT) && (!event_data_val.contains("user_id") || !event_data_val.contains("q"))) {
+                if((event_type == AnalyticsManager::SEARCH_EVENT) &&
+                   (!event_data_val.contains("user_id") || !event_data_val.contains("q"))) {
                     return Option<bool>(500,
                                         "search event json data fields should contain `user_id` and 'q'.");
-                }
-
-                if (!event_data_val.contains("doc_id") || !event_data_val["doc_id"].is_string()) {
+                } else if(!event_data_val.contains("doc_id") || !event_data_val["doc_id"].is_string()) {
                     return Option<bool>(500, "event should have 'doc_id' as string value.");
                 }
             }

--- a/src/query_analytics.cpp
+++ b/src/query_analytics.cpp
@@ -4,7 +4,8 @@
 #include <mutex>
 #include "string_utils.h"
 
-QueryAnalytics::QueryAnalytics(size_t k) : k(k), max_size(k * 2) {
+QueryAnalytics::QueryAnalytics(size_t k, bool enable_auto_aggregation)
+                : k(k), max_size(k * 2), auto_aggregation_enabled(enable_auto_aggregation) {
 
 }
 
@@ -122,4 +123,8 @@ tsl::htrie_map<char, uint32_t> QueryAnalytics::get_local_counts() {
 
 void QueryAnalytics::set_expand_query(bool expand_query) {
     this->expand_query = expand_query;
+}
+
+bool QueryAnalytics::is_auto_aggregation_enabled() const {
+    return auto_aggregation_enabled;
 }

--- a/test/analytics_manager_test.cpp
+++ b/test/analytics_manager_test.cpp
@@ -2037,3 +2037,113 @@ TEST_F(AnalyticsManagerTest, AddSuggestionByEvent) {
     ASSERT_FALSE(create_op.ok());
     ASSERT_EQ("Events must contain a unique name.", create_op.error());
 }
+
+TEST_F(AnalyticsManagerTest, EventsOnlySearchTest) {
+    nlohmann::json titles_schema = R"({
+            "name": "titles",
+            "fields": [
+                {"name": "title", "type": "string"}
+            ]
+        })"_json;
+
+    Collection* titles_coll = collectionManager.create_collection(titles_schema).get();
+
+    nlohmann::json doc;
+    doc["title"] = "Cool trousers";
+    ASSERT_TRUE(titles_coll->add(doc.dump()).ok());
+
+    // create a collection to store suggestions
+    nlohmann::json suggestions_schema = R"({
+        "name": "top_queries",
+        "fields": [
+          {"name": "q", "type": "string" },
+          {"name": "count", "type": "int32" }
+        ]
+      })"_json;
+
+    Collection* suggestions_coll = collectionManager.create_collection(suggestions_schema).get();
+
+    //enable_auto_aggregation flag enables query aggregation via events only
+    nlohmann::json analytics_rule = R"({
+        "name": "top_search_queries",
+        "type": "popular_queries",
+        "params": {
+            "limit": 100,
+            "enable_auto_aggregation": false,
+            "source": {
+                "collections": ["titles"],
+                "events":  [{"type": "search", "name": "coll_search"}]
+            },
+            "destination": {
+                "collection": "top_queries"
+            }
+        }
+    })"_json;
+
+    auto create_op = analyticsManager.create_rule(analytics_rule, false, true);
+    ASSERT_TRUE(create_op.ok());
+
+    std::string q = "coo";
+    analyticsManager.add_suggestion("titles", q, "cool", true, "1");
+
+    auto popularQueries = analyticsManager.get_popular_queries();
+    auto userQueries = popularQueries["top_queries"]->get_user_prefix_queries();
+    ASSERT_EQ(0, userQueries.size());
+
+    //try sending via events api
+    nlohmann::json event_data;
+    event_data["q"] = "coo";
+    event_data["user_id"] = "1";
+    event_data["expanded_query"] = "cool";
+    event_data["live_query"] = true;
+
+    analyticsManager.add_event("127.0.0.1", "search", "coll_search", event_data);
+
+    popularQueries = analyticsManager.get_popular_queries();
+    auto localCounts = popularQueries["top_queries"]->get_local_counts();
+    ASSERT_EQ(1, localCounts.size());
+    ASSERT_EQ(1, localCounts.count("coo"));
+    ASSERT_EQ(1, localCounts["coo"]);
+
+    //try with nohits analytic rule
+    analytics_rule = R"({
+        "name": "noresults_queries",
+        "type": "nohits_queries",
+        "params": {
+            "limit": 100,
+            "enable_auto_aggregation": false,
+            "source": {
+                "collections": ["titles"],
+                "events":  [{"type": "search", "name": "nohits_search"}]
+            },
+            "destination": {
+                "collection": "top_queries"
+            }
+        }
+    })"_json;
+
+    create_op = analyticsManager.create_rule(analytics_rule, false, true);
+    ASSERT_TRUE(create_op.ok());
+
+    q = "foobar";
+    analyticsManager.add_nohits_query("titles", q, true, "1");
+
+    auto noresults_queries = analyticsManager.get_nohits_queries();
+    userQueries = noresults_queries["top_queries"]->get_user_prefix_queries();
+
+    ASSERT_EQ(0, userQueries.size());
+
+    //send events for same
+    event_data["q"] = "foobar";
+    event_data["expanded_query"] = "foobar";
+    event_data["live_query"] = true;
+    event_data["user_id"] = "1";
+    analyticsManager.add_event("127.0.0.1", "search", "nohits_search", event_data);
+
+    noresults_queries = analyticsManager.get_nohits_queries();
+    localCounts = noresults_queries["top_queries"]->get_local_counts();
+
+    ASSERT_EQ(1, localCounts.size());
+    ASSERT_EQ(1, localCounts.count("foobar"));
+    ASSERT_EQ(1, localCounts["foobar"]);
+}


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- add flag `enable_auto_aggregation` to enable/disable automatic aggregation of search queries
- `enable_auto_aggregation` is defaulted to true
- add test
- update doc_id validation check for search events

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
