### PR TITLE
Numeric filters refactor.

### DIFF
--- a/include/filter.h
+++ b/include/filter.h
@@ -6,6 +6,8 @@
 #include "json.hpp"
 #include "store.h"
 
+constexpr uint32_t COMPUTE_FILTER_ITERATOR_THRESHOLD = 25'000;
+
 enum NUM_COMPARATOR {
     LESS_THAN,
     LESS_THAN_EQUALS,

--- a/include/filter_result_iterator.h
+++ b/include/filter_result_iterator.h
@@ -295,7 +295,7 @@ private:
     std::unique_ptr<filter_result_iterator_timeout_info> timeout_info;
 
     /// Initializes the state of iterator node after it's creation.
-    void init();
+    void init(const bool& enable_lazy_evaluation = false);
 
     /// Performs AND on the subtrees of operator.
     void and_filter_iterators();
@@ -351,6 +351,7 @@ public:
 
     explicit filter_result_iterator_t(const std::string& collection_name,
                                       Index const* const index, filter_node_t const* const filter_node,
+                                      const bool& enable_lazy_evaluation = false,
                                       uint64_t search_begin_us = 0, uint64_t search_stop_us = UINT64_MAX);
 
     ~filter_result_iterator_t();

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -753,7 +753,7 @@ void apply_not_equals(uint32_t*&& all_ids,
     result_ids_len = to_include_ids_len;
 }
 
-void filter_result_iterator_t::init() {
+void filter_result_iterator_t::init(const bool& enable_lazy_evaluation) {
     if (filter_node == nullptr) {
         return;
     }
@@ -905,6 +905,233 @@ void filter_result_iterator_t::init() {
     }
 
     field f = index->search_schema.at(a_filter.field_name);
+
+    if (!enable_lazy_evaluation && (f.is_integer() || f.is_float() || f.is_bool())) {
+        if (f.is_integer()) {
+            if (f.range_index) {
+                auto const& trie = index->range_index.at(a_filter.field_name);
+
+                for (size_t fi = 0; fi < a_filter.values.size(); fi++) {
+                    const std::string& filter_value = a_filter.values[fi];
+                    auto const& value = (int64_t)std::stol(filter_value);
+
+                    if (a_filter.comparators[fi] == RANGE_INCLUSIVE && fi+1 < a_filter.values.size()) {
+                        const std::string& next_filter_value = a_filter.values[fi + 1];
+                        auto const& range_end_value = (int64_t)std::stol(next_filter_value);
+                        trie->search_range(value, true, range_end_value, true, filter_result.docs, filter_result.count);
+                        fi++;
+                    } else if (a_filter.comparators[fi] == EQUALS) {
+                        trie->search_equal_to(value, filter_result.docs, filter_result.count);
+                    } else if (a_filter.comparators[fi] == NOT_EQUALS) {
+                        uint32_t* to_exclude_ids = nullptr;
+                        uint32_t to_exclude_ids_len = 0;
+                        trie->search_equal_to(value, to_exclude_ids, to_exclude_ids_len);
+
+                        auto all_ids = index->seq_ids->uncompress();
+                        filter_result.count = ArrayUtils::exclude_scalar(all_ids, index->seq_ids->num_ids(),
+                                                                         to_exclude_ids, to_exclude_ids_len, &filter_result.docs);
+
+                        delete[] all_ids;
+                        delete[] to_exclude_ids;
+                    } else if (a_filter.comparators[fi] == GREATER_THAN || a_filter.comparators[fi] == GREATER_THAN_EQUALS) {
+                        trie->search_greater_than(value, a_filter.comparators[fi] == GREATER_THAN_EQUALS,
+                                                  filter_result.docs, filter_result.count);
+                    } else if (a_filter.comparators[fi] == LESS_THAN || a_filter.comparators[fi] == LESS_THAN_EQUALS) {
+                        trie->search_less_than(value, a_filter.comparators[fi] == LESS_THAN_EQUALS,
+                                               filter_result.docs, filter_result.count);
+                    }
+                }
+            } else {
+                auto num_tree = index->numerical_index.at(a_filter.field_name);
+
+                for (size_t fi = 0; fi < a_filter.values.size(); fi++) {
+                    const std::string& filter_value = a_filter.values[fi];
+                    int64_t value = (int64_t)std::stol(filter_value);
+
+                    size_t result_size = filter_result.count;
+                    if (a_filter.comparators[fi] == RANGE_INCLUSIVE && fi+1 < a_filter.values.size()) {
+                        const std::string& next_filter_value = a_filter.values[fi + 1];
+                        auto const range_end_value = (int64_t)std::stol(next_filter_value);
+                        num_tree->range_inclusive_search(value, range_end_value, &filter_result.docs, result_size);
+                        fi++;
+                    } else if (a_filter.comparators[fi] == NOT_EQUALS) {
+                        numeric_not_equals_filter(num_tree, value,
+                                                  index->seq_ids->uncompress(), index->seq_ids->num_ids(),
+                                                  filter_result.docs, result_size);
+                    } else {
+                        num_tree->search(a_filter.comparators[fi], value, &filter_result.docs, result_size);
+                    }
+
+                    filter_result.count = result_size;
+                }
+            }
+
+            if (a_filter.apply_not_equals) {
+                apply_not_equals(index->seq_ids->uncompress(), index->seq_ids->num_ids(),
+                                 filter_result.docs, filter_result.count);
+            }
+
+            if (filter_result.count == 0) {
+                validity = invalid;
+                return;
+            }
+
+            seq_id = filter_result.docs[result_index];
+            is_filter_result_initialized = true;
+            approx_filter_ids_length = filter_result.count;
+            return;
+        } else if (f.is_float()) {
+            if (f.range_index) {
+                auto const& trie = index->range_index.at(a_filter.field_name);
+
+                for (size_t fi = 0; fi < a_filter.values.size(); fi++) {
+                    const std::string& filter_value = a_filter.values[fi];
+                    float value = (float)std::atof(filter_value.c_str());
+                    int64_t float_int64 = Index::float_to_int64_t(value);
+
+                    if (a_filter.comparators[fi] == RANGE_INCLUSIVE && fi+1 < a_filter.values.size()) {
+                        const std::string& next_filter_value = a_filter.values[fi + 1];
+                        int64_t range_end_value = Index::float_to_int64_t((float) std::atof(next_filter_value.c_str()));
+                        trie->search_range(float_int64, true, range_end_value, true, filter_result.docs, filter_result.count);
+                        fi++;
+                    } else if (a_filter.comparators[fi] == EQUALS) {
+                        trie->search_equal_to(float_int64, filter_result.docs, filter_result.count);
+                    } else if (a_filter.comparators[fi] == NOT_EQUALS) {
+                        uint32_t* to_exclude_ids = nullptr;
+                        uint32_t to_exclude_ids_len = 0;
+                        trie->search_equal_to(float_int64, to_exclude_ids, to_exclude_ids_len);
+
+                        auto all_ids = index->seq_ids->uncompress();
+                        filter_result.count = ArrayUtils::exclude_scalar(all_ids, index->seq_ids->num_ids(),
+                                                                         to_exclude_ids, to_exclude_ids_len, &filter_result.docs);
+
+                        delete[] all_ids;
+                        delete[] to_exclude_ids;
+                    } else if (a_filter.comparators[fi] == GREATER_THAN || a_filter.comparators[fi] == GREATER_THAN_EQUALS) {
+                        trie->search_greater_than(float_int64, a_filter.comparators[fi] == GREATER_THAN_EQUALS,
+                                                  filter_result.docs, filter_result.count);
+                    } else if (a_filter.comparators[fi] == LESS_THAN || a_filter.comparators[fi] == LESS_THAN_EQUALS) {
+                        trie->search_less_than(float_int64, a_filter.comparators[fi] == LESS_THAN_EQUALS,
+                                               filter_result.docs, filter_result.count);
+                    }
+                }
+            } else {
+                auto num_tree = index->numerical_index.at(a_filter.field_name);
+
+                for (size_t fi = 0; fi < a_filter.values.size(); fi++) {
+                    const std::string& filter_value = a_filter.values[fi];
+                    float value = (float)std::atof(filter_value.c_str());
+                    int64_t float_int64 = Index::float_to_int64_t(value);
+
+                    size_t result_size = filter_result.count;
+                    if (a_filter.comparators[fi] == RANGE_INCLUSIVE && fi+1 < a_filter.values.size()) {
+                        const std::string& next_filter_value = a_filter.values[fi+1];
+                        int64_t range_end_value = Index::float_to_int64_t((float) std::atof(next_filter_value.c_str()));
+                        num_tree->range_inclusive_search(float_int64, range_end_value, &filter_result.docs, result_size);
+                        fi++;
+                    } else if (a_filter.comparators[fi] == NOT_EQUALS) {
+                        numeric_not_equals_filter(num_tree, float_int64,
+                                                  index->seq_ids->uncompress(), index->seq_ids->num_ids(),
+                                                  filter_result.docs, result_size);
+                    } else {
+                        num_tree->search(a_filter.comparators[fi], float_int64, &filter_result.docs, result_size);
+                    }
+
+                    filter_result.count = result_size;
+                }
+            }
+
+            if (a_filter.apply_not_equals) {
+                apply_not_equals(index->seq_ids->uncompress(), index->seq_ids->num_ids(),
+                                 filter_result.docs, filter_result.count);
+            }
+
+            if (filter_result.count == 0) {
+                validity = invalid;
+                return;
+            }
+
+            seq_id = filter_result.docs[result_index];
+            is_filter_result_initialized = true;
+            approx_filter_ids_length = filter_result.count;
+            return;
+        } else if (f.is_bool()) {
+            if (f.range_index) {
+
+                auto const& trie = index->range_index.at(a_filter.field_name);
+
+                size_t value_index = 0;
+                for (const std::string& filter_value : a_filter.values) {
+                    int64_t bool_int64 = (filter_value == "1") ? 1 : 0;
+
+                    if (a_filter.comparators[value_index] == EQUALS) {
+                        trie->search_equal_to(bool_int64, filter_result.docs, filter_result.count);
+                    } else if (a_filter.comparators[value_index] == NOT_EQUALS) {
+                        uint32_t* to_exclude_ids = nullptr;
+                        uint32_t to_exclude_ids_len = 0;
+                        trie->search_equal_to(bool_int64, to_exclude_ids, to_exclude_ids_len);
+
+                        auto all_ids = index->seq_ids->uncompress();
+                        filter_result.count = ArrayUtils::exclude_scalar(all_ids, index->seq_ids->num_ids(),
+                                                                         to_exclude_ids, to_exclude_ids_len, &filter_result.docs);
+
+                        delete[] all_ids;
+                        delete[] to_exclude_ids;
+                    }
+
+                    value_index++;
+                }
+            } else {
+                auto num_tree = index->numerical_index.at(a_filter.field_name);
+
+                // For a boolean filter like `in_stock: true` that could match a large number of ids, we use bool_iterator.
+                if (a_filter.values.size() == 1 && a_filter.comparators[0] == EQUALS && !a_filter.apply_not_equals &&
+                    num_tree->approx_search_count(EQUALS, (a_filter.values[0] == "1" ? 1 : 0)) > bool_filter_ids_threshold) {
+                    bool_iterator = num_tree_t::iterator_t(num_tree, EQUALS, (a_filter.values[0] == "1" ? 1 : 0));
+                    if (!bool_iterator.is_valid) {
+                        validity = invalid;
+                        return;
+                    }
+
+                    seq_id = bool_iterator.seq_id;
+                    approx_filter_ids_length = bool_iterator.approx_filter_ids_length;
+                    return;
+                }
+
+                size_t value_index = 0;
+                for (const std::string& filter_value : a_filter.values) {
+                    int64_t bool_int64 = (filter_value == "1") ? 1 : 0;
+
+                    size_t result_size = filter_result.count;
+                    if (a_filter.comparators[value_index] == NOT_EQUALS) {
+                        numeric_not_equals_filter(num_tree, bool_int64,
+                                                  index->seq_ids->uncompress(), index->seq_ids->num_ids(),
+                                                  filter_result.docs, result_size);
+                    } else {
+                        num_tree->search(a_filter.comparators[value_index], bool_int64, &filter_result.docs, result_size);
+                    }
+
+                    filter_result.count = result_size;
+                    value_index++;
+                }
+            }
+
+            if (a_filter.apply_not_equals) {
+                apply_not_equals(index->seq_ids->uncompress(), index->seq_ids->num_ids(),
+                                 filter_result.docs, filter_result.count);
+            }
+
+            if (filter_result.count == 0) {
+                validity = invalid;
+                return;
+            }
+
+            seq_id = filter_result.docs[result_index];
+            is_filter_result_initialized = true;
+            approx_filter_ids_length = filter_result.count;
+            return;
+        }
+    }
 
     if (f.is_integer()) {
         if (f.range_index) {
@@ -2133,6 +2360,7 @@ void filter_result_iterator_t::and_scalar(const uint32_t* A, const uint32_t& len
 
 filter_result_iterator_t::filter_result_iterator_t(const std::string& collection_name, const Index *const index,
                                                    const filter_node_t *const filter_node,
+                                                   const bool& enable_lazy_evaluation,
                                                    uint64_t search_begin, uint64_t search_stop)  :
         collection_name(collection_name),
         index(index),
@@ -2149,7 +2377,7 @@ filter_result_iterator_t::filter_result_iterator_t(const std::string& collection
 
     // Generate the iterator tree and then initialize each node.
     if (filter_node->isOperator) {
-        left_it = new filter_result_iterator_t(collection_name, index, filter_node->left);
+        left_it = new filter_result_iterator_t(collection_name, index, filter_node->left, enable_lazy_evaluation);
         // If left subtree of && operator is invalid, we don't have to evaluate its right subtree.
         if (filter_node->filter_operator == AND && left_it->validity == invalid) {
             validity = invalid;
@@ -2159,10 +2387,10 @@ filter_result_iterator_t::filter_result_iterator_t(const std::string& collection
             return;
         }
 
-        right_it = new filter_result_iterator_t(collection_name, index, filter_node->right);
+        right_it = new filter_result_iterator_t(collection_name, index, filter_node->right, enable_lazy_evaluation);
     }
 
-    init();
+    init(enable_lazy_evaluation);
 
     if (!validity) {
         this->approx_filter_ids_length = 0;

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -760,15 +760,19 @@ void filter_result_iterator_t::init() {
 
     if (filter_node->isOperator) {
         if (filter_node->filter_operator == AND) {
-            and_filter_iterators();
             approx_filter_ids_length = std::min(left_it->approx_filter_ids_length, right_it->approx_filter_ids_length);
+            if (approx_filter_ids_length < COMPUTE_FILTER_ITERATOR_THRESHOLD) {
+                compute_iterators();
+            } else {
+                and_filter_iterators();
+            }
         } else {
             or_filter_iterators();
             approx_filter_ids_length = std::max(left_it->approx_filter_ids_length, right_it->approx_filter_ids_length);
         }
 
         // Rearranging the subtree in hope to reduce computation if/when compute_iterators() is called.
-        if (left_it->approx_filter_ids_length > right_it->approx_filter_ids_length) {
+        if (!is_filter_result_initialized && left_it->approx_filter_ids_length > right_it->approx_filter_ids_length) {
             std::swap(left_it, right_it);
         }
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2904,7 +2904,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
     }
 #else
 
-    if (!enable_lazy_filter || filter_result_iterator->approx_filter_ids_length < 25'000) {
+    if (!enable_lazy_filter || filter_result_iterator->approx_filter_ids_length < COMPUTE_FILTER_ITERATOR_THRESHOLD) {
         filter_result_iterator->compute_iterators();
     }
 #endif

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1805,7 +1805,7 @@ Option<bool> Index::do_filtering_with_lock(filter_node_t* const filter_tree_root
                                            const bool& should_timeout) const {
     std::shared_lock lock(mutex);
 
-    auto filter_result_iterator = filter_result_iterator_t(collection_name, this, filter_tree_root,
+    auto filter_result_iterator = filter_result_iterator_t(collection_name, this, filter_tree_root, false,
                                                            search_begin_us, should_timeout ? search_stop_us : UINT64_MAX);
     auto filter_init_op = filter_result_iterator.init_status();
     if (!filter_init_op.ok()) {
@@ -1865,7 +1865,7 @@ Option<bool> Index::do_reference_filtering_with_lock(filter_node_t* const filter
                                                      const std::string& field_name) const {
     std::shared_lock lock(mutex);
 
-    auto ref_filter_result_iterator = filter_result_iterator_t(ref_collection_name, this, filter_tree_root,
+    auto ref_filter_result_iterator = filter_result_iterator_t(ref_collection_name, this, filter_tree_root, false,
                                                                search_begin_us, search_stop_us);
     auto filter_init_op = ref_filter_result_iterator.init_status();
     if (!filter_init_op.ok()) {
@@ -2889,7 +2889,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
     std::shared_lock lock(mutex);
 
     auto filter_result_iterator = new filter_result_iterator_t(collection_name, this, filter_tree_root,
-                                                               search_begin_us, search_stop_us);
+                                                               enable_lazy_filter, search_begin_us, search_stop_us);
     std::unique_ptr<filter_result_iterator_t> filter_iterator_guard(filter_result_iterator);
 
     auto filter_init_op = filter_result_iterator->init_status();
@@ -6415,7 +6415,7 @@ Option<bool> Index::populate_sort_mapping(int* sort_order, std::vector<size_t>& 
             auto& eval_exp = sort_fields_std[i].eval;
             auto count = sort_fields_std[i].eval_expressions.size();
             for (uint32_t j = 0; j < count; j++) {
-                auto filter_result_iterator = filter_result_iterator_t("", this, eval_exp.filter_trees[j],
+                auto filter_result_iterator = filter_result_iterator_t("", this, eval_exp.filter_trees[j], false,
                                                                        search_begin_us, search_stop_us);
                 auto filter_init_op = filter_result_iterator.init_status();
                 if (!filter_init_op.ok()) {

--- a/test/filter_test.cpp
+++ b/test/filter_test.cpp
@@ -63,7 +63,9 @@ TEST_F(FilterTest, FilterTreeIterator) {
     const std::string doc_id_prefix = std::to_string(coll->get_collection_id()) + "_" + Collection::DOC_ID_PREFIX + "_";
     filter_node_t* filter_tree_root = nullptr;
 
-    auto iter_null_filter_tree_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto const enable_lazy_evaluation = true;
+    auto iter_null_filter_tree_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                               enable_lazy_evaluation);
 
     ASSERT_TRUE(iter_null_filter_tree_test.init_status().ok());
     ASSERT_EQ(filter_result_iterator_t::invalid, iter_null_filter_tree_test.validity);
@@ -72,7 +74,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                                         filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_no_match_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_no_match_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                       enable_lazy_evaluation);
 
     ASSERT_TRUE(iter_no_match_test.init_status().ok());
     ASSERT_EQ(filter_result_iterator_t::invalid, iter_no_match_test.validity);
@@ -83,7 +86,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                                         filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_no_match_multi_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_no_match_multi_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                             enable_lazy_evaluation);
 
     ASSERT_TRUE(iter_no_match_multi_test.init_status().ok());
     ASSERT_EQ(filter_result_iterator_t::invalid, iter_no_match_multi_test.validity);
@@ -94,7 +98,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_contains_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_contains_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                       enable_lazy_evaluation);
     ASSERT_TRUE(iter_contains_test.init_status().ok());
 
     for (uint32_t i = 0; i < 5; i++) {
@@ -110,7 +115,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_contains_multi_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_contains_multi_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                             enable_lazy_evaluation);
     ASSERT_TRUE(iter_contains_multi_test.init_status().ok());
 
     for (uint32_t i = 0; i < 5; i++) {
@@ -126,7 +132,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                                         filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_exact_match_1_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_exact_match_1_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                            enable_lazy_evaluation);
     ASSERT_TRUE(iter_exact_match_1_test.init_status().ok());
 
     for (uint32_t i = 0; i < 5; i++) {
@@ -142,7 +149,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_exact_match_2_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_exact_match_2_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                            enable_lazy_evaluation);
     ASSERT_TRUE(iter_exact_match_2_test.init_status().ok());
     ASSERT_EQ(filter_result_iterator_t::invalid, iter_exact_match_2_test.validity);
 
@@ -152,7 +160,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_exact_match_multi_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_exact_match_multi_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                                enable_lazy_evaluation);
     ASSERT_TRUE(iter_exact_match_multi_test.init_status().ok());
 
     std::vector<int> expected = {0, 2, 3, 4};
@@ -169,7 +178,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_not_equals_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_not_equals_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                         enable_lazy_evaluation);
     ASSERT_TRUE(iter_not_equals_test.init_status().ok());
 
     expected = {1, 3};
@@ -198,7 +208,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
     auto add_op = coll->add(doc.dump());
     ASSERT_TRUE(add_op.ok());
 
-    auto iter_or_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_or_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                 enable_lazy_evaluation);
     ASSERT_TRUE(iter_or_test.init_status().ok());
 
     expected = {2, 4, 5};
@@ -216,7 +227,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_complex_filter_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_complex_filter_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                             enable_lazy_evaluation);
     ASSERT_TRUE(iter_complex_filter_test.init_status().ok());
 
     ASSERT_EQ(filter_result_iterator_t::valid, iter_complex_filter_test.validity);
@@ -238,7 +250,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_validate_ids_test1 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_validate_ids_test1 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                            enable_lazy_evaluation);
     ASSERT_TRUE(iter_validate_ids_test1.init_status().ok());
 
     std::vector<int> validate_ids = {0, 1, 2, 3, 4, 5, 6};
@@ -255,7 +268,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_validate_ids_test2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_validate_ids_test2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                            enable_lazy_evaluation);
     ASSERT_TRUE(iter_validate_ids_test2.init_status().ok());
 
     validate_ids = {0, 1, 2, 3, 4, 5, 6}, seq_ids = {1, 1, 5, 5, 5, 5, 5};
@@ -271,7 +285,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_validate_ids_test3 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_validate_ids_test3 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                            enable_lazy_evaluation);
     ASSERT_TRUE(iter_validate_ids_test3.init_status().ok());
     ASSERT_TRUE(iter_validate_ids_test3._get_is_filter_result_initialized());
 
@@ -289,7 +304,7 @@ TEST_F(FilterTest, FilterTreeIterator) {
     ASSERT_TRUE(filter_op.ok());
 
     auto iter_compact_plist_contains_atleast_one_test1 = filter_result_iterator_t(coll->get_name(), coll->_get_index(),
-                                                                                  filter_tree_root);
+                                                                                  filter_tree_root, enable_lazy_evaluation);
     ASSERT_TRUE(iter_compact_plist_contains_atleast_one_test1.init_status().ok());
 
     std::vector<uint32_t> ids = {1, 3, 5};
@@ -301,7 +316,7 @@ TEST_F(FilterTest, FilterTreeIterator) {
     free(c_list1);
 
     auto iter_compact_plist_contains_atleast_one_test2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(),
-                                                                                  filter_tree_root);
+                                                                                  filter_tree_root, enable_lazy_evaluation);
     ASSERT_TRUE(iter_compact_plist_contains_atleast_one_test2.init_status().ok());
 
     ids = {1, 3, 4};
@@ -313,7 +328,7 @@ TEST_F(FilterTest, FilterTreeIterator) {
     free(c_list2);
 
     auto iter_plist_contains_atleast_one_test1 = filter_result_iterator_t(coll->get_name(), coll->_get_index(),
-                                                                                  filter_tree_root);
+                                                                          filter_tree_root, enable_lazy_evaluation);
     ASSERT_TRUE(iter_plist_contains_atleast_one_test1.init_status().ok());
 
     posting_list_t p_list1(2);
@@ -342,7 +357,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_reset_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_reset_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                    enable_lazy_evaluation);
     ASSERT_TRUE(iter_reset_test.init_status().ok());
 
     expected = {0, 2, 3, 4};
@@ -362,7 +378,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
     }
     ASSERT_EQ(filter_result_iterator_t::invalid, iter_reset_test.validity);
 
-    auto iter_move_assignment_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_move_assignment_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                              enable_lazy_evaluation);
 
     iter_reset_test.reset();
     iter_move_assignment_test = std::move(iter_reset_test);
@@ -381,7 +398,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                                 filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_to_array_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_to_array_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                       enable_lazy_evaluation);
     ASSERT_TRUE(iter_to_array_test.init_status().ok());
 
     uint32_t* filter_ids = nullptr;
@@ -398,7 +416,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
 
     delete[] filter_ids;
 
-    auto iter_and_scalar_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_and_scalar_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                         enable_lazy_evaluation);
     ASSERT_TRUE(iter_and_scalar_test.init_status().ok());
 
     uint32_t a_ids[6] = {0, 1, 3, 4, 5, 6};
@@ -430,7 +449,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
     filter_op = filter::parse_filter_query("tags: bronze", coll->get_schema(), store, doc_id_prefix,
                                            filter_tree_root);
 
-    auto iter_add_phrase_ids_test = new filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_add_phrase_ids_test = new filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                                 enable_lazy_evaluation);
     std::unique_ptr<filter_result_iterator_t> filter_iter_guard(iter_add_phrase_ids_test);
     ASSERT_TRUE(iter_add_phrase_ids_test->init_status().ok());
 
@@ -451,7 +471,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_string_multi_value_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_string_multi_value_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                                 enable_lazy_evaluation);
     ASSERT_TRUE(iter_string_multi_value_test.init_status().ok());
     ASSERT_FALSE(iter_string_multi_value_test._get_is_filter_result_initialized());
 
@@ -469,7 +490,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_string_equals_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_string_equals_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                            enable_lazy_evaluation);
     ASSERT_TRUE(iter_string_equals_test.init_status().ok());
     ASSERT_TRUE(iter_string_equals_test._get_is_filter_result_initialized());
 
@@ -488,7 +510,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_string_equals_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_string_equals_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                              enable_lazy_evaluation);
     ASSERT_TRUE(iter_string_equals_test_2.init_status().ok());
     ASSERT_FALSE(iter_string_equals_test_2._get_is_filter_result_initialized());
 
@@ -505,7 +528,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
     filter_op = filter::parse_filter_query("tags: != [gold, silver]", coll->get_schema(), store, doc_id_prefix,
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
-    auto iter_string_not_equals_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_string_not_equals_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                                  enable_lazy_evaluation);
     ASSERT_TRUE(iter_string_not_equals_test_2.init_status().ok());
     ASSERT_TRUE(iter_string_not_equals_test_2._get_is_filter_result_initialized());
 
@@ -558,7 +582,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_boolean_test = filter_result_iterator_t(bool_coll->get_name(), bool_coll->_get_index(), filter_tree_root);
+    auto iter_boolean_test = filter_result_iterator_t(bool_coll->get_name(), bool_coll->_get_index(), filter_tree_root,
+                                                      enable_lazy_evaluation);
     ASSERT_TRUE(iter_boolean_test.init_status().ok());
     ASSERT_TRUE(iter_boolean_test._get_is_filter_result_initialized());
     ASSERT_EQ(2, iter_boolean_test.approx_filter_ids_length);
@@ -577,7 +602,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_boolean_test_2 = filter_result_iterator_t(bool_coll->get_name(), bool_coll->_get_index(), filter_tree_root);
+    auto iter_boolean_test_2 = filter_result_iterator_t(bool_coll->get_name(), bool_coll->_get_index(), filter_tree_root,
+                                                        enable_lazy_evaluation);
     ASSERT_TRUE(iter_boolean_test_2.init_status().ok());
     ASSERT_FALSE(iter_boolean_test_2._get_is_filter_result_initialized());
     ASSERT_EQ(8, iter_boolean_test_2.approx_filter_ids_length);
@@ -629,7 +655,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_string_prefix_value_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_string_prefix_value_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                                  enable_lazy_evaluation);
     ASSERT_TRUE(iter_string_prefix_value_test.init_status().ok());
     ASSERT_FALSE(iter_string_prefix_value_test._get_is_filter_result_initialized());
     ASSERT_EQ(3, iter_string_prefix_value_test.approx_filter_ids_length); // document 0 and 2 have been deleted.
