### PR TITLE
ci: bump actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
           tar -czvf bazel-cache.tar.gz -C ~/.cache/bazel .
 
       - name: Save bazel cache
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: bazel-cache
@@ -96,7 +96,7 @@ jobs:
       - name: Set BAZEL_BIN_FULL_PATH
         run: echo "BAZEL_BIN_FULL_PATH=$(readlink -f bazel-bin)" >> $GITHUB_ENV
       - name: Save build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: typesense-server
           path: ${{ env.BAZEL_BIN_FULL_PATH }}/typesense-server


### PR DESCRIPTION
## Change Summary
Since `actions/upload-artifact@v3` is getting deprecated, new workflow runs will be failing after [Jan 30](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/). This just bumps the version to the latest supported one.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
