### PR TITLE
Fix deadlock when concurrenlty importing collections having async_reference.

### DIFF
--- a/include/batched_indexer.h
+++ b/include/batched_indexer.h
@@ -127,4 +127,6 @@ public:
     std::string get_collection_name(const std::shared_ptr<http_req>& req);
 
     std::shared_mutex& get_pause_mutex();
+
+    size_t get_reference_q_size();
 };

--- a/include/collection.h
+++ b/include/collection.h
@@ -729,9 +729,7 @@ public:
                const std::vector<std::string>& symbols_to_index, const std::vector<std::string>& token_separators,
                const bool enable_nested_fields, std::shared_ptr<VQModel> vq_model = nullptr,
                spp::sparse_hash_map<std::string, std::string> referenced_in = spp::sparse_hash_map<std::string, std::string>(),
-               const nlohmann::json& metadata = {},
-               spp::sparse_hash_map<std::string, std::set<reference_pair_t>> async_referenced_ins =
-                       spp::sparse_hash_map<std::string, std::set<reference_pair_t>>());
+               const nlohmann::json& metadata = {});
 
     ~Collection();
 
@@ -1090,11 +1088,12 @@ public:
     // Return a copy of the referenced field in the referencing collection to avoid schema lookups in the future. The
     // tradeoff is that we have to make sure any changes during collection alter operation are passed to the referencing
     // collection.
-    [[nodiscard]] std::set<update_reference_info_t> add_referenced_ins(const std::map<std::string, reference_info_t>& ref_infos);
+    [[nodiscard]] std::set<update_reference_info_t> add_referenced_ins(std::map<std::string, reference_info_t>& ref_infos);
 
-    [[nodiscard]] std::set<update_reference_info_t>  add_referenced_in(const std::string& collection_name,
-                                                                       const std::string& field_name, const bool& is_async,
-                                                                       const std::string& referenced_field_name);
+    [[nodiscard]] std::set<update_reference_info_t> add_referenced_in(const std::string& collection_name,
+                                                                      const std::string& field_name, const bool& is_async,
+                                                                      const std::string& referenced_field_name,
+                                                                      field& referenced_field);
 
     void remove_referenced_in(const std::string& collection_name, const std::string& field_name,
                               const bool& is_async, const std::string& referenced_field_name);

--- a/include/collection.h
+++ b/include/collection.h
@@ -1087,13 +1087,21 @@ public:
 
     bool is_referenced_in(const std::string& collection_name) const;
 
-    void add_referenced_ins(const std::set<reference_info_t>& ref_infos);
+    // Return a copy of the referenced field in the referencing collection to avoid schema lookups in the future. The
+    // tradeoff is that we have to make sure any changes during collection alter operation are passed to the referencing
+    // collection.
+    [[nodiscard]] std::set<update_reference_info_t> add_referenced_ins(const std::map<std::string, reference_info_t>& ref_infos);
 
-    void add_referenced_in(const std::string& collection_name, const std::string& field_name,
-                                   const bool& is_async, const std::string& referenced_field_name);
+    [[nodiscard]] std::set<update_reference_info_t>  add_referenced_in(const std::string& collection_name,
+                                                                       const std::string& field_name, const bool& is_async,
+                                                                       const std::string& referenced_field_name);
 
     void remove_referenced_in(const std::string& collection_name, const std::string& field_name,
                               const bool& is_async, const std::string& referenced_field_name);
+
+    void update_reference_field_with_lock(const std::string& field_name, const field& ref_field);
+
+    void update_reference_field(const std::string& field_name, const field& ref_field);
 
     Option<std::string> get_referenced_in_field_with_lock(const std::string& collection_name) const;
 

--- a/include/collection.h
+++ b/include/collection.h
@@ -729,7 +729,9 @@ public:
                const std::vector<std::string>& symbols_to_index, const std::vector<std::string>& token_separators,
                const bool enable_nested_fields, std::shared_ptr<VQModel> vq_model = nullptr,
                spp::sparse_hash_map<std::string, std::string> referenced_in = spp::sparse_hash_map<std::string, std::string>(),
-               const nlohmann::json& metadata = {});
+               const nlohmann::json& metadata = {},
+               spp::sparse_hash_map<std::string, std::set<reference_pair_t>> async_referenced_ins =
+                        spp::sparse_hash_map<std::string, std::set<reference_pair_t>>());
 
     ~Collection();
 

--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -77,8 +77,9 @@ private:
 
     std::atomic<bool>* quit;
 
-    // All the references to a particular collection are stored until it is created.
-    std::map<std::string, std::set<reference_info_t>> referenced_in_backlog;
+    // All the references to a particular collection are stored.
+    // referenced_coll_name -> referring_coll_name -> reference_info
+    std::map<std::string, std::map<std::string, reference_info_t>> referenced_ins;
 
     CollectionManager();
 
@@ -221,9 +222,11 @@ public:
 
     Option<bool> delete_preset(const std::string & preset_name);
 
-    void add_referenced_in_backlog(const std::string& collection_name, reference_info_t&& ref_info);
+    void add_referenced_ins(const std::string& collection_name, reference_info_t&& ref_info);
 
