### PR TITLE
Field token_separators and symbols_to_index

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -790,15 +790,13 @@ public:
     void parse_search_query(const std::string &query, std::vector<std::string>& q_include_tokens, std::vector<std::string>& q_include_tokens_non_stemmed,
                             std::vector<std::vector<std::string>>& q_exclude_tokens,
                             std::vector<std::vector<std::string>>& q_phrases,
-                            const std::string& locale, const bool already_segmented, const std::string& stopword_set="", std::shared_ptr<Stemmer> stemmer = nullptr,
-                            const std::vector<char>& field_token_separators = {}, const std::vector<char>& field_symbols_to_index = {}) const;
+                            const std::string& locale, const bool already_segmented, const std::string& stopword_set="", std::shared_ptr<Stemmer> stemmer = nullptr) const;
     
     void process_tokens(std::vector<std::string>& tokens, std::vector<std::string>& q_include_tokens,
                        std::vector<std::vector<std::string>>& q_exclude_tokens,
                        std::vector<std::vector<std::string>>& q_phrases, bool& exclude_operator_prior, 
                        bool& phrase_search_op_prior, std::vector<std::string>& phrase, const std::string& stopwords_set, 
-                       const bool& already_segmented, const std::string& locale, std::shared_ptr<Stemmer> stemmer,
-                        const std::vector<char>& local_token_separators, const std::vector<char>& local_symbols_to_index) const;
+                       const bool& already_segmented, const std::string& locale, std::shared_ptr<Stemmer> stemmer) const;
 
     // PUBLIC OPERATIONS
 

--- a/include/collection.h
+++ b/include/collection.h
@@ -790,13 +790,15 @@ public:
     void parse_search_query(const std::string &query, std::vector<std::string>& q_include_tokens, std::vector<std::string>& q_include_tokens_non_stemmed,
                             std::vector<std::vector<std::string>>& q_exclude_tokens,
                             std::vector<std::vector<std::string>>& q_phrases,
-                            const std::string& locale, const bool already_segmented, const std::string& stopword_set="", std::shared_ptr<Stemmer> stemmer = nullptr) const;
+                            const std::string& locale, const bool already_segmented, const std::string& stopword_set="", std::shared_ptr<Stemmer> stemmer = nullptr,
+                            const std::vector<char>& field_token_separators = {}, const std::vector<char>& field_symbols_to_index = {}) const;
     
     void process_tokens(std::vector<std::string>& tokens, std::vector<std::string>& q_include_tokens,
                        std::vector<std::vector<std::string>>& q_exclude_tokens,
                        std::vector<std::vector<std::string>>& q_phrases, bool& exclude_operator_prior, 
                        bool& phrase_search_op_prior, std::vector<std::string>& phrase, const std::string& stopwords_set, 
-                       const bool& already_segmented, const std::string& locale, std::shared_ptr<Stemmer> stemmer) const;
+                       const bool& already_segmented, const std::string& locale, std::shared_ptr<Stemmer> stemmer,
+                        const std::vector<char>& local_token_separators, const std::vector<char>& local_symbols_to_index) const;
 
     // PUBLIC OPERATIONS
 

