### PR TITLE
Add support for custom OpenAI conversation model path

### DIFF
--- a/include/conversation_model.h
+++ b/include/conversation_model.h
@@ -64,6 +64,7 @@ class OpenAIConversationModel : public ConversationModel {
         static const inline std::string QUESTION_STR = "\n\n<Question>\n";
         static const inline std::string ANSWER_STR = "\n\n<Answer>";
         static Option<std::string> get_openai_url(const nlohmann::json& model_config);
+        static Option<std::string> get_openai_path(const nlohmann::json& model_config);
         static bool async_res_set_headers_callback(const std::string& response, const std::shared_ptr<http_req> req, long status_code, char* content_type);
         static void async_res_write_callback(std::string& response, const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res);
         static bool async_res_done_callback(const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res);


### PR DESCRIPTION
### Usage
```json
{
        "id": "conv-model-1",
        "model_name": "openai/gpt-4",
        "history_collection": "conversation_store",
        "openai_url": "AZURE_OPENAI_URL",
        "openai_path": "openai/deployments/gpt-4/chat/completions?api-version=2025-01-01-preview",
        "api_key": "AZURE_API_KEY",
        "system_prompt": "You are an assistant for question-answering. You can only make conversations based on the provided context. If a response cannot be formed strictly using the provided context, politely say you do not have knowledge about that topic.",        
        "max_bytes": 16384
}

```