### PR TITLE
fix(k6): increase k6 timeout to 5m

### DIFF
--- a/benchmark/src/benchmarks/index.ts
+++ b/benchmark/src/benchmarks/index.ts
@@ -59,6 +59,7 @@ export default function () {
       "Content-Type": "application/json",
       "X-TYPESENSE-API-KEY": __ENV.API_KEY ?? "xyz",
     },
+    timeout: 30_0000, // 5 minutes
   };
 
   const startTime = new Date().getTime();


### PR DESCRIPTION
## Change Summary
This pull request includes a small change to the `benchmark/src/benchmarks/index.ts` file. The change sets a timeout value of 5 minutes for the API request.

```diff
+    timeout: 30_0000, // 5 minutes
```
The default timeout is 1m, which will get exceeded during the indexing benchmark, leading to failures.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
