### PR TITLE
Fix vector query format validation error messages

### DIFF
--- a/src/vector_query_ops.cpp
+++ b/src/vector_query_ops.cpp
@@ -11,15 +11,14 @@ Option<bool> VectorQueryOps::parse_vector_query_str(const std::string& vector_qu
     // field_name([0.34, 0.66, 0.12, 0.68], exact: false, k: 10)
     size_t i = 0;
     while(i < vector_query_str.size()) {
+        if(vector_query_str[i] == '(' || vector_query_str[i] == '[') {
+            // If we hit a bracket before a colon, it's a missing colon error
+            return Option<bool>(400, "Malformed vector query string: `:` is missing.");
+        }
         if(vector_query_str[i] != ':') {
             vector_query.field_name += vector_query_str[i];
             i++;
         } else {
-            if(vector_query_str[i] != ':') {
-                // missing ":"
-                return Option<bool>(400, "Malformed vector query string: `:` is missing.");
-            }
-
             // field name is done
             i++;
 
@@ -265,5 +264,6 @@ Option<bool> VectorQueryOps::parse_vector_query_str(const std::string& vector_qu
         }
     }
 
-    return Option<bool>(400, "Malformed vector query string.");
+    // We hit the end of the string without finding a colon
+    return Option<bool>(400, "Malformed vector query string: `:` is missing.");
 }

--- a/src/vector_query_ops.cpp
+++ b/src/vector_query_ops.cpp
@@ -13,7 +13,7 @@ Option<bool> VectorQueryOps::parse_vector_query_str(const std::string& vector_qu
     while(i < vector_query_str.size()) {
         if(vector_query_str[i] == '(' || vector_query_str[i] == '[') {
             // If we hit a bracket before a colon, it's a missing colon error
-            return Option<bool>(400, "Malformed vector query string: `:` is missing.");
+            return Option<bool>(400, "Malformed vector query string: `:` is missing after the vector field name.");
         }
         if(vector_query_str[i] != ':') {
             vector_query.field_name += vector_query_str[i];

--- a/src/vector_query_ops.cpp
+++ b/src/vector_query_ops.cpp
@@ -8,7 +8,7 @@ Option<bool> VectorQueryOps::parse_vector_query_str(const std::string& vector_qu
                                                     const Collection* coll,
                                                     const bool allow_empty_query) {
     // FORMAT:
-    // field_name([0.34, 0.66, 0.12, 0.68], exact: false, k: 10)
+    // field_name:([0.34, 0.66, 0.12, 0.68], k: 10)
     size_t i = 0;
     while(i < vector_query_str.size()) {
         if(vector_query_str[i] == '(' || vector_query_str[i] == '[') {

--- a/test/vector_query_ops_test.cpp
+++ b/test/vector_query_ops_test.cpp
@@ -72,5 +72,10 @@ TEST_F(VectorQueryOpsTest, ParseVectorQueryString) {
     vector_query._reset();
     parsed = VectorQueryOps::parse_vector_query_str("vec([0.34, 0.66, 0.12, 0.68])", vector_query, false, nullptr, false);
     ASSERT_FALSE(parsed.ok());
-    ASSERT_EQ("Malformed vector query string.", parsed.error());
+    ASSERT_EQ("Malformed vector query string: `:` is missing.", parsed.error());
+
+    vector_query._reset();
+    parsed = VectorQueryOps::parse_vector_query_str("vec([0.34, 0.66, 0.12, 0.68], k: 10)", vector_query, false, nullptr, false);
+    ASSERT_FALSE(parsed.ok());
+    ASSERT_EQ("Malformed vector query string: `:` is missing.", parsed.error());
 }

--- a/test/vector_query_ops_test.cpp
+++ b/test/vector_query_ops_test.cpp
@@ -72,10 +72,10 @@ TEST_F(VectorQueryOpsTest, ParseVectorQueryString) {
     vector_query._reset();
     parsed = VectorQueryOps::parse_vector_query_str("vec([0.34, 0.66, 0.12, 0.68])", vector_query, false, nullptr, false);
     ASSERT_FALSE(parsed.ok());
-    ASSERT_EQ("Malformed vector query string: `:` is missing.", parsed.error());
+    ASSERT_EQ("Malformed vector query string: `:` is missing after the vector field name.", parsed.error());
 
     vector_query._reset();
     parsed = VectorQueryOps::parse_vector_query_str("vec([0.34, 0.66, 0.12, 0.68], k: 10)", vector_query, false, nullptr, false);
     ASSERT_FALSE(parsed.ok());
-    ASSERT_EQ("Malformed vector query string: `:` is missing.", parsed.error());
+    ASSERT_EQ("Malformed vector query string: `:` is missing after the vector field name.", parsed.error());
 }


### PR DESCRIPTION
# What is this?
This PR improves error messaging when parsing vector queries by properly detecting and reporting format violations. 
Previously, the parser would:
1. Return inconsistent error messages due to redundant validation code
2. Get confused by colons in parameter values (like in `k: 10`), mistaking them for field separators
3. Not properly validate the required format: `field_name:(<vector>)`

This change ensures proper validation order and accurate error messages, making it clearer to users when 
their query format is incorrect.

# Changes

## Code Changes:
1. **In `vector_query_ops.cpp`**:
    - Fixed format validation order:
        ```cpp
        // OLD - problematic because it would catch k: 10's colon
        if(vector_query_str[i] != ':') {
            vector_query.field_name += vector_query_str[i];
        } else {
            // Redundant check - we're only here if we found ':'
            if(vector_query_str[i] != ':') {  // This can never be true
                return Option<bool>(400, "Malformed vector query string: `:` is missing.");
            }
        ```
        ```cpp
        // NEW - Checks for brackets before colon first
        if(vector_query_str[i] == '(' || vector_query_str[i] == '[') {
            return Option<bool>(400, "Malformed vector query string: `:` is missing.");
        }
        ```
    - Removed redundant colon validation that could never be reached
    - Improved validation order to catch format violations early

2. **In `vector_query_ops_test.cpp`**:
    - Added test cases to verify proper handling of:
        - Missing field colon: `vec([0.34, ...])` 
        - Parameter colons: `vec([...], k: 10)`
        - General malformed formats

# Context
After taking a look at typesense/typesense-website#279, the error thrown didn't match the one that should've been thrown. It matched for the unbalanced parentheses check, where after the first colon `:` token, the parser expects to find a `(` token.

The vector query parser must handle two types of colons:
1. Field separator colon: `field_name:([...])`
2. Parameter colons: `k: 10`, `alpha: 0.5`

Previous code had these issues:
1. A redundant check for missing colon inside a block that only executes when a colon is found
2. Could get confused by parameter colons if it didn't find the field colon first
3. Didn't enforce the required parentheses format after the field colon

The new validation order ensures:
1. We fail fast if we see brackets before a field colon
2. We properly handle parameter colons without confusing them for field colons
3. We give accurate error messages based on the actual formatting issue

Valid format example:
```cpp
field_name:([0.34, 0.66, 0.12, 0.68], k: 10)
^        ^  ^                       ^
|        |  |                       |
field    :  (required               parameters with their own colons
```


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
