### PR TITLE
truncate all docs in collection

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -1074,6 +1074,8 @@ public:
                                                const S2LatLng& reference_lat_lng, const bool& round_distance = false) const;
 
     Option<nlohmann::json> get_alter_schema_status() const;
+
+    Option<size_t> remove_all_docs();
 };
 
 template<class T>

--- a/include/core_api.h
+++ b/include/core_api.h
@@ -45,6 +45,8 @@ bool del_remove_document(const std::shared_ptr<http_req>& req, const std::shared
 
 bool del_remove_documents(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 
+bool del_remove_all_documents(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+
 // Alias
 
 bool get_alias(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -7505,6 +7505,48 @@ Option<nlohmann::json> Collection::get_alter_schema_status() const {
     return Option<nlohmann::json>(status_json);
 }
 
+Option<size_t> Collection::remove_all_docs() {
+    size_t num_docs_removed = 0;
+
+    const std::string seq_id_prefix = get_seq_id_collection_prefix();
+    std::string upper_bound_key = get_seq_id_collection_prefix() + "`";
+    rocksdb::Slice upper_bound(upper_bound_key);
+
+    rocksdb::Iterator* iter = store->scan(seq_id_prefix, &upper_bound);
+    nlohmann::json document;
+
+    auto begin = std::chrono::high_resolution_clock::now();
+    while(iter->Valid() && iter->key().starts_with(seq_id_prefix)) {
+        const uint32_t seq_id = Collection::get_seq_id_from_key(iter->key().ToString());
+        const std::string& doc_string = iter->value().ToString();
+
+        try {
+            document = nlohmann::json::parse(doc_string);
+        } catch(const std::exception& e) {
+            LOG(ERROR) << "JSON error: " << e.what();
+            return Option<size_t>(400, "Bad JSON.");
+        }
+
+        remove_document(document, seq_id, true);
+        num_docs_removed++;
+
+        if(num_docs_removed % ((1 << 14)) == 0) {
+            // having a cheaper higher layer check to prevent checking clock too often
+            auto time_elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+                    std::chrono::high_resolution_clock::now() - begin).count();
+
+            if(time_elapsed > 30) {
+                begin = std::chrono::high_resolution_clock::now();
+                LOG(INFO) << "Removed " << num_docs_removed << " so far.";
+            }
+        }
+
+        iter->Next();
+    }
+
+    return Option<size_t>(num_docs_removed);
+}
+
 std::shared_ptr<VQModel> Collection::get_vq_model() {
     return vq_model;
 }

--- a/src/main/typesense_server.cpp
+++ b/src/main/typesense_server.cpp
@@ -28,6 +28,7 @@ void master_server_routes() {
     // NOTE:`/documents/:id` end-points must be placed last in the list
     server->post("/collections/:collection/documents", post_add_document);
     server->del("/collections/:collection/documents", del_remove_documents, false, true);
+    server->del("/collections/:collection/documents/truncate_all", del_remove_all_documents, false, true);
 
     server->post("/collections/:collection/documents/import", post_import_documents, true, true);
     server->get("/collections/:collection/documents/export", get_export_documents, false, true);

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -5281,3 +5281,25 @@ TEST_F(CollectionTest, CatchPartialResponseFromRemoteEmbedding) {
     ASSERT_EQ(res["response"]["error"], "Malformed response from OpenAI API.");
     ASSERT_EQ(res["request"]["body"], req_body);
 }
+
+TEST_F(CollectionTest, TruncateAllDocuments) {
+    nlohmann::json results = collection->search("the", query_fields, "", {}, sort_fields, {0}, 10,
+                                                1, FREQUENCY, {false}).get();
+    ASSERT_EQ(7, results["hits"].size());
+    ASSERT_EQ(7, results["found"].get<int>());
+
+    auto op = collection->remove_all_docs();
+    ASSERT_TRUE(op.ok());
+    ASSERT_EQ(25, op.get()); //count of documents deleted (file count + dummy record)
+
+    results = collection->search("the", query_fields, "", {}, sort_fields, {0}, 10,
+                                                1, FREQUENCY, {false}).get();
+    ASSERT_EQ(0, results["hits"].size());
+    ASSERT_EQ(0, results["found"].get<int>());
+
+
+    //now all docs are deleted, try calling on empty collection
+    op = collection->remove_all_docs();
+    ASSERT_TRUE(op.ok());
+    ASSERT_EQ(0, op.get());
+}


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- add end-point `/collections/:collection/documents/truncate_all` to remove all docs from collection
- add test

### Truncate all docs from collection
To truncate all docs from a collection, one need to put a DELETE request to end-point `/collections/:collection/documents/truncate_all` like below,

```curl
curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -X DELETE  "http://localhost:8108/collections/hnstories/documents/truncate_all"
```
Here, `hnstories` is the collection to truncate all docs.


And we get the response like below,

```json
{"num_deleted":1000000}
```
Here `num_deleted` is the count of docs deleted.

In case of empty collection we get response accordingly,
```json
{"num_deleted":0}
```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