--- a/include/field.h
+++ b/include/field.h
@@ -67,6 +67,8 @@ namespace fields {
     static const std::string range_index = "range_index";
     static const std::string stem = "stem";
     static const std::string stem_dictionary = "stem_dictionary";
+    static const std::string token_separators = "token_separators";
+    static const std::string symbols_to_index = "symbols_to_index";
 
     // Some models require additional parameters to be passed to the model during indexing/querying
     // For e.g. e5-small model requires prefix "passage:" for indexing and "query:" for querying
@@ -142,6 +144,9 @@ struct field {
   
     nlohmann::json hnsw_params;
 
+    std::vector<char> token_separators;
+    std::vector<char> symbols_to_index;
+
     field() {}
 
     field(const std::string &name, const std::string &type, const bool facet, const bool optional = false,
@@ -149,7 +154,7 @@ struct field {
           int nested_array = 0, size_t num_dim = 0, vector_distance_type_t vec_dist = cosine,
           std::string reference = "", const nlohmann::json& embed = nlohmann::json(), const bool range_index = false,
           const bool store = true, const bool stem = false, const std::string& stem_dictionary = "", const nlohmann::json hnsw_params = nlohmann::json(),
-          const bool async_reference = false) :
+          const bool async_reference = false, const nlohmann::json& token_separators = {}, const nlohmann::json& symbols_to_index = {}) :
             name(name), type(type), facet(facet), optional(optional), index(index), locale(locale),
             nested(nested), nested_array(nested_array), num_dim(num_dim), vec_dist(vec_dist), reference(reference),
             embed(embed), range_index(range_index), store(store), stem(stem), stem_dictionary(stem_dictionary),
@@ -162,6 +167,14 @@ struct field {
         if (stem || !stem_dictionary.empty()) {
             this->stem = true;
             stemmer = StemmerManager::get_instance().get_stemmer(locale, stem_dictionary);
+        }
+
+        for(const auto& item : token_separators) {
+            this->token_separators.push_back(item.get<char>());
+        }
+
+        for(const auto& item : symbols_to_index) {
+            this->symbols_to_index.push_back(item.get<char>());
         }
     }
 

--- a/include/field.h
+++ b/include/field.h
@@ -170,11 +170,11 @@ struct field {
         }
 
         for(const auto& item : token_separators) {
-            this->token_separators.push_back(item.get<char>());
+            this->token_separators.push_back(item.get<std::string>()[0]);
         }
 
         for(const auto& item : symbols_to_index) {
-            this->symbols_to_index.push_back(item.get<char>());
+            this->symbols_to_index.push_back(item.get<std::string>()[0]);
         }
     }
 

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -2460,14 +2460,49 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
         }
     } else {
         field_query_tokens.emplace_back(query_tokens_t{});
-        auto most_weighted_field = search_schema.at(weighted_search_fields[0].name);
-        const std::string & field_locale = most_weighted_field.locale;
 
-        parse_search_query(query, q_include_tokens, q_unstemmed_tokens,
-                           field_query_tokens[0].q_exclude_tokens,
-                           field_query_tokens[0].q_phrases,
-                           field_locale, pre_segmented_query, stopwords_set, most_weighted_field.get_stemmer());
+        for(int i = 0; i < weighted_search_fields.size(); ++i) {
+            auto weighted_field = search_schema.at(weighted_search_fields[i].name);
+            const std::string& field_locale = weighted_field.locale;
+            const auto& field_token_separators = weighted_field.token_separators;
+            const auto& field_symbols_to_index = weighted_field.symbols_to_index;
 
+            if(i > 0 && field_locale.empty() && field_token_separators.empty() && field_symbols_to_index.empty()) {
+                //if no different locale, token_separators, symbols_to_index then no need to process query again
+                continue;
+            }
+
+            parse_search_query(query, q_include_tokens, q_unstemmed_tokens,
+                               field_query_tokens[0].q_exclude_tokens,
+                               field_query_tokens[0].q_phrases,
+                               field_locale, pre_segmented_query, stopwords_set, weighted_field.get_stemmer(),
+                               field_token_separators, field_symbols_to_index);
+        }
+
+        if(weighted_search_fields.size() > 1) {
+            //remove duplicate tokens found during multiple fields
+            std::set<std::string> tokens_mapping;
+            for (auto it = q_include_tokens.begin(); it != q_include_tokens.end();) {
+                if (tokens_mapping.find(*it) == tokens_mapping.end()) {
+                    tokens_mapping.insert(*it);
+                    it++;
+                } else {
+                    //duplicate
+                    it = q_include_tokens.erase(it);
+                }
+            }
+
+            tokens_mapping.clear();
+            for (auto it = q_unstemmed_tokens.begin(); it != q_unstemmed_tokens.end();) {
+                if (tokens_mapping.find(*it) == tokens_mapping.end()) {
+                    tokens_mapping.insert(*it);
+                    it++;
+                } else {
+                    //duplicate
+                    it = q_unstemmed_tokens.erase(it);
+                }
+            }
+        }
         // process filter overrides first, before synonyms (order is important)
 
         // included_ids, excluded_ids
@@ -4140,12 +4175,13 @@ void Collection::process_tokens(std::vector<std::string>& tokens, std::vector<st
                                 std::vector<std::vector<std::string>>& q_exclude_tokens,
                                 std::vector<std::vector<std::string>>& q_phrases, bool& exclude_operator_prior, 
                                 bool& phrase_search_op_prior, std::vector<std::string>& phrase, const std::string& stopwords_set,
-                                const bool& already_segmented, const std::string& locale, std::shared_ptr<Stemmer> stemmer) const{
+                                const bool& already_segmented, const std::string& locale, std::shared_ptr<Stemmer> stemmer,
+                                const std::vector<char>& local_token_separators, const std::vector<char>& local_symbols_to_index) const{
 
 
 
     auto symbols_to_index_has_minus =
-            std::find(symbols_to_index.begin(), symbols_to_index.end(), '-') != symbols_to_index.end();
+            std::find(local_symbols_to_index.begin(), local_symbols_to_index.end(), '-') != local_symbols_to_index.end();
 
     for(auto& token: tokens) {
         bool end_of_phrase = false;
@@ -4182,7 +4218,7 @@ void Collection::process_tokens(std::vector<std::string>& tokens, std::vector<st
         if(already_segmented) {
             StringUtils::split(token, sub_tokens, " ");
         } else {
-            Tokenizer(token, true, false, locale, symbols_to_index, token_separators, stemmer).tokenize(sub_tokens);
+            Tokenizer(token, true, false, locale, local_symbols_to_index, local_token_separators, stemmer).tokenize(sub_tokens);
         }
         
         for(auto& sub_token: sub_tokens) {
@@ -4239,11 +4275,18 @@ void Collection::process_tokens(std::vector<std::string>& tokens, std::vector<st
 void Collection::parse_search_query(const std::string &query, std::vector<std::string>& q_include_tokens, std::vector<std::string>& q_unstemmed_tokens,
                                     std::vector<std::vector<std::string>>& q_exclude_tokens,
                                     std::vector<std::vector<std::string>>& q_phrases,
-                                    const std::string& locale, const bool already_segmented, const std::string& stopwords_set, std::shared_ptr<Stemmer> stemmer) const {
+                                    const std::string& locale, const bool already_segmented,
+                                    const std::string& stopwords_set, std::shared_ptr<Stemmer> stemmer,
+                                    const std::vector<char>& field_token_separators,
+                                    const std::vector<char>& field_symbols_to_index) const {
     if(query == "*") {
         q_exclude_tokens = {};
         q_include_tokens = {query};
     } else {
+
+        const auto& local_token_separators = !field_token_separators.empty() ? field_token_separators : token_separators;
+        const auto& local_symbols_to_index = !field_symbols_to_index.empty() ? field_symbols_to_index : symbols_to_index;
+
         std::vector<std::string> tokens;
         std::vector<std::string> tokens_non_stemmed;
         stopword_struct_t stopwordStruct;
@@ -4258,13 +4301,13 @@ void Collection::parse_search_query(const std::string &query, std::vector<std::s
         if(already_segmented) {
             StringUtils::split(query, tokens, " ");
         } else {
-            std::vector<char> custom_symbols = symbols_to_index;
+            std::vector<char> custom_symbols = local_symbols_to_index;
             custom_symbols.push_back('-');
             custom_symbols.push_back('"');
 
-            Tokenizer(query, true, false, locale, custom_symbols, token_separators, stemmer).tokenize(tokens);
+            Tokenizer(query, true, false, locale, custom_symbols, local_token_separators, stemmer).tokenize(tokens);
             if(stemmer) {
-                Tokenizer(query, true, false, locale, custom_symbols, token_separators, nullptr).tokenize(tokens_non_stemmed);
+                Tokenizer(query, true, false, locale, custom_symbols, local_token_separators, nullptr).tokenize(tokens_non_stemmed);
             }
         }
 
@@ -4277,7 +4320,8 @@ void Collection::parse_search_query(const std::string &query, std::vector<std::s
         bool phrase_search_op_prior = false;
         std::vector<std::string> phrase;
 
-        process_tokens(tokens, q_include_tokens, q_exclude_tokens, q_phrases, exclude_operator_prior, phrase_search_op_prior, phrase, stopwords_set, already_segmented, locale, stemmer);
+        process_tokens(tokens, q_include_tokens, q_exclude_tokens, q_phrases, exclude_operator_prior, phrase_search_op_prior,
+                       phrase, stopwords_set, already_segmented, locale, stemmer, local_token_separators, local_symbols_to_index);
         
         if(stemmer) {
             exclude_operator_prior = false;
@@ -4287,7 +4331,9 @@ void Collection::parse_search_query(const std::string &query, std::vector<std::s
             std::vector<std::vector<std::string>> q_exclude_tokens_dummy;
             std::vector<std::vector<std::string>> q_phrases_dummy;
 
-            process_tokens(tokens_non_stemmed, q_unstemmed_tokens, q_exclude_tokens_dummy, q_phrases_dummy, exclude_operator_prior, phrase_search_op_prior, phrase, stopwords_set,  already_segmented, locale, nullptr);
+            process_tokens(tokens_non_stemmed, q_unstemmed_tokens, q_exclude_tokens_dummy, q_phrases_dummy, exclude_operator_prior,
+                           phrase_search_op_prior, phrase, stopwords_set,  already_segmented, locale, nullptr, local_token_separators,
+                           local_symbols_to_index);
         }
     }
 }

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -383,6 +383,22 @@ nlohmann::json Collection::get_summary_json() const {
             field_json[fields::async_reference] = coll_field.is_async_reference;
         }
 
+        if(!coll_field.token_separators.empty()) {
+            field_json[fields::token_separators] = nlohmann::json::array();
+
+            for(const auto& c : coll_field.token_separators) {
+                field_json[fields::token_separators].push_back(c);
+            }
+        }
+
+        if(!coll_field.symbols_to_index.empty()) {
+            field_json[fields::symbols_to_index] = nlohmann::json::array();
+
+            for(const auto& c : coll_field.symbols_to_index) {
+                field_json[fields::symbols_to_index].push_back(c);
+            }
+        }
+
         fields_arr.push_back(field_json);
     }
 

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -2460,49 +2460,14 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
         }
     } else {
         field_query_tokens.emplace_back(query_tokens_t{});
+        auto most_weighted_field = search_schema.at(weighted_search_fields[0].name);
+        const std::string & field_locale = most_weighted_field.locale;
 
-        for(int i = 0; i < weighted_search_fields.size(); ++i) {
-            auto weighted_field = search_schema.at(weighted_search_fields[i].name);
-            const std::string& field_locale = weighted_field.locale;
-            const auto& field_token_separators = weighted_field.token_separators;
-            const auto& field_symbols_to_index = weighted_field.symbols_to_index;
+        parse_search_query(query, q_include_tokens, q_unstemmed_tokens,
+                           field_query_tokens[0].q_exclude_tokens,
+                           field_query_tokens[0].q_phrases,
+                           field_locale, pre_segmented_query, stopwords_set, most_weighted_field.get_stemmer());
 
-            if(i > 0 && field_locale.empty() && field_token_separators.empty() && field_symbols_to_index.empty()) {
-                //if no different locale, token_separators, symbols_to_index then no need to process query again
-                continue;
-            }
-
-            parse_search_query(query, q_include_tokens, q_unstemmed_tokens,
-                               field_query_tokens[0].q_exclude_tokens,
-                               field_query_tokens[0].q_phrases,
-                               field_locale, pre_segmented_query, stopwords_set, weighted_field.get_stemmer(),
-                               field_token_separators, field_symbols_to_index);
-        }
-
-        if(weighted_search_fields.size() > 1) {
-            //remove duplicate tokens found during multiple fields
-            std::set<std::string> tokens_mapping;
-            for (auto it = q_include_tokens.begin(); it != q_include_tokens.end();) {
-                if (tokens_mapping.find(*it) == tokens_mapping.end()) {
-                    tokens_mapping.insert(*it);
-                    it++;
-                } else {
-                    //duplicate
-                    it = q_include_tokens.erase(it);
-                }
-            }
-
-            tokens_mapping.clear();
-            for (auto it = q_unstemmed_tokens.begin(); it != q_unstemmed_tokens.end();) {
-                if (tokens_mapping.find(*it) == tokens_mapping.end()) {
-                    tokens_mapping.insert(*it);
-                    it++;
-                } else {
-                    //duplicate
-                    it = q_unstemmed_tokens.erase(it);
-                }
-            }
-        }
         // process filter overrides first, before synonyms (order is important)
 
         // included_ids, excluded_ids
@@ -4175,13 +4140,12 @@ void Collection::process_tokens(std::vector<std::string>& tokens, std::vector<st
                                 std::vector<std::vector<std::string>>& q_exclude_tokens,
                                 std::vector<std::vector<std::string>>& q_phrases, bool& exclude_operator_prior, 
                                 bool& phrase_search_op_prior, std::vector<std::string>& phrase, const std::string& stopwords_set,
-                                const bool& already_segmented, const std::string& locale, std::shared_ptr<Stemmer> stemmer,
-                                const std::vector<char>& local_token_separators, const std::vector<char>& local_symbols_to_index) const{
+                                const bool& already_segmented, const std::string& locale, std::shared_ptr<Stemmer> stemmer) const{
 
 
 
     auto symbols_to_index_has_minus =
-            std::find(local_symbols_to_index.begin(), local_symbols_to_index.end(), '-') != local_symbols_to_index.end();
+            std::find(symbols_to_index.begin(), symbols_to_index.end(), '-') != symbols_to_index.end();
 
     for(auto& token: tokens) {
         bool end_of_phrase = false;
@@ -4218,7 +4182,7 @@ void Collection::process_tokens(std::vector<std::string>& tokens, std::vector<st
         if(already_segmented) {
             StringUtils::split(token, sub_tokens, " ");
         } else {
-            Tokenizer(token, true, false, locale, local_symbols_to_index, local_token_separators, stemmer).tokenize(sub_tokens);
+            Tokenizer(token, true, false, locale, symbols_to_index, token_separators, stemmer).tokenize(sub_tokens);
         }
         
         for(auto& sub_token: sub_tokens) {
@@ -4275,18 +4239,11 @@ void Collection::process_tokens(std::vector<std::string>& tokens, std::vector<st
 void Collection::parse_search_query(const std::string &query, std::vector<std::string>& q_include_tokens, std::vector<std::string>& q_unstemmed_tokens,
                                     std::vector<std::vector<std::string>>& q_exclude_tokens,
                                     std::vector<std::vector<std::string>>& q_phrases,
-                                    const std::string& locale, const bool already_segmented,
-                                    const std::string& stopwords_set, std::shared_ptr<Stemmer> stemmer,
-                                    const std::vector<char>& field_token_separators,
-                                    const std::vector<char>& field_symbols_to_index) const {
+                                    const std::string& locale, const bool already_segmented, const std::string& stopwords_set, std::shared_ptr<Stemmer> stemmer) const {
     if(query == "*") {
         q_exclude_tokens = {};
         q_include_tokens = {query};
     } else {
-
-        const auto& local_token_separators = !field_token_separators.empty() ? field_token_separators : token_separators;
-        const auto& local_symbols_to_index = !field_symbols_to_index.empty() ? field_symbols_to_index : symbols_to_index;
-
         std::vector<std::string> tokens;
         std::vector<std::string> tokens_non_stemmed;
         stopword_struct_t stopwordStruct;
@@ -4301,13 +4258,13 @@ void Collection::parse_search_query(const std::string &query, std::vector<std::s
         if(already_segmented) {
             StringUtils::split(query, tokens, " ");
         } else {
-            std::vector<char> custom_symbols = local_symbols_to_index;
+            std::vector<char> custom_symbols = symbols_to_index;
             custom_symbols.push_back('-');
             custom_symbols.push_back('"');
 
-            Tokenizer(query, true, false, locale, custom_symbols, local_token_separators, stemmer).tokenize(tokens);
+            Tokenizer(query, true, false, locale, custom_symbols, token_separators, stemmer).tokenize(tokens);
             if(stemmer) {
-                Tokenizer(query, true, false, locale, custom_symbols, local_token_separators, nullptr).tokenize(tokens_non_stemmed);
+                Tokenizer(query, true, false, locale, custom_symbols, token_separators, nullptr).tokenize(tokens_non_stemmed);
             }
         }
 
@@ -4320,8 +4277,7 @@ void Collection::parse_search_query(const std::string &query, std::vector<std::s
         bool phrase_search_op_prior = false;
         std::vector<std::string> phrase;
 
-        process_tokens(tokens, q_include_tokens, q_exclude_tokens, q_phrases, exclude_operator_prior, phrase_search_op_prior,
-                       phrase, stopwords_set, already_segmented, locale, stemmer, local_token_separators, local_symbols_to_index);
+        process_tokens(tokens, q_include_tokens, q_exclude_tokens, q_phrases, exclude_operator_prior, phrase_search_op_prior, phrase, stopwords_set, already_segmented, locale, stemmer);
         
         if(stemmer) {
             exclude_operator_prior = false;
@@ -4331,9 +4287,7 @@ void Collection::parse_search_query(const std::string &query, std::vector<std::s
             std::vector<std::vector<std::string>> q_exclude_tokens_dummy;
             std::vector<std::vector<std::string>> q_phrases_dummy;
 
-            process_tokens(tokens_non_stemmed, q_unstemmed_tokens, q_exclude_tokens_dummy, q_phrases_dummy, exclude_operator_prior,
-                           phrase_search_op_prior, phrase, stopwords_set,  already_segmented, locale, nullptr, local_token_separators,
-                           local_symbols_to_index);
+            process_tokens(tokens_non_stemmed, q_unstemmed_tokens, q_exclude_tokens_dummy, q_phrases_dummy, exclude_operator_prior, phrase_search_op_prior, phrase, stopwords_set,  already_segmented, locale, nullptr);
         }
     }
 }

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -387,7 +387,8 @@ nlohmann::json Collection::get_summary_json() const {
             field_json[fields::token_separators] = nlohmann::json::array();
 
             for(const auto& c : coll_field.token_separators) {
-                field_json[fields::token_separators].push_back(c);
+                std::string token{c};
+                field_json[fields::token_separators].push_back(token);
             }
         }
 
@@ -395,7 +396,8 @@ nlohmann::json Collection::get_summary_json() const {
             field_json[fields::symbols_to_index] = nlohmann::json::array();
 
             for(const auto& c : coll_field.symbols_to_index) {
-                field_json[fields::symbols_to_index].push_back(c);
+                std::string symbol{c};
+                field_json[fields::symbols_to_index].push_back(symbol);
             }
         }
 

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -100,6 +100,14 @@ Collection* CollectionManager::init_collection(const nlohmann::json & collection
             field_obj[fields::store] = true;
         }
 
+        if(field_obj.count(fields::token_separators) == 0) {
+            field_obj[fields::token_separators] = nlohmann::json::array();
+        }
+
+        if(field_obj.count(fields::symbols_to_index) == 0) {
+            field_obj[fields::symbols_to_index] = nlohmann::json::array();
+        }
+
         vector_distance_type_t vec_dist_type = vector_distance_type_t::cosine;
 
         if(field_obj.count(fields::vec_dist) != 0) {
@@ -132,7 +140,7 @@ Collection* CollectionManager::init_collection(const nlohmann::json & collection
                 -1, field_obj[fields::infix], field_obj[fields::nested], field_obj[fields::nested_array],
                 field_obj[fields::num_dim], vec_dist_type, field_obj[fields::reference], field_obj[fields::embed],
                 field_obj[fields::range_index], field_obj[fields::store], field_obj[fields::stem], field_obj[fields::stem_dictionary],
-                field_obj[fields::hnsw_params], field_obj[fields::async_reference]);
+                field_obj[fields::hnsw_params], field_obj[fields::async_reference], field_obj[fields::token_separators], field_obj[fields::symbols_to_index]);
 
         // value of `sort` depends on field type
         if(field_obj.count(fields::sort) == 0) {

--- a/src/facet_index.cpp
+++ b/src/facet_index.cpp
@@ -232,7 +232,7 @@ size_t facet_index_t::intersect(facet& a_facet, const field& facet_field,
                                 bool estimate_facets,
                                 size_t facet_sample_interval,
                                 const std::vector<std::vector<std::string>>& fvalue_searched_tokens,
-                                const std::vector<char>& symbols_to_index, const std::vector<char>& token_separators,
+                                const std::vector<char>& coll_symbols_to_index, const std::vector<char>& coll_token_separators,
                                 const uint32_t* result_ids, size_t result_ids_len,
                                 size_t max_facet_count, std::map<std::string, docid_count_t>& found,
                                 bool is_wildcard_no_filter_query, const std::string& sort_order) {
@@ -261,6 +261,9 @@ size_t facet_index_t::intersect(facet& a_facet, const field& facet_field,
             auto facet_str = facet_count_it->facet_value;
             std::vector<std::string> facet_tokens;
             if(facet_field.is_string()) {
+                const auto& token_separators = facet_field.token_separators.empty() ? coll_token_separators : facet_field.token_separators;
+                const auto& symbols_to_index = facet_field.symbols_to_index.empty() ? coll_symbols_to_index : facet_field.symbols_to_index;
+
                 Tokenizer(facet_str, true, false, facet_field.locale,
                           symbols_to_index, token_separators).tokenize(facet_tokens);
             } else {

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -427,10 +427,22 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
 
     if(field_json.count(fields::token_separators) == 0) {
         field_json[fields::token_separators] = nlohmann::json::array();
+    } else {
+        for(const auto& item : field_json[fields::token_separators]) {
+            if(!item.is_string() || item.empty() || item.get<std::string>().size() != 1) {
+                return Option<bool>(400, "Invalid field token_separators val.");
+            }
+        }
     }
 
     if(field_json.count(fields::symbols_to_index) == 0) {
         field_json[fields::symbols_to_index] = nlohmann::json::array();
+    } else {
+        for(const auto& item : field_json[fields::symbols_to_index]) {
+            if (!item.is_string() || item.empty() || item.get<std::string>().size() != 1) {
+                return Option<bool>(400, "Invalid field symbols_to_index val.");
+            }
+        }
     }
 
     the_fields.emplace_back(
@@ -846,7 +858,8 @@ Option<bool> field::fields_to_json_fields(const std::vector<field>& fields, cons
             field_val[fields::token_separators] = nlohmann::json::array();
 
             for(const auto& c : field.token_separators) {
-                field_val[fields::token_separators].push_back(c);
+                std::string token{c};
+                field_val[fields::token_separators].push_back(token);
             }
         }
 
@@ -854,7 +867,8 @@ Option<bool> field::fields_to_json_fields(const std::vector<field>& fields, cons
             field_val[fields::symbols_to_index] = nlohmann::json::array();
 
             for(const auto& c : field.symbols_to_index) {
-                field_val[fields::symbols_to_index].push_back(c);
+                std::string symbol{c};
+                field_val[fields::symbols_to_index].push_back(symbol);
             }
         }
 

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -425,6 +425,14 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
         }
     }
 
+    if(field_json.count(fields::token_separators) == 0) {
+        field_json[fields::token_separators] = nlohmann::json::array();
+    }
+
+    if(field_json.count(fields::symbols_to_index) == 0) {
+        field_json[fields::symbols_to_index] = nlohmann::json::array();
+    }
+
     the_fields.emplace_back(
             field(field_json[fields::name], field_json[fields::type], field_json[fields::facet],
                   field_json[fields::optional], field_json[fields::index], field_json[fields::locale],
@@ -432,7 +440,8 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
                   field_json[fields::nested_array], field_json[fields::num_dim], vec_dist,
                   field_json[fields::reference], field_json[fields::embed], field_json[fields::range_index], 
                   field_json[fields::store], field_json[fields::stem], field_json[fields::stem_dictionary],
-                  field_json[fields::hnsw_params], field_json[fields::async_reference])
+                  field_json[fields::hnsw_params], field_json[fields::async_reference], field_json[fields::token_separators],
+                  field_json[fields::symbols_to_index])
     );
 
     if (!field_json[fields::reference].get<std::string>().empty()) {
@@ -831,6 +840,22 @@ Option<bool> field::fields_to_json_fields(const std::vector<field>& fields, cons
         if (!field.reference.empty()) {
             field_val[fields::reference] = field.reference;
             field_val[fields::async_reference] = field.is_async_reference;
+        }
+
+        if(!field.token_separators.empty()) {
+            field_val[fields::token_separators] = nlohmann::json::array();
+
+            for(const auto& c : field.token_separators) {
+                field_val[fields::token_separators].push_back(c);
+            }
+        }
+
+        if(!field.symbols_to_index.empty()) {
+            field_val[fields::symbols_to_index] = nlohmann::json::array();
+
+            for(const auto& c : field.symbols_to_index) {
+                field_val[fields::symbols_to_index].push_back(c);
+            }
         }
 
         fields_json.push_back(field_val);

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -430,7 +430,7 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
     } else {
         for(const auto& item : field_json[fields::token_separators]) {
             if(!item.is_string() || item.empty() || item.get<std::string>().size() != 1) {
-                return Option<bool>(400, "Invalid field token_separators val.");
+                return Option<bool>(400, "The `token_separators` must be an array of characters.");
             }
         }
     }
@@ -440,7 +440,7 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
     } else {
         for(const auto& item : field_json[fields::symbols_to_index]) {
             if (!item.is_string() || item.empty() || item.get<std::string>().size() != 1) {
-                return Option<bool>(400, "Invalid field symbols_to_index val.");
+                return Option<bool>(400, "The `symbols_to_index` must be an array of characters.");
             }
         }
     }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -294,6 +294,9 @@ void Index::compute_token_offsets_facets(index_record& record,
 
         bool is_facet = search_schema.at(field_name).facet;
 
+        const auto& token_separators = the_field.token_separators.empty() ? local_token_separators : the_field.token_separators;
+        const auto& symbols_to_index = the_field.symbols_to_index.empty() ? local_symbols_to_index : the_field.symbols_to_index;
+
         // non-string, non-geo faceted field should be indexed as faceted string field as well
         if(the_field.facet && !the_field.is_string() && !the_field.is_geopoint()) {
             if(the_field.is_array()) {
@@ -322,7 +325,7 @@ void Index::compute_token_offsets_facets(index_record& record,
                 }
 
                 tokenize_string_array(strings, the_field,
-                                      local_symbols_to_index, local_token_separators,
+                                      symbols_to_index, token_separators,
                                       offset_facet_hashes.offsets);
             } else {
                 std::string text;
@@ -342,7 +345,7 @@ void Index::compute_token_offsets_facets(index_record& record,
                 }
 
                 tokenize_string(text, the_field,
-                                local_symbols_to_index, local_token_separators,
+                                symbols_to_index, token_separators,
                                 offset_facet_hashes.offsets);
             }
         }
@@ -350,11 +353,11 @@ void Index::compute_token_offsets_facets(index_record& record,
         if(the_field.is_string()) {
             if(the_field.type == field_types::STRING) {
                 tokenize_string(document[field_name], the_field,
-                                local_symbols_to_index, local_token_separators,
+                                symbols_to_index, token_separators,
                                 offset_facet_hashes.offsets);
             } else {
                 tokenize_string_array(document[field_name], the_field,
-                                      local_symbols_to_index, local_token_separators,
+                                      symbols_to_index, token_separators,
                                       offset_facet_hashes.offsets);
             }
         }

--- a/test/collection_all_fields_test.cpp
+++ b/test/collection_all_fields_test.cpp
@@ -1909,7 +1909,7 @@ TEST_F(CollectionAllFieldsTest, FieldTokenSeparators) {
 
     create_op = collectionManager.create_collection(invalid_schema);
     ASSERT_FALSE(create_op.ok());
-    ASSERT_EQ("Invalid field token_separators val.", create_op.error());
+    ASSERT_EQ("The `token_separators` must be an array of characters.", create_op.error());
 
     //non string vals not permitted
     invalid_schema = R"({
@@ -1921,7 +1921,7 @@ TEST_F(CollectionAllFieldsTest, FieldTokenSeparators) {
 
     create_op = collectionManager.create_collection(invalid_schema);
     ASSERT_FALSE(create_op.ok());
-    ASSERT_EQ("Invalid field symbols_to_index val.", create_op.error());
+    ASSERT_EQ("The `symbols_to_index` must be an array of characters.", create_op.error());
 }
 
 TEST_F(CollectionAllFieldsTest, FieldTokenSeparatorsOnRestart) {

--- a/test/collection_all_fields_test.cpp
+++ b/test/collection_all_fields_test.cpp
@@ -1800,3 +1800,24 @@ TEST_F(CollectionAllFieldsTest, GeopointSortValue) {
               " The sort index is used during GeoSearch.", create_op.error());
 
 }
+
+TEST_F(CollectionAllFieldsTest, FieldTokenSeparators) {
+    nlohmann::json schema = R"({
+        "name": "TokenSymbols",
+        "fields": [
+            {"name": "product", "type": "string", "token_separators":["-"], "symbols_to_index":["_"]}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+
+    Collection* coll = create_op.get();
+    const auto& fields = coll->get_fields();
+
+    ASSERT_EQ(1, fields.size());
+    ASSERT_EQ(1, fields[0].token_separators.size());
+    ASSERT_EQ('-', fields[0].token_separators.at(0));
+    ASSERT_EQ(1, fields[0].symbols_to_index.size());
+    ASSERT_EQ('_', fields[0].symbols_to_index.at(0));
+}


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->

- add support for field level token separators and symbols to index
- field level token separators will take precedence over collection level token separators and symbols to index
- add tests

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
