### PR TITLE
allow other sort params with random sort

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -1129,6 +1129,10 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
             eval_sort_count++;
             continue;
         } else if(_sort_field.name == sort_field_const::random_order) {
+            if(sort_fields.size() != 1) {
+                return Option<bool>(400, "random sort is not supported with other sort params.");
+            }
+
             sort_fields_std.emplace_back(_sort_field.name, _sort_field.order);
             auto& sort_field_std = sort_fields_std.back();
 
@@ -1303,6 +1307,10 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
 
                 sort_field_std.name = actual_field_name;
             } else if(actual_field_name == sort_field_const::random_order) {
+                if(sort_fields.size() != 1) {
+                    return Option<bool>(400, "random sort is not supported with other sort params.");
+                }
+
                 const std::string &random_sort_str = sort_field_std.name.substr(paran_start + 1,
                                                                                 sort_field_std.name.size() -
                                                                                  paran_start -2);

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -1129,10 +1129,6 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
             eval_sort_count++;
             continue;
         } else if(_sort_field.name == sort_field_const::random_order) {
-            if(sort_fields.size() != 1) {
-                return Option<bool>(400, "random sort is not supported with other sort params.");
-            }
-
             sort_fields_std.emplace_back(_sort_field.name, _sort_field.order);
             auto& sort_field_std = sort_fields_std.back();
 
@@ -1307,10 +1303,6 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
 
                 sort_field_std.name = actual_field_name;
             } else if(actual_field_name == sort_field_const::random_order) {
-                if(sort_fields.size() != 1) {
-                    return Option<bool>(400, "random sort is not supported with other sort params.");
-                }
-
                 const std::string &random_sort_str = sort_field_std.name.substr(paran_start + 1,
                                                                                 sort_field_std.name.size() -
                                                                                  paran_start -2);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -5256,7 +5256,7 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
     if(sort_fields.size() > 1) {
         auto reference_found = true;
         auto const& is_reference_sort = !sort_fields[1].reference_collection_name.empty();
-
+        auto is_random_sort = sort_fields[1].random_sort.is_enabled;
         // In case of reference sort_by, we need to get the sort score of the reference doc id.
         if (is_reference_sort) {
             auto const& ref_compute_op = ref_compute_sort_scores(sort_fields[1], seq_id, ref_seq_id, reference_found,
@@ -5346,7 +5346,9 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
             }
 
         } else {
-            if (!is_reference_sort || reference_found) {
+            if(is_random_sort) {
+                scores[1] = sort_fields[1].random_sort.generate_random();
+            } else if (!is_reference_sort || reference_found) {
                 auto it = field_values[1]->find(is_reference_sort ? ref_seq_id : seq_id);
                 scores[1] = (it == field_values[1]->end()) ? default_score : it->second;
             } else {
@@ -5367,6 +5369,7 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
     if(sort_fields.size() > 2) {
         auto reference_found = true;
         auto const& is_reference_sort = !sort_fields[2].reference_collection_name.empty();
+        auto is_random_sort = sort_fields[2].random_sort.is_enabled;
 
         // In case of reference sort_by, we need to get the sort score of the reference doc id.
         if (is_reference_sort) {
@@ -5456,7 +5459,9 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
                 // do nothing
             }
         } else {
-            if (!is_reference_sort || reference_found) {
+            if(is_random_sort) {
+                scores[2] = sort_fields[2].random_sort.generate_random();
+            } else if (!is_reference_sort || reference_found) {
                 auto it = field_values[2]->find(is_reference_sort ? ref_seq_id : seq_id);
                 scores[2] = (it == field_values[2]->end()) ? default_score : it->second;
             } else {

--- a/test/collection_sorting_test.cpp
+++ b/test/collection_sorting_test.cpp
@@ -2788,6 +2788,30 @@ TEST_F(CollectionSortingTest, TestSortByRandomOrder) {
     results = coll->search("*", {}, "", {}, sort_fields, {0}).get();
     ASSERT_EQ(5, results["hits"].size());
 
+    //should work with other sort params as tie breaker for first param
+    sort_fields = {
+            sort_by("_text_match", "desc"),
+            sort_by("_rand(5)", "asc")
+    };
+    results = coll->search("smartphone", {"product_name"}, "", {}, sort_fields, {0}).get();
+    ASSERT_EQ(5, results["hits"].size());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"]);
+    ASSERT_EQ("4", results["hits"][1]["document"]["id"]);
+    ASSERT_EQ("0", results["hits"][2]["document"]["id"]);
+    ASSERT_EQ("3", results["hits"][3]["document"]["id"]);
+    ASSERT_EQ("2", results["hits"][4]["document"]["id"]);
+
+    sort_fields = {
+            sort_by("_text_match", "desc"),
+            sort_by("_rand(8)", "asc")
+    };
+    results = coll->search("smartphone", {"product_name"}, "", {}, sort_fields, {0}).get();
+    ASSERT_EQ(5, results["hits"].size());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"]);
+    ASSERT_EQ("3", results["hits"][1]["document"]["id"]);
+    ASSERT_EQ("4", results["hits"][2]["document"]["id"]);
+    ASSERT_EQ("0", results["hits"][3]["document"]["id"]);
+    ASSERT_EQ("2", results["hits"][4]["document"]["id"]);
 
     //negative seed value is not allowed
     sort_fields = {
@@ -2818,21 +2842,4 @@ TEST_F(CollectionSortingTest, TestSortByRandomOrder) {
 
     results_op = coll->search("*", {}, "", {}, sort_fields, {0});
     ASSERT_EQ("Could not find a field named `_random` in the schema for sorting.", results_op.error());
-
-    //random sort is not allowed in association with other sort types
-    sort_fields = {
-            sort_by("_rand", "asc"),
-            sort_by("_text_match", "asc")
-    };
-
-    results_op = coll->search("*", {}, "", {}, sort_fields, {0});
-    ASSERT_EQ("random sort is not supported with other sort params.", results_op.error());
-
-    sort_fields = {
-            sort_by("_text_match", "asc"),
-            sort_by("_rand(5)", "asc")
-    };
-
-    results_op = coll->search("*", {}, "", {}, sort_fields, {0});
-    ASSERT_EQ("random sort is not supported with other sort params.", results_op.error());
 }

--- a/test/collection_sorting_test.cpp
+++ b/test/collection_sorting_test.cpp
@@ -2818,4 +2818,21 @@ TEST_F(CollectionSortingTest, TestSortByRandomOrder) {
 
     results_op = coll->search("*", {}, "", {}, sort_fields, {0});
     ASSERT_EQ("Could not find a field named `_random` in the schema for sorting.", results_op.error());
+
+    //random sort is not allowed in association with other sort types
+    sort_fields = {
+            sort_by("_rand", "asc"),
+            sort_by("_text_match", "asc")
+    };
+
+    results_op = coll->search("*", {}, "", {}, sort_fields, {0});
+    ASSERT_EQ("random sort is not supported with other sort params.", results_op.error());
+
+    sort_fields = {
+            sort_by("_text_match", "asc"),
+            sort_by("_rand(5)", "asc")
+    };
+
+    results_op = coll->search("*", {}, "", {}, sort_fields, {0});
+    ASSERT_EQ("random sort is not supported with other sort params.", results_op.error());
 }


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- allow _rand to be used with other sort params
- add missing scores for _rand as 2nd and 3rd param
- add test

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