@@ -648,7 +675,8 @@ TEST_F(FilterTest, FilterTreeIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_string_prefix_value_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_string_prefix_value_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                                    enable_lazy_evaluation);
     ASSERT_TRUE(iter_string_prefix_value_test_2.init_status().ok());
     ASSERT_FALSE(iter_string_prefix_value_test_2._get_is_filter_result_initialized());
     ASSERT_EQ(4, iter_string_prefix_value_test_2.approx_filter_ids_length); // 7 total docs, 3 approx count for equals.
@@ -753,7 +781,9 @@ TEST_F(FilterTest, FilterTreeInitialization) {
                                                         filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_left_subtree_0_matches = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto const enable_lazy_evaluation = true;
+    auto iter_left_subtree_0_matches = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                                enable_lazy_evaluation);
 
     ASSERT_TRUE(iter_left_subtree_0_matches.init_status().ok());
     ASSERT_EQ(filter_result_iterator_t::invalid, iter_left_subtree_0_matches.validity);
@@ -769,7 +799,8 @@ TEST_F(FilterTest, FilterTreeInitialization) {
                                                         filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_right_subtree_0_matches = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_right_subtree_0_matches = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                                 enable_lazy_evaluation);
 
     ASSERT_TRUE(iter_right_subtree_0_matches.init_status().ok());
     ASSERT_EQ(filter_result_iterator_t::invalid, iter_right_subtree_0_matches.validity);
