### PR TITLE
Fix vector query parsing with escape

### DIFF
--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -12,7 +12,6 @@
 #include <unicode/normalizer2.h>
 #include <set>
 #include "option.h"
-#include "logger.h"
 
 struct StringUtils {
 

--- a/src/vector_query_ops.cpp
+++ b/src/vector_query_ops.cpp
@@ -213,7 +213,7 @@ Option<bool> VectorQueryOps::parse_vector_query_str(const std::string& vector_qu
                     param_kv[1].pop_back();
 
                     std::vector<std::string> qs;
-                    StringUtils::split(param_kv[1], qs, ",");
+                    StringUtils::split(param_kv[1], qs, ",", false, true, 0, std::numeric_limits<size_t>::max(), '`');
                     for(auto& q: qs) {
                         StringUtils::trim(q);
                         vector_query.queries.push_back(q);

--- a/src/vector_query_ops.cpp
+++ b/src/vector_query_ops.cpp
@@ -213,7 +213,7 @@ Option<bool> VectorQueryOps::parse_vector_query_str(const std::string& vector_qu
                     param_kv[1].pop_back();
 
                     std::vector<std::string> qs;
-                    StringUtils::split(param_kv[1], qs, ",", false, true, 0, std::numeric_limits<size_t>::max(), '`');
+                    StringUtils::split_list_with_backticks(param_kv[1], qs);
                     for(auto& q: qs) {
                         StringUtils::trim(q);
                         vector_query.queries.push_back(q);


### PR DESCRIPTION
## Usage

```
vector_field:([], queries:[query_one, `this, query, will be, a single, query`)
```