-    std::map<std::string, std::set<reference_info_t>> _get_referenced_in_backlog() const;
+    void remove_referenced_ins(const std::string& referenced_coll_name, const std::string& referring_coll_name = "");
+
+    std::map<std::string, std::map<std::string, reference_info_t>> _get_referenced_ins() const;
 
     void process_embedding_field_delete(const std::string& model_name);
 

--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -101,6 +101,7 @@ public:
     static constexpr const char* NEXT_COLLECTION_ID_KEY = "$CI";
     static constexpr const char* SYMLINK_PREFIX = "$SL";
     static constexpr const char* PRESET_PREFIX = "$PS";
+    static constexpr const char* REFERENCED_INS = "$REFERENCED_INS";
 
     uint16_t filter_by_max_ops;
 
@@ -116,15 +117,13 @@ public:
                                        const uint32_t collection_next_seq_id,
                                        Store* store,
                                        float max_memory_ratio,
-                                       spp::sparse_hash_map<std::string, std::string>& referenced_in,
-                                       spp::sparse_hash_map<std::string, std::set<reference_pair_t>>& async_referenced_ins);
+                                       const std::map<std::string, std::map<std::string, reference_info_t>>& referenced_infos);
 
     static Option<bool> load_collection(const nlohmann::json& collection_meta,
                                         const size_t batch_size,
                                         const StoreStatus& next_coll_id_status,
                                         const std::atomic<bool>& quit,
-                                        spp::sparse_hash_map<std::string, std::string>& referenced_in,
-                                        spp::sparse_hash_map<std::string, std::set<reference_pair_t>>& async_referenced_ins);
+                                        const std::map<std::string, std::map<std::string, reference_info_t>>& referenced_infos);
 
     Option<Collection*> clone_collection(const std::string& existing_name, const nlohmann::json& req_json);
 
@@ -230,9 +229,8 @@ public:
 
     void process_embedding_field_delete(const std::string& model_name);
 
-    static void _populate_referenced_ins(const std::string& collection_meta_json,
-                                         std::map<std::string, spp::sparse_hash_map<std::string, std::string>>& referenced_ins,
-                                         std::map<std::string, spp::sparse_hash_map<std::string, std::set<reference_pair_t>>>& async_referenced_ins);
+    static void _populate_referenced_ins(const std::vector<std::string>& collection_meta_jsons,
+                                         std::map<std::string, std::map<std::string, reference_info_t>>& referenced_ins);
 
     std::unordered_set<std::string> get_collection_references(const std::string& coll_name);
 

