### PR TITLE
Dictionary based stemming

### DIFF
--- a/include/core_api.h
+++ b/include/core_api.h
@@ -176,11 +176,11 @@ bool get_analytics_events(const std::shared_ptr<http_req>& req, const std::share
 //plurals, nouns
 bool post_import_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 
-bool get_dictionaries(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+bool get_stemming_dictionaries(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 
-bool get_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+bool get_stemming_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 
-bool del_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+bool del_stemming_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 
 // Misc helpers
 

--- a/include/core_api.h
+++ b/include/core_api.h
@@ -171,6 +171,9 @@ bool del_analytics_rules(const std::shared_ptr<http_req>& req, const std::shared
 
 bool post_write_analytics_to_db(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 
+//plurals, nouns
+bool post_import_plurals(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+
 // Misc helpers
 
 void get_collections_for_auth(std::map<std::string, std::string>& req_params, const std::string& body,

--- a/include/core_api.h
+++ b/include/core_api.h
@@ -174,7 +174,7 @@ bool post_write_analytics_to_db(const std::shared_ptr<http_req>& req, const std:
 bool get_analytics_events(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 
 //plurals, nouns
-bool post_import_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+bool post_import_stemming_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 
 bool get_stemming_dictionaries(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 

--- a/include/core_api.h
+++ b/include/core_api.h
@@ -172,7 +172,7 @@ bool del_analytics_rules(const std::shared_ptr<http_req>& req, const std::shared
 bool post_write_analytics_to_db(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 
 //plurals, nouns
-bool post_import_plurals(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+bool post_import_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 
 // Misc helpers
 

--- a/include/core_api.h
+++ b/include/core_api.h
@@ -176,6 +176,12 @@ bool get_analytics_events(const std::shared_ptr<http_req>& req, const std::share
 //plurals, nouns
 bool post_import_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 
+bool get_dictionaries(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+
+bool get_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+
+bool del_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+
 // Misc helpers
 
 void get_collections_for_auth(std::map<std::string, std::string>& req_params, const std::string& body,

--- a/include/field.h
+++ b/include/field.h
@@ -137,7 +137,7 @@ struct field {
     bool is_reference_helper = false;
 
     bool stem = false;
-    bool stem_dictionary = false;
+    std::string stem_dictionary = "";
     std::shared_ptr<Stemmer> stemmer;
   
     nlohmann::json hnsw_params;
@@ -148,7 +148,7 @@ struct field {
           bool index = true, std::string locale = "", int sort = -1, int infix = -1, bool nested = false,
           int nested_array = 0, size_t num_dim = 0, vector_distance_type_t vec_dist = cosine,
           std::string reference = "", const nlohmann::json& embed = nlohmann::json(), const bool range_index = false,
-          const bool store = true, const bool stem = false, const bool stem_dictionary = false, const nlohmann::json hnsw_params = nlohmann::json(),
+          const bool store = true, const bool stem = false, const std::string& stem_dictionary = "", const nlohmann::json hnsw_params = nlohmann::json(),
           const bool async_reference = false) :
             name(name), type(type), facet(facet), optional(optional), index(index), locale(locale),
             nested(nested), nested_array(nested_array), num_dim(num_dim), vec_dist(vec_dist), reference(reference),
@@ -159,7 +159,7 @@ struct field {
 
         auto const suffix = std::string(fields::REFERENCE_HELPER_FIELD_SUFFIX);
         is_reference_helper = name.size() > suffix.size() && name.substr(name.size() - suffix.size()) == suffix;
-        if (stem || stem_dictionary) {
+        if (stem || !stem_dictionary.empty()) {
             this->stem = true;
             stemmer = StemmerManager::get_instance().get_stemmer(locale, stem_dictionary);
         }

--- a/include/field.h
+++ b/include/field.h
@@ -66,6 +66,7 @@ namespace fields {
     static const std::string model_name = "model_name";
     static const std::string range_index = "range_index";
     static const std::string stem = "stem";
+    static const std::string stem_dictionary = "stem_dictionary";
 
     // Some models require additional parameters to be passed to the model during indexing/querying
     // For e.g. e5-small model requires prefix "passage:" for indexing and "query:" for querying
@@ -136,6 +137,7 @@ struct field {
     bool is_reference_helper = false;
 
     bool stem = false;
+    bool stem_dictionary = false;
     std::shared_ptr<Stemmer> stemmer;
   
     nlohmann::json hnsw_params;
@@ -146,19 +148,20 @@ struct field {
           bool index = true, std::string locale = "", int sort = -1, int infix = -1, bool nested = false,
           int nested_array = 0, size_t num_dim = 0, vector_distance_type_t vec_dist = cosine,
           std::string reference = "", const nlohmann::json& embed = nlohmann::json(), const bool range_index = false,
-          const bool store = true, const bool stem = false, const nlohmann::json hnsw_params = nlohmann::json(),
+          const bool store = true, const bool stem = false, const bool stem_dictionary = false, const nlohmann::json hnsw_params = nlohmann::json(),
           const bool async_reference = false) :
             name(name), type(type), facet(facet), optional(optional), index(index), locale(locale),
             nested(nested), nested_array(nested_array), num_dim(num_dim), vec_dist(vec_dist), reference(reference),
-            embed(embed), range_index(range_index), store(store), stem(stem), hnsw_params(hnsw_params),
-            is_async_reference(async_reference) {
+            embed(embed), range_index(range_index), store(store), stem(stem), stem_dictionary(stem_dictionary),
+            hnsw_params(hnsw_params), is_async_reference(async_reference) {
 
         set_computed_defaults(sort, infix);
 
         auto const suffix = std::string(fields::REFERENCE_HELPER_FIELD_SUFFIX);
         is_reference_helper = name.size() > suffix.size() && name.substr(name.size() - suffix.size()) == suffix;
-        if (stem) {
-            stemmer = StemmerManager::get_instance().get_stemmer(locale);
+        if (stem || stem_dictionary) {
+            this->stem = true;
+            stemmer = StemmerManager::get_instance().get_stemmer(locale, stem_dictionary);
         }
     }
 

--- a/include/stemmer_manager.h
+++ b/include/stemmer_manager.h
@@ -9,6 +9,7 @@
 #include "lru/lru.hpp"
 #include "sparsepp.h"
 #include "json.hpp"
+#include "store.h"
 
 
 class Stemmer {
@@ -30,24 +31,52 @@ class StemmerManager {
         StemmerManager() {}
         std::mutex mutex;
         spp::sparse_hash_map<std::string, spp::sparse_hash_map<std::string, std::string>> stem_dictionaries;
+        Store* store;
+
+        std::string get_stemming_dictionary_key(const std::string& dictionary_name);
+
     public:
         static StemmerManager& get_instance() {
             static StemmerManager instance;
             return instance;
         }
+
+        static constexpr const char* STEMMING_DICTIONARY_PREFIX = "$SD";
+
         StemmerManager(StemmerManager const&) = delete;
+
         void operator=(StemmerManager const&) = delete;
+
         StemmerManager(StemmerManager&&) = delete;
+
         void operator=(StemmerManager&&) = delete;
+
         ~StemmerManager();
+
+        void init(Store* _store);
+
+        void dispose();
+
         std::shared_ptr<Stemmer> get_stemmer(const std::string& language, const std::string& dictionary_name="");
+
         void delete_stemmer(const std::string& language);
+
         void delete_all_stemmers();
+
         const bool validate_language(const std::string& language);
-        bool save_words(const std::string& dictionary_name, const std::vector<std::string> &json_lines);
+
+        Option<bool> upsert_stemming_dictionary(const std::string& dictionary_name, const std::vector<std::string> &json_lines,
+                                        bool write_to_store = true);
+
+        bool load_stemming_dictioary(const nlohmann::json& dictionary);
+
         std::string get_normalized_word(const std::string& dictionary_name, const std::string& word);
+
         void get_stemming_dictionaries(nlohmann::json& dictionaries);
+
         bool get_stemming_dictionary(const std::string& id, nlohmann::json& dictionary);
-        void del_stemming_dictionary(const std::string& id);
+
+        Option<bool> del_stemming_dictionary(const std::string& id);
+
         void delete_all_stemming_dictionaries();
 };

--- a/include/stemmer_manager.h
+++ b/include/stemmer_manager.h
@@ -16,9 +16,9 @@ class Stemmer {
         sb_stemmer * stemmer = nullptr;
         LRU::Cache<std::string, std::string> cache;
         std::mutex mutex;
-        bool use_dictionary = false;
+        std::string dictionary_name;
     public:
-        Stemmer(const char * language, bool use_dictionary = false);
+        Stemmer(const char * language, const std::string& dictionary_name="");
         ~Stemmer();
         std::string stem(const std::string & word);
 };
@@ -29,7 +29,7 @@ class StemmerManager {
         std::unordered_map<std::string, std::shared_ptr<Stemmer>> stemmers;
         StemmerManager() {}
         std::mutex mutex;
-        spp::sparse_hash_map<std::string, std::string> stem_dictionary;
+        spp::sparse_hash_map<std::string, spp::sparse_hash_map<std::string, std::string>> stem_dictionary;
     public:
         static StemmerManager& get_instance() {
             static StemmerManager instance;
@@ -40,10 +40,10 @@ class StemmerManager {
         StemmerManager(StemmerManager&&) = delete;
         void operator=(StemmerManager&&) = delete;
         ~StemmerManager();
-        std::shared_ptr<Stemmer> get_stemmer(const std::string& language, bool stem_dictionary = false);
+        std::shared_ptr<Stemmer> get_stemmer(const std::string& language, const std::string& dictionary_name="");
         void delete_stemmer(const std::string& language);
         void delete_all_stemmers();
         const bool validate_language(const std::string& language);
-        bool save_words(const std::vector<std::string> &json_lines);
-        spp::sparse_hash_map<std::string, std::string> get_dictionary();
+        bool save_words(const std::string& dictionary_name, const std::vector<std::string> &json_lines);
+        spp::sparse_hash_map<std::string, std::string> get_dictionary(const std::string& dictionary_name);
 };

--- a/include/stemmer_manager.h
+++ b/include/stemmer_manager.h
@@ -7,6 +7,8 @@
 #include <mutex>
 #include <libstemmer.h>
 #include "lru/lru.hpp"
+#include "sparsepp.h"
+#include "json.hpp"
 
 
 class Stemmer {
@@ -14,8 +16,9 @@ class Stemmer {
         sb_stemmer * stemmer = nullptr;
         LRU::Cache<std::string, std::string> cache;
         std::mutex mutex;
+        bool use_dictionary = false;
     public:
-        Stemmer(const char * language);
+        Stemmer(const char * language, bool use_dictionary = false);
         ~Stemmer();
         std::string stem(const std::string & word);
 };
@@ -26,6 +29,7 @@ class StemmerManager {
         std::unordered_map<std::string, std::shared_ptr<Stemmer>> stemmers;
         StemmerManager() {}
         std::mutex mutex;
+        spp::sparse_hash_map<std::string, std::string> stem_dictionary;
     public:
         static StemmerManager& get_instance() {
             static StemmerManager instance;
@@ -36,8 +40,10 @@ class StemmerManager {
         StemmerManager(StemmerManager&&) = delete;
         void operator=(StemmerManager&&) = delete;
         ~StemmerManager();
-        std::shared_ptr<Stemmer> get_stemmer(const std::string& language);
+        std::shared_ptr<Stemmer> get_stemmer(const std::string& language, bool stem_dictionary = false);
         void delete_stemmer(const std::string& language);
         void delete_all_stemmers();
         const bool validate_language(const std::string& language);
+        bool save_words(const std::vector<std::string> &json_lines);
+        spp::sparse_hash_map<std::string, std::string> get_dictionary();
 };

--- a/include/stemmer_manager.h
+++ b/include/stemmer_manager.h
@@ -29,7 +29,7 @@ class StemmerManager {
         std::unordered_map<std::string, std::shared_ptr<Stemmer>> stemmers;
         StemmerManager() {}
         std::mutex mutex;
-        spp::sparse_hash_map<std::string, spp::sparse_hash_map<std::string, std::string>> stem_dictionary;
+        spp::sparse_hash_map<std::string, spp::sparse_hash_map<std::string, std::string>> stem_dictionaries;
     public:
         static StemmerManager& get_instance() {
             static StemmerManager instance;
@@ -45,5 +45,5 @@ class StemmerManager {
         void delete_all_stemmers();
         const bool validate_language(const std::string& language);
         bool save_words(const std::string& dictionary_name, const std::vector<std::string> &json_lines);
-        spp::sparse_hash_map<std::string, std::string> get_dictionary(const std::string& dictionary_name);
+        std::string get_normalized_word(const std::string& dictionary_name, const std::string& word);
 };

--- a/include/stemmer_manager.h
+++ b/include/stemmer_manager.h
@@ -46,4 +46,8 @@ class StemmerManager {
         const bool validate_language(const std::string& language);
         bool save_words(const std::string& dictionary_name, const std::vector<std::string> &json_lines);
         std::string get_normalized_word(const std::string& dictionary_name, const std::string& word);
+        void get_dictionaries(nlohmann::json& dictionaries);
+        bool get_dictionary(const std::string& id, nlohmann::json& dictionary);
+        void del_dictionary(const std::string& id);
+        void delete_all_dictionaries();
 };

--- a/include/stemmer_manager.h
+++ b/include/stemmer_manager.h
@@ -46,8 +46,8 @@ class StemmerManager {
         const bool validate_language(const std::string& language);
         bool save_words(const std::string& dictionary_name, const std::vector<std::string> &json_lines);
         std::string get_normalized_word(const std::string& dictionary_name, const std::string& word);
-        void get_dictionaries(nlohmann::json& dictionaries);
-        bool get_dictionary(const std::string& id, nlohmann::json& dictionary);
-        void del_dictionary(const std::string& id);
-        void delete_all_dictionaries();
+        void get_stemming_dictionaries(nlohmann::json& dictionaries);
+        bool get_stemming_dictionary(const std::string& id, nlohmann::json& dictionary);
+        void del_stemming_dictionary(const std::string& id);
+        void delete_all_stemming_dictionaries();
 };

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -350,6 +350,7 @@ nlohmann::json Collection::get_summary_json() const {
         field_json[fields::locale] = coll_field.locale;
         field_json[fields::stem] = coll_field.stem;
         field_json[fields::store] = coll_field.store;
+        field_json[fields::stem_dictionary] = coll_field.stem_dictionary;
 
         if(coll_field.range_index) {
             field_json[fields::range_index] = coll_field.range_index;

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -87,6 +87,10 @@ Collection* CollectionManager::init_collection(const nlohmann::json & collection
             field_obj[fields::stem] = false;
         }
 
+        if(field_obj.count(fields::stem_dictionary) == 0) {
+            field_obj[fields::stem_dictionary] = false;
+        }
+
         if(field_obj.count(fields::range_index) == 0) {
             field_obj[fields::range_index] = false;
         }
@@ -123,7 +127,7 @@ Collection* CollectionManager::init_collection(const nlohmann::json & collection
                 field_obj[fields::optional], field_obj[fields::index], field_obj[fields::locale],
                 -1, field_obj[fields::infix], field_obj[fields::nested], field_obj[fields::nested_array],
                 field_obj[fields::num_dim], vec_dist_type, field_obj[fields::reference], field_obj[fields::embed],
-                field_obj[fields::range_index], field_obj[fields::store], field_obj[fields::stem],
+                field_obj[fields::range_index], field_obj[fields::store], field_obj[fields::stem], field_obj[fields::stem_dictionary],
                 field_obj[fields::hnsw_params], field_obj[fields::async_reference]);
 
         // value of `sort` depends on field type

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -88,7 +88,7 @@ Collection* CollectionManager::init_collection(const nlohmann::json & collection
         }
 
         if(field_obj.count(fields::stem_dictionary) == 0) {
-            field_obj[fields::stem_dictionary] = false;
+            field_obj[fields::stem_dictionary] = "";
         }
 
         if(field_obj.count(fields::range_index) == 0) {

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -2986,7 +2986,7 @@ bool post_import_dictionary(const std::shared_ptr<http_req>& req, const std::sha
 
 bool get_dictionaries(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     nlohmann::json dictionaries;
-    StemmerManager::get_instance().get_dictionaries(dictionaries);
+    StemmerManager::get_instance().get_stemming_dictionaries(dictionaries);
 
     res->set_200(dictionaries.dump());
     return true;
@@ -2996,7 +2996,7 @@ bool get_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<
     const std::string& id = req->params["id"];
     nlohmann::json dictionary;
 
-    if(!StemmerManager::get_instance().get_dictionary(id, dictionary)) {
+    if(!StemmerManager::get_instance().get_stemming_dictionary(id, dictionary)) {
         res->set_404();
         return false;
     }
@@ -3009,7 +3009,7 @@ bool del_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<
     const std::string& id = req->params["id"];
     nlohmann::json dictionary;
 
-    StemmerManager::get_instance().del_dictionary(id);
+    StemmerManager::get_instance().del_stemming_dictionary(id);
 
     nlohmann::json res_json;
     res_json["id"] = id;

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -2918,17 +2918,17 @@ bool post_write_analytics_to_db(const std::shared_ptr<http_req>& req, const std:
     return true;
 }
 
-bool post_import_plurals(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
+bool post_import_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     const char *BATCH_SIZE = "batch_size";
-    const char *PLURALS_SET = "plurals_set";
+    const char *DICTIONARY_SET = "dictionary_set";
 
     if(req->params.count(BATCH_SIZE) == 0) {
         req->params[BATCH_SIZE] = "40";
     }
 
-    if(req->params.count(PLURALS_SET) == 0) {
+    if(req->params.count(DICTIONARY_SET) == 0) {
         res->final = true;
-        res->set_400("Parameter `" + std::string(PLURALS_SET) + "` must be provided while importing plurals.");
+        res->set_400("Parameter `" + std::string(DICTIONARY_SET) + "` must be provided while importing dictionary words.");
         stream_response(req, res);
         return false;
     }
@@ -2953,7 +2953,7 @@ bool post_import_plurals(const std::shared_ptr<http_req>& req, const std::shared
     std::stringstream response_stream;
 
     if(!single_partial_record_body) {
-        if(!StemmerManager::get_instance().save_words(req->params.at(PLURALS_SET), json_lines)) {
+        if(!StemmerManager::get_instance().save_words(req->params.at(DICTIONARY_SET), json_lines)) {
             res->set_400("Bad/malformed dictionary import.");
             stream_response(req, res);
         }

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -2953,8 +2953,9 @@ bool post_import_stemming_dictionary(const std::shared_ptr<http_req>& req, const
     std::stringstream response_stream;
 
     if(!single_partial_record_body) {
-        if(!StemmerManager::get_instance().save_words(req->params.at(ID), json_lines)) {
-            res->set_400("Bad/malformed dictionary import.");
+        auto op = StemmerManager::get_instance().upsert_stemming_dictionary(req->params.at(ID), json_lines);
+        if(!op.ok()) {
+            res->set(op.code(), op.error());
             stream_response(req, res);
         }
 
@@ -3009,7 +3010,11 @@ bool del_stemming_dictionary(const std::shared_ptr<http_req>& req, const std::sh
     const std::string& id = req->params["id"];
     nlohmann::json dictionary;
 
-    StemmerManager::get_instance().del_stemming_dictionary(id);
+    auto delete_op = StemmerManager::get_instance().del_stemming_dictionary(id);
+
+    if(!delete_op.ok()) {
+        res->set(delete_op.code(), delete_op.error());
+    }
 
     nlohmann::json res_json;
     res_json["id"] = id;

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -2918,7 +2918,7 @@ bool post_write_analytics_to_db(const std::shared_ptr<http_req>& req, const std:
     return true;
 }
 
-bool post_import_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
+bool post_import_stemming_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     const char *BATCH_SIZE = "batch_size";
     const char *ID = "id";
 
@@ -2984,7 +2984,7 @@ bool post_import_dictionary(const std::shared_ptr<http_req>& req, const std::sha
     return true;
 }
 
-bool get_dictionaries(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
+bool get_stemming_dictionaries(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     nlohmann::json dictionaries;
     StemmerManager::get_instance().get_stemming_dictionaries(dictionaries);
 
@@ -2992,7 +2992,7 @@ bool get_dictionaries(const std::shared_ptr<http_req>& req, const std::shared_pt
     return true;
 }
 
-bool get_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
+bool get_stemming_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     const std::string& id = req->params["id"];
     nlohmann::json dictionary;
 
@@ -3005,7 +3005,7 @@ bool get_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<
     return true;
 }
 
-bool del_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
+bool del_stemming_dictionary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     const std::string& id = req->params["id"];
     nlohmann::json dictionary;
 

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -2900,6 +2900,64 @@ bool post_write_analytics_to_db(const std::shared_ptr<http_req>& req, const std:
     return true;
 }
 
+bool post_import_plurals(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
+    const char *BATCH_SIZE = "batch_size";
+
+    if(req->params.count(BATCH_SIZE) == 0) {
+        req->params[BATCH_SIZE] = "40";
+    }
+
+    if(!StringUtils::is_uint32_t(req->params[BATCH_SIZE])) {
+        res->final = true;
+        res->set_400("Parameter `" + std::string(BATCH_SIZE) + "` must be a positive integer.");
+        stream_response(req, res);
+        return false;
+    }
+
+    std::vector<std::string> json_lines;
+    StringUtils::split(req->body, json_lines, "\n", false, false);
+
+    if(req->last_chunk_aggregate) {
+        //LOG(INFO) << "req->last_chunk_aggregate is true";
+        req->body = "";
+    }
+
+    // When only one partial record arrives as a chunk, an empty body is pushed to response stream
+    bool single_partial_record_body = (json_lines.empty() && !req->body.empty());
+    std::stringstream response_stream;
+
+    if(!single_partial_record_body) {
+        if(!StemmerManager::get_instance().save_words(json_lines)) {
+            res->set_400("Bad/malformed dictionary import.");
+            stream_response(req, res);
+        }
+
+        for (size_t i = 0; i < json_lines.size(); i++) {
+            bool res_start = (res->status_code == 0) && (i == 0);
+
+            if(res_start) {
+                // indicates first import result to be streamed
+                response_stream << json_lines[i];
+            } else {
+                response_stream << "\n" << json_lines[i];
+            }
+        }
+
+        // Since we use `res->status_code == 0` for flagging `res_start`, we will only set this
+        // when we have accumulated enough response data to stream.
+        // Otherwise, we will send an empty line as first response.
+        res->status_code = 200;
+    }
+
+    res->content_type_header = "text/plain; charset=utf-8";
+    res->body = response_stream.str();
+
+    res->final.store(req->last_chunk_aggregate);
+    stream_response(req, res);
+
+    return true;
+}
+
 bool post_proxy(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     HttpProxy& proxy = HttpProxy::get_instance();
 

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -2920,9 +2920,17 @@ bool post_write_analytics_to_db(const std::shared_ptr<http_req>& req, const std:
 
 bool post_import_plurals(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     const char *BATCH_SIZE = "batch_size";
+    const char *PLURALS_SET = "plurals_set";
 
     if(req->params.count(BATCH_SIZE) == 0) {
         req->params[BATCH_SIZE] = "40";
+    }
+
+    if(req->params.count(PLURALS_SET) == 0) {
+        res->final = true;
+        res->set_400("Parameter `" + std::string(PLURALS_SET) + "` must be provided while importing plurals.");
+        stream_response(req, res);
+        return false;
     }
 
     if(!StringUtils::is_uint32_t(req->params[BATCH_SIZE])) {
@@ -2945,7 +2953,7 @@ bool post_import_plurals(const std::shared_ptr<http_req>& req, const std::shared
     std::stringstream response_stream;
 
     if(!single_partial_record_body) {
-        if(!StemmerManager::get_instance().save_words(json_lines)) {
+        if(!StemmerManager::get_instance().save_words(req->params.at(PLURALS_SET), json_lines)) {
             res->set_400("Bad/malformed dictionary import.");
             stream_response(req, res);
         }

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -118,6 +118,10 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
         field_json[fields::stem] = false;
     }
 
+    if(field_json.count(fields::stem_dictionary) == 0) {
+        field_json[fields::stem_dictionary] = false;
+    }
+
     if (field_json.count(fields::range_index) != 0) {
         if (!field_json.at(fields::range_index).is_boolean()) {
             return Option<bool>(400, std::string("The `range_index` property of the field `") +
@@ -427,8 +431,8 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
                   field_json[fields::sort], field_json[fields::infix], field_json[fields::nested],
                   field_json[fields::nested_array], field_json[fields::num_dim], vec_dist,
                   field_json[fields::reference], field_json[fields::embed], field_json[fields::range_index], 
-                  field_json[fields::store], field_json[fields::stem], field_json[fields::hnsw_params],
-                  field_json[fields::async_reference])
+                  field_json[fields::store], field_json[fields::stem], field_json[fields::stem_dictionary],
+                  field_json[fields::hnsw_params], field_json[fields::async_reference])
     );
 
     if (!field_json[fields::reference].get<std::string>().empty()) {
@@ -808,6 +812,7 @@ Option<bool> field::fields_to_json_fields(const std::vector<field>& fields, cons
         field_val[fields::store] = field.store;
         field_val[fields::stem] = field.stem;
         field_val[fields::range_index] = field.range_index;
+        field_val[fields::stem_dictionary] = field.stem_dictionary;
 
         if(field.embed.count(fields::from) != 0) {
             field_val[fields::embed] = field.embed;

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -119,7 +119,7 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
     }
 
     if(field_json.count(fields::stem_dictionary) == 0) {
-        field_json[fields::stem_dictionary] = false;
+        field_json[fields::stem_dictionary] = "";
     }
 
     if (field_json.count(fields::range_index) != 0) {

--- a/src/main/typesense_server.cpp
+++ b/src/main/typesense_server.cpp
@@ -85,9 +85,9 @@ void master_server_routes() {
     server->get("/analytics/events", get_analytics_events);
 
     // for plurals, nouns
-    server->post("/stemming/dictionary/import", post_import_dictionary, true, true);
-    server->get("/stemming/dictionaries", get_dictionaries);
-    server->get("/stemming/dictionary/:id", get_dictionary);
+    server->post("/stemming/dictionary/import", post_import_stemming_dictionary, true, true);
+    server->get("/stemming/dictionaries", get_stemming_dictionaries);
+    server->get("/stemming/dictionary/:id", get_stemming_dictionary);
 
     // meta
     server->get("/metrics.json", get_metrics_json);

--- a/src/main/typesense_server.cpp
+++ b/src/main/typesense_server.cpp
@@ -86,6 +86,8 @@ void master_server_routes() {
 
     // for plurals, nouns
     server->post("/stemming/dictionary/import", post_import_dictionary, true, true);
+    server->get("/stemming/dictionaries", get_dictionaries);
+    server->get("/stemming/dictionary/:id", get_dictionary);
 
     // meta
     server->get("/metrics.json", get_metrics_json);

--- a/src/main/typesense_server.cpp
+++ b/src/main/typesense_server.cpp
@@ -84,7 +84,7 @@ void master_server_routes() {
     server->post("/analytics/aggregate_events", post_write_analytics_to_db);
 
     // for plurals, nouns
-    server->post("/stemming/plurals/import", post_import_plurals);
+    server->post("/stemming/dictionary/import", post_import_dictionary);
 
     // meta
     server->get("/metrics.json", get_metrics_json);

--- a/src/main/typesense_server.cpp
+++ b/src/main/typesense_server.cpp
@@ -83,6 +83,9 @@ void master_server_routes() {
     server->post("/analytics/events", post_create_event);
     server->post("/analytics/aggregate_events", post_write_analytics_to_db);
 
+    // for plurals, nouns
+    server->post("/stemming/plurals/import", post_import_plurals);
+
     // meta
     server->get("/metrics.json", get_metrics_json);
     server->get("/stats.json", get_stats_json);

--- a/src/main/typesense_server.cpp
+++ b/src/main/typesense_server.cpp
@@ -85,9 +85,9 @@ void master_server_routes() {
     server->get("/analytics/events", get_analytics_events);
 
     // for plurals, nouns
-    server->post("/stemming/dictionary/import", post_import_stemming_dictionary, true, true);
+    server->post("/stemming/dictionaries/import", post_import_stemming_dictionary, true, true);
     server->get("/stemming/dictionaries", get_stemming_dictionaries);
-    server->get("/stemming/dictionary/:id", get_stemming_dictionary);
+    server->get("/stemming/dictionaries/:id", get_stemming_dictionary);
 
     // meta
     server->get("/metrics.json", get_metrics_json);

--- a/src/main/typesense_server.cpp
+++ b/src/main/typesense_server.cpp
@@ -85,7 +85,7 @@ void master_server_routes() {
     server->get("/analytics/events", get_analytics_events);
 
     // for plurals, nouns
-    server->post("/stemming/dictionary/import", post_import_dictionary);
+    server->post("/stemming/dictionary/import", post_import_dictionary, true, true);
 
     // meta
     server->get("/metrics.json", get_metrics_json);

--- a/src/stemmer_manager.cpp
+++ b/src/stemmer_manager.cpp
@@ -117,3 +117,50 @@ std::string StemmerManager::get_normalized_word(const std::string &dictionary_na
 
     return normalized_word;
 }
+
+void StemmerManager::get_dictionaries(nlohmann::json &dictionaries) {
+    std::lock_guard<std::mutex> lock(mutex);
+
+    if(!stem_dictionaries.empty()) {
+        dictionaries["dictionaries"] = nlohmann::json::array();
+        for (const auto &kv: stem_dictionaries) {
+                dictionaries["dictionaries"].push_back(kv.first);
+        }
+    }
+}
+
+bool StemmerManager::get_dictionary(const std::string &id, nlohmann::json &dictionary) {
+    std::lock_guard<std::mutex> lock(mutex);
+
+    auto found = stem_dictionaries.find(id);
+    if(found != stem_dictionaries.end()) {
+
+        dictionary["id"] = id;
+        dictionary["words"] = nlohmann::json::array();
+
+        for (const auto &kv: found->second) {
+            nlohmann::json line;
+            line["word"] = kv.first;
+            line["root"] = kv.second;
+            dictionary["words"].push_back(line);
+        }
+
+        return true;
+    }
+
+    return false;
+}
+
+void StemmerManager::del_dictionary(const std::string &id) {
+    std::lock_guard<std::mutex> lock(mutex);
+
+    auto found = stem_dictionaries.find(id);
+    if(found != stem_dictionaries.end()) {
+        stem_dictionaries.erase(found);
+    }
+}
+
+void StemmerManager::delete_all_dictionaries() {
+    std::lock_guard<std::mutex> lock(mutex);
+    stem_dictionaries.clear();
+}

--- a/src/stemmer_manager.cpp
+++ b/src/stemmer_manager.cpp
@@ -118,7 +118,7 @@ std::string StemmerManager::get_normalized_word(const std::string &dictionary_na
     return normalized_word;
 }
 
-void StemmerManager::get_dictionaries(nlohmann::json &dictionaries) {
+void StemmerManager::get_stemming_dictionaries(nlohmann::json &dictionaries) {
     std::lock_guard<std::mutex> lock(mutex);
 
     if(!stem_dictionaries.empty()) {
@@ -129,7 +129,7 @@ void StemmerManager::get_dictionaries(nlohmann::json &dictionaries) {
     }
 }
 
-bool StemmerManager::get_dictionary(const std::string &id, nlohmann::json &dictionary) {
+bool StemmerManager::get_stemming_dictionary(const std::string &id, nlohmann::json &dictionary) {
     std::lock_guard<std::mutex> lock(mutex);
 
     auto found = stem_dictionaries.find(id);
@@ -151,7 +151,7 @@ bool StemmerManager::get_dictionary(const std::string &id, nlohmann::json &dicti
     return false;
 }
 
-void StemmerManager::del_dictionary(const std::string &id) {
+void StemmerManager::del_stemming_dictionary(const std::string &id) {
     std::lock_guard<std::mutex> lock(mutex);
 
     auto found = stem_dictionaries.find(id);
@@ -160,7 +160,7 @@ void StemmerManager::del_dictionary(const std::string &id) {
     }
 }
 
-void StemmerManager::delete_all_dictionaries() {
+void StemmerManager::delete_all_stemming_dictionaries() {
     std::lock_guard<std::mutex> lock(mutex);
     stem_dictionaries.clear();
 }

--- a/src/stemmer_manager.cpp
+++ b/src/stemmer_manager.cpp
@@ -104,9 +104,12 @@ std::string StemmerManager::get_normalized_word(const std::string &dictionary_na
     std::lock_guard<std::mutex> lock(mutex);
 
     std::string normalized_word;
-    if(stem_dictionaries.count(dictionary_name) != 0) {
-        const auto& dictionary = stem_dictionaries.at(dictionary_name);
+
+    auto stem_dictionaries_it = stem_dictionaries.find(dictionary_name);
+    if(stem_dictionaries_it != stem_dictionaries.end()) {
+        const auto& dictionary = stem_dictionaries_it->second;
         auto found = dictionary.find(word);
+
         if(found != dictionary.end()) {
             normalized_word = found->second;
         }

--- a/src/stemmer_manager.cpp
+++ b/src/stemmer_manager.cpp
@@ -1,13 +1,20 @@
 #include "stemmer_manager.h"
 
 
-Stemmer::Stemmer(const char * language) {
-    this->stemmer = sb_stemmer_new(language, nullptr);
+Stemmer::Stemmer(const char * language, bool use_dictionary) {
+    if(!use_dictionary) {
+        this->stemmer = sb_stemmer_new(language, nullptr);
+    } else {
+        this->use_dictionary = true;
+    }
+
     this->cache = LRU::Cache<std::string, std::string>(20);
 }
 
 Stemmer::~Stemmer() {
-    sb_stemmer_delete(stemmer);
+    if(stemmer) {
+        sb_stemmer_delete(stemmer);
+    }
 }
 
 std::string Stemmer::stem(const std::string & word) {
@@ -16,22 +23,35 @@ std::string Stemmer::stem(const std::string & word) {
     if (cache.contains(word)) {
         return cache.lookup(word);
     }
-    auto stemmed = sb_stemmer_stem(stemmer, reinterpret_cast<const sb_symbol*>(word.c_str()), word.length());
-    stemmed_word = std::string(reinterpret_cast<const char*>(stemmed));
+
+    if(!use_dictionary) {
+        auto stemmed = sb_stemmer_stem(stemmer, reinterpret_cast<const sb_symbol *>(word.c_str()), word.length());
+        stemmed_word = std::string(reinterpret_cast<const char *>(stemmed));
+    } else {
+        const auto& stem_dictionary = StemmerManager::get_instance().get_dictionary();
+        auto it = stem_dictionary.find(word);
+        if(it == stem_dictionary.end()) {
+            stemmed_word = word;
+        } else {
+            stemmed_word = it->second;
+        }
+    }
+
     cache.insert(word, stemmed_word);
     return stemmed_word;
 }
 
 StemmerManager::~StemmerManager() {
     delete_all_stemmers();
+    stem_dictionary.clear();
 }
 
-std::shared_ptr<Stemmer> StemmerManager::get_stemmer(const std::string& language) {
+std::shared_ptr<Stemmer> StemmerManager::get_stemmer(const std::string& language, bool use_dictionary) {
     std::unique_lock<std::mutex> lock(mutex);
     // use english as default language
     const std::string language_ = language.empty() ? "english" : language;
     if (stemmers.find(language_) == stemmers.end()) {
-        stemmers[language] = std::make_shared<Stemmer>(language_.c_str());
+        stemmers[language] = std::make_shared<Stemmer>(language_.c_str(), use_dictionary);
     }
     return stemmers[language];
 }
@@ -56,4 +76,29 @@ const bool StemmerManager::validate_language(const std::string& language) {
     }
     sb_stemmer_delete(stemmer);
     return true;
+}
+
+bool StemmerManager::save_words(const std::vector<std::string> &json_lines) {
+    if(json_lines.empty()) {
+        return false;
+    }
+
+    nlohmann::json json_line;
+    for(const auto& line_str : json_lines) {
+        try {
+            json_line = nlohmann::json::parse(line_str);
+        } catch(...) {
+            return false;
+        }
+
+        if(!json_line.contains("word") || !json_line.contains("root")) {
+            return false;
+        }
+        stem_dictionary.emplace(json_line["word"], json_line["root"]);
+    }
+    return true;
+}
+
+spp::sparse_hash_map<std::string, std::string> StemmerManager::get_dictionary() {
+    return stem_dictionary;
 }

--- a/src/typesense_server_utils.cpp
+++ b/src/typesense_server_utils.cpp
@@ -25,6 +25,7 @@
 #include "stopwords_manager.h"
 #include "conversation_manager.h"
 #include "vq_model_manager.h"
+#include "stemmer_manager.h"
 
 #ifndef ASAN_BUILD
 #include "jemalloc.h"
@@ -475,6 +476,9 @@ int run_server(const Config & config, const std::string & version, void (*master
 
     StopwordsManager& stopwordsManager = StopwordsManager::get_instance();
     stopwordsManager.init(&store);
+
+    StemmerManager& stemmerManager = StemmerManager::get_instance();
+    stemmerManager.init(&store);
 
     RateLimitManager *rateLimitManager = RateLimitManager::getInstance();
     auto rate_limit_manager_init = rateLimitManager->init(&meta_store);

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -137,7 +137,7 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"string",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": false
+              "stem_dictionary": ""
             },
             {
               "facet":false,
@@ -152,7 +152,7 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"string",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": false
+              "stem_dictionary": ""
             },
             {
               "facet":true,
@@ -167,7 +167,7 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"string[]",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": false
+              "stem_dictionary": ""
             },
             {
               "facet":true,
@@ -182,7 +182,7 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"int32",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": false
+              "stem_dictionary": ""
             },
             {
               "facet":false,
@@ -197,7 +197,7 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"geopoint",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": false
+              "stem_dictionary": ""
             },
             {
               "facet":false,
@@ -212,7 +212,7 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"string",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": false
+              "stem_dictionary": ""
             },
             {
               "facet":false,
@@ -227,7 +227,7 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"int32",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": false
+              "stem_dictionary": ""
             },
             {
               "facet":false,
@@ -243,7 +243,7 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"object",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": false
+              "stem_dictionary": ""
             },
             {
               "facet":false,
@@ -260,7 +260,7 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "vec_dist":"cosine",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": false
+              "stem_dictionary": ""
             },
             {
               "async_reference":true,
@@ -277,7 +277,7 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "reference":"Products.product_id",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": false
+              "stem_dictionary": ""
             },
             {
               "facet":false,
@@ -292,7 +292,7 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"int64",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": false
+              "stem_dictionary": ""
             }
           ],
           "id":0,
@@ -1681,7 +1681,7 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
                     "type":"string",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": false
+                    "stem_dictionary": ""
                 },
                 {
                     "facet":true,
@@ -1697,7 +1697,7 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": false
+                    "stem_dictionary": ""
                 },{
                     "facet":true,
                     "index":true,
@@ -1712,7 +1712,7 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": false
+                    "stem_dictionary": ""
                 },{
                     "facet":true,
                     "index":true,
@@ -1727,7 +1727,7 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": false
+                    "stem_dictionary": ""
                 }
             ],
             "id":1,

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -136,7 +136,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "store":true,
               "type":"string",
               "range_index":false,
-              "stem":false
+              "stem":false,
+              "stem_dictionary": false
             },
             {
               "facet":false,
@@ -150,7 +151,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "store":true,
               "type":"string",
               "range_index":false,
-              "stem":false
+              "stem":false,
+              "stem_dictionary": false
             },
             {
               "facet":true,
@@ -164,7 +166,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "store":true,
               "type":"string[]",
               "range_index":false,
-              "stem":false
+              "stem":false,
+              "stem_dictionary": false
             },
             {
               "facet":true,
@@ -178,7 +181,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "store":true,
               "type":"int32",
               "range_index":false,
-              "stem":false
+              "stem":false,
+              "stem_dictionary": false
             },
             {
               "facet":false,
@@ -192,7 +196,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "store":true,
               "type":"geopoint",
               "range_index":false,
-              "stem":false
+              "stem":false,
+              "stem_dictionary": false
             },
             {
               "facet":false,
@@ -206,7 +211,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "store":true,
               "type":"string",
               "range_index":false,
-              "stem":false
+              "stem":false,
+              "stem_dictionary": false
             },
             {
               "facet":false,
@@ -220,7 +226,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "store":true,
               "type":"int32",
               "range_index":false,
-              "stem":false
+              "stem":false,
+              "stem_dictionary": false
             },
             {
               "facet":false,
@@ -235,7 +242,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "store":true,
               "type":"object",
               "range_index":false,
-              "stem":false
+              "stem":false,
+              "stem_dictionary": false
             },
             {
               "facet":false,
@@ -251,7 +259,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"float[]",
               "vec_dist":"cosine",
               "range_index":false,
-              "stem":false
+              "stem":false,
+              "stem_dictionary": false
             },
             {
               "async_reference":true,
@@ -267,7 +276,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"string",
               "reference":"Products.product_id",
               "range_index":false,
-              "stem":false
+              "stem":false,
+              "stem_dictionary": false
             },
             {
               "facet":false,
@@ -281,7 +291,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "store":true,
               "type":"int64",
               "range_index":false,
-              "stem":false
+              "stem":false,
+              "stem_dictionary": false
             }
           ],
           "id":0,
@@ -1669,7 +1680,8 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
                     "store":true,
                     "type":"string",
                     "range_index":false,
-                    "stem":false
+                    "stem":false,
+                    "stem_dictionary": false
                 },
                 {
                     "facet":true,
@@ -1684,7 +1696,8 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
                     "store":true,
                     "type":"int32",
                     "range_index":false,
-                    "stem":false
+                    "stem":false,
+                    "stem_dictionary": false
                 },{
                     "facet":true,
                     "index":true,
@@ -1698,7 +1711,8 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
                     "store":true,
                     "type":"int32",
                     "range_index":false,
-                    "stem":false
+                    "stem":false,
+                    "stem_dictionary": false
                 },{
                     "facet":true,
                     "index":true,
@@ -1712,7 +1726,8 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
                     "store":true,
                     "type":"int32",
                     "range_index":false,
-                    "stem":false
+                    "stem":false,
+                    "stem_dictionary": false
                 }
             ],
             "id":1,

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -3437,7 +3437,7 @@ TEST_F(CollectionSpecificMoreTest, StemmingDictionary) {
 }
 
 TEST_F(CollectionSpecificMoreTest, StemmingDictionaryBasics) {
-    StemmerManager::get_instance().delete_all_dictionaries();
+    StemmerManager::get_instance().delete_all_stemming_dictionaries();
 
     std::string json_line = "{\"word\": \"people\", \"root\":\"person\"}";
     std::vector<std::string> json_lines;
@@ -3448,7 +3448,7 @@ TEST_F(CollectionSpecificMoreTest, StemmingDictionaryBasics) {
 
     //get dictionary set
     nlohmann::json dictionary;
-    ASSERT_TRUE(StemmerManager::get_instance().get_dictionary("set1", dictionary));
+    ASSERT_TRUE(StemmerManager::get_instance().get_stemming_dictionary("set1", dictionary));
     ASSERT_EQ("set1", dictionary["id"]);
     ASSERT_EQ(1, dictionary["words"].size());
     ASSERT_EQ("people", dictionary["words"][0]["word"]);
@@ -3460,7 +3460,7 @@ TEST_F(CollectionSpecificMoreTest, StemmingDictionaryBasics) {
     json_lines.push_back(json_line);
     ASSERT_TRUE(StemmerManager::get_instance().save_words("set2", json_lines));
 
-    ASSERT_TRUE(StemmerManager::get_instance().get_dictionary("set2", dictionary));
+    ASSERT_TRUE(StemmerManager::get_instance().get_stemming_dictionary("set2", dictionary));
     ASSERT_EQ("set2", dictionary["id"]);
     ASSERT_EQ(1, dictionary["words"].size());
     ASSERT_EQ("qualities", dictionary["words"][0]["word"]);
@@ -3472,7 +3472,7 @@ TEST_F(CollectionSpecificMoreTest, StemmingDictionaryBasics) {
     json_lines.push_back(json_line);
     ASSERT_TRUE(StemmerManager::get_instance().save_words("set2", json_lines));
 
-    ASSERT_TRUE(StemmerManager::get_instance().get_dictionary("set2", dictionary));
+    ASSERT_TRUE(StemmerManager::get_instance().get_stemming_dictionary("set2", dictionary));
     ASSERT_EQ("set2", dictionary["id"]);
     ASSERT_EQ(2, dictionary["words"].size());
     ASSERT_EQ("qualities", dictionary["words"][0]["word"]);
@@ -3482,15 +3482,15 @@ TEST_F(CollectionSpecificMoreTest, StemmingDictionaryBasics) {
 
     //get all dictionary sets
     nlohmann::json dictionary_sets;
-    StemmerManager::get_instance().get_dictionaries(dictionary_sets);
+    StemmerManager::get_instance().get_stemming_dictionaries(dictionary_sets);
     ASSERT_EQ(2, dictionary_sets["dictionaries"].size());
     ASSERT_EQ("set1", dictionary_sets["dictionaries"][0].get<std::string>());
     ASSERT_EQ("set2", dictionary_sets["dictionaries"][1].get<std::string>());
 
     //del dictionary set and get
     dictionary_sets.clear();
-    StemmerManager::get_instance().del_dictionary("set2");
-    StemmerManager::get_instance().get_dictionaries(dictionary_sets);
+    StemmerManager::get_instance().del_stemming_dictionary("set2");
+    StemmerManager::get_instance().get_stemming_dictionaries(dictionary_sets);
     ASSERT_EQ(1, dictionary_sets["dictionaries"].size());
     ASSERT_EQ("set1", dictionary_sets["dictionaries"][0].get<std::string>());
 }

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -3396,7 +3396,7 @@ TEST_F(CollectionSpecificMoreTest, StemmingPlurals) {
     nlohmann::json schema = R"({
          "name": "titles",
          "fields": [
-           {"name": "title", "type": "string", "stem_dictionary": true }
+           {"name": "title", "type": "string", "stem_dictionary": "set1" }
          ]
        })"_json;
 
@@ -3409,12 +3409,12 @@ TEST_F(CollectionSpecificMoreTest, StemmingPlurals) {
     std::vector<std::string> json_lines;
     json_lines.push_back(json_line);
 
-    ASSERT_TRUE(StemmerManager::get_instance().save_words(json_lines));
+    ASSERT_TRUE(StemmerManager::get_instance().save_words("set1", json_lines));
 
     schema = R"({
          "name": "titles_no_stem",
          "fields": [
-           {"name": "title", "type": "string", "stem_dictionary": false }
+           {"name": "title", "type": "string" }
          ]
        })"_json;
 

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -10,6 +10,7 @@ class CollectionSpecificMoreTest : public ::testing::Test {
 protected:
     Store *store;
     CollectionManager & collectionManager = CollectionManager::get_instance();
+    StemmerManager& stemmerManager = StemmerManager::get_instance();
     std::atomic<bool> quit = false;
 
     std::vector<std::string> query_fields;
@@ -21,6 +22,7 @@ protected:
         system(("rm -rf "+state_dir_path+" && mkdir -p "+state_dir_path).c_str());
 
         store = new Store(state_dir_path);
+        stemmerManager.init(store);
         collectionManager.init(store, 1.0, "auth_key", quit);
         collectionManager.load(8, 1000);
     }
@@ -3409,7 +3411,7 @@ TEST_F(CollectionSpecificMoreTest, StemmingDictionary) {
     std::vector<std::string> json_lines;
     json_lines.push_back(json_line);
 
-    ASSERT_TRUE(StemmerManager::get_instance().save_words("set1", json_lines));
+    ASSERT_TRUE(stemmerManager.upsert_stemming_dictionary("set1", json_lines).ok());
 
     schema = R"({
          "name": "titles_no_stem",
@@ -3437,18 +3439,18 @@ TEST_F(CollectionSpecificMoreTest, StemmingDictionary) {
 }
 
 TEST_F(CollectionSpecificMoreTest, StemmingDictionaryBasics) {
-    StemmerManager::get_instance().delete_all_stemming_dictionaries();
+    stemmerManager.delete_all_stemming_dictionaries();
 
     std::string json_line = "{\"word\": \"people\", \"root\":\"person\"}";
     std::vector<std::string> json_lines;
     json_lines.push_back(json_line);
 
     //add dictionary set
-    ASSERT_TRUE(StemmerManager::get_instance().save_words("set1", json_lines));
+    ASSERT_TRUE(stemmerManager.upsert_stemming_dictionary("set1", json_lines).ok());
 
     //get dictionary set
     nlohmann::json dictionary;
-    ASSERT_TRUE(StemmerManager::get_instance().get_stemming_dictionary("set1", dictionary));
+    ASSERT_TRUE(stemmerManager.get_stemming_dictionary("set1", dictionary));
     ASSERT_EQ("set1", dictionary["id"]);
     ASSERT_EQ(1, dictionary["words"].size());
     ASSERT_EQ("people", dictionary["words"][0]["word"]);
@@ -3458,9 +3460,9 @@ TEST_F(CollectionSpecificMoreTest, StemmingDictionaryBasics) {
     json_lines.clear();
     json_line = "{\"word\": \"qualities\", \"root\":\"quality\"}";
     json_lines.push_back(json_line);
-    ASSERT_TRUE(StemmerManager::get_instance().save_words("set2", json_lines));
+    ASSERT_TRUE(stemmerManager.upsert_stemming_dictionary("set2", json_lines).ok());
 
-    ASSERT_TRUE(StemmerManager::get_instance().get_stemming_dictionary("set2", dictionary));
+    ASSERT_TRUE(stemmerManager.get_stemming_dictionary("set2", dictionary));
     ASSERT_EQ("set2", dictionary["id"]);
     ASSERT_EQ(1, dictionary["words"].size());
     ASSERT_EQ("qualities", dictionary["words"][0]["word"]);
@@ -3470,9 +3472,9 @@ TEST_F(CollectionSpecificMoreTest, StemmingDictionaryBasics) {
     json_lines.clear();
     json_line = "{\"word\": \"mangoes\", \"root\":\"mango\"}";
     json_lines.push_back(json_line);
-    ASSERT_TRUE(StemmerManager::get_instance().save_words("set2", json_lines));
+    ASSERT_TRUE(stemmerManager.upsert_stemming_dictionary("set2", json_lines).ok());
 
-    ASSERT_TRUE(StemmerManager::get_instance().get_stemming_dictionary("set2", dictionary));
+    ASSERT_TRUE(stemmerManager.get_stemming_dictionary("set2", dictionary));
     ASSERT_EQ("set2", dictionary["id"]);
     ASSERT_EQ(2, dictionary["words"].size());
     ASSERT_EQ("qualities", dictionary["words"][0]["word"]);
@@ -3482,15 +3484,54 @@ TEST_F(CollectionSpecificMoreTest, StemmingDictionaryBasics) {
 
     //get all dictionary sets
     nlohmann::json dictionary_sets;
-    StemmerManager::get_instance().get_stemming_dictionaries(dictionary_sets);
+    stemmerManager.get_stemming_dictionaries(dictionary_sets);
     ASSERT_EQ(2, dictionary_sets["dictionaries"].size());
     ASSERT_EQ("set1", dictionary_sets["dictionaries"][0].get<std::string>());
     ASSERT_EQ("set2", dictionary_sets["dictionaries"][1].get<std::string>());
 
     //del dictionary set and get
     dictionary_sets.clear();
-    StemmerManager::get_instance().del_stemming_dictionary("set2");
-    StemmerManager::get_instance().get_stemming_dictionaries(dictionary_sets);
+    stemmerManager.del_stemming_dictionary("set2");
+    stemmerManager.get_stemming_dictionaries(dictionary_sets);
     ASSERT_EQ(1, dictionary_sets["dictionaries"].size());
     ASSERT_EQ("set1", dictionary_sets["dictionaries"][0].get<std::string>());
+}
+
+TEST_F(CollectionSpecificMoreTest, ReloadStemmingDictionaryOnRestart) {
+    stemmerManager.delete_all_stemming_dictionaries();
+
+    std::string json_line = "{\"word\": \"people\", \"root\":\"person\"}";
+    std::vector<std::string> json_lines;
+    json_lines.push_back(json_line);
+
+    //add dictionary set
+    ASSERT_TRUE(stemmerManager.upsert_stemming_dictionary("set1", json_lines).ok());
+
+    //get dictionary set
+    nlohmann::json dictionary;
+    ASSERT_TRUE(stemmerManager.get_stemming_dictionary("set1", dictionary));
+    ASSERT_EQ("set1", dictionary["id"]);
+    ASSERT_EQ(1, dictionary["words"].size());
+    ASSERT_EQ("people", dictionary["words"][0]["word"]);
+    ASSERT_EQ("person", dictionary["words"][0]["root"]);
+
+    //dispose collection manager and reload all stemming dictionaries
+    collectionManager.dispose();
+    stemmerManager.dispose();
+    delete store;
+
+    std::string state_dir_path = "/tmp/typesense_test/collection_specific_more";
+    store = new Store(state_dir_path);
+
+    stemmerManager.init(store);
+    collectionManager.init(store, 1.0, "auth_key", quit);
+    collectionManager.load(8, 1000);
+
+    ASSERT_TRUE(stemmerManager.get_stemming_dictionary("set1", dictionary));
+    ASSERT_EQ("set1", dictionary["id"]);
+    ASSERT_EQ(1, dictionary["words"].size());
+    ASSERT_EQ("people", dictionary["words"][0]["word"]);
+    ASSERT_EQ("person", dictionary["words"][0]["root"]);
+
+    collectionManager.drop_collection("coll1");
 }

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -1791,7 +1791,8 @@ TEST_F(CoreAPIUtilsTest, CollectionsPagination) {
               "sort":false,
               "stem":false,
               "store": true,
-              "type":"string"
+              "type":"string",
+              "stem_dictionary": false
             }
           ],
           "name":"cp2",
@@ -2004,7 +2005,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "store":true,
                     "type":"string",
                     "range_index":false,
-                    "stem":false
+                    "stem":false,
+                    "stem_dictionary": false
                 },
                 {
                     "facet":true,
@@ -2019,7 +2021,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "store":true,
                     "type":"int32",
                     "range_index":false,
-                    "stem":false
+                    "stem":false,
+                    "stem_dictionary": false
                 },{
                     "facet":true,
                     "index":true,
@@ -2033,7 +2036,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "store":true,
                     "type":"int32",
                     "range_index":false,
-                    "stem":false
+                    "stem":false,
+                    "stem_dictionary": false
                 },{
                     "facet":true,
                     "index":true,
@@ -2047,7 +2051,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "store":true,
                     "type":"int32",
                     "range_index":false,
-                    "stem":false
+                    "stem":false,
+                    "stem_dictionary": false
                 }
             ],
             "id":1,
@@ -2099,7 +2104,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "store":true,
                     "type":"string",
                     "range_index":false,
-                    "stem":false
+                    "stem":false,
+                    "stem_dictionary": false
                 },
                 {
                     "facet":true,
@@ -2114,7 +2120,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "store":true,
                     "type":"int32",
                     "range_index":false,
-                    "stem":false
+                    "stem":false,
+                    "stem_dictionary": false
                 },{
                     "facet":true,
                     "index":true,
@@ -2128,7 +2135,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "store":true,
                     "type":"int32",
                     "range_index":false,
-                    "stem":false
+                    "stem":false,
+                    "stem_dictionary": false
                 },{
                     "facet":true,
                     "index":true,
@@ -2142,7 +2150,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "store":true,
                     "type":"int32",
                     "range_index":false,
-                    "stem":false
+                    "stem":false,
+                    "stem_dictionary": false
                 }
             ],
             "id":1,
@@ -2353,7 +2362,8 @@ TEST_F(CoreAPIUtilsTest, CollectionSchemaResponseWithStoreValue) {
                     "sort":false,
                     "stem":false,
                     "store":false,
-                    "type":"string"
+                    "type":"string",
+                    "stem_dictionary": false
                 },
                 {
                     "facet":false,
@@ -2365,7 +2375,8 @@ TEST_F(CoreAPIUtilsTest, CollectionSchemaResponseWithStoreValue) {
                     "sort":true,
                     "stem":false,
                     "store":true,
-                    "type":"int32"
+                    "type":"int32",
+                    "stem_dictionary": false
                 }],
                 "name":"collection3",
                 "num_documents":0,

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -1831,7 +1831,7 @@ TEST_F(CoreAPIUtilsTest, CollectionsPagination) {
               "stem":false,
               "store": true,
               "type":"string",
-              "stem_dictionary": false
+              "stem_dictionary": ""
             }
           ],
           "name":"cp2",
@@ -2045,7 +2045,7 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"string",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": false
+                    "stem_dictionary": ""
                 },
                 {
                     "facet":true,
@@ -2061,7 +2061,7 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": false
+                    "stem_dictionary": ""
                 },{
                     "facet":true,
                     "index":true,
@@ -2076,7 +2076,7 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": false
+                    "stem_dictionary": ""
                 },{
                     "facet":true,
                     "index":true,
@@ -2091,7 +2091,7 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": false
+                    "stem_dictionary": ""
                 }
             ],
             "id":1,
@@ -2144,7 +2144,7 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"string",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": false
+                    "stem_dictionary": ""
                 },
                 {
                     "facet":true,
@@ -2160,7 +2160,7 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": false
+                    "stem_dictionary": ""
                 },{
                     "facet":true,
                     "index":true,
@@ -2175,7 +2175,7 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": false
+                    "stem_dictionary": ""
                 },{
                     "facet":true,
                     "index":true,
@@ -2190,7 +2190,7 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": false
+                    "stem_dictionary": ""
                 }
             ],
             "id":1,
@@ -2402,7 +2402,7 @@ TEST_F(CoreAPIUtilsTest, CollectionSchemaResponseWithStoreValue) {
                     "stem":false,
                     "store":false,
                     "type":"string",
-                    "stem_dictionary": false
+                    "stem_dictionary": ""
                 },
                 {
                     "facet":false,
@@ -2415,7 +2415,7 @@ TEST_F(CoreAPIUtilsTest, CollectionSchemaResponseWithStoreValue) {
                     "stem":false,
                     "store":true,
                     "type":"int32",
-                    "stem_dictionary": false
+                    "stem_dictionary": ""
                 }],
                 "name":"collection3",
                 "num_documents":0,


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- add functionality to import plurals via end-point
- normalize plurals with stem_dictionary=true per field
- add test

## adding dictionary via end-point
To add plurals, we need to import jsonl file to end-point `/stemming/dictionaries/import` via POST request like below,
```curl
curl -k -H 'Content-Type:' -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -X POST --data-binary @plurals.jsonl "http://localhost:8108/stemming/dictionaries/import?id=set1"
```
Here `id` is dictionary name we want to store.

jsonl file should contain plurals in below format
```json
{"word": "meetings", "root":"meeting"}
{"word": "people", "root":"person"}
{"word": "attentions", "root":"attention"}
{"word": "leathers", "root":"leather"}
{"word": "qualities", "root":"quality"}
```
## get specific dictionary
To get the stored dictionary, we need to request via GET request to end-point `/stemming/dictionaries/:id` like below,
```curl
curl "http://localhost:8108/stemming/dictionaries/set1" -X GET -H "Content-Type: application/json" -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}"
```
Here `set1` is the id of dictionary given while storing the dictionary. We will get the response like below.

```json
{"id":"set1","words":[{"root":"attention","word":"attentions"},{"root":"quality","word":"qualities"},{"root":"leather","word":"leathers"},{"root":"person","word":"people"},{"root":"meeting","word":"meetings"}]}
```
## get all stored dictionaries
To fetch all dictionary sets stored on typesense server, we need to send a GET request to end-point `/stemming/dictionaries` like below,
```curl
curl "http://localhost:8108/stemming/dictionaries" -X GET -H "Content-Type: application/json" -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}"
```

Which will respond in below format,
```json
{"dictionaries":["set1"]}
```

## using the dictionary with collection search

We need to specify dictionary name while creating collection in order to use with searches in collection.
Here's how it can be created,
```curl
curl "http://localhost:8108/collections" \
       -X POST \
       -H "Content-Type: application/json" \
       -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
       -d '{
         "name": "companies",
         "fields": [
           {"name": "country", "type": "string", "stem_dictionary": "set1" }
       }'
```

Here `stem_dictionary` param specifies which dictionary to use for normalizing words while searching.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
