### PR TITLE
add support for events_only for search events

### DIFF
--- a/include/analytics_manager.h
+++ b/include/analytics_manager.h
@@ -224,7 +224,7 @@ public:
     void get_last_N_events(const std::string& userid, const std::string& event_type, uint32_t N, std::vector<std::string>& values);
 
 #ifdef TEST_BUILD
-    std::unordered_map<std::string, std::vector<event_t>> get_log_events() {
+    std::unordered_map<std::string, std::vector<event_t>> get_events() {
         return query_collection_events;
     }
 #endif


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- make destination collection optional for search events 
- allow search events to be logged to analytics store directly without adding to destination collection
- update tests
## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
