### PR TITLE
feat(api): add option to return deleted documents and IDs

### DIFF
--- a/include/core_api_utils.h
+++ b/include/core_api_utils.h
@@ -10,6 +10,11 @@ struct deletion_state_t: public req_state_t {
     std::vector<std::pair<size_t, uint32_t*>> index_ids;  // ids_len -> ids
     std::vector<size_t> offsets;
     size_t num_removed;
+    
+    bool return_doc = false;
+    bool return_id = false;
+    std::vector<nlohmann::json> removed_docs;
+    std::vector<nlohmann::json> removed_ids;
 
     ~deletion_state_t() override {
         for(auto& kv: index_ids) {


### PR DESCRIPTION


## Change Summary
- Add `return_doc` and `return_id` parameters to document deletion API
- Store deleted document content and IDs when requested
- Include deleted items in API response when parameters are enabled
- Add tests for both single and batch document deletion scenarios

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
