### PR TITLE
Cleanup data directories between integration tests

### DIFF
--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -1,0 +1,52 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies including locales
+RUN apt-get update && apt-get install -y \
+    software-properties-common \
+    curl \
+    locales \
+    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && apt-get update \
+    && apt-get install -y \
+    g++-10 \
+    make \
+    git \
+    zlib1g-dev \
+    m4 \
+    lld \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set up compiler alternatives
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 30 \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 30 \
+    && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30 \
+    && update-alternatives --set cc /usr/bin/gcc \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30 \
+    && update-alternatives --set c++ /usr/bin/g++
+
+# Install architecture-specific Bazelisk
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+    curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.16.0/bazelisk-linux-arm64" && \
+    mv bazelisk-linux-arm64 /usr/local/bin/bazel; \
+    else \
+    curl -LO "https://github.com/bazelbuild/bazelisk/releases/download/v1.16.0/bazelisk-linux-amd64" && \
+    mv bazelisk-linux-amd64 /usr/local/bin/bazel; \
+    fi && \
+    chmod +x /usr/local/bin/bazel
+
+# Set up locale
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+# Set the filesystem encoding
+ENV LANG C.UTF-8
+
+VOLUME /root/.cache/bazel
+
+WORKDIR /app
+ENTRYPOINT ["/bin/bash"]

