### PR TITLE
refactor(benchmark): enhance failure threshold configuration

### DIFF
--- a/benchmark/src/commands/benchmark.ts
+++ b/benchmark/src/commands/benchmark.ts
@@ -76,8 +76,14 @@ export const BenchmarkConfigSchema = z
       .record(
         KeySchema,
         z.object({
-          "50vu": z.number().min(0).max(100),
-          "100vu": z.number().min(0).max(100),
+          "50vu": z.object({
+            percentage: z.number().min(0).max(100),
+            milliseconds: z.number().min(0),
+          }),
+          "100vu": z.object({
+            percentage: z.number().min(0).max(100),
+            milliseconds: z.number().min(0),
+          }),
         }),
       )
       .refine((obj): obj is Required<typeof obj> => KeySchema.options.every((key) => obj[key] != null)),
@@ -89,40 +95,94 @@ type BenchmarkConfig = z.infer<typeof BenchmarkConfigSchema>;
 export const defaultConfig: BenchmarkConfig = {
   failureThresholds: {
     filter_complex: {
-      "100vu": 50,
-      "50vu": 50,
+      "100vu": {
+        milliseconds: 1500,
+        percentage: 50,
+      },
+      "50vu": {
+        milliseconds: 1500,
+        percentage: 50,
+      },
     },
     filter_simple: {
-      "100vu": 50,
-      "50vu": 50,
+      "100vu": {
+        milliseconds: 200,
+        percentage: 50,
+      },
+      "50vu": {
+        milliseconds: 200,
+        percentage: 50,
+      },
     },
     group: {
-      "100vu": 50,
-      "50vu": 50,
+      "100vu": {
+        milliseconds: 6000,
+        percentage: 50,
+      },
+      "50vu": {
+        milliseconds: 6000,
+        percentage: 50,
+      },
     },
     just_q: {
-      "100vu": 50,
-      "50vu": 50,
+      "100vu": {
+        milliseconds: 7,
+        percentage: 50,
+      },
+      "50vu": {
+        milliseconds: 7,
+        percentage: 50,
+      },
     },
     q_star: {
-      "100vu": 50,
-      "50vu": 50,
+      "100vu": {
+        milliseconds: 5,
+        percentage: 50,
+      },
+      "50vu": {
+        milliseconds: 5,
+        percentage: 50,
+      },
     },
     sort_eval_condition: {
-      "100vu": 50,
-      "50vu": 50,
+      "100vu": {
+        milliseconds: 750,
+        percentage: 50,
+      },
+      "50vu": {
+        milliseconds: 750,
+        percentage: 50,
+      },
     },
     sort_eval_score: {
-      "100vu": 50,
-      "50vu": 50,
+      "100vu": {
+        milliseconds: 800,
+        percentage: 50,
+      },
+      "50vu": {
+        milliseconds: 800,
+        percentage: 50,
+      },
     },
     sort_simple: {
-      "100vu": 50,
-      "50vu": 50,
+      "100vu": {
+        milliseconds: 600,
+        percentage: 50,
+      },
+      "50vu": {
+        milliseconds: 600,
+        percentage: 50,
+      },
     },
     facet: {
-      "100vu": 50,
-      "50vu": 50,
+      "100vu": {
+        milliseconds: 1500,
+        percentage: 50,
+      },
+      "50vu": {
+        milliseconds: 1500,
+        percentage: 50,
+      },
     },
   },
 };
@@ -282,7 +342,7 @@ class Benchmarks {
     const { searchResults } = results;
     const failingBenchmarks = searchResults.filter((row) => {
       const threshold = this.percentagesForFailure[row.scenario][`${row.vus}vu`];
-      return row.percentageChange > threshold;
+      return row.percentageChange > threshold.percentage && row.newValue > row.oldValue + threshold.milliseconds;
     });
     const passingBenchmarks = searchResults.filter((row) => !failingBenchmarks.includes(row));
 
@@ -298,7 +358,7 @@ class Benchmarks {
         const failures = failingBenchmarks
           .map((row) => {
             const threshold = this.percentagesForFailure[row.scenario][`${row.vus}vu`];
-            return `${row.metric} for ${row.displayVariable || `${row.scenario} (${row.vus}vu)`} changed by ${row.formattedPercentageChange} (threshold: ${threshold}%)`;
+            return `${row.metric} for ${row.displayVariable || `${row.scenario} (${row.vus}vu)`} changed by ${row.formattedPercentageChange} (threshold: ${threshold.percentage}%) or exceeded the time threshold of ${threshold.milliseconds}ms`;
           })
           .join("\n");
 


### PR DESCRIPTION
### TLDR
Add absolute time threshold alongside percentage change for more reliable benchmarking.

## Change Summary
### What is this?
This PR improves the benchmark tool's failure detection by introducing a dual-threshold approach, combining both percentage change and absolute time metrics. This addresses issues where small absolute changes in fast operations could trigger false alarms (like a 2ms regression from 0ms causing an infinite percentage increase in the `q_*` benchmarks).

### Changes
#### Code Changes:
1. **In `benchmark/src/commands/benchmark.ts`**:
   - Modified `failureThresholds` schema to use objects with `percentage` and `milliseconds` properties instead of simple percentage values
   - Updated the failure detection logic to require both percentage change AND absolute time threshold violation
   - Added specific millisecond thresholds for each query type based on expected performance characteristics

#### Documentation Updates:
1. **In `benchmark/README.md`**:
   - Added detailed explanation of configuration file locations and formats
   - Documented the new threshold structure with examples
   - Fixed command line options documentation with correct defaults
   - Enhanced the overall structure of the configuration documentation
   - Reorganized development section for better readability


### Context
- The previous implementation only checked percentage changes, which caused false alarms for fast operations where small absolute time changes resulted in large percentage increases.
- For example, the `q_*` benchmark would fail if it increased from 0ms to 2ms (infinite percentage increase) even though the absolute change was minimal.
- This new approach prevents these false positives by requiring both a significant percentage change AND a meaningful absolute time increase.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
