### PR TITLE
fix(stemmer): always return dictionaries array even when empty

### DIFF
--- a/src/stemmer_manager.cpp
+++ b/src/stemmer_manager.cpp
@@ -157,11 +157,9 @@ std::string StemmerManager::get_normalized_word(const std::string &dictionary_na
 void StemmerManager::get_stemming_dictionaries(nlohmann::json &dictionaries) {
     std::lock_guard<std::mutex> lock(mutex);
 
-    if(!stem_dictionaries.empty()) {
-        dictionaries["dictionaries"] = nlohmann::json::array();
-        for (const auto &kv: stem_dictionaries) {
-                dictionaries["dictionaries"].push_back(kv.first);
-        }
+    dictionaries["dictionaries"] = nlohmann::json::array();
+    for (const auto &kv: stem_dictionaries) {
+        dictionaries["dictionaries"].push_back(kv.first);
     }
 }
 

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -3497,6 +3497,14 @@ TEST_F(CollectionSpecificMoreTest, StemmingDictionaryBasics) {
     ASSERT_EQ("set1", dictionary_sets["dictionaries"][0].get<std::string>());
 }
 
+TEST_F(CollectionSpecificMoreTest, StemmingDictionaryEmpty) {
+    stemmerManager.delete_all_stemming_dictionaries();
+    nlohmann::json dictionary_sets;
+    stemmerManager.get_stemming_dictionaries(dictionary_sets);
+    ASSERT_EQ(0, dictionary_sets["dictionaries"].size());
+    ASSERT_TRUE(dictionary_sets["dictionaries"].is_array());
+}
+
 TEST_F(CollectionSpecificMoreTest, ReloadStemmingDictionaryOnRestart) {
     stemmerManager.delete_all_stemming_dictionaries();
 


### PR DESCRIPTION
## Change Summary

Changes to `StemmerManager` class:

* [`src/stemmer_manager.cpp`](diffhunk://#diff-012700b83855dd992d545cdbdec01a1c1dbcd51a6c4df6ad7bd422ac04d3e8ddL160-L166): Removed a redundant check for non-empty `stem_dictionaries` in the `get_stemming_dictionaries` method.

Enhancements to tests:

* [`test/collection_specific_more_test.cpp`](diffhunk://#diff-c3686f4cc5850b29c5795bd81d7cef78ddc3600f577de687735d123002f78fdbR3500-R3507): Added a new test case `StemmingDictionaryEmpty` to verify the behavior when all stemming dictionaries are deleted and the resulting dictionary set is empty.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
