### PR TITLE
Fix stray logs from image embeddings

### DIFF
--- a/src/image_embedder.cpp
+++ b/src/image_embedder.cpp
@@ -30,7 +30,7 @@ embedding_res_t CLIPImageEmbedder::embed(const std::string& encoded_image) {
     std::vector<const char*> output_names = {"image_embeds"};
 
     // run inference
-    LOG(INFO) << "Running image embedder";
+    // LOG(INFO) << "Running image embedder";
     auto output_tensors = session_->Run(Ort::RunOptions{nullptr}, input_names.data(), &input_tensor, 1, output_names.data(), output_names.size());
 
     // get output tensor
@@ -108,7 +108,7 @@ std::vector<embedding_res_t> CLIPImageEmbedder::batch_embed(const std::vector<st
 
 
     // run inference
-    LOG(INFO) << "Running image embedder";
+    // LOG(INFO) << "Running image embedder";
     auto output_tensors = session_->Run(Ort::RunOptions{nullptr}, input_names.data(), input_tensors.data(), input_tensors.size(), output_names.data(), output_names.size());
 
     // get output tensor

--- a/src/image_processor.cpp
+++ b/src/image_processor.cpp
@@ -33,7 +33,7 @@ Option<processed_image_t> CLIPImageProcessor::process_image(const std::string& i
 
     // Run inference
     std::vector<Ort::Value> output_tensors;
-    LOG(INFO) << "Running image processor";
+    // LOG(INFO) << "Running image processor";
     try {
         output_tensors = session_->Run(Ort::RunOptions{nullptr}, input_names.data(), &input_tensor, 1, output_names.data(), output_names.size());
     } catch (...) {
@@ -61,7 +61,7 @@ Option<processed_image_t> CLIPImageProcessor::process_image(const std::string& i
         }
     }
 
-    LOG(INFO) << "Image processed";
+    // LOG(INFO) << "Image processed";
 
     return Option<processed_image_t>(std::move(output));
 }


### PR DESCRIPTION
These lines are being logged for each image embedding generation call