### PR TITLE
Hybrid search aux score

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -581,7 +581,8 @@ public:
                                   bool synonym_prefix = false,
                                   uint32_t synonym_num_typos = 0,
                                   bool enable_lazy_filter = false,
-                                  bool enable_typos_for_alpha_numerical_tokens = true) const;
+                                  bool enable_typos_for_alpha_numerical_tokens = true,
+                                  bool use_aux_score = false) const;
 
     Option<bool> get_filter_ids(const std::string & filter_query, filter_result_t& filter_result,
                                 const bool& should_timeout = true) const;

--- a/include/collection.h
+++ b/include/collection.h
@@ -586,7 +586,7 @@ public:
                                   bool enable_lazy_filter = false,
                                   bool enable_typos_for_alpha_numerical_tokens = true,
                                   const size_t& max_filter_by_candidates = DEFAULT_FILTER_BY_CANDIDATES,
-                                  bool use_aux_score = false) const;
+                                  bool rerank_hybrid_matches = false) const;
 
     Option<bool> get_filter_ids(const std::string & filter_query, filter_result_t& filter_result,
                                 const bool& should_timeout = true) const;

--- a/include/index.h
+++ b/include/index.h
@@ -716,7 +716,7 @@ public:
                 bool enable_lazy_filter = false,
                 bool enable_typos_for_alpha_numerical_tokens = true,
                 const size_t& max_filter_by_candidates = DEFAULT_FILTER_BY_CANDIDATES,
-                bool use_aux_score = false,
+                bool use_aux_score = false
                 ) const;
 
     void remove_field(uint32_t seq_id, nlohmann::json& document, const std::string& field_name,

--- a/include/index.h
+++ b/include/index.h
@@ -679,7 +679,7 @@ public:
     Option<bool> run_search(search_args* search_params, const std::string& collection_name,
                             const std::vector<facet_index_type_t>& facet_index_types, bool enable_typos_for_numerical_tokens,
                             bool enable_synonyms, bool synonym_prefix, uint32_t synonym_num_typos,
-                            bool enable_typos_for_alpha_numerical_tokens, bool use_aux_score);
+                            bool enable_typos_for_alpha_numerical_tokens, bool rerank_hybrid_matches);
 
     Option<bool> search(std::vector<query_tokens_t>& field_query_tokens, const std::vector<search_field_t>& the_fields,
                 const text_match_type_t match_type,
@@ -716,7 +716,7 @@ public:
                 bool enable_lazy_filter = false,
                 bool enable_typos_for_alpha_numerical_tokens = true,
                 const size_t& max_filter_by_candidates = DEFAULT_FILTER_BY_CANDIDATES,
-                bool use_aux_score = false
+                bool rerank_hybrid_matches = false
                 ) const;
 
     void remove_field(uint32_t seq_id, nlohmann::json& document, const std::string& field_name,

--- a/include/index.h
+++ b/include/index.h
@@ -677,7 +677,7 @@ public:
     Option<bool> run_search(search_args* search_params, const std::string& collection_name,
                             const std::vector<facet_index_type_t>& facet_index_types, bool enable_typos_for_numerical_tokens,
                             bool enable_synonyms, bool synonym_prefix, uint32_t synonym_num_typos,
-                            bool enable_typos_for_alpha_numerical_tokens);
+                            bool enable_typos_for_alpha_numerical_tokens, bool use_aux_score);
 
     Option<bool> search(std::vector<query_tokens_t>& field_query_tokens, const std::vector<search_field_t>& the_fields,
                 const text_match_type_t match_type,
@@ -712,7 +712,8 @@ public:
                 bool synonym_prefix = false,
                 uint32_t synonym_num_typos = 0,
                 bool enable_lazy_filter = false,
-                bool enable_typos_for_alpha_numerical_tokens = true
+                bool enable_typos_for_alpha_numerical_tokens = true,
+                bool use_aux_score = false
                 ) const;
 
     void remove_field(uint32_t seq_id, nlohmann::json& document, const std::string& field_name,

--- a/include/index.h
+++ b/include/index.h
@@ -1072,6 +1072,11 @@ public:
                        const S2LatLng& reference_lat_lng) const;
 
     void get_top_k_result_ids(const std::vector<std::vector<KV*>>& raw_result_kvs, std::vector<uint32_t>& result_ids) const;
