### PR TITLE
add endpoint to get status of alter schema ooperation of collections

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -654,6 +654,8 @@ private:
 
     Option<bool> run_search_with_lock(search_args* search_params) const;
 
+    void reset_alter_status_counters();
+
 public:
 
     enum {MAX_ARRAY_MATCHES = 5};
@@ -1071,7 +1073,7 @@ public:
     Option<int64_t> get_geo_distance_with_lock(const std::string& geo_field_name, const uint32_t& seq_id,
                                                const S2LatLng& reference_lat_lng, const bool& round_distance = false) const;
 
-    nlohmann::json get_alter_schema_status() const;
+    Option<nlohmann::json> get_alter_schema_status() const;
 };
 
 template<class T>

--- a/include/collection.h
+++ b/include/collection.h
@@ -420,6 +420,10 @@ private:
 
     nlohmann::json metadata;
 
+    std::atomic<bool> alter_in_progress;
+    std::atomic<size_t> altered_docs;
+    std::atomic<size_t> validated_docs;
+
     // methods
 
     std::string get_doc_id_key(const std::string & doc_id) const;
@@ -1066,6 +1070,8 @@ public:
 
     Option<int64_t> get_geo_distance_with_lock(const std::string& geo_field_name, const uint32_t& seq_id,
                                                const S2LatLng& reference_lat_lng, const bool& round_distance = false) const;
+
+    nlohmann::json get_alter_schema_status() const;
 };
 
 template<class T>

--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -236,4 +236,6 @@ public:
     bool is_valid_api_key_collection(const std::vector<std::string>& api_key_collections, Collection* coll) const;
 
     Option<bool> update_collection_metadata(const std::string& collection, const nlohmann::json& metadata);
+
+    Option<nlohmann::json> get_collection_alter_status() const;
 };

--- a/include/core_api.h
+++ b/include/core_api.h
@@ -135,6 +135,8 @@ bool post_compact_db(const std::shared_ptr<http_req>& req, const std::shared_ptr
 
 bool post_reset_peers(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 
+bool get_schema_changes(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+
 // Rate Limiting
 
 bool get_rate_limits(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -7498,9 +7498,9 @@ Option<nlohmann::json> Collection::get_alter_schema_status() const {
     }
 
     nlohmann::json status_json;
-
-    status_json["validated_docs"] = validated_docs;
-    status_json["altered_docs"] = altered_docs;
+    status_json["collection"] = name;
+    status_json["validated_docs"] = validated_docs.load();
+    status_json["altered_docs"] = altered_docs.load();
 
     return Option<nlohmann::json>(status_json);
 }

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -2017,8 +2017,10 @@ Option<nlohmann::json> CollectionManager::get_collection_alter_status() const {
     std::unique_lock lock(mutex);
 
     for(const auto& kv : collections) {
-        auto coll_alter_status = kv.second->get_alter_schema_status();
-        collection_alter_status.push_back(coll_alter_status);
+        auto op = kv.second->get_alter_schema_status();
+        if(op.ok()) {
+            collection_alter_status.push_back(op.get());
+        }
     }
 
     return Option<nlohmann::json>(collection_alter_status);

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -2006,3 +2006,20 @@ Option<bool> CollectionManager::update_collection_metadata(const std::string& co
 
     return Option<bool>(400, "failed to insert into store.");
 }
+
+Option<nlohmann::json> CollectionManager::get_collection_alter_status() const {
+    nlohmann::json collection_alter_status = nlohmann::json::array();
+
+    if(collections.empty()) {
+        return Option<nlohmann::json>(400, "No collections are added.");
+    }
+
+    std::unique_lock lock(mutex);
+
+    for(const auto& kv : collections) {
+        auto coll_alter_status = kv.second->get_alter_schema_status();
+        collection_alter_status.push_back(coll_alter_status);
+    }
+
+    return Option<nlohmann::json>(collection_alter_status);
+}

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -2213,6 +2213,19 @@ bool post_reset_peers(const std::shared_ptr<http_req>& req, const std::shared_pt
     return true;
 }
 
+bool get_schema_changes(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
+    CollectionManager & collectionManager = CollectionManager::get_instance();
+    auto op = collectionManager.get_collection_alter_status();
+
+    if(!op.ok()) {
+        res->set(op.code(), op.error());
+    }
+
+    res->set_200(op.get().dump());
+
+    return true;
+}
+
 bool get_synonyms(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     CollectionManager & collectionManager = CollectionManager::get_instance();
     auto collection = collectionManager.get_collection(req->params["collection"]);

--- a/src/main/typesense_server.cpp
+++ b/src/main/typesense_server.cpp
@@ -103,6 +103,7 @@ void master_server_routes() {
     server->post("/operations/cache/clear", post_clear_cache, false, false);
     server->post("/operations/db/compact", post_compact_db, false, false);
     server->post("/operations/reset_peers", post_reset_peers, false, false);
+    server->get("/operations/schema_changes", get_schema_changes);
 
     server->post("/conversations/models", post_conversation_model);
     server->get("/conversations/models", get_conversation_models);


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- add endpoint `/operations/schema_changes` to get the status of alter schema operation status of collections going through alter operation 


## Get status of alter schema operation
To get status of alter schema operations one need to put GET request on endpoint `/operations/schema_changes` like following,
```curl
curl "http://localhost:8108/operations/schema_changes" -X GET -H "Content-Type: application/json" -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}
``` 
If no collection is not going through  alter schema operation then we get the empty response.

If collection is going through alter schema operation is then we get responses like following as per on going operation state for 1 million dataset,
```json
[{"altered_docs":0,"collection":"hnstories","validated_docs":873000}]
``` 
Here, currently alter schema is under validation state and had validated `873000` docs so far.

similarly,
```json
[{"altered_docs":21480,"collection":"hnstories","validated_docs":1000000}]
``` 
Here, alter schema is in altering state and has altered `21480` docs so far.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