@@ -785,7 +816,8 @@ TEST_F(FilterTest, FilterTreeInitialization) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_inner_subtree_0_matches = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_inner_subtree_0_matches = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                                 enable_lazy_evaluation);
 
     ASSERT_TRUE(iter_inner_subtree_0_matches.init_status().ok());
     ASSERT_EQ(filter_result_iterator_t::invalid, iter_inner_subtree_0_matches.validity);
@@ -825,7 +857,9 @@ TEST_F(FilterTest, NotEqualsStringFilter) {
                                                         filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto computed_not_equals_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto const enable_lazy_evaluation = true;
+    auto computed_not_equals_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                             enable_lazy_evaluation);
     ASSERT_TRUE(computed_not_equals_test.init_status().ok());
     ASSERT_TRUE(computed_not_equals_test._get_is_filter_result_initialized());
 
@@ -843,7 +877,8 @@ TEST_F(FilterTest, NotEqualsStringFilter) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_string_not_equals_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_string_not_equals_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                                enable_lazy_evaluation);
     ASSERT_TRUE(iter_string_not_equals_test.init_status().ok());
     ASSERT_FALSE(iter_string_not_equals_test._get_is_filter_result_initialized());
 
@@ -870,7 +905,8 @@ TEST_F(FilterTest, NotEqualsStringFilter) {
     filter_op = filter::parse_filter_query("tags: != [gold, silver]", coll->get_schema(), store, doc_id_prefix,
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
-    auto iter_string_array_not_equals_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_string_array_not_equals_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                                      enable_lazy_evaluation);
     ASSERT_TRUE(iter_string_array_not_equals_test.init_status().ok());
     ASSERT_FALSE(iter_string_array_not_equals_test._get_is_filter_result_initialized());
     ASSERT_EQ(5, iter_string_array_not_equals_test.approx_filter_ids_length);
@@ -916,7 +952,8 @@ TEST_F(FilterTest, NotEqualsStringFilter) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_string_not_equals_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_string_not_equals_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                                  enable_lazy_evaluation);
     ASSERT_TRUE(iter_string_not_equals_test_2.init_status().ok());
     ASSERT_FALSE(iter_string_not_equals_test_2._get_is_filter_result_initialized());
 
