### PR TITLE
Improve error message, to prevent confusion with auto-embedding feature

### DIFF
--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1289,7 +1289,7 @@ Option<bool> CollectionManager::do_search(std::map<std::string, std::string>& re
 
         // overwrite = true as embedded params have higher priority
         if (!AuthManager::add_item_to_params(req_params, item, true)) {
-            return Option<bool>(400, "Error while applying embedded parameters.");
+            return Option<bool>(400, "Error applying search parameters inside Scoped Search API key");
         }
     }
 

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -8354,7 +8354,7 @@ TEST_F(CollectionJoinTest, EmbeddedParamsJoin) {
 
     search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
     ASSERT_FALSE(search_op.ok());
-    ASSERT_EQ("Error while applying embedded parameters.", search_op.error());
+    ASSERT_EQ("Error applying search parameters inside Scoped Search API key", search_op.error());
 
     req_params = {
             {"collection", "Products"},


### PR DESCRIPTION
Current error message uses the word "embedded" which sounds like it might be related to vector search, when it's not. 

This PR changes:

`Error while applying embedded parameters.` to `Error applying search parameters inside Scoped Search API key`