### PR TITLE
add analytics rate limit config

### DIFF
--- a/include/analytics_manager.h
+++ b/include/analytics_manager.h
@@ -179,7 +179,7 @@ public:
     AnalyticsManager(AnalyticsManager const&) = delete;
     void operator=(AnalyticsManager const&) = delete;
 
-    void init(Store* store, Store* analytics_store, uint32_t analytics_minute_rate_limit = 5);
+    void init(Store* store, Store* analytics_store, uint32_t analytics_minute_rate_limit);
 
     void run(ReplicationState* raft_server);
 

--- a/include/analytics_manager.h
+++ b/include/analytics_manager.h
@@ -146,6 +146,8 @@ private:
 
     bool isRateLimitEnabled = true;
 
+    uint32_t analytics_minute_rate_limit;
+
     AnalyticsManager() {}
 
     ~AnalyticsManager();
@@ -177,7 +179,7 @@ public:
     AnalyticsManager(AnalyticsManager const&) = delete;
     void operator=(AnalyticsManager const&) = delete;
 
-    void init(Store* store, Store* analytics_store);
+    void init(Store* store, Store* analytics_store, uint32_t analytics_minute_rate_limit = 5);
 
     void run(ReplicationState* raft_server);
 

--- a/include/tsconfig.h
+++ b/include/tsconfig.h
@@ -13,6 +13,7 @@ private:
     std::string log_dir;
     std::string analytics_dir;
     int32_t analytics_db_ttl = 2419200; //four weeks in secs
+    uint32_t analytics_minute_rate_limit = 5;
     std::string api_key;
 
     // @deprecated
@@ -156,6 +157,10 @@ public:
         this->analytics_db_ttl = analytics_db_ttl;
     }
 
+    void set_analytics_minute_rate_limit(int32_t analytics_minute_rate_limit) {
+        this->analytics_minute_rate_limit = analytics_minute_rate_limit;
+    }
+
     void set_api_key(const std::string & api_key) {
         this->api_key = api_key;
     }