@@ -965,7 +1002,7 @@ TEST_F(FilterTest, NotEqualsStringFilter) {
     ASSERT_TRUE(filter_op.ok());
 
     auto iter_not_equals_or_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(),
-                                                            filter_tree_root);
+                                                            filter_tree_root, enable_lazy_evaluation);
     ASSERT_TRUE(iter_not_equals_or_test.init_status().ok());
     ASSERT_FALSE(iter_not_equals_or_test._get_is_filter_result_initialized());
 
@@ -990,7 +1027,7 @@ TEST_F(FilterTest, NotEqualsStringFilter) {
     ASSERT_TRUE(filter_op.ok());
 
     auto iter_not_equals_or_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(),
-                                                               filter_tree_root);
+                                                               filter_tree_root, enable_lazy_evaluation);
     ASSERT_TRUE(iter_not_equals_or_test_2.init_status().ok());
 
     validate_ids = {0, 1, 2, 3, 4, 5, 6, 7, 8};
@@ -1014,7 +1051,7 @@ TEST_F(FilterTest, NotEqualsStringFilter) {
     ASSERT_TRUE(filter_op.ok());
 
     auto iter_not_equals_and_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(),
-                                                             filter_tree_root);
+                                                             filter_tree_root, enable_lazy_evaluation);
     ASSERT_TRUE(iter_not_equals_and_test.init_status().ok());
     ASSERT_TRUE(iter_not_equals_and_test._get_is_filter_result_initialized());
 
