### PR TITLE
Filtering shouldn't timeout during `Export`, `Delete by query`, `Update by query`, `Cascade deletion of references`, and `Updating async references`.

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -583,7 +583,8 @@ public:
                                   bool enable_lazy_filter = false,
                                   bool enable_typos_for_alpha_numerical_tokens = true) const;
 
-    Option<bool> get_filter_ids(const std::string & filter_query, filter_result_t& filter_result) const;
+    Option<bool> get_filter_ids(const std::string & filter_query, filter_result_t& filter_result,
+                                const bool& should_timeout = true) const;
 
     Option<bool> get_reference_filter_ids(const std::string& filter_query,
                                           filter_result_t& filter_result,

--- a/include/index.h
+++ b/include/index.h
@@ -766,7 +766,8 @@ public:
 
     Option<bool> do_filtering_with_lock(filter_node_t* const filter_tree_root,
                                         filter_result_t& filter_result,
-                                        const std::string& collection_name = "") const;
+                                        const std::string& collection_name = "",
+                                        const bool& should_timeout = true) const;
 
     Option<bool> do_reference_filtering_with_lock(filter_node_t* const filter_tree_root,
                                                   filter_result_t& filter_result,

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -1113,7 +1113,7 @@ bool get_export_documents(const std::shared_ptr<http_req>& req, const std::share
             export_state->iter_upper_bound = new rocksdb::Slice(export_state->iter_upper_bound_key);
             export_state->it = collectionManager.get_store()->scan(seq_id_prefix, export_state->iter_upper_bound);
         } else {
-            auto filter_ids_op = collection->get_filter_ids(filter_query, export_state->filter_result);
+            auto filter_ids_op = collection->get_filter_ids(filter_query, export_state->filter_result, false);
 
             if(!filter_ids_op.ok()) {
                 res->set(filter_ids_op.code(), filter_ids_op.error());
@@ -1750,9 +1750,8 @@ bool del_remove_documents(const std::shared_ptr<http_req>& req, const std::share
         // destruction of data is managed by req destructor
         req->data = deletion_state;
 
-        search_stop_us = UINT64_MAX; // Filtering shouldn't timeout during delete operation.
         filter_result_t filter_result;
-        auto filter_ids_op = collection->get_filter_ids(simple_filter_query, filter_result);
+        auto filter_ids_op = collection->get_filter_ids(simple_filter_query, filter_result, false);
 
         if(!filter_ids_op.ok()) {
             res->set(filter_ids_op.code(), filter_ids_op.error());

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1801,11 +1801,12 @@ bool Index::field_is_indexed(const std::string& field_name) const {
 
 Option<bool> Index::do_filtering_with_lock(filter_node_t* const filter_tree_root,
                                            filter_result_t& filter_result,
-                                           const std::string& collection_name) const {
+                                           const std::string& collection_name,
+                                           const bool& should_timeout) const {
     std::shared_lock lock(mutex);
 
     auto filter_result_iterator = filter_result_iterator_t(collection_name, this, filter_tree_root,
-                                                           search_begin_us, search_stop_us);
+                                                           search_begin_us, should_timeout ? search_stop_us : UINT64_MAX);
     auto filter_init_op = filter_result_iterator.init_status();
     if (!filter_init_op.ok()) {
         return filter_init_op;


### PR DESCRIPTION

## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
