### PR TITLE
Add dimension truncation support for GCP models

### DIFF
--- a/include/text_embedder_remote.h
+++ b/include/text_embedder_remote.h
@@ -135,7 +135,8 @@ class GCPEmbedder : public RemoteEmbedder {
         std::string client_id;
         std::string client_secret;
         std::string model_name;
-
+        bool has_custom_dims;
+        size_t num_dims;
         inline static const std::string GCP_EMBEDDING_BASE_URL = "https://us-central1-aiplatform.googleapis.com/v1/projects/";
         inline static const std::string GCP_EMBEDDING_PATH = "/locations/us-central1/publishers/google/models/";
         inline static const std::string GCP_EMBEDDING_PREDICT = ":predict";
@@ -146,7 +147,7 @@ class GCPEmbedder : public RemoteEmbedder {
         }
     public: 
         GCPEmbedder(const std::string& project_id, const std::string& model_name, const std::string& access_token, 
-                    const std::string& refresh_token, const std::string& client_id, const std::string& client_secret);
+                    const std::string& refresh_token, const std::string& client_id, const std::string& client_secret, const bool has_custom_dims = false, const size_t num_dims = 0);
         static Option<bool> is_model_valid(const nlohmann::json& model_config, size_t& num_dims);
         embedding_res_t Embed(const std::string& text, const size_t remote_embedder_timeout_ms = 30000, const size_t remote_embedding_num_tries = 2) override;
         std::vector<embedding_res_t> batch_embed(const std::vector<std::string>& inputs, const size_t remote_embedding_batch_size = 200,

--- a/include/text_embedder_remote.h
+++ b/include/text_embedder_remote.h
@@ -52,7 +52,7 @@ class AzureEmbedder : public RemoteEmbedder {
 
     public:
         AzureEmbedder(const std::string& azure_url, const std::string& api_key, const size_t num_dims, const bool has_custom_dims);
-        static Option<bool> is_model_valid(const nlohmann::json& model_config, size_t& num_dims);
+        static Option<bool> is_model_valid(const nlohmann::json& model_config, size_t& num_dims, const bool has_custom_dims);
         embedding_res_t Embed(const std::string& text, const size_t remote_embedder_timeout_ms = 30000, const size_t remote_embedding_num_tries = 2) override;
         std::vector<embedding_res_t> batch_embed(const std::vector<std::string>& inputs, const size_t remote_embedding_batch_size = 200,
                                                  const size_t remote_embedding_timeout_ms = 60000, const size_t remote_embedding_num_tries = 2) override;
@@ -88,7 +88,7 @@ class OpenAIEmbedder : public RemoteEmbedder {
         static nlohmann::json get_error_json(const nlohmann::json& req_body, long res_code, const std::string& res_body, const std::string& url);
     public:
         OpenAIEmbedder(const std::string& openai_model_path, const std::string& api_key, const size_t num_dims, const bool has_custom_dims, const std::string& openai_url);
-        static Option<bool> is_model_valid(const nlohmann::json& model_config, size_t& num_dims);
+        static Option<bool> is_model_valid(const nlohmann::json& model_config, size_t& num_dims, const bool has_custom_dims);
         embedding_res_t Embed(const std::string& text, const size_t remote_embedder_timeout_ms = 30000, const size_t remote_embedding_num_tries = 2) override;
         std::vector<embedding_res_t> batch_embed(const std::vector<std::string>& inputs, const size_t remote_embedding_batch_size = 200,
                                                  const size_t remote_embedding_timeout_ms = 60000, const size_t remote_embedding_num_tries = 2) override;
@@ -112,7 +112,7 @@ class GoogleEmbedder : public RemoteEmbedder {
         std::string google_api_key;
     public:
         GoogleEmbedder(const std::string& google_api_key);
-        static Option<bool> is_model_valid(const nlohmann::json& model_config, size_t& num_dims);
+        static Option<bool> is_model_valid(const nlohmann::json& model_config, size_t& num_dims, const bool has_custom_dims);
         embedding_res_t Embed(const std::string& text, const size_t remote_embedder_timeout_ms = 30000, const size_t remote_embedding_num_tries = 2) override;
         std::vector<embedding_res_t> batch_embed(const std::vector<std::string>& inputs, const size_t remote_embedding_batch_size = 200,
                                                  const size_t remote_embedding_timeout_ms = 60000, const size_t remote_embedding_num_tries = 2) override;
@@ -148,7 +148,7 @@ class GCPEmbedder : public RemoteEmbedder {
     public: 
         GCPEmbedder(const std::string& project_id, const std::string& model_name, const std::string& access_token, 
                     const std::string& refresh_token, const std::string& client_id, const std::string& client_secret, const bool has_custom_dims = false, const size_t num_dims = 0);
-        static Option<bool> is_model_valid(const nlohmann::json& model_config, size_t& num_dims);
+        static Option<bool> is_model_valid(const nlohmann::json& model_config, size_t& num_dims, const bool has_custom_dims);
         embedding_res_t Embed(const std::string& text, const size_t remote_embedder_timeout_ms = 30000, const size_t remote_embedding_num_tries = 2) override;
         std::vector<embedding_res_t> batch_embed(const std::vector<std::string>& inputs, const size_t remote_embedding_batch_size = 200,
                                                  const size_t remote_embedding_timeout_ms = 60000, const size_t remote_embedding_num_tries = 2) override;

--- a/src/embedder_manager.cpp
+++ b/src/embedder_manager.cpp
@@ -29,31 +29,25 @@ Option<bool> EmbedderManager::validate_and_init_remote_model(const nlohmann::jso
                                                                  size_t& num_dims) {
     const std::string& model_name = model_config["model_name"].get<std::string>();
     auto model_namespace = EmbedderManager::get_model_namespace(model_name);
-    bool has_custom_dims = false;
+    bool has_custom_dims = num_dims > 0;
     if(model_namespace == "openai") {
-        auto num_dims_before = num_dims;
-        auto op = OpenAIEmbedder::is_model_valid(model_config, num_dims);
+        auto op = OpenAIEmbedder::is_model_valid(model_config, num_dims, has_custom_dims);
         // if the dimensions did not change, it means the model has custom dimensions
-        has_custom_dims = num_dims_before == num_dims;
         if(!op.ok()) {
             return op;
         }
     } else if(model_namespace == "google") {
-        auto op = GoogleEmbedder::is_model_valid(model_config, num_dims);
+        auto op = GoogleEmbedder::is_model_valid(model_config, num_dims, has_custom_dims);
         if(!op.ok()) {
             return op;
         }
     } else if(model_namespace == "gcp") {
-        auto num_dims_before = num_dims;
-        auto op = GCPEmbedder::is_model_valid(model_config, num_dims);
-        has_custom_dims = num_dims_before == num_dims;
+        auto op = GCPEmbedder::is_model_valid(model_config, num_dims, has_custom_dims);
         if(!op.ok()) {
             return op;
         }
     } else if(model_namespace == "azure") {
-        auto num_dims_before = num_dims;
-        auto op = AzureEmbedder::is_model_valid(model_config, num_dims);
-        has_custom_dims = num_dims_before == num_dims;
+        auto op = AzureEmbedder::is_model_valid(model_config, num_dims, has_custom_dims);
         if(!op.ok()) {
             return op;
         }

--- a/src/embedder_manager.cpp
+++ b/src/embedder_manager.cpp
@@ -44,7 +44,9 @@ Option<bool> EmbedderManager::validate_and_init_remote_model(const nlohmann::jso
             return op;
         }
     } else if(model_namespace == "gcp") {
+        auto num_dims_before = num_dims;
         auto op = GCPEmbedder::is_model_valid(model_config, num_dims);
+        has_custom_dims = num_dims_before == num_dims;
         if(!op.ok()) {
             return op;
         }

--- a/src/text_embedder.cpp
+++ b/src/text_embedder.cpp
@@ -352,11 +352,6 @@ Option<bool> TextEmbedder::validate() {
 
     Ort::AllocatorWithDefaultOptions allocator;
     auto input_ids_name = session_->GetInputNameAllocated(0, allocator);
-    auto input_count = session_->GetInputCount();
-    for(size_t i = 0; i < input_count; i++) {
-        auto name = session_->GetInputNameAllocated(i, allocator);
-        LOG(INFO) << "Input tensor name: " << name.get();
-    }
     if (std::strcmp(input_ids_name.get(), "input_ids") != 0) {
         LOG(ERROR) << "Invalid model: input_ids tensor not found";
         return Option<bool>(400, "Invalid model: input_ids tensor not found");

--- a/src/text_embedder.cpp
+++ b/src/text_embedder.cpp
@@ -85,7 +85,7 @@ TextEmbedder::TextEmbedder(const nlohmann::json& model_config, size_t num_dims, 
         auto client_id = model_config["client_id"].get<std::string>();
         auto client_secret = model_config["client_secret"].get<std::string>();
 
-        remote_embedder_ = std::make_unique<GCPEmbedder>(project_id, model_name, access_token, refresh_token, client_id, client_secret);
+        remote_embedder_ = std::make_unique<GCPEmbedder>(project_id, model_name, access_token, refresh_token, client_id, client_secret, has_custom_dims, num_dims);
     } else if(model_namespace == "azure") {
         auto azure_url = model_config["url"].get<std::string>();
         auto api_key = model_config["api_key"].get<std::string>();
@@ -352,6 +352,11 @@ Option<bool> TextEmbedder::validate() {
 
     Ort::AllocatorWithDefaultOptions allocator;
     auto input_ids_name = session_->GetInputNameAllocated(0, allocator);
+    auto input_count = session_->GetInputCount();
+    for(size_t i = 0; i < input_count; i++) {
+        auto name = session_->GetInputNameAllocated(i, allocator);
+        LOG(INFO) << "Input tensor name: " << name.get();
+    }
     if (std::strcmp(input_ids_name.get(), "input_ids") != 0) {
         LOG(ERROR) << "Invalid model: input_ids tensor not found";
         return Option<bool>(400, "Invalid model: input_ids tensor not found");

--- a/src/text_embedder_remote.cpp
+++ b/src/text_embedder_remote.cpp
@@ -79,7 +79,7 @@ OpenAIEmbedder::OpenAIEmbedder(const std::string& openai_model_path, const std::
     }
 }
 
-Option<bool> OpenAIEmbedder::is_model_valid(const nlohmann::json& model_config, size_t& num_dims) {
+Option<bool> OpenAIEmbedder::is_model_valid(const nlohmann::json& model_config, size_t& num_dims, const bool has_custom_dims) {
     auto validate_properties = validate_string_properties(model_config, {"model_name", "api_key"});
     
     if (!validate_properties.ok()) {
@@ -105,7 +105,7 @@ Option<bool> OpenAIEmbedder::is_model_valid(const nlohmann::json& model_config, 
     auto model_name_without_namespace = EmbedderManager::get_model_name_without_namespace(model_name);
     req_body["model"] = model_name_without_namespace;
 
-    if(num_dims > 0) {
+    if(has_custom_dims) {
         req_body["dimensions"] = num_dims;
     }
 
@@ -306,7 +306,7 @@ GoogleEmbedder::GoogleEmbedder(const std::string& google_api_key) : google_api_k
 
 }
 
-Option<bool> GoogleEmbedder::is_model_valid(const nlohmann::json& model_config, size_t& num_dims) {
+Option<bool> GoogleEmbedder::is_model_valid(const nlohmann::json& model_config, size_t& num_dims, const bool has_custom_dims) {
     auto validate_properties = validate_string_properties(model_config, {"model_name", "api_key"});
     
     if (!validate_properties.ok()) {
@@ -444,7 +444,7 @@ GCPEmbedder::GCPEmbedder(const std::string& project_id, const std::string& model
     this->model_name = EmbedderManager::get_model_name_without_namespace(model_name);
 }
 
-Option<bool> GCPEmbedder::is_model_valid(const nlohmann::json& model_config, size_t& num_dims)  {
+Option<bool> GCPEmbedder::is_model_valid(const nlohmann::json& model_config, size_t& num_dims, const bool has_custom_dims)  {
     auto validate_properties = validate_string_properties(model_config, {"model_name", "project_id", "access_token", "refresh_token", "client_id", "client_secret"});
 
     if (!validate_properties.ok()) {
@@ -474,7 +474,7 @@ Option<bool> GCPEmbedder::is_model_valid(const nlohmann::json& model_config, siz
     nlohmann::json instance;
     instance["content"] = "typesense";
     req_body["instances"].push_back(instance);
-    if(num_dims > 0) {
+    if(has_custom_dims) {
         nlohmann::json dimensions;
         dimensions["outputDimensionality"] = num_dims;
         req_body["parameters"] = dimensions;
@@ -748,7 +748,7 @@ AzureEmbedder::AzureEmbedder(const std::string& azure_url, const std::string& ap
     azure_url(azure_url), api_key(api_key), num_dims(num_dims), has_custom_dims(has_custom_dims) {
 }
 
-Option<bool> AzureEmbedder::is_model_valid(const nlohmann::json& model_config, size_t& num_dims) {
+Option<bool> AzureEmbedder::is_model_valid(const nlohmann::json& model_config, size_t& num_dims, const bool has_custom_dims) {
     auto validate_properties = validate_string_properties(model_config, {"model_name", "api_key", "url"});
     
     if (!validate_properties.ok()) {
@@ -771,7 +771,7 @@ Option<bool> AzureEmbedder::is_model_valid(const nlohmann::json& model_config, s
     nlohmann::json req_body;
     req_body["input"] = "typesense";
 
-    if(num_dims > 0) {
+    if(has_custom_dims) {
         req_body["dimensions"] = num_dims;
     }
 


### PR DESCRIPTION
## Usage
You should set `num_dim` manually while creating the collection for desired dimensions.

`POST /collection`
```json
{
        "name": "products",
        "fields": [
          {
            "name": "product_name",
            "type": "string"
          },
          {
            "name": "embedding",
            "type": "float[]",
            "num_dim": 512,
            "embed": {
              "from": [
                "product_name"
              ],
              "model_config": {
                "model_name": "gcp/text-embedding-005",
                "access_token": "your_gcp_access_token",
                "refresh_token": "your_gcp_refresh_token",
                "client_id": "your_gcp_app_client_id",
                "client_secret": "your_gcp_client_secret",
                "project_id": "your_gcp_project_id"
              }
            }
          }
        ]
      }
```