@@ -1041,7 +1078,7 @@ TEST_F(FilterTest, NotEqualsStringFilter) {
     ASSERT_TRUE(iter_not_equals_and_test._get_is_filter_result_initialized());
 
     auto iter_not_equals_and_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(),
-                                                             filter_tree_root);
+                                                                filter_tree_root, enable_lazy_evaluation);
     ASSERT_TRUE(iter_not_equals_and_test_2.init_status().ok());
 
     validate_ids = {0, 1, 2, 3, 4, 5, 6, 7, 8};
@@ -1091,7 +1128,9 @@ TEST_F(FilterTest, NumericFilterIterator) {
                                                         filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto computed_greater_than_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto const enable_lazy_evaluation = true;
+    auto computed_greater_than_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                               enable_lazy_evaluation);
     ASSERT_TRUE(computed_greater_than_test.init_status().ok());
     ASSERT_TRUE(computed_greater_than_test._get_is_filter_result_initialized());
 
@@ -1109,7 +1148,8 @@ TEST_F(FilterTest, NumericFilterIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_greater_than_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_greater_than_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                           enable_lazy_evaluation);
     ASSERT_TRUE(iter_greater_than_test.init_status().ok());
     ASSERT_FALSE(iter_greater_than_test._get_is_filter_result_initialized());
 