--- a/include/field.h
+++ b/include/field.h
@@ -383,7 +383,8 @@ struct field {
     }
 
     static field field_from_json(const nlohmann::json& json) {
-        return field(json[fields::name].get<std::string>(), json[fields::type].get<std::string>(), json[fields::facet].get<bool>(),
+        return field(json[fields::name].get<std::string>(), json[fields::type].get<std::string>(),
+                     json.contains(fields::facet) ? json[fields::facet].get<bool>() : false,
                      json.contains(fields::optional) ? json[fields::optional].get<bool>() : false,
                      json.contains(fields::index) ? json[fields::index].get<bool>() : true,
                      json.contains(fields::locale) ? json[fields::locale].get<std::string>() : "",

--- a/include/field.h
+++ b/include/field.h
@@ -382,6 +382,29 @@ struct field {
         return false;
     }
 
+    static field field_from_json(const nlohmann::json& json) {
+        return field(json[fields::name].get<std::string>(), json[fields::type].get<std::string>(), json[fields::facet].get<bool>(),
+                     json.contains(fields::optional) ? json[fields::optional].get<bool>() : false,
+                     json.contains(fields::index) ? json[fields::index].get<bool>() : true,
+                     json.contains(fields::locale) ? json[fields::locale].get<std::string>() : "",
+                     json.contains(fields::sort) ? json[fields::sort].get<int>() : -1,
+                     json.contains(fields::infix) ? json[fields::infix].get<int>() : -1,
+                     json.contains(fields::nested) ? json[fields::nested].get<bool>() : false,
+                     json.contains(fields::nested_array) ? json[fields::nested_array].get<int>() : 0,
+                     json.contains(fields::num_dim) ? json[fields::num_dim].get<size_t>() : 0,
+                     json.contains(fields::vec_dist) ? (json[fields::vec_dist].get<std::string>() == "ip" ? ip : cosine) : cosine,
+                     json.contains(fields::reference) ? json[fields::reference].get<std::string>() : "",
+                     json.contains(fields::embed) ? json[fields::embed].get<nlohmann::json>() : nlohmann::json(),
+                     json.contains(fields::range_index) ? json[fields::range_index].get<bool>() : false,
+                     json.contains(fields::store) ? json[fields::store].get<bool>() : true,
+                     json.contains(fields::stem) ? json[fields::stem].get<bool>() : false,
+                     json.contains(fields::stem_dictionary) ? json[fields::stem_dictionary].get<std::string>() : "",
+                     json.contains(fields::hnsw_params) ? json[fields::hnsw_params].get<nlohmann::json>() : nlohmann::json(),
+                     json.contains(fields::async_reference) ? json[fields::async_reference].get<bool>() : false,
+                     json.contains(fields::token_separators) ? json[fields::token_separators].get<nlohmann::json>() : nlohmann::json(),
+                     json.contains(fields::symbols_to_index) ? json[fields::symbols_to_index].get<nlohmann::json>() : nlohmann::json());
+    }
+
     static Option<bool> fields_to_json_fields(const std::vector<field> & fields,
                                               const std::string & default_sorting_field,
                                               nlohmann::json& fields_json);
@@ -417,6 +440,8 @@ struct field {
                                     bool is_update, std::vector<field>& flattened_fields);
 
     static void compact_nested_fields(tsl::htrie_map<char, field>& nested_fields);
+
+    static nlohmann::json field_to_json_field(const struct field& field);
 };
 
 enum index_operation_t {

--- a/include/join.h
+++ b/include/join.h
@@ -7,24 +7,37 @@
 #include "tsl/htrie_set.h"
 #include "filter_result_iterator.h"
 
-struct reference_info_t {
+struct base_reference_info_t {
     std::string collection;
     std::string field;
-    bool is_async;
 
-    std::string referenced_field_name;
+    base_reference_info_t(std::string collection, std::string field) :
+    collection(std::move(collection)), field(std::move(field)) {}
 
-    reference_info_t(std::string collection, std::string field, bool is_async, std::string referenced_field_name = "") :
-            collection(std::move(collection)), field(std::move(field)), is_async(is_async),
-            referenced_field_name(std::move(referenced_field_name)) {}
-
-    bool operator < (const reference_info_t& other) const noexcept {
+    bool operator < (const base_reference_info_t& other) const noexcept {
         if (collection == other.collection) {
             return field < other.field;
         }
 
         return collection < other.collection;
     }
+};
+
+struct reference_info_t: base_reference_info_t {
+    bool is_async;
+    std::string referenced_field_name;
+    struct field referenced_field{};
+
+    reference_info_t(std::string collection, std::string field, bool is_async, std::string referenced_field_name = "") :
+            base_reference_info_t(std::move(collection), std::move(field)), is_async(is_async),
+            referenced_field_name(std::move(referenced_field_name)) {}
+};
+
+struct update_reference_info_t: base_reference_info_t {
+    struct field referenced_field;
+
+    update_reference_info_t(std::string collection, std::string field, struct field referenced_field) :
+            base_reference_info_t(std::move(collection), std::move(field)), referenced_field(std::move(referenced_field)) {}
 };
 
 struct ref_include_collection_names_t {

--- a/include/join.h
+++ b/include/join.h
@@ -31,6 +31,23 @@ struct reference_info_t: base_reference_info_t {
     reference_info_t(std::string collection, std::string field, bool is_async, std::string referenced_field_name = "") :
             base_reference_info_t(std::move(collection), std::move(field)), is_async(is_async),
             referenced_field_name(std::move(referenced_field_name)) {}
+
+    reference_info_t(const nlohmann::json& json): reference_info_t(json["collection"],
+                                                                   json["field"],
+                                                                   json["is_async"],
+                                                                   json["referenced_field_name"]) {
+        referenced_field = field::field_from_json(json["referenced_field"]);
+    }
+
+    static nlohmann::json to_json(const reference_info_t& ref_info) {
+        nlohmann::json json;
+        json["collection"] = ref_info.collection;
+        json["field"] = ref_info.field;
+        json["is_async"] = ref_info.is_async;
+        json["referenced_field_name"] = ref_info.referenced_field_name;
+        json["referenced_field"] = field::field_to_json_field(ref_info.referenced_field);
+        return json;
+    }
 };
 
 struct update_reference_info_t: base_reference_info_t {

--- a/src/batched_indexer.cpp
+++ b/src/batched_indexer.cpp
@@ -181,6 +181,12 @@ std::string BatchedIndexer::get_collection_name(const std::shared_ptr<http_req>&
                 coll_name = obj["history_collection"];
             }
         }
+    } else {
+        // Resolves alias if used in schema.
+        auto coll_op = CollectionManager::get_instance().resolve_symlink(coll_name);
+        if(coll_op.ok()) {
+            coll_name = coll_op.get();
+        }
     }
 
     return coll_name;
@@ -638,4 +644,8 @@ void BatchedIndexer::clear_skip_indices() {
     }
 
     meta_store->flush();
+}
+
+size_t BatchedIndexer::get_reference_q_size() {
+    return reference_q.size();
 }

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -6890,7 +6890,6 @@ Index* Collection::init_index() {
                                                                     ref_field_name);
             }
 
-            // todo: foo was not replaced with product_id
             collectionManager.add_referenced_ins(ref_coll_name, reference_info_t{name, field.name, field.is_async_reference,
                                                                          ref_field_name});
 

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -791,6 +791,8 @@ Option<nlohmann::json> CollectionManager::drop_collection(const std::string& col
         const auto& field_name = item.first;
         const auto& ref_coll_name = reference_info.collection;
 
+        remove_referenced_ins(ref_coll_name, actual_coll_name);
+
         auto& cm = CollectionManager::get_instance();
         auto ref_coll = cm.get_collection(ref_coll_name);
         if (ref_coll == nullptr) {
@@ -799,9 +801,7 @@ Option<nlohmann::json> CollectionManager::drop_collection(const std::string& col
         }
 
         ref_coll->remove_referenced_in(actual_coll_name, field_name, reference_info.is_async, reference_info.field);
-        remove_referenced_ins(ref_coll_name, actual_coll_name);
     }
-    remove_referenced_ins(actual_coll_name);
 
     std::unique_lock u_lock(mutex);
     collections.erase(actual_coll_name);
@@ -1965,6 +1965,10 @@ void CollectionManager::remove_referenced_ins(const std::string& referenced_coll
         return;
     }
     it->second.erase(referring_coll_name);
+
+    if (it->second.empty()) {
+        referenced_ins.erase(it);
+    }
 }
 
 std::map<std::string, std::map<std::string, reference_info_t>> CollectionManager::_get_referenced_ins() const {

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -901,9 +901,9 @@ nlohmann::json field::field_to_json_field(const struct field& field) {
         }
     }
 
-//    if (!field.hnsw_params.empty()) {
-//        field_val[fields::hnsw_params] = field.hnsw_params;
-//    }
+    if (field.num_dim > 0 && !field.hnsw_params.empty()) {
+        field_val[fields::hnsw_params] = field.hnsw_params;
+    }
     return field_val;
 }
 

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -901,9 +901,9 @@ nlohmann::json field::field_to_json_field(const struct field& field) {
         }
     }
 
-    if (!field.hnsw_params.empty()) {
-        field_val[fields::hnsw_params] = field.hnsw_params;
-    }
+//    if (!field.hnsw_params.empty()) {
+//        field_val[fields::hnsw_params] = field.hnsw_params;
+//    }
     return field_val;
 }
 

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -847,6 +847,66 @@ Option<bool> field::validate_and_init_embed_field(const tsl::htrie_map<char, fie
     return Option<bool>(true);
 }
 