--- a/benchmark/src/commands/benchmark.ts
+++ b/benchmark/src/commands/benchmark.ts
@@ -691,7 +691,7 @@ class Benchmarks {
 
     const importPercentageChange = this.calculatePercentageChange(importDuration, importDurationNew);
 
-    const FormattedIndexResult: FormattedIndexResult = {
+    const formattedIndexResult: FormattedIndexResult = {
       metric: "Time to bulk import",
       oldValue: `${(importDuration / 1000).toFixed(5)}s`,
       newValue: `${(importDurationNew / 1000).toFixed(5)}s`,
@@ -745,6 +745,14 @@ class Benchmarks {
       });
     }
 
+    const displayIndexResults: [string, string, string, string, string] = [
+      formattedIndexResult.metric,
+      formattedIndexResult.displayVariable,
+      formattedIndexResult.oldValue,
+      formattedIndexResult.newValue,
+      formattedIndexResult.formattedPercentageChange,
+    ];
+
     // For display, use the displayVariable
     const columns: [string, string, string, string, string][] = [
       [
@@ -754,6 +762,7 @@ class Benchmarks {
         `Value for commit ${this.commitHashes[1].slice(0, 7)}`,
         "Percentage Change",
       ],
+      displayIndexResults,
       ...formatedSearchResults.map(
         (row) =>
           [row.metric, row.displayVariable, row.oldValue, row.newValue, row.formattedPercentageChange] as [
@@ -777,7 +786,7 @@ class Benchmarks {
     };
 
     logger.info(table(columns, tableConfig));
-    return okAsync({ searchResults: formatedSearchResults, indexingResults: FormattedIndexResult });
+    return okAsync({ searchResults: formatedSearchResults, indexingResults: formattedIndexResult });
   }
 
   benchmark() {

--- a/benchmark/src/commands/benchmark.ts
+++ b/benchmark/src/commands/benchmark.ts
@@ -796,6 +796,7 @@ class Benchmarks {
       .andThen(() =>
         this.getComparisonResults()
           .orElse((error) => {
+            logger.warn(error.message);
             if (error.commitHash) {
               return this.performBenchmarks([error.commitHash]);
             }

--- a/benchmark/src/commands/benchmark.ts
+++ b/benchmark/src/commands/benchmark.ts
@@ -310,11 +310,10 @@ class Benchmarks {
     });
 
     const indexDurationQuery = `
-    SELECT mean("value") AS "mean_import_duration"
-    FROM "import_duration"
-    WHERE ("commitHash" = '${this.commitHashes[0]}' OR "commitHash" = '${this.commitHashes[1]}')
-    AND time >= now() - 24h
-    GROUP BY "commitHash"
+      SELECT mean("value") AS "mean_import_duration"
+      FROM "import_duration"
+      WHERE ("commitHash" = '${this.commitHashes[0]}' OR "commitHash" = '${this.commitHashes[1]}')
+      GROUP BY "commitHash"
     `;
 
     const searchDurationQuery = `

--- a/benchmark/src/commands/tests.ts
+++ b/benchmark/src/commands/tests.ts
@@ -569,8 +569,8 @@ const test = new Command()
       .andThen((integrationTests) =>
         integrationTests
           .setupProcesses()
-          // .andThen(() => integrationTests.conversationTest())
-          // .andThen(() => integrationTests.emptyDataDirectories())
+          .andThen(() => integrationTests.conversationTest())
+          .andThen(() => integrationTests.emptyDataDirectories())
           .andThen(() => integrationTests.snapshotTest())
           .andThen(() => integrationTests.emptyDataDirectories())
           .andThen(() => integrationTests.openAIEmbeddingTest())

--- a/benchmark/src/commands/tests.ts
+++ b/benchmark/src/commands/tests.ts
@@ -128,6 +128,17 @@ class IntegrationTests {
     );
   }
 
+  emptyDataDirectories(): ResultAsync<string[], ErrorWithMessage> {
+    this.spinner.start("Emptying data directories");
+
+    return ResultAsync.combine(this.nodes.map((node) => this.services.get("fs").emptyDirectory(node.dataDir))).map(
+      () => {
+        this.spinner.succeed("Data directories emptied");
+        return this.nodes.map((node) => node.dataDir);
+      },
+    );
+  }
+
   setupProcesses(): ResultAsync<TypesenseProcessController[], ErrorWithMessage> {
     this.spinner.start("Setting up Typesense processes");
 
@@ -225,6 +236,7 @@ class IntegrationTests {
       id: IntegrationTests.conversationModelName,
       system_prompt:
         "You are an assistant for question-answering like Paul Graham. You can only make conversations based on the provided context. If a response cannot be formed strictly using the context, politely say you don't have knowledge about that topic. Do not answer questions that are not strictly on the topic of Paul Graham'''s essays.",
+      //@ts-expect-error - history_collection is not in the ConversationModelSchema
       history_collection: "conversation_store",
       model_name: "openai/gpt-4-turbo",
       max_bytes: 16384,
@@ -557,9 +569,12 @@ const test = new Command()
       .andThen((integrationTests) =>
         integrationTests
           .setupProcesses()
-          .andThen(() => integrationTests.conversationTest())
+          // .andThen(() => integrationTests.conversationTest())
+          // .andThen(() => integrationTests.emptyDataDirectories())
           .andThen(() => integrationTests.snapshotTest())
-          .andThen(() => integrationTests.openAIEmbeddingTest()),
+          .andThen(() => integrationTests.emptyDataDirectories())
+          .andThen(() => integrationTests.openAIEmbeddingTest())
+          .andThen(() => integrationTests.emptyDataDirectories()),
       )
       .then((result) => {
         if (result.isErr()) {

--- a/benchmark/src/services/fs.ts
+++ b/benchmark/src/services/fs.ts
@@ -137,7 +137,7 @@ export class FilesystemService {
     });
   }
 
-  private emptyDirectory(directory: string): ResultAsync<string, ErrorWithMessage> {
+  emptyDirectory(directory: string): ResultAsync<string, ErrorWithMessage> {
     this.spinner.text = `Emptying directory ${directory}`;
     return ResultAsync.fromPromise(emptyDir(directory), toErrorWithMessage).map(() => {
       this.spinner.succeed(`Directory ${directory} emptied`);


### PR DESCRIPTION
## Change Summary
### TLDR
Empty data directories between tests, to avoid redudant re-embedding from OpenAI
### Docker Setup Enhancements:
* [`benchmark/Dockerfile`](diffhunk://#diff-5b448215f5a2b2c7bd6e5c23a7a52bfd24454fe3b3c4045fefbac8313195f201R1-R52): Added a new Dockerfile based on Ubuntu 22.04, which installs necessary dependencies, sets up compiler alternatives, installs Bazelisk, and configures locale settings.

### New Functionality for Data Directory Management:
* [`benchmark/src/commands/tests.ts`](diffhunk://#diff-d43d7a08393410cb9a14af5d547efa9dd58411152fcbaa5255e68812f97b87fcR131-R141): Introduced a new method `emptyDataDirectories` in the `IntegrationTests` class to empty data directories and updated the integration test sequence to incorporate this method. [[1]](diffhunk://#diff-d43d7a08393410cb9a14af5d547efa9dd58411152fcbaa5255e68812f97b87fcR131-R141) [[2]](diffhunk://#diff-d43d7a08393410cb9a14af5d547efa9dd58411152fcbaa5255e68812f97b87fcL560-R577)
* [`benchmark/src/services/fs.ts`](diffhunk://#diff-0d619cf4808cd6f76a51f1600c667e91937de68bf60efbe4cb711b0d75a9563bL140-R140): Changed the `emptyDirectory` method in the `FilesystemService` class from private to public to allow it to be called from other classes.


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