@@ -1152,7 +1192,8 @@ TEST_F(FilterTest, NumericFilterIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_not_equals_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_not_equals_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                         enable_lazy_evaluation);
     ASSERT_TRUE(iter_not_equals_test.init_status().ok());
     ASSERT_FALSE(iter_not_equals_test._get_is_filter_result_initialized());
 
@@ -1177,7 +1218,8 @@ TEST_F(FilterTest, NumericFilterIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_not_equals_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_not_equals_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                           enable_lazy_evaluation);
     ASSERT_TRUE(iter_not_equals_test_2.init_status().ok());
     ASSERT_FALSE(iter_not_equals_test_2._get_is_filter_result_initialized());
 
@@ -1207,7 +1249,8 @@ TEST_F(FilterTest, NumericFilterIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_multivalue_filter = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_multivalue_filter = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                           enable_lazy_evaluation);
     ASSERT_TRUE(iter_multivalue_filter.init_status().ok());
     ASSERT_FALSE(iter_multivalue_filter._get_is_filter_result_initialized());
 
@@ -1236,7 +1279,8 @@ TEST_F(FilterTest, NumericFilterIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_multivalue_filter_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_multivalue_filter_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                             enable_lazy_evaluation);
     ASSERT_TRUE(iter_multivalue_filter_2.init_status().ok());
     ASSERT_FALSE(iter_multivalue_filter_2._get_is_filter_result_initialized());
 