@@ -237,6 +242,9 @@ public:
 
     int32_t get_analytics_db_ttl() const {
         return this->analytics_db_ttl;
+    }
+    int32_t get_analytics_minute_rate_limit() const {
+        return this->analytics_minute_rate_limit;
     }
 
     std::string get_api_key() const {

--- a/src/tsconfig.cpp
+++ b/src/tsconfig.cpp
@@ -268,6 +268,10 @@ void Config::load_config_env() {
     if(!get_env("TYPESENSE_ANALYTICS_DB_TTL").empty()) {
         this->analytics_db_ttl = std::stoi(get_env("TYPESENSE_ANALYTICS_DB_TTL"));
     }
+
+    if(!get_env("TYPESENSE_ANALYTICS_MINUTE_RATE_LIMIT").empty()) {
+        this->analytics_minute_rate_limit = std::stoi(get_env("TYPESENSE_ANALYTICS_MINUTE_RATE_LIMIT"));
+    }
 }
 
 void Config::load_config_file(cmdline::parser& options) {
@@ -303,11 +307,11 @@ void Config::load_config_file(cmdline::parser& options) {
     }
 
     if(reader.Exists("server", "analytics-db-ttl")) {
-        this->analytics_db_ttl = std::stoi(reader.Get("server", "analytics-db-ttl", "0"));
+        this->analytics_db_ttl = reader.GetInteger("server", "analytics-db-ttl", 0);
     }
 
     if(reader.Exists("server", "analytics-minute-rate-limit")) {
-        this->analytics_minute_rate_limit = std::stoi(reader.Get("server", "analytics-minute-rate-limit", "5"));
+        this->analytics_minute_rate_limit = reader.GetInteger("server", "analytics-minute-rate-limit", 5);
     }
 
     if(reader.Exists("server", "api-key")) {

--- a/src/tsconfig.cpp
+++ b/src/tsconfig.cpp
@@ -306,6 +306,10 @@ void Config::load_config_file(cmdline::parser& options) {
         this->analytics_db_ttl = std::stoi(reader.Get("server", "analytics-db-ttl", "0"));
     }
 
+    if(reader.Exists("server", "analytics-minute-rate-limit")) {
+        this->analytics_minute_rate_limit = std::stoi(reader.Get("server", "analytics-minute-rate-limit", "5"));
+    }
+
     if(reader.Exists("server", "api-key")) {
         this->api_key = reader.Get("server", "api-key", "");
     }
@@ -496,6 +500,10 @@ void Config::load_config_cmd_args(cmdline::parser& options)  {
 
     if(options.exist("analytics-db-ttl")) {
         this->analytics_db_ttl = options.get<uint32_t>("analytics-db-ttl");
+    }
+
+    if(options.exist("analytics-minute-rate-limit")) {
+        this->analytics_minute_rate_limit = options.get<uint32_t>("analytics-minute-rate-limit");
     }
 
     if(options.exist("api-key")) {

--- a/src/typesense_server_utils.cpp
+++ b/src/typesense_server_utils.cpp
@@ -67,6 +67,8 @@ void init_cmdline_options(cmdline::parser & options, int argc, char **argv) {
     options.add<std::string>("health-rusage-api-key", '\0', "API key that allows access to health end-point with resource usage.", false);
     options.add<std::string>("analytics-dir", '\0', "Directory where Analytics will be stored.", false);
     options.add<uint32_t>("analytics-db-ttl", '\0', "TTL in seconds for events stored in analytics db", false);
+    options.add<uint32_t>("analytics-minute-rate-limit", '\0', "per minute rate limit for /events endpoint", false);
+
 
     options.add<std::string>("api-address", '\0', "Address to which Typesense API service binds.", false, "0.0.0.0");
     options.add<uint32_t>("api-port", '\0', "Port on which Typesense API service listens.", false, 8108);
@@ -386,6 +388,7 @@ int run_server(const Config & config, const std::string & version, void (*master
     std::string meta_dir = config.get_data_dir() + "/meta";
     std::string analytics_dir = config.get_analytics_dir();
     int32_t analytics_db_ttl = config.get_analytics_db_ttl();
+    uint32_t analytics_minute_rate_limit = config.get_analytics_minute_rate_limit();
 
     size_t thread_pool_size = config.get_thread_pool_size();
 
@@ -414,7 +417,7 @@ int run_server(const Config & config, const std::string & version, void (*master
     HttpClient & httpClient = HttpClient::get_instance();
     httpClient.init(config.get_api_key());
 
-    AnalyticsManager::get_instance().init(&store, &analytics_store);
+    AnalyticsManager::get_instance().init(&store, &analytics_store, analytics_minute_rate_limit);
 
     server = new HttpServer(
         version,

--- a/test/analytics_manager_test.cpp
+++ b/test/analytics_manager_test.cpp
@@ -18,6 +18,7 @@ protected:
     std::vector<sort_by> sort_fields;
 
     AnalyticsManager& analyticsManager = AnalyticsManager::get_instance();
+    uint32_t analytics_minute_rate_limit = 5;
 
     void setupCollection() {
         state_dir_path = "/tmp/typesense_test/analytics_manager_test";
@@ -36,7 +37,7 @@ protected:
         collectionManager.init(store, 1.0, "auth_key", quit);
         collectionManager.load(8, 1000);
 
-        analyticsManager.init(store, analytic_store);
+        analyticsManager.init(store, analytic_store, analytics_minute_rate_limit);
         analyticsManager.resetToggleRateLimit(false);
     }
 
@@ -843,7 +844,7 @@ TEST_F(AnalyticsManagerTest, EventsRateLimitTest) {
     analyticsManager.dispose();
     analyticsManager.stop();
 
-    uint32_t analytics_minute_rate_limit = 20;
+    analytics_minute_rate_limit = 20;
     analyticsManager.init(store, analytic_store, analytics_minute_rate_limit);
 
     analytics_rule = R"({
@@ -1291,7 +1292,7 @@ TEST_F(AnalyticsManagerTest, PopularityScoreValidation) {
     //restart analytics manager as fresh
     analyticsManager.dispose();
     analyticsManager.stop();
-    analyticsManager.init(store, analytic_store);
+    analyticsManager.init(store, analytic_store, analytics_minute_rate_limit);
 
     nlohmann::json products_schema = R"({
             "name": "books",
@@ -1653,7 +1654,7 @@ TEST_F(AnalyticsManagerTest, PopularityScoreValidation) {
 
     analyticsManager.dispose();
     analyticsManager.stop();
-    analyticsManager.init(store, analytic_store);
+    analyticsManager.init(store, analytic_store, analytics_minute_rate_limit);
 
     analytics_rule = R"({
         "name": "books_popularity3",
@@ -1701,7 +1702,7 @@ TEST_F(AnalyticsManagerTest, AnalyticsStoreTTL) {
     system(("rm -rf "+ analytics_dir_path +" && mkdir -p "+analytics_dir_path).c_str());
 
     analytic_store = new Store(analytics_dir_path, 24*60*60, 1024, true, FOURWEEKS_SECS);
-    analyticsManager.init(store, analytic_store);
+    analyticsManager.init(store, analytic_store, analytics_minute_rate_limit);
 
     auto analytics_rule = R"({
         "name": "product_events2",
@@ -1780,7 +1781,7 @@ TEST_F(AnalyticsManagerTest, AnalyticsStoreGetLastN) {
     system(("rm -rf "+ analytics_dir_path +" && mkdir -p "+analytics_dir_path).c_str());
 
     analytic_store = new Store(analytics_dir_path, 24*60*60, 1024, true, FOURWEEKS_SECS);
-    analyticsManager.init(store, analytic_store);
+    analyticsManager.init(store, analytic_store, analytics_minute_rate_limit);
 
     auto analytics_rule = R"({
         "name": "product_events2",

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -28,7 +28,7 @@ protected:
         collectionManager.init(store, 1.0, "auth_key", quit);
         collectionManager.load(8, 1000);
 
-        AnalyticsManager::get_instance().init(store, analytic_store);
+        AnalyticsManager::get_instance().init(store, analytic_store, 5);
 
         schema = R"({
             "name": "collection1",


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- add config `analytics-minute-rate-limit` to set analytics per minute rate limit
- defaulted to 5 events per minute
- tests

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
