### PR TITLE
Benchmark Reproduction Guide Generation

### DIFF
--- a/.github/workflows/benchmark-testing.yml
+++ b/.github/workflows/benchmark-testing.yml
@@ -186,6 +186,14 @@ jobs:
           compression-level: 6
           overwrite: false
 
+      - name: Upload reproduction guide
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: reproduction-guide
+          path: benchmark/reproduction-guide.md
+          if-no-files-found: ignore
+
       - name: Stop containers
         if: always()
         working-directory: benchmark

--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -4,3 +4,4 @@ dist
 node_modules
 binaries
 .env
+reproduction-guide.md

--- a/benchmark/src/commands/benchmark.ts
+++ b/benchmark/src/commands/benchmark.ts
@@ -21,6 +21,7 @@ import { searchScenarios } from "@/benchmarks/k6-utils";
 import { ServiceContainer } from "@/services/container";
 import { DEFAULT_TYPESENSE_GIT_URL } from "@/services/git";
 import { K6Benchmarks } from "@/services/k6";
+import { ReproductionService } from "@/services/reproduction";
 import { TypesenseProcessManager } from "@/services/typesense-process";
 import { toErrorWithMessage } from "@/utils/error";
 import { delay } from "@/utils/execa";
@@ -196,6 +197,7 @@ class Benchmarks {
   private readonly port: number;
   private readonly spinner: Ora;
   private readonly benchmarkGroupsByCommitHash: Record<string, BenchmarkGroup>;
+  private readonly reproductionService: ReproductionService;
 
   constructor(options: {
     typesenseProcessManagers: [TypesenseProcessManager, TypesenseProcessManager];
@@ -220,6 +222,7 @@ class Benchmarks {
     this.commitHashes = options.commitHashes;
     this.isInCi = Boolean(process.env.CI) || false;
     this.percentagesForFailure = options.failAtPercentage;
+    this.reproductionService = new ReproductionService();
 
     this.benchmarkGroupsByCommitHash = Object.fromEntries(
       this.commitHashes.map((hash, index) => [
@@ -291,9 +294,17 @@ class Benchmarks {
         })
         .join("\n");
 
-      return errAsync({
-        message: `Performance degradation exceeded configured thresholds:\n${failures}`,
-      });
+      return this.reproductionService
+        .generateReproductionFile({
+          failingResults: failingRows,
+          apiKey: this.apiKey,
+          commitHash: this.commitHashes[1],
+        })
+        .andThen((filePath) =>
+          errAsync({
+            message: `Performance degradation exceeded configured thresholds:\n${failures}\nSee \`${filePath}\` for more information`,
+          }),
+        );
     }
 
     return okAsync(undefined);
@@ -808,11 +819,6 @@ class Benchmarks {
 
   private performBenchmarks(commitHashes: string[]) {
     return this.createDataDirectories()
-      .andThen(() =>
-        this.services
-          .get("fs")
-          .downloadTypesenseDataset("https://dl.typesense.org/datasets/musicbrainz-1M-songs.jsonl.tar.gz"),
-      )
       .andThen(() => this.services.get("fs").downloadTypesenseDataset(K6Benchmarks.DATASET_URL))
       .andThen(() =>
         commitHashes.reduce(

--- a/benchmark/src/commands/benchmark.ts
+++ b/benchmark/src/commands/benchmark.ts
@@ -813,6 +813,7 @@ class Benchmarks {
           .get("fs")
           .downloadTypesenseDataset("https://dl.typesense.org/datasets/musicbrainz-1M-songs.jsonl.tar.gz"),
       )
+      .andThen(() => this.services.get("fs").downloadTypesenseDataset(K6Benchmarks.DATASET_URL))
       .andThen(() =>
         commitHashes.reduce(
           (promise, commitHash, index) =>

--- a/benchmark/src/commands/benchmark.ts
+++ b/benchmark/src/commands/benchmark.ts
@@ -45,7 +45,7 @@ interface BaseFormattedResult {
   displayVariable: string;
 }
 
-interface FormattedSearchResult extends BaseFormattedResult {
+export interface FormattedSearchResult extends BaseFormattedResult {
   scenario: ScenarioNames;
   vus: 50 | 100;
 }

--- a/benchmark/src/services/reproduction.ts
+++ b/benchmark/src/services/reproduction.ts
@@ -1,0 +1,111 @@
+import { writeFile } from "fs/promises";
+import path from "path";
+import type { FormattedSearchResult } from "@/commands/benchmark";
+import type { SearchParams } from "typesense/lib/Typesense/Documents";
+
+import { ResultAsync } from "neverthrow";
+
+import { searchScenarios } from "@/benchmarks/k6-utils";
+import { K6Benchmarks } from "@/services/k6";
+import { toErrorWithMessage } from "@/utils/error";
+
+export class ReproductionService {
+  generateReproductionFile(params: { failingResults: FormattedSearchResult[]; commitHash: string; apiKey: string }) {
+    const markdownGuide = this.generateMarkdownGuide(params);
+    const filePath = path.resolve("reproduction-guide.md");
+    return ResultAsync.fromPromise(writeFile(filePath, markdownGuide), toErrorWithMessage).map(() => filePath);
+  }
+
+  private formatSearchParams(params: SearchParams) {
+    Object.entries(params).forEach(([key, value]) => {
+      if (Array.isArray(value)) {
+        (params as Record<string, unknown>)[key] = value.join(",");
+      }
+    });
+    return new URLSearchParams(params as Record<string, string>).toString();
+  }
+
+  private generateFailingScenariosMarkdown(params: { failingResults: FormattedSearchResult[]; apiKey: string }) {
+    const scenarioGroups = new Map<
+      string,
+      {
+        scenario: (typeof searchScenarios)[number] | undefined;
+        results: (typeof params.failingResults)[number][];
+      }
+    >();
+
+    params.failingResults.forEach((result) => {
+      if (!scenarioGroups.has(result.scenario)) {
+        const scenario = searchScenarios.find((s) => s.name === result.scenario);
+        scenarioGroups.set(result.scenario, {
+          scenario: scenario,
+          results: [],
+        });
+      }
+      const scenarioGroup = scenarioGroups.get(result.scenario);
+      if (scenarioGroup) {
+        scenarioGroup.results.push(result);
+      }
+    });
+
+    return Array.from(scenarioGroups.entries())
+      .map(([scenarioName, { scenario, results }]) => {
+        const vuInfo = results
+          .map(
+            (r) =>
+              `${r.vus} VUs: ${r.newValue} vs ${r.oldValue} (${
+                Number.isInteger(r.percentageChange) ? r.percentageChange : r.percentageChange.toFixed(3)
+              }%)`,
+          )
+          .join("\n# ");
+        return `
+### ${scenarioName}
+### Search Parameters
+\`\`\`json
+${JSON.stringify(scenario?.params, null, 2)}
+\`\`\`
+### Curl Request
+\`\`\`bash
+# ${vuInfo}
+curl "http://localhost:8108/collections/${K6Benchmarks.COLLECTION_NAME}/documents/search?${this.formatSearchParams(scenario!.params)}" \\
+    -X GET \\
+    -H "Content-Type: application/json" \\
+    -H "X-TYPESENSE-API-KEY: ${params.apiKey}"
+\`\`\``;
+      })
+      .join("");
+  }
+
+  private generateMarkdownGuide(params: {
+    failingResults: FormattedSearchResult[];
+    commitHash: string;
+    apiKey: string;
+  }) {
+    return `
+# Reproduction Guide
+## Failing commit
+\`${params.commitHash}\`
+## Steps to reproduce
+1. Create the collection
+\`\`\`bash
+curl "http://localhost:8108/collections" \\
+    -X POST \\
+    -H "Content-Type: application/json" \\
+    -H "X-TYPESENSE-API-KEY: ${params.apiKey}" \\
+    -d '${JSON.stringify(K6Benchmarks.COLLECTION_SCHEMA)}'
+\`\`\`
+2. Download the dataset from [here](${K6Benchmarks.DATASET_URL})
+3. Index the dataset
+\`\`\`bash
+curl "http://localhost:8108/collections/${K6Benchmarks.COLLECTION_NAME}/documents/import" \\
+    -X POST \\
+    -H "Content-Type: application/json" \\
+    -H "X-TYPESENSE-API-KEY: ${params.apiKey}" \\
+    --data-binary @musicbrainz-1M-songs.jsonl
+\`\`\`
+  
+4. Run the failing test benchmark scenarios
+## Failing Scenarios
+${this.generateFailingScenariosMarkdown({ failingResults: params.failingResults, apiKey: params.apiKey })}`;
+  }
+}


### PR DESCRIPTION
### TLDR
Add an automated generation of reproduction guides for failing benchmark tests to help developers debug performance regressions more effectively

## Change Summary
### What is this?
This PR improves the developer experience when debugging performance regressions in benchmark tests. When a benchmark test fails due to performance degradation, the system now automatically generates a markdown guide with step-by-step instructions to reproduce the issue locally. This makes it easier for developers to investigate and fix performance problems by providing them with exact commands and parameters needed to replicate the failing scenarios.

### Changes
#### Added Features:
1. **New `ReproductionService` Class in `services/reproduction.ts`**:
   - `generateReproductionFile()`: Creates a markdown guide with reproduction steps
   - `formatSearchParams()`: Formats search parameters for curl commands
   - `generateFailingScenariosMarkdown()`: Generates markdown sections for each failing scenario
   - `generateMarkdownGuide()`: Assembles the complete reproduction guide

2. **CI Integration in `.github/workflows/benchmark-testing.yml`**:
   - Added step to upload reproduction guide as workflow artifact when benchmarks fail
   - Configured to ignore if guide file is not found

#### Code Changes:
1. **In `services/k6.ts`**:
   - Refactored collection schema into static `COLLECTION_SCHEMA` property
   - Added static `DATASET_URL` property for consistent dataset reference
   - Made `COLLECTION_NAME` property public and static

2. **In `commands/benchmark.ts`**:
   - Integrated `ReproductionService` into benchmark command
   - Updated error messages to reference generated guide file
   - Exported `FormattedSearchResult` interface for reuse
   - Removed duplicate dataset download
   - Added reproduction service initialization in constructor

### Context
This change streamlines the process of debugging performance regressions by:
- Providing exact curl commands that can be copy-pasted to reproduce issues
- Including all necessary search parameters and collection setup steps
- Making the reproduction guide available as a CI artifact for easy access
- Ensuring consistent configuration across benchmark runs

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