@@ -1266,7 +1310,8 @@ TEST_F(FilterTest, NumericFilterIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_multivalue_filter_3 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_multivalue_filter_3 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                             enable_lazy_evaluation);
     ASSERT_TRUE(iter_multivalue_filter_3.init_status().ok());
     ASSERT_FALSE(iter_multivalue_filter_3._get_is_filter_result_initialized());
 
@@ -1300,7 +1345,8 @@ TEST_F(FilterTest, NumericFilterIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto computed_greater_than_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto computed_greater_than_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                                 enable_lazy_evaluation);
     ASSERT_TRUE(computed_greater_than_test_2.init_status().ok());
     ASSERT_TRUE(computed_greater_than_test_2._get_is_filter_result_initialized());
 
@@ -1318,7 +1364,8 @@ TEST_F(FilterTest, NumericFilterIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_greater_than_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_greater_than_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                             enable_lazy_evaluation);
     ASSERT_TRUE(iter_greater_than_test_2.init_status().ok());
     ASSERT_FALSE(iter_greater_than_test_2._get_is_filter_result_initialized());
 
@@ -1365,7 +1412,8 @@ TEST_F(FilterTest, NumericFilterIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_not_equals_test_3 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_not_equals_test_3 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                           enable_lazy_evaluation);
     ASSERT_TRUE(iter_not_equals_test_3.init_status().ok());
     ASSERT_FALSE(iter_not_equals_test_3._get_is_filter_result_initialized());
 
@@ -1390,7 +1438,8 @@ TEST_F(FilterTest, NumericFilterIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_not_equals_test_4 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_not_equals_test_4 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                           enable_lazy_evaluation);
     ASSERT_TRUE(iter_not_equals_test_4.init_status().ok());
     ASSERT_FALSE(iter_not_equals_test_4._get_is_filter_result_initialized());
 
@@ -1420,7 +1469,8 @@ TEST_F(FilterTest, NumericFilterIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_multivalue_filter_4 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_multivalue_filter_4 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                             enable_lazy_evaluation);
     ASSERT_TRUE(iter_multivalue_filter_4.init_status().ok());
     ASSERT_FALSE(iter_multivalue_filter_4._get_is_filter_result_initialized());
 
@@ -1449,7 +1499,8 @@ TEST_F(FilterTest, NumericFilterIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_multivalue_filter_5 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_multivalue_filter_5 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                             enable_lazy_evaluation);
     ASSERT_TRUE(iter_multivalue_filter_5.init_status().ok());
     ASSERT_FALSE(iter_multivalue_filter_5._get_is_filter_result_initialized());
 
@@ -1479,7 +1530,8 @@ TEST_F(FilterTest, NumericFilterIterator) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_multivalue_filter_6 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_multivalue_filter_6 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                             enable_lazy_evaluation);
     ASSERT_TRUE(iter_multivalue_filter_6.init_status().ok());
     ASSERT_FALSE(iter_multivalue_filter_6._get_is_filter_result_initialized());
 
@@ -1543,7 +1595,9 @@ TEST_F(FilterTest, PrefixStringFilter) {
                                                         filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto computed_exact_prefix_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto const enable_lazy_evaluation = true;
+    auto computed_exact_prefix_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                               enable_lazy_evaluation);
     ASSERT_TRUE(computed_exact_prefix_test.init_status().ok());
     ASSERT_TRUE(computed_exact_prefix_test._get_is_filter_result_initialized());
 
@@ -1561,7 +1615,8 @@ TEST_F(FilterTest, PrefixStringFilter) {
                                                         filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto computed_contains_prefix_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto computed_contains_prefix_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                                  enable_lazy_evaluation);
     ASSERT_TRUE(computed_contains_prefix_test.init_status().ok());
     ASSERT_TRUE(computed_contains_prefix_test._get_is_filter_result_initialized());
 
@@ -1597,7 +1652,8 @@ TEST_F(FilterTest, PrefixStringFilter) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_exact_prefix_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_exact_prefix_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                           enable_lazy_evaluation);
     ASSERT_TRUE(iter_exact_prefix_test.init_status().ok());
     ASSERT_FALSE(iter_exact_prefix_test._get_is_filter_result_initialized());
 
@@ -1629,7 +1685,8 @@ TEST_F(FilterTest, PrefixStringFilter) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_contains_prefix_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_contains_prefix_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                              enable_lazy_evaluation);
     ASSERT_TRUE(iter_contains_prefix_test.init_status().ok());
     ASSERT_FALSE(iter_contains_prefix_test._get_is_filter_result_initialized());
 
@@ -1661,7 +1718,8 @@ TEST_F(FilterTest, PrefixStringFilter) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto computed_exact_prefix_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto computed_exact_prefix_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                                 enable_lazy_evaluation);
     ASSERT_TRUE(computed_exact_prefix_test_2.init_status().ok());
     ASSERT_TRUE(computed_exact_prefix_test_2._get_is_filter_result_initialized());
 