+nlohmann::json field::field_to_json_field(const struct field& field) {
+    nlohmann::json field_val;
+    field_val[fields::name] = field.name;
+    field_val[fields::type] = field.type;
+    field_val[fields::facet] = field.facet;
+    field_val[fields::optional] = field.optional;
+    field_val[fields::index] = field.index;
+    field_val[fields::sort] = field.sort;
+    field_val[fields::infix] = field.infix;
+
+    field_val[fields::locale] = field.locale;
+
+    field_val[fields::store] = field.store;
+    field_val[fields::stem] = field.stem;
+    field_val[fields::range_index] = field.range_index;
+    field_val[fields::stem_dictionary] = field.stem_dictionary;
+
+    if(field.embed.count(fields::from) != 0) {
+        field_val[fields::embed] = field.embed;
+    }
+
+    field_val[fields::nested] = field.nested;
+    if(field.nested) {
+        field_val[fields::nested_array] = field.nested_array;
+    }
+
+    if(field.num_dim > 0) {
+        field_val[fields::num_dim] = field.num_dim;
+        field_val[fields::vec_dist] = field.vec_dist == ip ? "ip" : "cosine";
+    }
+
+    if (!field.reference.empty()) {
+        field_val[fields::reference] = field.reference;
+        field_val[fields::async_reference] = field.is_async_reference;
+    }
+
+    if(!field.token_separators.empty()) {
+        field_val[fields::token_separators] = nlohmann::json::array();
+
+        for(const auto& c : field.token_separators) {
+            std::string token{c};
+            field_val[fields::token_separators].push_back(token);
+        }
+    }
+
+    if(!field.symbols_to_index.empty()) {
+        field_val[fields::symbols_to_index] = nlohmann::json::array();
+
+        for(const auto& c : field.symbols_to_index) {
+            std::string symbol{c};
+            field_val[fields::symbols_to_index].push_back(symbol);
+        }
+    }
+
+    if (!field.hnsw_params.empty()) {
+        field_val[fields::hnsw_params] = field.hnsw_params;
+    }
+    return field_val;
+}
+
 Option<bool> field::fields_to_json_fields(const std::vector<field>& fields, const string& default_sorting_field,
                                           nlohmann::json& fields_json) {
     bool found_default_sorting_field = false;
@@ -861,60 +921,7 @@ Option<bool> field::fields_to_json_fields(const std::vector<field>& fields, cons
             continue;
         }
 
-        nlohmann::json field_val;
-        field_val[fields::name] = field.name;
-        field_val[fields::type] = field.type;
-        field_val[fields::facet] = field.facet;
-        field_val[fields::optional] = field.optional;
-        field_val[fields::index] = field.index;
-        field_val[fields::sort] = field.sort;
-        field_val[fields::infix] = field.infix;
-
-        field_val[fields::locale] = field.locale;
-
-        field_val[fields::store] = field.store;
-        field_val[fields::stem] = field.stem;
-        field_val[fields::range_index] = field.range_index;
-        field_val[fields::stem_dictionary] = field.stem_dictionary;
-
-        if(field.embed.count(fields::from) != 0) {
-            field_val[fields::embed] = field.embed;
-        }
-
-        field_val[fields::nested] = field.nested;
-        if(field.nested) {
-            field_val[fields::nested_array] = field.nested_array;
-        }
-
-        if(field.num_dim > 0) {
-            field_val[fields::num_dim] = field.num_dim;
-            field_val[fields::vec_dist] = field.vec_dist == ip ? "ip" : "cosine";
-        }
-
-        if (!field.reference.empty()) {
-            field_val[fields::reference] = field.reference;
-            field_val[fields::async_reference] = field.is_async_reference;
-        }
-
-        if(!field.token_separators.empty()) {
-            field_val[fields::token_separators] = nlohmann::json::array();
-
-            for(const auto& c : field.token_separators) {
-                std::string token{c};
-                field_val[fields::token_separators].push_back(token);
-            }
-        }
-
-        if(!field.symbols_to_index.empty()) {
-            field_val[fields::symbols_to_index] = nlohmann::json::array();
-
-            for(const auto& c : field.symbols_to_index) {
-                std::string symbol{c};
-                field_val[fields::symbols_to_index].push_back(symbol);
-            }
-        }
-
-        fields_json.push_back(field_val);
+        fields_json.push_back(field_to_json_field(field));
 
         if(!field.has_valid_type()) {
             return Option<bool>(400, "Field `" + field.name +

--- a/src/join.cpp
+++ b/src/join.cpp
@@ -95,9 +95,9 @@ Option<bool> Join::add_reference_helper_fields(nlohmann::json& document,
             continue;
         }
 
-        auto reference_pair = pair.second;
-        auto reference_collection_name = reference_pair.collection;
-        auto reference_field_name = reference_pair.field;
+        const auto& ref_info = pair.second;
+        const auto& reference_collection_name = ref_info.collection;
+        const auto& reference_field_name = ref_info.field;
         auto& cm = CollectionManager::get_instance();
         auto ref_collection = cm.get_collection(reference_collection_name);
 
@@ -231,12 +231,12 @@ Option<bool> Join::add_reference_helper_fields(nlohmann::json& document,
             continue;
         }
 
-        if (ref_collection->get_schema().count(reference_field_name) == 0) {
+        if (ref_info.referenced_field.name.empty()) {
             return Option<bool>(400, "Referenced field `" + reference_field_name +
                                      "` not found in the collection `" += reference_collection_name + "`.");
         }
 
-        auto const ref_field = ref_collection->get_schema().at(reference_field_name);
+        const auto& ref_field = ref_info.referenced_field;
         if (!ref_field.index) {
             return Option<bool>(400, "Referenced field `" + reference_field_name +
                                      "` in the collection `" += reference_collection_name + "` must be indexed.");
@@ -612,7 +612,8 @@ Option<bool> Join::include_references(nlohmann::json& doc, const uint32_t& seq_i
             }
             auto const& field_name = get_reference_field_op.get();
             auto const& reference_helper_field_name = field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX;
-            if (collection->get_schema().count(reference_helper_field_name) == 0) {
+            const auto& schema = collection->get_schema();
+            if (schema.count(reference_helper_field_name) == 0) {
                 continue;
             }
 
@@ -623,7 +624,6 @@ Option<bool> Join::include_references(nlohmann::json& doc, const uint32_t& seq_i
 
                 if (!doc.contains(key)) {
                     if (!original_doc.contains(key)) {
-                        auto const& schema = collection->get_schema();
                         auto it = schema.find(field_name);
                         if (it == schema.end() || it->optional) {
                             continue;
@@ -671,7 +671,7 @@ Option<bool> Join::include_references(nlohmann::json& doc, const uint32_t& seq_i
                     }
                     reference_filter_result_t result(ids.size(), &ids[0]);
                     prune_doc_op = prune_ref_doc(doc[key], result, ref_include_fields_full, ref_exclude_fields_full,
-                                                 collection->get_schema().at(field_name).is_array(), ref_include_exclude);
+                                                 schema.at(field_name).is_array(), ref_include_exclude);
                     result.docs = nullptr;
                 }
             } else {
@@ -683,7 +683,7 @@ Option<bool> Join::include_references(nlohmann::json& doc, const uint32_t& seq_i
                 }
                 reference_filter_result_t result(ids.size(), &ids[0]);
                 prune_doc_op = prune_ref_doc(doc, result, ref_include_fields_full, ref_exclude_fields_full,
-                                             collection->get_schema().at(field_name).is_array(), ref_include_exclude);
+                                             schema.at(field_name).is_array(), ref_include_exclude);
                 result.docs = nullptr;
             }
         } else if (joined_coll_has_reference) {
@@ -693,7 +693,8 @@ Option<bool> Join::include_references(nlohmann::json& doc, const uint32_t& seq_i
             }
 
             auto reference_field_name_op = ref_collection->get_referenced_in_field_with_lock(joined_coll_having_reference);
-            if (!reference_field_name_op.ok() || joined_collection->get_schema().count(reference_field_name_op.get()) == 0) {
+            const auto& joined_coll_schema = joined_collection->get_schema();
+            if (!reference_field_name_op.ok() || joined_coll_schema.count(reference_field_name_op.get()) == 0) {
                 continue;
             }
 
@@ -716,7 +717,7 @@ Option<bool> Join::include_references(nlohmann::json& doc, const uint32_t& seq_i
             result.count = ids.size();
             result.docs = &ids[0];
             prune_doc_op = prune_ref_doc(doc, result, ref_include_fields_full, ref_exclude_fields_full,
-                                         joined_collection->get_schema().at(reference_field_name).is_array(),
+                                         joined_coll_schema.at(reference_field_name).is_array(),
                                          ref_include_exclude);
             result.docs = nullptr;
         }

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -5358,6 +5358,7 @@ TEST_F(CollectionJoinTest, FilterByObjectReferenceField) {
 
     auto add_op = collectionManager.get_collection_unsafe("Foods")->add(doc.dump(), index_operation_t::UPDATE, "1",
                                                                         DIRTY_VALUES::REJECT);
+    LOG(INFO) << add_op.error();
     ASSERT_TRUE(add_op.ok());
 
     req_params = {

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -5358,7 +5358,6 @@ TEST_F(CollectionJoinTest, FilterByObjectReferenceField) {
 
     auto add_op = collectionManager.get_collection_unsafe("Foods")->add(doc.dump(), index_operation_t::UPDATE, "1",
                                                                         DIRTY_VALUES::REJECT);
-    LOG(INFO) << add_op.error();
     ASSERT_TRUE(add_op.ok());
 
     req_params = {

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -247,6 +247,7 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
             },
             {
               "facet":false,
+              "hnsw_params": {"M": 16, "ef_construction": 200},
               "index":true,
               "infix":false,
               "locale":"",

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -1766,49 +1766,53 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
 }
 
 TEST_F(CollectionManagerTest, PopulateReferencedIns) {
-//    std::vector<std::string> collection_meta_jsons = {
-//            R"({
-//                "name": "A",
-//                "fields": [
-//                  {"name": "a_id", "type": "string"}
-//                ]
-//            })"_json.dump(),
-//            R"({
-//                "name": "B",
-//                "fields": [
-//                  {"name": "b_id", "type": "string"},
-//                  {"name": "a_ref", "type": "string", "reference": "A.a_id"},
-//                  {"name": "c_ref", "type": "string", "reference": "C.c_id", "async_reference": true}
-//                ]
-//            })"_json.dump(),
-//            R"({
-//                "name": "C",
-//                "fields": [
-//                  {"name": "c_id", "type": "string"}
-//                ]
-//            })"_json.dump(),
-//    };
-//    std::map<std::string, std::map<std::string, reference_info_t>> referenced_ins;
-//
-//    CollectionManager::_populate_referenced_ins(collection_meta_jsons, referenced_ins);
-//
-//    ASSERT_EQ(2, referenced_ins.size());
-//    ASSERT_EQ(1, referenced_ins.count("A"));
-//    ASSERT_EQ(1, referenced_ins["A"].size());
-//    ASSERT_EQ(1, referenced_ins["A"].count("B"));
-//    ASSERT_EQ("a_ref", referenced_ins["A"]["B"]);
-//
-//    ASSERT_EQ(1, referenced_ins.count("C"));
-//    ASSERT_EQ(1, referenced_ins["C"].size());
-//    ASSERT_EQ(1, referenced_ins["C"].count("B"));
-//    ASSERT_EQ("c_ref", referenced_ins["C"]["B"]);
-//
-//    ASSERT_EQ(1, async_referenced_ins.count("C"));
-//    ASSERT_EQ(1, async_referenced_ins["C"].size());
-//    ASSERT_EQ(1, async_referenced_ins["C"].count("c_id"));
-//    ASSERT_EQ(1, async_referenced_ins["C"]["c_id"].size());
-//    ASSERT_EQ("B", async_referenced_ins["C"]["c_id"].begin()->collection);
-//    ASSERT_EQ("c_ref", async_referenced_ins["C"]["c_id"].begin()->field);
+    std::vector<std::string> collection_meta_jsons = {
+            R"({
+                "name": "A",
+                "fields": [
+                  {"name": "a_id", "type": "string", "index": false}
+                ]
+            })"_json.dump(),
+            R"({
+                "name": "B",
+                "fields": [
+                  {"name": "b_id", "type": "string"},
+                  {"name": "a_ref", "type": "string", "reference": "A.a_id"},
+                  {"name": "c_ref", "type": "string", "reference": "C.c_id", "async_reference": true}
+                ]
+            })"_json.dump(),
+            R"({
+                "name": "C",
+                "fields": [
+                  {"name": "c_id", "type": "int32", "optional": true}
+                ]
+            })"_json.dump(),
+    };
+
+    std::map<std::string, std::map<std::string, reference_info_t>> referenced_ins;
+    CollectionManager::_populate_referenced_ins(collection_meta_jsons, referenced_ins);
+
+    ASSERT_EQ(2, referenced_ins.size());
+    ASSERT_EQ(1, referenced_ins.count("A"));
+    ASSERT_EQ(1, referenced_ins["A"].size());
+    ASSERT_EQ(1, referenced_ins["A"].count("B"));
+    ASSERT_EQ("B", referenced_ins["A"].at("B").collection);
+    ASSERT_EQ("a_ref", referenced_ins["A"].at("B").field);
+    ASSERT_FALSE(referenced_ins["A"].at("B").is_async);
+    ASSERT_EQ("a_id", referenced_ins["A"].at("B").referenced_field.name);
+    ASSERT_EQ("string", referenced_ins["A"].at("B").referenced_field.type);
+    ASSERT_FALSE(referenced_ins["A"].at("B").referenced_field.index);
+
+    ASSERT_EQ(1, referenced_ins.count("C"));
+    ASSERT_EQ(1, referenced_ins["C"].size());
+    ASSERT_EQ(1, referenced_ins["C"].count("B"));
+    ASSERT_EQ("B", referenced_ins["C"].at("B").collection);
+    ASSERT_EQ("c_ref", referenced_ins["C"].at("B").field);
+    ASSERT_TRUE(referenced_ins["C"].at("B").is_async);
+    ASSERT_EQ("c_id", referenced_ins["C"].at("B").referenced_field.name);
+    ASSERT_EQ("int32", referenced_ins["C"].at("B").referenced_field.type);
+    ASSERT_TRUE(referenced_ins["C"].at("B").referenced_field.index);
+    ASSERT_TRUE(referenced_ins["C"].at("B").referenced_field.optional);
 }
 
 TEST_F(CollectionManagerTest, CollectionPagination) {

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -1551,13 +1551,14 @@ TEST_F(CollectionManagerTest, CloneCollection) {
 }
 
 TEST_F(CollectionManagerTest, ReferencedInBacklog) {
-    auto referenced_ins_backlog = collectionManager._get_referenced_in_backlog();
-    ASSERT_EQ(1, referenced_ins_backlog.count("Products"));
+    auto referenced_ins = collectionManager._get_referenced_ins();
+    ASSERT_EQ(1, referenced_ins.count("Products"));
 
-    auto const& references = referenced_ins_backlog.at("Products");
-    ASSERT_EQ(1, references.size());
-    ASSERT_EQ("collection1", references.cbegin()->collection);
-    ASSERT_EQ("product_id", references.cbegin()->field);
+    auto const& map = referenced_ins.at("Products");
+    ASSERT_EQ(1, map.size());
+    auto const& references = map.at("collection1");
+    ASSERT_EQ("collection1", references.collection);
+    ASSERT_EQ("product_id", references.field);
 
     auto schema_json =
             R"({
@@ -1571,8 +1572,9 @@ TEST_F(CollectionManagerTest, ReferencedInBacklog) {
     auto create_op = collectionManager.create_collection(schema_json);
     ASSERT_TRUE(create_op.ok());
 
-    referenced_ins_backlog = collectionManager._get_referenced_in_backlog();
-    ASSERT_EQ(0, referenced_ins_backlog.count("Products"));
+    referenced_ins = collectionManager._get_referenced_ins();
+    // Not deleting ref_info even after creation of Products collection.
+    ASSERT_EQ(1, referenced_ins.count("Products"));
 
     auto get_reference_field_op = create_op.get()->get_referenced_in_field_with_lock("collection1");
     ASSERT_TRUE(get_reference_field_op.ok());

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -350,11 +350,8 @@ TEST_F(CollectionManagerTest, ShouldInitCollection) {
             nlohmann::json::parse("{\"name\": \"foobar\", \"id\": 100, \"fields\": [{\"name\": \"org\", \"type\": "
                                   "\"string\", \"facet\": false}, {\"name\": \"vector_field\", \"type\": \"float[]\", \"num_dim\": 128, \"facet\": false}], \"default_sorting_field\": \"foo\"}");
 
-    spp::sparse_hash_map<std::string, std::string> referenced_in;
-    spp::sparse_hash_map<std::string, std::set<reference_pair_t>> async_referenced_ins;
-
-    Collection *collection = collectionManager.init_collection(collection_meta1, 100, store, 1.0f, referenced_in,
-                                                               async_referenced_ins);
+    std::map<std::string, std::map<std::string, reference_info_t>> referenced_ins;
+    Collection *collection = collectionManager.init_collection(collection_meta1, 100, store, 1.0f, referenced_ins);
     ASSERT_EQ("foobar", collection->get_name());
     ASSERT_EQ(100, collection->get_collection_id());
     ASSERT_EQ(2, collection->get_fields().size());
@@ -377,9 +374,7 @@ TEST_F(CollectionManagerTest, ShouldInitCollection) {
                                   "\"default_sorting_field\": \"foo\","
                                   "\"symbols_to_index\": [\"+\"], \"token_separators\": [\"-\"]}");
 
-
-    collection = collectionManager.init_collection(collection_meta2, 100, store, 1.0f, referenced_in,
-                                                   async_referenced_ins);
+    collection = collectionManager.init_collection(collection_meta2, 100, store, 1.0f, referenced_ins);
     ASSERT_EQ(12345, collection->get_created_at());
 
     std::vector<char> expected_symbols = {'+'};
@@ -1771,52 +1766,49 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
 }
 
 TEST_F(CollectionManagerTest, PopulateReferencedIns) {
-    std::vector<std::string> collection_meta_jsons = {
-            R"({
-                "name": "A",
-                "fields": [
-                  {"name": "a_id", "type": "string"}
-                ]
-            })"_json.dump(),
-            R"({
-                "name": "B",
-                "fields": [
-                  {"name": "b_id", "type": "string"},
-                  {"name": "a_ref", "type": "string", "reference": "A.a_id"},
-                  {"name": "c_ref", "type": "string", "reference": "C.c_id", "async_reference": true}
-                ]
-            })"_json.dump(),
-            R"({
-                "name": "C",
-                "fields": [
-                  {"name": "c_id", "type": "string"}
-                ]
-            })"_json.dump(),
-    };
-    std::map<std::string, spp::sparse_hash_map<std::string, std::string>> referenced_ins;
-    std::map<std::string, spp::sparse_hash_map<std::string, std::set<reference_pair_t>>> async_referenced_ins;
-
-    for (const auto &collection_meta_json: collection_meta_jsons) {
-        CollectionManager::_populate_referenced_ins(collection_meta_json, referenced_ins, async_referenced_ins);
-    }
-
-    ASSERT_EQ(2, referenced_ins.size());
-    ASSERT_EQ(1, referenced_ins.count("A"));
-    ASSERT_EQ(1, referenced_ins["A"].size());
-    ASSERT_EQ(1, referenced_ins["A"].count("B"));
-    ASSERT_EQ("a_ref", referenced_ins["A"]["B"]);
-
-    ASSERT_EQ(1, referenced_ins.count("C"));
-    ASSERT_EQ(1, referenced_ins["C"].size());
-    ASSERT_EQ(1, referenced_ins["C"].count("B"));
-    ASSERT_EQ("c_ref", referenced_ins["C"]["B"]);
-
-    ASSERT_EQ(1, async_referenced_ins.count("C"));
-    ASSERT_EQ(1, async_referenced_ins["C"].size());
-    ASSERT_EQ(1, async_referenced_ins["C"].count("c_id"));
-    ASSERT_EQ(1, async_referenced_ins["C"]["c_id"].size());
-    ASSERT_EQ("B", async_referenced_ins["C"]["c_id"].begin()->collection);
-    ASSERT_EQ("c_ref", async_referenced_ins["C"]["c_id"].begin()->field);
+//    std::vector<std::string> collection_meta_jsons = {
+//            R"({
+//                "name": "A",
+//                "fields": [
+//                  {"name": "a_id", "type": "string"}
+//                ]
+//            })"_json.dump(),
+//            R"({
+//                "name": "B",
+//                "fields": [
+//                  {"name": "b_id", "type": "string"},
+//                  {"name": "a_ref", "type": "string", "reference": "A.a_id"},
+//                  {"name": "c_ref", "type": "string", "reference": "C.c_id", "async_reference": true}
+//                ]
+//            })"_json.dump(),
+//            R"({
+//                "name": "C",
+//                "fields": [
+//                  {"name": "c_id", "type": "string"}
+//                ]
+//            })"_json.dump(),
+//    };
+//    std::map<std::string, std::map<std::string, reference_info_t>> referenced_ins;
+//
+//    CollectionManager::_populate_referenced_ins(collection_meta_jsons, referenced_ins);
+//
+//    ASSERT_EQ(2, referenced_ins.size());
+//    ASSERT_EQ(1, referenced_ins.count("A"));
+//    ASSERT_EQ(1, referenced_ins["A"].size());
+//    ASSERT_EQ(1, referenced_ins["A"].count("B"));
+//    ASSERT_EQ("a_ref", referenced_ins["A"]["B"]);
+//
+//    ASSERT_EQ(1, referenced_ins.count("C"));
+//    ASSERT_EQ(1, referenced_ins["C"].size());
+//    ASSERT_EQ(1, referenced_ins["C"].count("B"));
+//    ASSERT_EQ("c_ref", referenced_ins["C"]["B"]);
+//
+//    ASSERT_EQ(1, async_referenced_ins.count("C"));
+//    ASSERT_EQ(1, async_referenced_ins["C"].size());
+//    ASSERT_EQ(1, async_referenced_ins["C"].count("c_id"));
+//    ASSERT_EQ(1, async_referenced_ins["C"]["c_id"].size());
+//    ASSERT_EQ("B", async_referenced_ins["C"]["c_id"].begin()->collection);
+//    ASSERT_EQ("c_ref", async_referenced_ins["C"]["c_id"].begin()->field);
 }
 
 TEST_F(CollectionManagerTest, CollectionPagination) {

--- a/test/collection_vector_search_test.cpp
+++ b/test/collection_vector_search_test.cpp
@@ -4990,6 +4990,7 @@ TEST_F(CollectionVectorTest, TestRestoringImages) {
 
     auto collection_create_op = collectionManager.create_collection(schema_json);
     auto coll = collection_create_op.get();
+    ASSERT_TRUE(collection_create_op.ok());
 
     auto add_op = coll->add(R"({
         "name": "dog",


### PR DESCRIPTION
## Change Summary
In  `Join::add_reference_helper_fields`, instead of looking up the referenced field in referenced collection schema, we now save a copy of `field` in the schema of the referencing collection. This avoids a deadlock situation involving async reference where both collections import documents concurrently.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
