### PR TITLE
Fix typesense-server.service

### DIFF
--- a/debian-pkg/typesense-server/etc/systemd/system/typesense-server.service
+++ b/debian-pkg/typesense-server/etc/systemd/system/typesense-server.service
@@ -5,7 +5,7 @@ Requires=network.target remote-fs.target
 After=network.target remote-fs.target
 
 [Service]
-ExecStart=/usr/bin/typesense-server --config=/etc/typesense/typesense-server.ini
+ExecStart=/usr/bin/typesense-server --config=/etc/typesense/typesense.ini
 Restart=on-failure
 LimitNOFILE=64000
 LimitMEMLOCK=infinity


### PR DESCRIPTION
When installing the deb package I noticed that the path in the service is incorrect, this is a fix.