+
+    void compute_aux_scores(Topster *topster, const std::vector<search_field_t>& the_fields,
+                            const std::vector<token_t>& query_tokens, uint16_t search_query_size,
+                            const std::vector<sort_by>& sort_fields_std, const int* sort_order,
+                            const vector_query_t& vector_query) const;
 };
 
 template<class T>

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -1682,7 +1682,8 @@ Option<nlohmann::json> Collection::search(std::string raw_query,
                                   bool synonym_prefix,
                                   uint32_t synonyms_num_typos,
                                   bool enable_lazy_filter,
-                                  bool enable_typos_for_alpha_numerical_tokens) const {
+                                  bool enable_typos_for_alpha_numerical_tokens,
+                                  bool use_aux_score) const {
     std::shared_lock lock(mutex);
 
     // setup thread local vars
@@ -2318,7 +2319,7 @@ Option<nlohmann::json> Collection::search(std::string raw_query,
 
     auto search_op = index->run_search(search_params, name, facet_index_types,
                                        enable_typos_for_numerical_tokens, enable_synonyms, synonym_prefix,
-                                       synonyms_num_typos, enable_typos_for_alpha_numerical_tokens);
+                                       synonyms_num_typos, enable_typos_for_alpha_numerical_tokens, use_aux_score);
 
     // filter_tree_root might be updated in Index::static_filter_query_eval.
     filter_tree_root_guard.release();

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -1686,7 +1686,7 @@ Option<nlohmann::json> Collection::search(std::string raw_query,
                                   bool enable_lazy_filter,
                                   bool enable_typos_for_alpha_numerical_tokens,
                                   const size_t& max_filter_by_candidates,
-                                  bool use_aux_score) const {
+                                  bool rerank_hybrid_matches) const {
     std::shared_lock lock(mutex);
 
     // setup thread local vars
@@ -2322,7 +2322,7 @@ Option<nlohmann::json> Collection::search(std::string raw_query,
 
     auto search_op = index->run_search(search_params, name, facet_index_types,
                                        enable_typos_for_numerical_tokens, enable_synonyms, synonym_prefix,
-                                       synonyms_num_typos, enable_typos_for_alpha_numerical_tokens, use_aux_score);
+                                       synonyms_num_typos, enable_typos_for_alpha_numerical_tokens, rerank_hybrid_matches);
 
     // filter_tree_root might be updated in Index::static_filter_query_eval.
     filter_tree_root_guard.release();

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1268,7 +1268,7 @@ Option<bool> CollectionManager::do_search(std::map<std::string, std::string>& re
     const char *ENABLE_ANALYTICS = "enable_analytics";
 
     //for hybrid search, compute text_match_score for only vector search results and vector_distance for only text_match results
-    const char* USE_AUX_SCORE = "use_aux_score";
+    const char* RERANK_HYBRID_MATCHES = "rerank_hybrid_matches";
 
     // enrich params with values from embedded params
     for(auto& item: embedded_params.items()) {
@@ -1417,7 +1417,7 @@ Option<bool> CollectionManager::do_search(std::map<std::string, std::string>& re
 
     std::string voice_query;
     bool enable_analytics = true;
-    bool use_aux_score = false;
+    bool rerank_hybrid_matches = false;
 
     std::unordered_map<std::string, size_t*> unsigned_int_values = {
         {MIN_LEN_1TYPO, &min_len_1typo},
@@ -1481,7 +1481,7 @@ Option<bool> CollectionManager::do_search(std::map<std::string, std::string>& re
         {ENABLE_TYPOS_FOR_ALPHA_NUMERICAL_TOKENS, &enable_typos_for_alpha_numerical_tokens},
         {FILTER_CURATED_HITS, &filter_curated_hits_option},
         {ENABLE_ANALYTICS, &enable_analytics},
-        {USE_AUX_SCORE, &use_aux_score}
+        {RERANK_HYBRID_MATCHES, &rerank_hybrid_matches}
     };
 
     std::unordered_map<std::string, std::vector<std::string>*> str_list_values = {
@@ -1703,7 +1703,7 @@ Option<bool> CollectionManager::do_search(std::map<std::string, std::string>& re
                                                           enable_lazy_filter,
                                                           enable_typos_for_alpha_numerical_tokens,
                                                           max_filter_by_candidates,
-                                                          use_aux_score);
+                                                          rerank_hybrid_matches);
 
     uint64_t timeMillis = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::high_resolution_clock::now() - begin).count();

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1266,6 +1266,9 @@ Option<bool> CollectionManager::do_search(std::map<std::string, std::string>& re
     //query time flag to enable analyitcs for that query
     const char *ENABLE_ANALYTICS = "enable_analytics";
 
+    //for hybrid search, compute text_match_score for only vector search results and vector_distance for only text_match results
+    const char* USE_AUX_SCORE = "use_aux_score";
+
     // enrich params with values from embedded params
     for(auto& item: embedded_params.items()) {
         if(item.key() == "expires_at") {
@@ -1412,6 +1415,7 @@ Option<bool> CollectionManager::do_search(std::map<std::string, std::string>& re
 
     std::string voice_query;
     bool enable_analytics = true;
+    bool use_aux_score = false;
 
     std::unordered_map<std::string, size_t*> unsigned_int_values = {
         {MIN_LEN_1TYPO, &min_len_1typo},
@@ -1474,6 +1478,7 @@ Option<bool> CollectionManager::do_search(std::map<std::string, std::string>& re
         {ENABLE_TYPOS_FOR_ALPHA_NUMERICAL_TOKENS, &enable_typos_for_alpha_numerical_tokens},
         {FILTER_CURATED_HITS, &filter_curated_hits_option},
         {ENABLE_ANALYTICS, &enable_analytics},
+        {USE_AUX_SCORE, &use_aux_score}
     };
 
     std::unordered_map<std::string, std::vector<std::string>*> str_list_values = {
@@ -1693,7 +1698,8 @@ Option<bool> CollectionManager::do_search(std::map<std::string, std::string>& re
                                                           synonym_prefix,
                                                           synonym_num_typos,
                                                           enable_lazy_filter,
-                                                          enable_typos_for_alpha_numerical_tokens);
+                                                          enable_typos_for_alpha_numerical_tokens,
+                                                          use_aux_score);
 
     uint64_t timeMillis = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::high_resolution_clock::now() - begin).count();

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2341,7 +2341,7 @@ Option<filter_result_t> Index::do_filtering_with_reference_ids(const std::string
 Option<bool> Index::run_search(search_args* search_params, const std::string& collection_name,
                                const std::vector<facet_index_type_t>& facet_index_types, bool enable_typos_for_numerical_tokens,
                                bool enable_synonyms, bool synonym_prefix, uint32_t synonym_num_typos,
-                               bool enable_typos_for_alpha_numerical_tokens, bool use_aux_score) {
+                               bool enable_typos_for_alpha_numerical_tokens, bool rerank_hybrid_matches) {
 
     auto res = search(search_params->field_query_tokens,
                   search_params->search_fields,
@@ -2390,7 +2390,7 @@ Option<bool> Index::run_search(search_args* search_params, const std::string& co
                   search_params->enable_lazy_filter,
                   enable_typos_for_alpha_numerical_tokens,
                   search_params->max_filter_by_candidates,
-                  use_aux_score
+                  rerank_hybrid_matches
     );
 
     return res;
@@ -2890,7 +2890,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                    uint32_t synonym_num_typos,
                    bool enable_lazy_filter,
                    bool enable_typos_for_alpha_numerical_tokens, const size_t& max_filter_by_candidates,
-                   bool use_aux_score) const {
+                   bool rerank_hybrid_matches) const {
     std::shared_lock lock(mutex);
 
     auto filter_result_iterator = new filter_result_iterator_t(collection_name, this, filter_tree_root,
@@ -3706,7 +3706,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
     process_search_results:
 
     //for hybrid search, optionally compute aux scores
-    if(!vector_query.field_name.empty() && !is_wildcard_query && use_aux_score) {
+    if(!vector_query.field_name.empty() && !is_wildcard_query && rerank_hybrid_matches) {
         compute_aux_scores(topster, the_fields, field_query_tokens[0].q_include_tokens, searched_queries.size(),
                            sort_fields_std, sort_order, vector_query);
         compute_aux_scores(curated_topster, the_fields, field_query_tokens[0].q_include_tokens, searched_queries.size(),

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -5345,7 +5345,7 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
                 const auto& dist_func = sort_fields[i].vector_query.vector_index->space->get_dist_func();
                 float dist = dist_func(sort_fields[i].vector_query.query.values.data(), values.data(), &sort_fields[i].vector_query.vector_index->num_dim);
 
-                if(dist > sort_fields[0].vector_query.query.distance_threshold) {
+                if(dist > sort_fields[i].vector_query.query.distance_threshold) {
                     //if computed distance is more then distance_thershold then we set it to max float,
                     //so that other sort conditions can execute
                     dist = std::numeric_limits<float>::max();

--- a/test/collection_vector_search_test.cpp
+++ b/test/collection_vector_search_test.cpp
@@ -5059,36 +5059,29 @@ TEST_F(CollectionVectorTest, HybridSearchAuxScoreTest) {
     auto coll = collection_create_op.get();
 
     auto add_op = coll->add(R"({
-        "name": "soccer",
+        "name": "Nike running shoes for men",
         "id": "0"
     })"_json.dump());
 
     ASSERT_TRUE(add_op.ok());
 
     add_op = coll->add(R"({
-        "name": "basketball",
+        "name": "Nike running sneakers",
         "id": "1"
     })"_json.dump());
 
     ASSERT_TRUE(add_op.ok());
 
     add_op = coll->add(R"({
-        "name": "typesense",
+        "name": "adidas shoes",
         "id": "2"
-    })"_json.dump());
-
-    ASSERT_TRUE(add_op.ok());
-
-    add_op = coll->add(R"({
-        "name": "potato",
-        "id": "3"
     })"_json.dump());
 
     ASSERT_TRUE(add_op.ok());
 
     bool use_aux_score = false;
 
-    auto res = coll->search("basket", {"name", "embedding"}, "", {},
+    auto res = coll->search("nike running shoes", {"name", "embedding"}, "", {},
                              {}, {2}, 10, 1,FREQUENCY, {true},
                              Index::DROP_TOKENS_THRESHOLD, spp::sparse_hash_set<std::string>(),
                              {"embedding"}, 10, "",
@@ -5106,20 +5099,18 @@ TEST_F(CollectionVectorTest, HybridSearchAuxScoreTest) {
                              "", true, true, false, 0, true,
                              true, use_aux_score).get();
 
-    ASSERT_EQ(4, res["hits"].size());
-    ASSERT_FLOAT_EQ(0.13851940631866455, res["hits"][0]["vector_distance"].get<float>());
-    ASSERT_FLOAT_EQ(0.15999853610992432, res["hits"][1]["vector_distance"].get<float>());
-    ASSERT_FLOAT_EQ(0.19285917282104492, res["hits"][2]["vector_distance"].get<float>());
-    ASSERT_FLOAT_EQ(0.19428515434265137, res["hits"][3]["vector_distance"].get<float>());
+    ASSERT_EQ(3, res["hits"].size());
+    ASSERT_FLOAT_EQ(0.09585630893707275, res["hits"][0]["vector_distance"].get<float>());
+    ASSERT_FLOAT_EQ(0.07914221286773682, res["hits"][1]["vector_distance"].get<float>());
+    ASSERT_FLOAT_EQ(0.15472877025604248, res["hits"][2]["vector_distance"].get<float>());
 
-    ASSERT_FLOAT_EQ(1060320051, res["hits"][0]["text_match"].get<size_t >());
-    ASSERT_FLOAT_EQ(0, res["hits"][1]["text_match"].get<size_t >());
-    ASSERT_FLOAT_EQ(0, res["hits"][2]["text_match"].get<size_t >());
-    ASSERT_FLOAT_EQ(0, res["hits"][3]["text_match"].get<size_t >());
+    ASSERT_EQ("517734", res["hits"][0]["text_match_info"]["best_field_score"].get<std::string >());
+    ASSERT_EQ("0", res["hits"][1]["text_match_info"]["best_field_score"].get<std::string >());
+    ASSERT_EQ("0", res["hits"][2]["text_match_info"]["best_field_score"].get<std::string >());
 
     use_aux_score = true;
 
-    res = coll->search("basket", {"name", "embedding"}, "", {},
+    res = coll->search("nike running shoes", {"name", "embedding"}, "", {},
                             {}, {2}, 10, 1,FREQUENCY, {true},
                             Index::DROP_TOKENS_THRESHOLD, spp::sparse_hash_set<std::string>(),
                             {"embedding"}, 10, "",
@@ -5137,14 +5128,13 @@ TEST_F(CollectionVectorTest, HybridSearchAuxScoreTest) {
                             "", true, true, false, 0, true,
                             true, use_aux_score).get();
 
-    ASSERT_EQ(4, res["hits"].size());
-    ASSERT_FLOAT_EQ(0.13851940631866455, res["hits"][0]["vector_distance"].get<float>());
-    ASSERT_FLOAT_EQ(0.15999853610992432, res["hits"][1]["vector_distance"].get<float>());
-    ASSERT_FLOAT_EQ(0.19285917282104492, res["hits"][2]["vector_distance"].get<float>());
-    ASSERT_FLOAT_EQ(0.19428515434265137, res["hits"][3]["vector_distance"].get<float>());
 
-    ASSERT_FLOAT_EQ(1060320051, res["hits"][0]["text_match"].get<size_t >());
-    ASSERT_FLOAT_EQ(0, res["hits"][1]["text_match"].get<size_t >());
-    ASSERT_FLOAT_EQ(0, res["hits"][2]["text_match"].get<size_t >());
-    ASSERT_FLOAT_EQ(0, res["hits"][3]["text_match"].get<size_t >());
+    ASSERT_EQ(3, res["hits"].size());
+    ASSERT_FLOAT_EQ(0.09585630893707275, res["hits"][0]["vector_distance"].get<float>());
+    ASSERT_FLOAT_EQ(0.07914221286773682, res["hits"][1]["vector_distance"].get<float>());
+    ASSERT_FLOAT_EQ(0.15472877025604248, res["hits"][2]["vector_distance"].get<float>());
+
+    ASSERT_EQ("517734", res["hits"][0]["text_match_info"]["best_field_score"].get<std::string >());
+    ASSERT_EQ("1618996288", res["hits"][1]["text_match_info"]["best_field_score"].get<std::string>());
+    ASSERT_EQ("1618996288", res["hits"][2]["text_match_info"]["best_field_score"].get<std::string>());
 }

--- a/test/collection_vector_search_test.cpp
+++ b/test/collection_vector_search_test.cpp
@@ -5144,7 +5144,7 @@ TEST_F(CollectionVectorTest, HybridSearchAuxScoreTest) {
     ASSERT_FLOAT_EQ(0.19428515434265137, res["hits"][3]["vector_distance"].get<float>());
 
     ASSERT_FLOAT_EQ(1060320051, res["hits"][0]["text_match"].get<size_t >());
-    ASSERT_FLOAT_EQ(1108091338752, res["hits"][1]["text_match"].get<size_t >());
-    ASSERT_FLOAT_EQ(1108091338752, res["hits"][2]["text_match"].get<size_t >());
-    ASSERT_FLOAT_EQ(1108091338752, res["hits"][3]["text_match"].get<size_t >());
+    ASSERT_FLOAT_EQ(0, res["hits"][1]["text_match"].get<size_t >());
+    ASSERT_FLOAT_EQ(0, res["hits"][2]["text_match"].get<size_t >());
+    ASSERT_FLOAT_EQ(0, res["hits"][3]["text_match"].get<size_t >());
 }

--- a/test/collection_vector_search_test.cpp
+++ b/test/collection_vector_search_test.cpp
@@ -5106,7 +5106,7 @@ TEST_F(CollectionVectorTest, HybridSearchAuxScoreTest) {
                              {},{}, "right_to_left", true,
                              true, false, "", "", "",
                              "", true, true, false, 0, true,
-                             true, use_aux_score).get();
+                             true, DEFAULT_FILTER_BY_CANDIDATES, use_aux_score).get();
 
     ASSERT_EQ(3, res["hits"].size());
     ASSERT_FLOAT_EQ(0.09585630893707275, res["hits"][0]["vector_distance"].get<float>());
@@ -5135,7 +5135,7 @@ TEST_F(CollectionVectorTest, HybridSearchAuxScoreTest) {
                             {},{}, "right_to_left", true,
                             true, false, "", "", "",
                             "", true, true, false, 0, true,
-                            true, use_aux_score).get();
+                            true, DEFAULT_FILTER_BY_CANDIDATES, use_aux_score).get();
 
 
     ASSERT_EQ(3, res["hits"].size());

--- a/test/collection_vector_search_test.cpp
+++ b/test/collection_vector_search_test.cpp
@@ -5027,3 +5027,124 @@ TEST_F(CollectionVectorTest, TestDistanceThresholdWithIP) {
     ASSERT_EQ("document_0", res["hits"][4]["document"]["name"]);
     ASSERT_EQ(288.0364685058594, res["hits"][4]["vector_distance"].get<float>());
 }
+
+TEST_F(CollectionVectorTest, HybridSearchAuxScoreTest) {
+    nlohmann::json schema = R"({
+                "name": "test",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "embedding",
+                        "type": "float[]",
+                        "embed": {
+                            "from": [
+                                "name"
+                            ],
+                            "model_config": {
+                                "model_name": "ts/e5-small"
+                            }
+                        }
+                    }
+                ]
+                })"_json;
+
+    EmbedderManager::set_model_dir("/tmp/typesense_test/models");
+
+    auto collection_create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(collection_create_op.ok());
+
+    auto coll = collection_create_op.get();
+
+    auto add_op = coll->add(R"({
+        "name": "soccer",
+        "id": "0"
+    })"_json.dump());
+
+    ASSERT_TRUE(add_op.ok());
+
+    add_op = coll->add(R"({
+        "name": "basketball",
+        "id": "1"
+    })"_json.dump());
+
+    ASSERT_TRUE(add_op.ok());
+
+    add_op = coll->add(R"({
+        "name": "typesense",
+        "id": "2"
+    })"_json.dump());
+
+    ASSERT_TRUE(add_op.ok());
+
+    add_op = coll->add(R"({
+        "name": "potato",
+        "id": "3"
+    })"_json.dump());
+
+    ASSERT_TRUE(add_op.ok());
+
+    bool use_aux_score = false;
+
+    auto res = coll->search("basket", {"name", "embedding"}, "", {},
+                             {}, {2}, 10, 1,FREQUENCY, {true},
+                             Index::DROP_TOKENS_THRESHOLD, spp::sparse_hash_set<std::string>(),
+                             {"embedding"}, 10, "",
+                             30, 4, "", 40,
+                             {}, {}, {}, 0,"<mark>",
+                             "</mark>", {}, 1000,true,
+                             false, true, "", false,
+                             6000*1000, 4, 7, fallback, 4,
+                             {off}, INT16_MAX, INT16_MAX,2,
+                             2, false, "", true,
+                             0, max_score, 100, 0, 0,
+                             "exhaustive", 30000, 2, "",
+                             {},{}, "right_to_left", true,
+                             true, false, "", "", "",
+                             "", true, true, false, 0, true,
+                             true, use_aux_score).get();
+
+    ASSERT_EQ(4, res["hits"].size());
+    ASSERT_FLOAT_EQ(0.13851940631866455, res["hits"][0]["vector_distance"].get<float>());
+    ASSERT_FLOAT_EQ(0.15999853610992432, res["hits"][1]["vector_distance"].get<float>());
+    ASSERT_FLOAT_EQ(0.19285917282104492, res["hits"][2]["vector_distance"].get<float>());
+    ASSERT_FLOAT_EQ(0.19428515434265137, res["hits"][3]["vector_distance"].get<float>());
+
+    ASSERT_FLOAT_EQ(1060320051, res["hits"][0]["text_match"].get<size_t >());
+    ASSERT_FLOAT_EQ(0, res["hits"][1]["text_match"].get<size_t >());
+    ASSERT_FLOAT_EQ(0, res["hits"][2]["text_match"].get<size_t >());
+    ASSERT_FLOAT_EQ(0, res["hits"][3]["text_match"].get<size_t >());
+
+    use_aux_score = true;
+
+    res = coll->search("basket", {"name", "embedding"}, "", {},
+                            {}, {2}, 10, 1,FREQUENCY, {true},
+                            Index::DROP_TOKENS_THRESHOLD, spp::sparse_hash_set<std::string>(),
+                            {"embedding"}, 10, "",
+                            30, 4, "", 40,
+                            {}, {}, {}, 0,"<mark>",
+                            "</mark>", {}, 1000,true,
+                            false, true, "", false,
+                            6000*1000, 4, 7, fallback, 4,
+                            {off}, INT16_MAX, INT16_MAX,2,
+                            2, false, "", true,
+                            0, max_score, 100, 0, 0,
+                            "exhaustive", 30000, 2, "",
+                            {},{}, "right_to_left", true,
+                            true, false, "", "", "",
+                            "", true, true, false, 0, true,
+                            true, use_aux_score).get();
+
+    ASSERT_EQ(4, res["hits"].size());
+    ASSERT_FLOAT_EQ(0.13851940631866455, res["hits"][0]["vector_distance"].get<float>());
+    ASSERT_FLOAT_EQ(0.15999853610992432, res["hits"][1]["vector_distance"].get<float>());
+    ASSERT_FLOAT_EQ(0.19285917282104492, res["hits"][2]["vector_distance"].get<float>());
+    ASSERT_FLOAT_EQ(0.19428515434265137, res["hits"][3]["vector_distance"].get<float>());
+
+    ASSERT_FLOAT_EQ(1060320051, res["hits"][0]["text_match"].get<size_t >());
+    ASSERT_FLOAT_EQ(1108091338752, res["hits"][1]["text_match"].get<size_t >());
+    ASSERT_FLOAT_EQ(1108091338752, res["hits"][2]["text_match"].get<size_t >());
+    ASSERT_FLOAT_EQ(1108091338752, res["hits"][3]["text_match"].get<size_t >());
+}


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- add flag `use_aux_score` to enable computing aux scores during hybrid search
- when enabled, it'll compute text_match_score for records found with vector search only and vice versa
- moved redundant code to loop in compute_sort_scores

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
