### PR TITLE
Fix embeddings during document updates with initially empty vector fields

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -7456,7 +7456,11 @@ void Index::process_embed_results(std::vector<std::pair<index_record*, std::stri
                 embedding_vals = existing_embedding;
             }
 
-            doc[the_field.name] = embedding_vals;
+            if(value_to_embed.first->is_update) {
+                value_to_embed.first->new_doc[the_field.name] = embedding_vals;
+            }
+            value_to_embed.first->doc[the_field.name] = embedding_vals;
+
             count++;
         }
     }


### PR DESCRIPTION
## Change Summary
- Modified `process_embed_results` to always update both `doc` and `new_doc` fields for update operations, similar to how `v26.0` worked
- Ensures embeddings are consistently stored regardless of whether it's a new embedding or an accumulated one
- Fixes #1986 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
