### PR TITLE
filtering on fields inside nested object/field

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -255,8 +255,8 @@ new_git_repository(
     name = "icu",
     build_file = "//bazel/icu:BUILD",
     patches = ["//bazel/icu:icu.patch"],
-    remote = "https://github.com/unicode-org/icu.git",
-    tag = "release-71-1",
+    remote = "https://github.com/typesense/icu.git",
+    tag = "release-71-1-patch",
 )
 
 git_repository(

--- a/include/filter.h
+++ b/include/filter.h
@@ -6,7 +6,12 @@
 #include "json.hpp"
 #include "store.h"
 
-constexpr uint32_t COMPUTE_FILTER_ITERATOR_THRESHOLD = 25'000;
+#ifdef TEST_BUILD
+    constexpr uint32_t COMPUTE_FILTER_ITERATOR_THRESHOLD = 3;
+#else
+    constexpr uint32_t COMPUTE_FILTER_ITERATOR_THRESHOLD = 25'000;
+#endif
+
 constexpr size_t DEFAULT_FILTER_BY_CANDIDATES = 4;
 
 enum NUM_COMPARATOR {

--- a/include/filter.h
+++ b/include/filter.h
@@ -79,7 +79,8 @@ struct filter {
                                            const Store* store,
                                            const std::string& doc_id_prefix,
                                            filter_node_t*& root,
-                                           const bool& validate_field_names = true);
+                                           const bool& validate_field_names = true,
+                                           const std::string& object_field_prefix = "");
 };
 
 struct filter_node_t {
@@ -89,8 +90,8 @@ struct filter_node_t {
     filter_node_t* left = nullptr;
     filter_node_t* right = nullptr;
     std::string filter_query;
-    bool is_nested_object_filter = false;
-    std::string nested_object_parent;
+    bool is_object_filter_root = false;
+    std::string object_field_name;
 
     filter_node_t() = default;
 

--- a/include/filter.h
+++ b/include/filter.h
@@ -84,6 +84,8 @@ struct filter_node_t {
     filter_node_t* left = nullptr;
     filter_node_t* right = nullptr;
     std::string filter_query;
+    bool is_nested_object_filter = false;
+    std::string nested_object_parent;
 
     filter_node_t() = default;
 

--- a/include/filter_result_iterator.h
+++ b/include/filter_result_iterator.h
@@ -341,6 +341,10 @@ private:
 
     bool validate_filter_nested_object(nlohmann::json doc, const filter_node_t* filter_node);
 
+    bool validate_document_with_filters(uint32_t seqid);
+
+    void init_nested_object_filter();
+
 public:
     uint32_t seq_id = 0;
     /// Collection name -> references
@@ -422,8 +426,6 @@ public:
 
     static void add_phrase_ids(filter_result_iterator_t*& filter_result_iterator,
                                uint32_t* phrase_result_ids, const uint32_t& phrase_result_count);
-
-    void post_filtering_validate_docs();
 
     [[nodiscard]] bool _get_is_filter_result_initialized() const {
         return is_filter_result_initialized;

--- a/include/filter_result_iterator.h
+++ b/include/filter_result_iterator.h
@@ -421,6 +421,8 @@ public:
     static void add_phrase_ids(filter_result_iterator_t*& filter_result_iterator,
                                uint32_t* phrase_result_ids, const uint32_t& phrase_result_count);
 
+    void post_filtering_validate_docs();
+
     [[nodiscard]] bool _get_is_filter_result_initialized() const {
         return is_filter_result_initialized;
     }

--- a/include/filter_result_iterator.h
+++ b/include/filter_result_iterator.h
@@ -339,11 +339,10 @@ private:
     /// this operation.
     void skip_to(uint32_t id);
 
-    bool validate_object_filter_helper(nlohmann::json doc, const filter_node_t* filter_node);
+    static bool validate_object_filter_helper(Index const* const index, const nlohmann::json& doc,
+                                              const filter_node_t* filter_node);
 
-    bool validate_object_filter(uint32_t seqid, filter_node_t* filter_node = nullptr);
-
-    void init_nested_object_filter();
+    bool validate_object_filter();
 
 public:
     uint32_t seq_id = 0;

--- a/include/filter_result_iterator.h
+++ b/include/filter_result_iterator.h
@@ -421,7 +421,7 @@ public:
     static void add_phrase_ids(filter_result_iterator_t*& filter_result_iterator,
                                uint32_t* phrase_result_ids, const uint32_t& phrase_result_count);
 
-    void post_filtering_validate_docs();
+    void post_filtering_validate_docs(bool enable_lazy_filter);
 
     [[nodiscard]] bool _get_is_filter_result_initialized() const {
         return is_filter_result_initialized;

--- a/include/filter_result_iterator.h
+++ b/include/filter_result_iterator.h
@@ -339,6 +339,8 @@ private:
     /// this operation.
     void skip_to(uint32_t id);
 
+    bool validate_filter_nested_object(nlohmann::json doc, const filter_node_t* filter_node);
+
 public:
     uint32_t seq_id = 0;
     /// Collection name -> references
@@ -421,7 +423,7 @@ public:
     static void add_phrase_ids(filter_result_iterator_t*& filter_result_iterator,
                                uint32_t* phrase_result_ids, const uint32_t& phrase_result_count);
 
-    void post_filtering_validate_docs(bool enable_lazy_filter);
+    void post_filtering_validate_docs();
 
     [[nodiscard]] bool _get_is_filter_result_initialized() const {
         return is_filter_result_initialized;

--- a/include/filter_result_iterator.h
+++ b/include/filter_result_iterator.h
@@ -339,9 +339,9 @@ private:
     /// this operation.
     void skip_to(uint32_t id);
 
-    bool validate_filter_nested_object(nlohmann::json doc, const filter_node_t* filter_node);
+    bool validate_object_filter_helper(nlohmann::json doc, const filter_node_t* filter_node);
 
-    bool validate_document_with_filters(uint32_t seqid);
+    bool validate_object_filter(uint32_t seqid, filter_node_t* filter_node = nullptr);
 
     void init_nested_object_filter();
 

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -331,7 +331,7 @@ struct StringUtils {
 
     static size_t get_num_chars(const std::string& text);
 
-    static Option<bool> tokenize_filter_query(const std::string& filter_query, std::queue<std::string>& tokens);
+    static Option<bool> tokenize_filter_query(const std::string& filter_query, std::queue<std::string>& tokens, bool is_nested_object_field=false);
 
     static Option<bool> split_include_exclude_fields(const std::string& include_exclude_fields,
                                                      std::vector<std::string>& tokens);

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -331,8 +331,7 @@ struct StringUtils {
 
     static size_t get_num_chars(const std::string& text);
 
-    static Option<bool> tokenize_filter_query(const std::string& filter_query, std::queue<std::string>& tokens,
-                                              std::set<std::string>& nested_object_fields);
+    static Option<bool> tokenize_filter_query(const std::string& filter_query, std::queue<std::string>& tokens);
 
     static Option<bool> split_include_exclude_fields(const std::string& include_exclude_fields,
                                                      std::vector<std::string>& tokens);

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -331,7 +331,8 @@ struct StringUtils {
 
     static size_t get_num_chars(const std::string& text);
 
-    static Option<bool> tokenize_filter_query(const std::string& filter_query, std::queue<std::string>& tokens, bool is_nested_object_field=false);
+    static Option<bool> tokenize_filter_query(const std::string& filter_query, std::queue<std::string>& tokens,
+                                              std::set<std::string>& nested_object_fields);
 
     static Option<bool> split_include_exclude_fields(const std::string& include_exclude_fields,
                                                      std::vector<std::string>& tokens);

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -714,7 +714,7 @@ Option<bool> toParseTree(std::queue<std::string>& postfix, filter_node_t*& root,
 
             filter_node = new filter_node_t(expression == "&&" ? AND : OR, operandA, operandB);
             filter_node->filter_query = operandA->filter_query + " " + expression + " " + operandB->filter_query;
-            if(operandA->is_nested_object_filter || operandB->is_nested_object_filter) {
+            if(operandA->is_nested_object_filter && operandB->is_nested_object_filter) {
                 filter_node->is_nested_object_filter = true;
                 filter_node->nested_object_parent = !operandA->nested_object_parent.empty() ?
                         operandA->nested_object_parent : operandB->nested_object_parent;

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -665,6 +665,8 @@ void filter_result_iterator_t::next() {
     }
 
     if (filter_node->isOperator) {
+        auto last_seq_id = seq_id;
+
         // Advance the subtrees and then apply operators to arrive at the next valid doc.
         if (filter_node->filter_operator == AND) {
             left_it->next();
@@ -686,6 +688,11 @@ void filter_result_iterator_t::next() {
         if(filter_node->is_nested_object_filter) {
             if(!validate_object_filter(seq_id)) {
                 next();
+                if(validity == invalid) {
+                    //case to handle if ids are valid in sub tree independently but not as whole expression
+                    //and there is no valid ids left
+                    seq_id = last_seq_id;
+                }
             }
         }
 

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -1738,8 +1738,17 @@ void filter_result_iterator_t::skip_to(uint32_t id) {
             seq_id = id;
             return;
         }
-        //advance iterators in case didnt match
-        next();
+
+        if(id > seq_id) {
+            while(validity == valid) {
+                next();
+                if(id == seq_id) {
+                    seq_id = id;
+                    return;
+                }
+            }
+        }
+
         return;
     }
 
@@ -2181,6 +2190,10 @@ void filter_result_iterator_t::reset(const bool& override_timeout) {
             and_filter_iterators();
         } else {
             or_filter_iterators();
+        }
+
+        if(filter_node->is_nested_object_filter) {
+            init_nested_object_filter();
         }
 
         return;

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -2976,16 +2976,12 @@ bool filter_result_iterator_t::validate_object_filter_helper(nlohmann::json doc,
             }
 
             auto val = filter_exp.values[i];
-            auto comparator = filter_exp.comparators[i];
+            auto comparator = filter_exp.comparators.size() < filter_exp.values.size() && f.is_string() ?
+                                filter_exp.comparators[0] : filter_exp.comparators[i];
 
             if (f.is_string()) {
                 if(val.at(val.size() - 1) == '*' && comparator == CONTAINS) {//prefix match
                     val.pop_back();
-                }
-
-                //apply string values filter to all values
-                if(filter_exp.values.size() > filter_exp.comparators.size()) {
-                    comparator = filter_exp.comparators[0];
                 }
 
                 filter_val = val;

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -2887,7 +2887,7 @@ filter_result_iterator_timeout_info::filter_result_iterator_timeout_info(uint64_
                                                                          search_stop_us(search_stop) {}
 
 
-void filter_result_iterator_t::post_filtering_validate_docs() {
+void filter_result_iterator_t::post_filtering_validate_docs(bool enable_lazy_filter) {
     std::function<bool(nlohmann::json, const filter_node_t*)> validate_filter_condition;
     validate_filter_condition = [&](nlohmann::json doc, const filter_node_t* filter_node) -> bool {
         if(filter_node->isOperator) {
@@ -2993,6 +2993,12 @@ void filter_result_iterator_t::post_filtering_validate_docs() {
     std::vector<uint32_t> results;
 
     if (collection.get() != nullptr) {
+
+        if(enable_lazy_filter) {
+            //in case of lazy evalution, filter_result won't be ready hence need to enforce it
+            compute_iterators();
+        }
+
         for (auto j = 0; j < filter_result.count; ++j) {
             const std::string& seq_id_key = collection->get_seq_id_key(filter_result.docs[j]);
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3340,7 +3340,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
     }
 
     if(filter_tree_root && filter_tree_root->is_nested_object_filter) {
-        filter_result_iterator->post_filtering_validate_docs();
+        filter_result_iterator->post_filtering_validate_docs(enable_lazy_filter);
     }
 
 #ifdef TEST_BUILD

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -6246,11 +6246,6 @@ Option<bool> Index::search_wildcard(filter_node_t const* const& filter_tree_root
 
     filter_result_iterator->compute_iterators();
 
-    //validate filter if any nested object fields are there
-    if(filter_tree_root && filter_tree_root->is_nested_object_filter) {
-        filter_result_iterator->post_filtering_validate_docs();
-    }
-
     auto const& approx_filter_ids_length = filter_result_iterator->approx_filter_ids_length;
 
     // Timed out during computation of filter_result_iterator. We should still process the partial ids.

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3339,10 +3339,6 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
         return filter_init_op;
     }
 
-    if(filter_tree_root && filter_tree_root->is_nested_object_filter) {
-        filter_result_iterator->post_filtering_validate_docs(enable_lazy_filter);
-    }
-
 #ifdef TEST_BUILD
 
     if (filter_result_iterator->approx_filter_ids_length > 20) {
@@ -6249,6 +6245,12 @@ Option<bool> Index::search_wildcard(filter_node_t const* const& filter_tree_root
     }
 
     filter_result_iterator->compute_iterators();
+
+    //validate filter if any nested object fields are there
+    if(filter_tree_root && filter_tree_root->is_nested_object_filter) {
+        filter_result_iterator->post_filtering_validate_docs();
+    }
+
     auto const& approx_filter_ids_length = filter_result_iterator->approx_filter_ids_length;
 
     // Timed out during computation of filter_result_iterator. We should still process the partial ids.

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3339,6 +3339,10 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
         return filter_init_op;
     }
 
+    if(filter_tree_root && filter_tree_root->is_nested_object_filter) {
+        filter_result_iterator->post_filtering_validate_docs();
+    }
+
 #ifdef TEST_BUILD
 
     if (filter_result_iterator->approx_filter_ids_length > 20) {

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -443,13 +443,25 @@ Option<bool> StringUtils::tokenize_filter_query(const std::string& filter_query,
                     is_geo_value = false;
                 }
 
-                if(c == '{' && is_nested_object_field) {
+                if(c == '{') {
+                    if(filter_query[i-1] != '.') {
+                        return Option<bool>(400, "Bad nested filter query syntax.");
+                    }
+
                     c = filter_query[++i];
                 }
 
-                if( c == '}' && is_nested_object_field) {
+                if(c == '}') {
+                    if(!is_nested_object_field) {
+                        return Option<bool>(400, "Bad nested filter query syntax.");
+                    }
                     ++i;
                     break;
+                }
+
+                if((c == '(' || c == ')') && is_nested_object_field) {
+                    tokens.push(std::string(1, c));
+                    c = filter_query[++i];
                 }
 
                 ss << c;

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -388,7 +388,16 @@ Option<bool> StringUtils::tokenize_filter_query(const std::string& filter_query,
 
     for (size_t i = 0; i < size;) {
         auto c = filter_query[i];
-        if (c == ' ' || c == '}') {
+        if (c == ' ') {
+            i++;
+            continue;
+        }
+
+        if(c == '}') {
+            if (is_nested_object_field) {
+                is_nested_object_field = false;
+                tokens.push(")");
+            }
             i++;
             continue;
         }
@@ -469,6 +478,7 @@ Option<bool> StringUtils::tokenize_filter_query(const std::string& filter_query,
                     is_nested_object_field = true;
                     //clear buffer
                     ss.str("");
+                    tokens.push("(");
                     c = filter_query[++i];
                 }
             } while (i < size && (inBacktick || is_geo_value ||
@@ -483,6 +493,7 @@ Option<bool> StringUtils::tokenize_filter_query(const std::string& filter_query,
 
                 if(c == '}') {
                     is_nested_object_field = false;
+                    tokens.push(")");
                 }
             }
         }

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -3514,4 +3514,23 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
     ASSERT_EQ(2, result["hits"].size());
     ASSERT_EQ("Pizza", result["hits"][0]["document"]["name"]);
     ASSERT_EQ("Pasta", result["hits"][1]["document"]["name"]);
+
+    req_params = {
+            {"collection",     "menu"},
+            {"q",              "*"},
+            {"filter_by",      "ingredients.{name : olives && concentration :<50} || ingredients.{name : cheese && concentration :>50}"},
+            {"include_fields", "name, ingredients"}
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    json_res.clear();
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(3, result["found"].get<size_t>());
+    ASSERT_EQ(3, result["hits"].size());
+    ASSERT_EQ("Pizza Rolls", result["hits"][0]["document"]["name"]);
+    ASSERT_EQ("Lasagna", result["hits"][1]["document"]["name"]);
+    ASSERT_EQ("Pizza", result["hits"][2]["document"]["name"]);
 }

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -3375,6 +3375,7 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
             {"collection",     "menu"},
             {"q",              "*"},
             {"filter_by",      "ingredients.{name : cheese && concentration :<50}"},
+            {"enable_lazy_filter", "true"},
             {"include_fields", "name, ingredients"}
     };
     nlohmann::json embedded_params;
@@ -3394,6 +3395,7 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
             {"collection",     "menu"},
             {"q",              "*"},
             {"filter_by",      "ingredients.{name : [jalepeno, olives] && concentration :<30}"},
+            {"enable_lazy_filter", "true"},
             {"include_fields", "name, ingredients"}
     };
     now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
@@ -3411,6 +3413,7 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
             {"collection",     "menu"},
             {"q",              "*"},
             {"filter_by",      "ingredients.{name : [jalepeno, olives] && concentration :[10..20]}"},
+            {"enable_lazy_filter", "true"},
             {"include_fields", "name, ingredients"}
     };
     now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
@@ -3428,6 +3431,7 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
             {"collection",     "menu"},
             {"q",              "*"},
             {"filter_by",      "ingredients.{name : cheese && concentration :[10..30, >=60]}"},
+            {"enable_lazy_filter", "true"},
             {"include_fields", "name, ingredients"}
     };
     now_ts = std::chrono::duration_cast<std::chrono::microseconds>(

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -3374,8 +3374,7 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
     std::map<std::string, std::string> req_params = {
             {"collection",     "menu"},
             {"q",              "*"},
-            {"filter_by",      "ingredients.{name : cheese && concentration :<50}"},
-            {"enable_lazy_filter", "true"},
+            {"filter_by",      "name: p* && ingredients.{name : cheese && concentration :<50}"},
             {"include_fields", "name, ingredients"}
     };
     nlohmann::json embedded_params;
@@ -3394,13 +3393,49 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
     req_params = {
             {"collection",     "menu"},
             {"q",              "*"},
-            {"filter_by",      "ingredients.{name : [jalepeno, olives] && concentration :<30}"},
-            {"enable_lazy_filter", "true"},
+            {"filter_by",      "ingredients.{name : olives && concentration :<50} && name : l*"},
             {"include_fields", "name, ingredients"}
     };
     now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::system_clock::now().time_since_epoch()).count();
 
+    json_res.clear();
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, result["found"].get<size_t>());
+    ASSERT_EQ(1, result["hits"].size());
+    ASSERT_EQ("Lasagna", result["hits"][0]["document"]["name"]);
+
+    req_params = {
+            {"collection",     "menu"},
+            {"q",              "p*"},
+            {"query_by",       "name"},
+            {"filter_by",      "ingredients.{name : cheese && concentration :<50}"},
+            {"include_fields", "name, ingredients"}
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    json_res.clear();
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, result["found"].get<size_t>());
+    ASSERT_EQ(2, result["hits"].size());
+    ASSERT_EQ("Pizza", result["hits"][0]["document"]["name"]);
+    ASSERT_EQ("Pasta", result["hits"][1]["document"]["name"]);
+
+    req_params = {
+            {"collection",     "menu"},
+            {"q",              "*"},
+            {"filter_by",      "ingredients.{name : [jalepeno, olives] && concentration :<30}"},
+            {"include_fields", "name, ingredients"}
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    json_res.clear();
     search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
     ASSERT_TRUE(search_op.ok());
     result = nlohmann::json::parse(json_res);
@@ -3413,12 +3448,12 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
             {"collection",     "menu"},
             {"q",              "*"},
             {"filter_by",      "ingredients.{name : [jalepeno, olives] && concentration :[10..20]}"},
-            {"enable_lazy_filter", "true"},
             {"include_fields", "name, ingredients"}
     };
     now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::system_clock::now().time_since_epoch()).count();
 
+    json_res.clear();
     search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
     ASSERT_TRUE(search_op.ok());
     result = nlohmann::json::parse(json_res);
@@ -3431,12 +3466,12 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
             {"collection",     "menu"},
             {"q",              "*"},
             {"filter_by",      "ingredients.{name : cheese && concentration :[10..30, >=60]}"},
-            {"enable_lazy_filter", "true"},
             {"include_fields", "name, ingredients"}
     };
     now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::system_clock::now().time_since_epoch()).count();
 
+    json_res.clear();
     search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
     ASSERT_TRUE(search_op.ok());
     result = nlohmann::json::parse(json_res);

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -3421,7 +3421,6 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
             {"collection",     "menu"},
             {"q",              "p*"},
             {"query_by",       "name"},
-            {"enable_lazy_filter",       "true"},
             {"filter_by",      "ingredients.{name : cheese && concentration :<50}"},
             {"include_fields", "name, ingredients"}
     };
@@ -3517,8 +3516,11 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
 
     req_params = {
             {"collection",     "menu"},
-            {"q",              "*"},
+            {"q",              "a"},
+            {"query_by",       "name"},
+            {"infix",          "always"},
             {"filter_by",      "ingredients.{name : olives && concentration :<50} || ingredients.{name : cheese && concentration :>50}"},
+            {"enable_lazy_filter", "true"},
             {"include_fields", "name, ingredients"}
     };
     now_ts = std::chrono::duration_cast<std::chrono::microseconds>(

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -3330,3 +3330,115 @@ TEST_F(CollectionFilteringTest, IgnoreFieldValidation) {
     ASSERT_EQ(1, res_obj["hits"].size());
     ASSERT_EQ("8", res_obj["hits"][0]["document"].at("id"));
 }
+
+TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
+    auto schema_json =
+            R"({
+                "name": "menu",
+                "fields": [
+                    {"name": "name", "type": "string"},
+                    {"name": "ingredients", "type": "object[]"},
+                    {"name": "ingredients.*", "type": "auto", "optional": true}
+                ],
+                "enable_nested_fields": true
+            })"_json;
+    std::vector<nlohmann::json> documents = {
+            R"({
+                "name": "Pasta",
+                "ingredients": [{"name": "cheese", "concentration": 40}, {"name" : "spinach", "concentration": 10},
+                                {"name": "jalepeno", "concentration": 20}]
+            })"_json,
+            R"({
+                "name": "Pizza",
+                "ingredients": [{"name": "cheese", "concentration": 30}, {"name": "pizza sauce", "concentration": 30},
+                                {"name": "olives", "concentration": 30}]
+            })"_json,
+            R"({
+                "name": "Lasagna",
+                "ingredients": [{"name": "cheese", "concentration": 60}, {"name": "jalepeno", "concentration": 20},
+                                {"name": "olives", "concentration": 20}]
+            })"_json
+    };
+
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    for (auto const& json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    std::map<std::string, std::string> req_params = {
+            {"collection",     "menu"},
+            {"q",              "*"},
+            {"filter_by",      "ingredients.{name : cheese && concentration :<50}"},
+            {"include_fields", "name, ingredients"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    auto result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, result["found"].get<size_t>());
+    ASSERT_EQ(2, result["hits"].size());
+    ASSERT_EQ("Pizza", result["hits"][0]["document"]["name"]);
+    ASSERT_EQ("Pasta", result["hits"][1]["document"]["name"]);
+
+    req_params = {
+            {"collection",     "menu"},
+            {"q",              "*"},
+            {"filter_by",      "ingredients.{name : [jalepeno, olives] && concentration :<30}"},
+            {"include_fields", "name, ingredients"}
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, result["found"].get<size_t>());
+    ASSERT_EQ(2, result["hits"].size());
+    ASSERT_EQ("Lasagna", result["hits"][0]["document"]["name"]);
+    ASSERT_EQ("Pasta", result["hits"][1]["document"]["name"]);
+
+    req_params = {
+            {"collection",     "menu"},
+            {"q",              "*"},
+            {"filter_by",      "ingredients.{name : [jalepeno, olives] && concentration :[10..20]}"},
+            {"include_fields", "name, ingredients"}
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, result["found"].get<size_t>());
+    ASSERT_EQ(2, result["hits"].size());
+    ASSERT_EQ("Lasagna", result["hits"][0]["document"]["name"]);
+    ASSERT_EQ("Pasta", result["hits"][1]["document"]["name"]);
+
+    req_params = {
+            {"collection",     "menu"},
+            {"q",              "*"},
+            {"filter_by",      "ingredients.{name : cheese && concentration :[10..30, >=60]}"},
+            {"include_fields", "name, ingredients"}
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, result["found"].get<size_t>());
+    ASSERT_EQ(2, result["hits"].size());
+    ASSERT_EQ("Lasagna", result["hits"][0]["document"]["name"]);
+    ASSERT_EQ("Pizza", result["hits"][1]["document"]["name"]);
+
+}

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -3535,4 +3535,206 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
     ASSERT_EQ("Pizza Rolls", result["hits"][0]["document"]["name"]);
     ASSERT_EQ("Lasagna", result["hits"][1]["document"]["name"]);
     ASSERT_EQ("Pizza", result["hits"][2]["document"]["name"]);
+
+    req_params = {
+            {"collection",     "menu"},
+            {"q",              "a"},
+            {"query_by",       "name"},
+            {"infix",          "always"},
+            {"filter_by",      "ingredients.{(name : olives && concentration :<50) || (name : cheese && concentration :>50)}"},
+            {"enable_lazy_filter", "true"},
+            {"include_fields", "name, ingredients"}
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    json_res.clear();
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(3, result["found"].get<size_t>());
+    ASSERT_EQ(3, result["hits"].size());
+    ASSERT_EQ("Pizza Rolls", result["hits"][0]["document"]["name"]);
+    ASSERT_EQ("Lasagna", result["hits"][1]["document"]["name"]);
+    ASSERT_EQ("Pizza", result["hits"][2]["document"]["name"]);
+
+    //validation tests
+    req_params = {
+            {"collection",     "menu"},
+            {"q",              "*"},
+            {"filter_by",      "ingredients.{name : cheese && }"},
+            {"enable_lazy_filter", "true"},
+            {"include_fields", "name, ingredients"}
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    json_res.clear();
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_FALSE(search_op.ok());
+    ASSERT_EQ("Could not parse the filter query: unbalanced `&&` operands.", search_op.error());
+
+    //missing } at end
+    req_params = {
+            {"collection",     "menu"},
+            {"q",              "*"},
+            {"filter_by",      "ingredients.{name : cheese && concentration:30"},
+            {"enable_lazy_filter", "true"},
+            {"include_fields", "name, ingredients"}
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    json_res.clear();
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_FALSE(search_op.ok());
+    ASSERT_EQ("Could not parse the filter query: unbalanced parentheses.", search_op.error());
+
+    //typo in nested field name
+    req_params = {
+            {"collection",     "menu"},
+            {"q",              "*"},
+            {"filter_by",      "ingredients.{name : cheese && concentrations:30}"},
+            {"enable_lazy_filter", "true"},
+            {"include_fields", "name, ingredients"}
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    json_res.clear();
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_FALSE(search_op.ok());
+    ASSERT_EQ("Could not find a filter field named `ingredients.concentrations` in the schema.", search_op.error());
+
+    //invalid nested field
+    req_params = {
+            {"collection",     "menu"},
+            {"q",              "*"},
+            {"filter_by",      "ingredients.{name : cheese && concentration:30 && cost:<100}"},
+            {"enable_lazy_filter", "true"},
+            {"include_fields", "name, ingredients"}
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    json_res.clear();
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_FALSE(search_op.ok());
+    ASSERT_EQ("Could not find a filter field named `ingredients.cost` in the schema.", search_op.error());
+
+    //missing . after {
+    req_params = {
+            {"collection",     "menu"},
+            {"q",              "*"},
+            {"filter_by",      "ingredients{name : cheese && concentration:30}"},
+            {"enable_lazy_filter", "true"},
+            {"include_fields", "name, ingredients"}
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    json_res.clear();
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_FALSE(search_op.ok());
+    ASSERT_EQ("Bad nested filter query syntax.", search_op.error());
+}
+
+TEST_F(CollectionFilteringTest, NestedObjectFieldsFilteringMultiple) {
+    auto schema_json =
+            R"({
+                "name": "menu",
+                "fields": [
+                    {"name": "name", "type": "string", "infix": true},
+                    {"name": "ingredients", "type": "object[]"},
+                    {"name": "ingredients.*", "type": "auto", "optional": true},
+                    {"name": "country", "type": "object[]"},
+                    {"name": "country.*", "type": "auto", "optional": true}
+                ],
+                "enable_nested_fields": true
+            })"_json;
+
+    std::vector<nlohmann::json> documents = {
+            R"({
+                "name": "Pasta",
+                "ingredients": [{"name": "cheese", "concentration": 40}, {"name" : "spinach", "concentration": 10},
+                                {"name": "jalepeno", "concentration": 20}],
+                "country": [{"name": "Italy", "consumption": 60}, {"name": "India", "consumption": 20},
+                            {"name": "England", "consumption": 45}]
+            })"_json,
+            R"({
+                "name": "Pizza",
+                "ingredients": [{"name": "cheese", "concentration": 30}, {"name": "pizza sauce", "concentration": 30},
+                                {"name": "olives", "concentration": 30}],
+                "country": [{"name": "Italy", "consumption": 80}, {"name": "India", "consumption": 50},
+                            {"name": "England", "consumption": 75}]
+            })"_json,
+            R"({
+                "name": "Lasagna",
+                "ingredients": [{"name": "cheese", "concentration": 60}, {"name": "jalepeno", "concentration": 20},
+                                {"name": "olives", "concentration": 20}],
+                "country": [{"name": "Italy", "consumption": 44}, {"name": "India", "consumption": 12},
+                            {"name": "England", "consumption": 55}]
+            })"_json,
+            R"({
+                "name": "Popcorn",
+                "ingredients": [{"name": "cheese", "concentration": 30}],
+                "country": [{"name": "Italy", "consumption": 20}, {"name": "India", "consumption": 70},
+                            {"name": "England", "consumption": 35}]
+            })"_json,
+            R"({
+                "name": "Pizza Rolls",
+                "ingredients": [{"name": "cheese", "concentration": 60}, {"name": "pizza sauce", "concentration": 5},
+                                {"name" : "corn", "concentration": 40}],
+                "country": [{"name": "Italy", "consumption": 10}, {"name": "India", "consumption": 50},
+                            {"name": "England", "consumption": 15}]
+            })"_json
+    };
+
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    for (auto const& json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    std::map<std::string, std::string> req_params = {
+            {"collection",     "menu"},
+            {"q",              "*"},
+            {"filter_by",      "country.{name : India && consumption :>20} && ingredients.{name : cheese && concentration :<50}"},
+            {"include_fields", "name, ingredients, country"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    auto result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, result["found"].get<size_t>());
+    ASSERT_EQ(2, result["hits"].size());
+    ASSERT_EQ("Popcorn", result["hits"][0]["document"]["name"]);
+    ASSERT_EQ("Pizza", result["hits"][1]["document"]["name"]);
+
+    req_params = {
+            {"collection",     "menu"},
+            {"q",              "*"},
+            {"filter_by",      "country.{name : I* && consumption :>20} && name: l* && ingredients.{name : olives && concentration :20}"},
+            {"include_fields", "name, ingredients, country"}
+    };
+    embedded_params;
+    json_res.clear();
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, result["found"].get<size_t>());
+    ASSERT_EQ(1, result["hits"].size());
+    ASSERT_EQ("Lasagna", result["hits"][0]["document"]["name"]);
 }

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -3726,7 +3726,6 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFilteringMultiple) {
             {"filter_by",      "country.{name : I* && consumption :>20} && name: l* && ingredients.{name : olives && concentration :20}"},
             {"include_fields", "name, ingredients, country"}
     };
-    embedded_params;
     json_res.clear();
     now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::system_clock::now().time_since_epoch()).count();

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -3588,7 +3588,7 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
     json_res.clear();
     search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
     ASSERT_FALSE(search_op.ok());
-    ASSERT_EQ("Could not parse the filter query: unbalanced parentheses.", search_op.error());
+    ASSERT_EQ("Could not parse the object filter: unbalanced curly braces.", search_op.error());
 
     //typo in nested field name
     req_params = {
@@ -3636,7 +3636,7 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
     json_res.clear();
     search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
     ASSERT_FALSE(search_op.ok());
-    ASSERT_EQ("Bad nested filter query syntax.", search_op.error());
+    ASSERT_EQ("Could not find a filter field named `ingredients{name` in the schema.", search_op.error());
 }
 
 TEST_F(CollectionFilteringTest, NestedObjectFieldsFilteringMultiple) {

--- a/test/filter_test.cpp
+++ b/test/filter_test.cpp
@@ -2346,6 +2346,9 @@ TEST_F(FilterTest, ObjectFitlterIterator) {
     }
     ASSERT_EQ(filter_result_iterator_t::invalid, root_object_filter_test.validity);
 
+    delete filter_tree_root;
+    filter_tree_root = nullptr;
+
     filter_op = filter::parse_filter_query("ingredients.{name : cheese && concentration : >50} || "
                                            "ingredients.{name : cheese && concentration : [25..45]}",
                                            coll->get_schema(), store, doc_id_prefix, filter_tree_root);
@@ -2367,4 +2370,7 @@ TEST_F(FilterTest, ObjectFitlterIterator) {
         ASSERT_EQ(seq_ids[i], root_object_filter_test.seq_id);
     }
     ASSERT_EQ(filter_result_iterator_t::invalid, root_object_filter_test.validity);
+
+    delete filter_tree_root;
+    filter_tree_root = nullptr;
 }

--- a/test/filter_test.cpp
+++ b/test/filter_test.cpp
@@ -2294,10 +2294,17 @@ TEST_F(FilterTest, ObjectFitlterIterator) {
     ASSERT_FALSE(root_object_filter_test._get_is_filter_result_initialized());
     ASSERT_EQ(3, root_object_filter_test.approx_filter_ids_length);
     ASSERT_EQ(1, root_object_filter_test.seq_id);
+
     std::vector<uint32_t> validate_ids = {0, 1, 2, 3, 4, 5};    // Equivalent to `take_id()` call.
     std::vector<int> expected = {0, 1, 0, 0, 1, -1};            // The result of `is_valid()` call.
     std::vector<uint32_t> seq_ids = {1, 4, 4, 4, 4, 4};         // The id filter_result_iterator is at after `take_id()` call.
     for (uint32_t i = 0; i < validate_ids.size(); i++) {
+        if (i < 5) {
+            ASSERT_EQ(filter_result_iterator_t::valid, root_object_filter_test.validity);
+        } else {
+            ASSERT_EQ(filter_result_iterator_t::invalid, root_object_filter_test.validity);
+        }
+
         ASSERT_EQ(expected[i], root_object_filter_test.is_valid(validate_ids[i]));
         if (expected[i] == 1) { // We call `next()` in `take_id()` when there is a match.
             root_object_filter_test.next();
@@ -2305,16 +2312,19 @@ TEST_F(FilterTest, ObjectFitlterIterator) {
         ASSERT_EQ(seq_ids[i], root_object_filter_test.seq_id);
     }
     ASSERT_EQ(filter_result_iterator_t::invalid, root_object_filter_test.validity);
+
     root_object_filter_test.reset();
     ASSERT_EQ(filter_result_iterator_t::valid, root_object_filter_test.validity);
     ASSERT_EQ(0, root_object_filter_test.is_valid(0));
     ASSERT_EQ(1, root_object_filter_test.is_valid(1));
     ASSERT_EQ(-1, root_object_filter_test.is_valid(10));
     ASSERT_EQ(filter_result_iterator_t::invalid, root_object_filter_test.validity);
+
     root_object_filter_test.compute_iterators();
     ASSERT_TRUE(root_object_filter_test._get_is_filter_result_initialized());
     ASSERT_EQ(2, root_object_filter_test.approx_filter_ids_length);
     ASSERT_EQ(1, root_object_filter_test.seq_id);
+
     uint32_t excluded_result_index = 0;
     auto result = new filter_result_t();
     root_object_filter_test.get_n_ids(2, excluded_result_index, nullptr, 0, result);
@@ -2322,9 +2332,8 @@ TEST_F(FilterTest, ObjectFitlterIterator) {
     ASSERT_EQ(1, result->docs[0]);
     ASSERT_EQ(4, result->docs[1]);
     delete result;
-    delete filter_tree_root;
-    filter_tree_root = nullptr;
 
+    delete filter_tree_root;
     filter_op = filter::parse_filter_query("ingredients.{name : cheese && concentration : [25..45]}",
                                                         coll->get_schema(), store, doc_id_prefix, filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
@@ -2334,10 +2343,17 @@ TEST_F(FilterTest, ObjectFitlterIterator) {
     ASSERT_FALSE(root_object_filter_test._get_is_filter_result_initialized());
     ASSERT_EQ(4, root_object_filter_test.approx_filter_ids_length);
     ASSERT_EQ(0, root_object_filter_test.seq_id);
+
     validate_ids = {0, 1, 2, 3, 4, 5};    // Equivalent to `take_id()` call.
     expected = {1, 0, 1, 1, -1, -1};      // The result of `is_valid()` call.
-    seq_ids = {2, 2, 3, 3, 3, 3};         // The id filter_result_iterator is at after `take_id()` call.
+    seq_ids = {2, 2, 3, 4, 4, 4};         // The id filter_result_iterator is at after `take_id()` call.
     for (uint32_t i = 0; i < validate_ids.size(); i++) {
+        if (i < 4) {
+            ASSERT_EQ(filter_result_iterator_t::valid, root_object_filter_test.validity);
+        } else {
+            ASSERT_EQ(filter_result_iterator_t::invalid, root_object_filter_test.validity);
+        }
+
         ASSERT_EQ(expected[i], root_object_filter_test.is_valid(validate_ids[i]));
         if (expected[i] == 1) { // We call `next()` in `take_id()` when there is a match.
             root_object_filter_test.next();
@@ -2353,24 +2369,127 @@ TEST_F(FilterTest, ObjectFitlterIterator) {
                                            "ingredients.{name : cheese && concentration : [25..45]}",
                                            coll->get_schema(), store, doc_id_prefix, filter_tree_root);
     ASSERT_TRUE(filter_op.ok());
-    root_object_filter_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+    auto or_object_filters_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
                                                        enable_lazy_evaluation);
-    ASSERT_TRUE(root_object_filter_test.init_status().ok());
-    ASSERT_FALSE(root_object_filter_test._get_is_filter_result_initialized());
-    ASSERT_EQ(7, root_object_filter_test.approx_filter_ids_length);
-    ASSERT_EQ(0, root_object_filter_test.seq_id);
+    ASSERT_TRUE(or_object_filters_test.init_status().ok());
+    ASSERT_FALSE(or_object_filters_test._get_is_filter_result_initialized());
+    ASSERT_EQ(7, or_object_filters_test.approx_filter_ids_length);
+    ASSERT_EQ(0, or_object_filters_test.seq_id);
+
     validate_ids = {0, 1, 2, 3, 4, 5};
     expected = {1, 1, 1, 1, 1, -1};
     seq_ids = {1, 2, 3, 4, 4, 4};
     for (uint32_t i = 0; i < validate_ids.size(); i++) {
-        ASSERT_EQ(expected[i], root_object_filter_test.is_valid(validate_ids[i]));
-        if (expected[i] == 1) { // We call `next()` in `take_id()` when there is a match.
-            root_object_filter_test.next();
+        if (i < 5) {
+            ASSERT_EQ(filter_result_iterator_t::valid, or_object_filters_test.validity);
+        } else {
+            ASSERT_EQ(filter_result_iterator_t::invalid, or_object_filters_test.validity);
         }
-        ASSERT_EQ(seq_ids[i], root_object_filter_test.seq_id);
+
+        ASSERT_EQ(expected[i], or_object_filters_test.is_valid(validate_ids[i]));
+        if (expected[i] == 1) { // We call `next()` in `take_id()` when there is a match.
+            or_object_filters_test.next();
+        }
+        ASSERT_EQ(seq_ids[i], or_object_filters_test.seq_id);
     }
     ASSERT_EQ(filter_result_iterator_t::invalid, root_object_filter_test.validity);
 
     delete filter_tree_root;
     filter_tree_root = nullptr;
+
+    filter_op = filter::parse_filter_query("ingredients.{ (name: spinach && concentration: >50) || "
+                                                            "(name: jalepeno && concentration: [25..45]) ||"
+                                                            "(name: pizza sauce && concentration: <30) }",
+                                           coll->get_schema(), store, doc_id_prefix, filter_tree_root);
+    ASSERT_TRUE(filter_op.ok());
+    auto or_object_filter_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                           enable_lazy_evaluation);
+    ASSERT_TRUE(or_object_filter_test.init_status().ok());
+    ASSERT_FALSE(or_object_filter_test._get_is_filter_result_initialized());
+    ASSERT_EQ(3, or_object_filter_test.approx_filter_ids_length);
+    ASSERT_EQ(0, or_object_filter_test.seq_id);
+
+    validate_ids = {0, 1, 2, 3, 4, 5};
+    expected = {1, 0, 0, 0, 1, -1};
+    seq_ids = {4, 4, 4, 4, 4, 4};
+    for (uint32_t i = 0; i < validate_ids.size(); i++) {
+        if (i < 5) {
+            ASSERT_EQ(filter_result_iterator_t::valid, or_object_filter_test.validity);
+        } else {
+            ASSERT_EQ(filter_result_iterator_t::invalid, or_object_filter_test.validity);
+        }
+
+        ASSERT_EQ(expected[i], or_object_filter_test.is_valid(validate_ids[i]));
+        if (expected[i] == 1) { // We call `next()` in `take_id()` when there is a match.
+            or_object_filter_test.next();
+        }
+        ASSERT_EQ(seq_ids[i], or_object_filter_test.seq_id);
+    }
+    ASSERT_EQ(filter_result_iterator_t::invalid, root_object_filter_test.validity);
+
+    delete filter_tree_root;
+    filter_tree_root = nullptr;
+
+    filter_op = filter::parse_filter_query("name: p* && ingredients.{name : cheese && concentration : [25..45]}",
+                                           coll->get_schema(), store, doc_id_prefix, filter_tree_root);
+    ASSERT_TRUE(filter_op.ok());
+
+    search_stop_us = UINT64_MAX; // `Index::fuzzy_search_fields` checks for timeout.
+    auto and_object_filter_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                       enable_lazy_evaluation);
+    ASSERT_TRUE(and_object_filter_test.init_status().ok());
+    ASSERT_FALSE(and_object_filter_test._get_is_filter_result_initialized());
+    ASSERT_EQ(4, and_object_filter_test.approx_filter_ids_length);
+    ASSERT_EQ(0, and_object_filter_test.seq_id);
+
+    validate_ids = {0, 1, 2, 3, 4, 5};
+    expected = {1, 0, 1, 1, -1, -1};
+    seq_ids = {2, 2, 3, 3, 3, 3};
+    for (uint32_t i = 0; i < validate_ids.size(); i++) {
+        if (i < 4) {
+            ASSERT_EQ(filter_result_iterator_t::valid, and_object_filter_test.validity);
+        } else {
+            ASSERT_EQ(filter_result_iterator_t::invalid, and_object_filter_test.validity);
+        }
+
+        ASSERT_EQ(expected[i], and_object_filter_test.is_valid(validate_ids[i]));
+        if (expected[i] == 1) { // We call `next()` in `take_id()` when there is a match.
+            and_object_filter_test.next();
+        }
+        ASSERT_EQ(seq_ids[i], and_object_filter_test.seq_id);
+    }
+    ASSERT_EQ(filter_result_iterator_t::invalid, and_object_filter_test.validity);
+
+    delete filter_tree_root;
+
+    filter_op = filter::parse_filter_query("ingredients.{name: != spinach && concentration: >50}",
+                                           coll->get_schema(), store, doc_id_prefix, filter_tree_root);
+    ASSERT_TRUE(filter_op.ok());
+
+    auto not_object_filter_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                           enable_lazy_evaluation);
+    ASSERT_TRUE(not_object_filter_test.init_status().ok());
+    ASSERT_FALSE(not_object_filter_test._get_is_filter_result_initialized());
+    ASSERT_EQ(3, not_object_filter_test.approx_filter_ids_length);
+    ASSERT_EQ(1, not_object_filter_test.seq_id);
+
+    validate_ids = {0, 1, 2, 3, 4, 5};
+    expected = {0, 1, 0, 0, 1, -1};
+    seq_ids = {1, 4, 4, 4, 4, 4};
+    for (uint32_t i = 0; i < validate_ids.size(); i++) {
+        if (i < 5) {
+            ASSERT_EQ(filter_result_iterator_t::valid, not_object_filter_test.validity);
+        } else {
+            ASSERT_EQ(filter_result_iterator_t::invalid, not_object_filter_test.validity);
+        }
+
+        ASSERT_EQ(expected[i], not_object_filter_test.is_valid(validate_ids[i]));
+        if (expected[i] == 1) { // We call `next()` in `take_id()` when there is a match.
+            not_object_filter_test.next();
+        }
+        ASSERT_EQ(seq_ids[i], not_object_filter_test.seq_id);
+    }
+    ASSERT_EQ(filter_result_iterator_t::invalid, not_object_filter_test.validity);
+
+    delete filter_tree_root;
 }

--- a/test/filter_test.cpp
+++ b/test/filter_test.cpp
@@ -2345,4 +2345,26 @@ TEST_F(FilterTest, ObjectFitlterIterator) {
         ASSERT_EQ(seq_ids[i], root_object_filter_test.seq_id);
     }
     ASSERT_EQ(filter_result_iterator_t::invalid, root_object_filter_test.validity);
+
+    filter_op = filter::parse_filter_query("ingredients.{name : cheese && concentration : >50} || "
+                                           "ingredients.{name : cheese && concentration : [25..45]}",
+                                           coll->get_schema(), store, doc_id_prefix, filter_tree_root);
+    ASSERT_TRUE(filter_op.ok());
+    root_object_filter_test = filter_result_iterator_t(coll->get_name(), coll->_get_index(), filter_tree_root,
+                                                       enable_lazy_evaluation);
+    ASSERT_TRUE(root_object_filter_test.init_status().ok());
+    ASSERT_FALSE(root_object_filter_test._get_is_filter_result_initialized());
+    ASSERT_EQ(7, root_object_filter_test.approx_filter_ids_length);
+    ASSERT_EQ(0, root_object_filter_test.seq_id);
+    validate_ids = {0, 1, 2, 3, 4, 5};
+    expected = {1, 1, 1, 1, 1, -1};
+    seq_ids = {1, 2, 3, 4, 4, 4};
+    for (uint32_t i = 0; i < validate_ids.size(); i++) {
+        ASSERT_EQ(expected[i], root_object_filter_test.is_valid(validate_ids[i]));
+        if (expected[i] == 1) { // We call `next()` in `take_id()` when there is a match.
+            root_object_filter_test.next();
+        }
+        ASSERT_EQ(seq_ids[i], root_object_filter_test.seq_id);
+    }
+    ASSERT_EQ(filter_result_iterator_t::invalid, root_object_filter_test.validity);
 }

--- a/test/string_utils_test.cpp
+++ b/test/string_utils_test.cpp
@@ -347,7 +347,8 @@ TEST(StringUtilsTest, ShouldSplitRangeFacet){
 
 void tokenizeTestHelper(const std::string& filter_query, const std::vector<std::string>& tokenList) {
     std::queue<std::string> tokenizeOutput;
-    auto tokenize_op = StringUtils::tokenize_filter_query(filter_query, tokenizeOutput);
+    std::set<std::string> nested_object_fields;
+    auto tokenize_op = StringUtils::tokenize_filter_query(filter_query, tokenizeOutput, nested_object_fields);
     ASSERT_TRUE(tokenize_op.ok());
     for (auto const& token: tokenList) {
         ASSERT_EQ(token, tokenizeOutput.front());

--- a/test/string_utils_test.cpp
+++ b/test/string_utils_test.cpp
@@ -347,8 +347,7 @@ TEST(StringUtilsTest, ShouldSplitRangeFacet){
 
 void tokenizeTestHelper(const std::string& filter_query, const std::vector<std::string>& tokenList) {
     std::queue<std::string> tokenizeOutput;
-    std::set<std::string> nested_object_fields;
-    auto tokenize_op = StringUtils::tokenize_filter_query(filter_query, tokenizeOutput, nested_object_fields);
+    auto tokenize_op = StringUtils::tokenize_filter_query(filter_query, tokenizeOutput);
     ASSERT_TRUE(tokenize_op.ok());
     for (auto const& token: tokenList) {
         ASSERT_EQ(token, tokenizeOutput.front());
@@ -401,6 +400,22 @@ TEST(StringUtilsTest, TokenizeFilterQuery) {
 
     filter_query = "$Customers(customer_id:=customer_a) || !$Customers_2(customer_id:=customer_a)";
     tokenList = {"$Customers(customer_id:=customer_a)", "||", "!$Customers_2(customer_id:=customer_a)"};
+    tokenizeTestHelper(filter_query, tokenList);
+
+    filter_query = "ingredients.{name: != spinach && concentration: >50}";
+    tokenList = {"ingredients.{name: != spinach && concentration: >50}"};
+    tokenizeTestHelper(filter_query, tokenList);
+
+    filter_query = "name: p* && ingredients.{name : cheese && concentration : [25..45]}";
+    tokenList = {"name: p*", "&&", "ingredients.{name : cheese && concentration : [25..45]}"};
+    tokenizeTestHelper(filter_query, tokenList);
+
+    filter_query = "ingredients.{name : cheese && concentration : >50} || ingredients.{name : cheese && concentration : [25..45]}";
+    tokenList = {"ingredients.{name : cheese && concentration : >50}", "||", "ingredients.{name : cheese && concentration : [25..45]}"};
+    tokenizeTestHelper(filter_query, tokenList);
+
+    filter_query = "ingredients.{(name : olives && concentration :<50) || (name : cheese && concentration :>50)}";
+    tokenList = {"ingredients.{(name : olives && concentration :<50) || (name : cheese && concentration :>50)}"};
     tokenizeTestHelper(filter_query, tokenList);
 }
 


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).

## Filtering on fields inside a nested field/object
Syntax : `<nested_field_parent>.{<nested_field1> : <val> ...}`

Let's suppose we've the following schema,
```json
{
      "name": "menu",
      "fields": [
           {"name": "name", "type": "string"},
           {"name": "ingredients", "type": "object[]"},
           {"name": "ingredients.*", "type": "auto", "optional": true}
       ],
       "enable_nested_fields": true
}
```
And following records,
```json
{ 
   "name": "Pasta",
   "ingredients": [{"name": "cheese", "concentration": 40}, {"name" : "spinach", "concentration": 10}, {"name": "jalepeno", "concentration": 20}]
}
{
   "name": "Pizza",
   "ingredients": [{"name": "cheese", "concentration": 30}, {"name": "pizza sauce", "concentration": 30}, {"name": "olives", "concentration": 30}]
}
{
   "name": "Lasagna",
   "ingredients": [{"name": "cheese", "concentration": 60}, {"name": "jalepeno", "concentration": 20}, {"name": "olives", "concentration": 20}]
}
```

Now to filter using nested fields of `ingredients` we've to use special filter_by query syntax like below,
`filter_by=ingredients.{name : cheese && concentration :<50}`
Above filter_by string will filter results with records `Pizza` and `Pasta`

Likewise, 
we can pass all kind of filter_by string expressions inside `{}`
filter_query can be extended to multiple nested object filters too.
#### Note : should be mindful on syntax part for targeting such filtering. Going by traditional filter_by syntax `ingredients.name: cheese && ingredients.concentration:<50` will match all 3 records.