### PR TITLE
Schema change status history

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -424,6 +424,8 @@ private:
     std::atomic<size_t> altered_docs;
     std::atomic<size_t> validated_docs;
 
+    std::deque<std::string> last_alter_msgs;
+
     // methods
 
     std::string get_doc_id_key(const std::string & doc_id) const;
@@ -1076,6 +1078,8 @@ public:
     Option<nlohmann::json> get_alter_schema_status() const;
 
     Option<size_t> remove_all_docs();
+
+    bool check_store_alter_status_msg(const std::string& msg);
 };
 
 template<class T>

--- a/include/collection.h
+++ b/include/collection.h
@@ -424,7 +424,7 @@ private:
     std::atomic<size_t> altered_docs;
     std::atomic<size_t> validated_docs;
 
-    std::deque<std::string> last_alter_msgs;
+    std::deque<nlohmann::json> alter_history;
 
     // methods
 
@@ -1079,7 +1079,7 @@ public:
 
     Option<size_t> remove_all_docs();
 
-    bool check_store_alter_status_msg(const std::string& msg);
+    bool check_store_alter_status_msg(bool success, const std::string& msg = "");
 };
 
 template<class T>


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- show status of last 5 schema change operations in rolling fashion

## Get status of alter schema operation

To get status of alter schema operations one need to put GET request on endpoint `/operations/schema_changes` like following,
```curl
curl "http://localhost:8108/operations/schema_changes" -X GET -H "Content-Type: application/json" -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}"
```
- If no collection is not going through alter schema operation then we get the empty response.

- If collection is going through alter schema operation is then we get responses like following as per on going operation state for 1 million dataset,
```json
[{"alter_history":[{"message":"Alter failed validation: Field `points` is already part of the schema: To change this field, drop it first before adding it back to the schema.","success":false,"timestamp":"1738232983756361642"},{"message":"Alter failed during alter data: Field `points` has an invalid data type `int3`, see docs for supported data types.","success":false,"timestamp":"1738232983756048047"},{"success":true,"timestamp":"1738232976929637546"}],"altered_docs":841000,"collection":"hnstories","validated_docs":1000000}]
```
Here, currently alter schema is under altering state and had altered `135285` docs so far.
Additionally, another status array we get `alter_history` which displays status of last 5 alter operations in most recent to least recent order.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