@@ -1679,7 +1737,8 @@ TEST_F(FilterTest, PrefixStringFilter) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto computed_contains_prefix_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto computed_contains_prefix_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                                    enable_lazy_evaluation);
     ASSERT_TRUE(computed_contains_prefix_test_2.init_status().ok());
     ASSERT_TRUE(computed_contains_prefix_test_2._get_is_filter_result_initialized());
 
@@ -1712,7 +1771,8 @@ TEST_F(FilterTest, PrefixStringFilter) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_exact_prefix_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_exact_prefix_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                             enable_lazy_evaluation);
     ASSERT_TRUE(iter_exact_prefix_test_2.init_status().ok());
     ASSERT_FALSE(iter_exact_prefix_test_2._get_is_filter_result_initialized());
 
@@ -1744,7 +1804,8 @@ TEST_F(FilterTest, PrefixStringFilter) {
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
 
-    auto iter_contains_prefix_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
+    auto iter_contains_prefix_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                                enable_lazy_evaluation);
     ASSERT_TRUE(iter_contains_prefix_test_2.init_status().ok());
     ASSERT_FALSE(iter_contains_prefix_test_2._get_is_filter_result_initialized());
 

--- a/test/filter_test.cpp
+++ b/test/filter_test.cpp
@@ -273,8 +273,9 @@ TEST_F(FilterTest, FilterTreeIterator) {
 
     auto iter_validate_ids_test3 = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root);
     ASSERT_TRUE(iter_validate_ids_test3.init_status().ok());
+    ASSERT_TRUE(iter_validate_ids_test3._get_is_filter_result_initialized());
 
-    validate_ids = {0, 1, 2, 3, 4, 5, 6}, seq_ids = {0, 3, 3, 4, 4, 4, 4};
+    validate_ids = {0, 1, 2, 3, 4, 5, 6}, seq_ids = {0, 4, 4, 4, 4, 4, 4};
     expected = {1, 0, 0, 0, 1, -1, -1};
     for (uint32_t i = 0; i < validate_ids.size(); i++) {
         ASSERT_EQ(expected[i], iter_validate_ids_test3.is_valid(validate_ids[i]));
@@ -773,9 +774,9 @@ TEST_F(FilterTest, FilterTreeInitialization) {
     ASSERT_TRUE(iter_right_subtree_0_matches.init_status().ok());
     ASSERT_EQ(filter_result_iterator_t::invalid, iter_right_subtree_0_matches.validity);
     ASSERT_EQ(0, iter_right_subtree_0_matches.approx_filter_ids_length);
-    ASSERT_FALSE(iter_right_subtree_0_matches._get_is_filter_result_initialized());
-    ASSERT_NE(nullptr, iter_right_subtree_0_matches._get_left_it());
-    ASSERT_NE(nullptr, iter_right_subtree_0_matches._get_right_it());
+    ASSERT_TRUE(iter_right_subtree_0_matches._get_is_filter_result_initialized());
+    ASSERT_EQ(nullptr, iter_right_subtree_0_matches._get_left_it());
+    ASSERT_EQ(nullptr, iter_right_subtree_0_matches._get_right_it());
 
     delete filter_tree_root;
     filter_tree_root = nullptr;
@@ -1015,12 +1016,14 @@ TEST_F(FilterTest, NotEqualsStringFilter) {
     auto iter_not_equals_and_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(),
                                                              filter_tree_root);
     ASSERT_TRUE(iter_not_equals_and_test.init_status().ok());
+    ASSERT_TRUE(iter_not_equals_and_test._get_is_filter_result_initialized());
 
-    validate_ids = {5, 6, 7, 8};
-    seq_ids = {6, 7, 8, 8};
-    expected = {1, 1, 0, -1};
+    validate_ids = {4, 5, 6, 7};
+    seq_ids = {5, 6, 6, 6};
+    expected = {0, 1, 1, -1};
+
+    ASSERT_EQ(filter_result_iterator_t::valid, iter_not_equals_and_test.validity);
     for (uint32_t i = 0; i < validate_ids.size(); i++) {
-        ASSERT_EQ(filter_result_iterator_t::valid, iter_not_equals_and_test.validity);
         ASSERT_EQ(expected[i], iter_not_equals_and_test.is_valid(validate_ids[i]));
 
         if (expected[i] == 1) {
@@ -1035,16 +1038,18 @@ TEST_F(FilterTest, NotEqualsStringFilter) {
     filter_op = filter::parse_filter_query("tags: != silver && tags: != gold", coll->get_schema(), store, doc_id_prefix,
                                            filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
+    ASSERT_TRUE(iter_not_equals_and_test._get_is_filter_result_initialized());
 
     auto iter_not_equals_and_test_2 = filter_result_iterator_t(coll->get_name(), coll->_get_index(),
                                                              filter_tree_root);
     ASSERT_TRUE(iter_not_equals_and_test_2.init_status().ok());
 
     validate_ids = {0, 1, 2, 3, 4, 5, 6, 7, 8};
-    seq_ids = {1, 2, 3, 4, 5, 6, 7, 8, 8};
-    expected = {0, 1, 0, 0, 0, 1, 1, 0, -1};
+    seq_ids = {1, 5, 5, 5, 5, 6, 6, 6, 6};
+    expected = {0, 1, 0, 0, 0, 1, 1, -1, -1};
+
+    ASSERT_EQ(filter_result_iterator_t::valid, iter_not_equals_and_test_2.validity);
     for (uint32_t i = 0; i < validate_ids.size(); i++) {
-        ASSERT_EQ(filter_result_iterator_t::valid, iter_not_equals_and_test_2.validity);
         ASSERT_EQ(expected[i], iter_not_equals_and_test_2.is_valid(validate_ids[i]));
 
         if (expected[i] == 1) {


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
* Optimized evaluation of `&&` filter node.
* When `enable_lazy_filter` is false, don't initialize the numeric filter iterators.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
