### PR TITLE
support to add stopwords as string given by double quotes

### DIFF
--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -338,4 +338,6 @@ struct StringUtils {
                                                      std::vector<std::string>& tokens);
 
     static size_t get_occurence_count(const std::string& str, char symbol);
+
+    static std::string remove_words_from_string(const std::string& s, const std::string& word);
 };

--- a/src/stopwords_manager.cpp
+++ b/src/stopwords_manager.cpp
@@ -59,15 +59,21 @@ Option<bool> StopwordsManager::upsert_stopword(const std::string& stopword_name,
     std::vector<std::string> tokens;
     spp::sparse_hash_set<std::string> stopwords_set;
     const auto& stopwords = stopwords_json[STOPWORD_VALUES];
+    std::vector<char> custom_symbols;
 
     for (const auto &stopword: stopwords.items()) {
         const auto& val = stopword.value().get<std::string>();
-        Tokenizer(val, true, false, locale, {}, {}).tokenize(tokens);
 
-        for(const auto& tok : tokens) {
+        if (val[0] == '\"') {  //if starts with '"', should add ' ' as custom symbol to tokenize whole string
+            custom_symbols.push_back(' ');
+        }
+        Tokenizer(val, true, false, locale, custom_symbols, {}).tokenize(tokens);
+
+        for (const auto& tok : tokens) {
             stopwords_set.emplace(tok);
         }
         tokens.clear();
+        custom_symbols.clear();
     }
     stopword_configs[stopword_name] = stopword_struct_t{stopword_name, stopwords_set, locale};
     return Option<bool>(true);

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -557,3 +557,8 @@ size_t StringUtils::split_facet(const std::string &s, std::vector<std::string> &
 size_t StringUtils::get_occurence_count(const std::string &str, char symbol) {
     return std::count(str.begin(), str.end(), symbol);
 }
+
+std::string StringUtils::remove_words_from_string(const std::string &s, const std::string &word) {
+    std::regex reg("\\s*\\b" + word + "\\b");
+    return std::regex_replace(s, reg, "");
+}


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- Support to add stopwords as string given by enclosing in double quotes
- add tests

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
