### PR TITLE
Add support for GCP conversation models

### DIFF
--- a/include/conversation_model.h
+++ b/include/conversation_model.h
@@ -31,6 +31,10 @@ class ConversationModel {
         static Option<std::string> get_answer_stream(const std::string& context, const std::string& prompt, const nlohmann::json& model_config,
                                                     const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res, 
                                                     const std::string conversation_id);
+        // for testing
+        static inline void _add_async_conversation(std::shared_ptr<http_req> req, const std::string& conversation_id) {
+            async_conversations[req].conversation_id = conversation_id;
+        }
     protected:
         static const inline std::string CONVERSATION_HISTORY = "\n\n<Conversation history>\n";
         static const inline std::string QUESTION = "\n\n<Question>\n";
@@ -149,6 +153,10 @@ class GeminiConversationModel : public ConversationModel {
         )";
         // prevent instantiation
         GeminiConversationModel() = delete;
+        static void _async_write_callback(std::string& response, const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res) {
+            // for testing purposes
+            return async_res_write_callback(response, req, res);
+        }
     private:
         static constexpr char* GEMINI_URL = "https://generativelanguage.googleapis.com/v1beta/models/";
         static constexpr char* NON_STREAM_RESPONSE_STR = ":generateContent";

--- a/include/conversation_model.h
+++ b/include/conversation_model.h
@@ -65,7 +65,7 @@ class OpenAIConversationModel : public ConversationModel {
         static const inline std::string ANSWER_STR = "\n\n<Answer>";
         static Option<std::string> get_openai_url(const nlohmann::json& model_config);
         static Option<std::string> get_openai_path(const nlohmann::json& model_config);
-        static bool async_res_set_headers_callback(const std::string& response, const std::shared_ptr<http_req> req, long status_code, char* content_type);
+        static bool async_res_set_headers_callback(const std::string& response, const std::shared_ptr<http_req> req, long status_code, std::string& content_type);
         static void async_res_write_callback(std::string& response, const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res);
         static bool async_res_done_callback(const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res);
 };
@@ -96,7 +96,7 @@ class CFConversationModel : public ConversationModel {
         static const inline std::string SPLITTER_STR = "---------------------\n";
         static const inline std::string QUERY_STR = "Given the context information and not prior knowledge, answer the query. Context is JSON format, do not return data directly, answer like a human assistant.\nQuery: ";
         static const inline std::string ANSWER_STR = "\n\nAnswer:\n";
-        static bool async_res_set_headers_callback(const std::string& response, const std::shared_ptr<http_req> req, long status_code, char* content_type);
+        static bool async_res_set_headers_callback(const std::string& response, const std::shared_ptr<http_req> req, long status_code, std::string& content_type);
         static void async_res_write_callback(std::string& response, const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res);
         static bool async_res_done_callback(const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res);
 };
@@ -125,7 +125,39 @@ class vLLMConversationModel : public ConversationModel {
         static const inline std::string DATA_STR = "<Data>\n";
         static const inline std::string QUESTION_STR = "\n\n<Question>\n";
         static const inline std::string ANSWER_STR = "\n\n<Answer>";
-        static bool async_res_set_headers_callback(const std::string& response, const std::shared_ptr<http_req> req, long status_code, char* content_type);
+        static bool async_res_set_headers_callback(const std::string& response, const std::shared_ptr<http_req> req, long status_code, std::string& content_type);
+        static void async_res_write_callback(std::string& response, const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res);
+        static bool async_res_done_callback(const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res);
+};
+
+
+class GeminiConversationModel : public ConversationModel {
+    public:
+        static Option<std::string> get_answer(const std::string& context, const std::string& prompt, const std::string& system_prompt, const nlohmann::json& model_config);
+        static Option<bool> validate_model(const nlohmann::json& model_config);
+        static Option<std::string> get_standalone_question(const nlohmann::json& conversation_history, const std::string& question, const nlohmann::json& model_config);
+        static Option<nlohmann::json> format_question(const std::string& message);
+        static Option<nlohmann::json> format_answer(const std::string& message);
+        static Option<std::string> get_answer_stream(const std::string& context, const std::string& prompt, const std::string& system_prompt, const nlohmann::json& model_config,
+                                                    const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res);
+        // max_bytes must be greater than or equal to the minimum required bytes
+        static const size_t get_minimum_required_bytes() {
+            return  DATA_STR.size() + QUESTION_STR.size() + ANSWER_STR.size();
+        }
+        static const inline std::string STANDALONE_QUESTION_PROMPT = R"(
+            Rewrite the follow-up question on top of a human-assistant conversation history as a standalone question that encompasses all pertinent context.
+        )";
+        // prevent instantiation
+        GeminiConversationModel() = delete;
+    private:
+        static constexpr char* GEMINI_URL = "https://generativelanguage.googleapis.com/v1beta/models/";
+        static constexpr char* NON_STREAM_RESPONSE_STR = ":generateContent";
+        static constexpr char* STREAM_RESPONSE_STR = ":streamGenerateContent";
+        static const inline std::string DATA_STR = "<Data>\n";
+        static const inline std::string QUESTION_STR = "\n\n<Question>\n";
+        static const inline std::string ANSWER_STR = "\n\n<Answer>";
+        static Option<std::string> get_gemini_url(const nlohmann::json& model_config, const bool stream);
+        static bool async_res_set_headers_callback(const std::string& response, const std::shared_ptr<http_req> req, long status_code, std::string& content_type);
         static void async_res_write_callback(std::string& response, const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res);
         static bool async_res_done_callback(const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res);
 };

--- a/include/http_data.h
+++ b/include/http_data.h
@@ -304,7 +304,7 @@ struct http_req {
 
     std::atomic<bool> is_write = false;
 
-    bool (*async_res_set_headers_callback)(const std::string&, const std::shared_ptr<http_req>, long, char*) = nullptr;
+    bool (*async_res_set_headers_callback)(const std::string&, const std::shared_ptr<http_req>, long, std::string&) = nullptr;
     void (*async_res_write_callback)(std::string&, const std::shared_ptr<http_req>, const std::shared_ptr<http_res>) = nullptr;
     bool (*async_res_done_callback)(const std::shared_ptr<http_req>, const std::shared_ptr<http_res>) = nullptr;
 

--- a/src/conversation_model.cpp
+++ b/src/conversation_model.cpp
@@ -51,7 +51,7 @@ Option<bool> ConversationModel::validate_model(const nlohmann::json& model_confi
         return CFConversationModel::validate_model(model_config);
     } else if(model_namespace == "vllm") {
         return vLLMConversationModel::validate_model(model_config);
-    } else if(model_namespace == "gemini") {
+    } else if(model_namespace == "gcp") {
         return GeminiConversationModel::validate_model(model_config);
     }
 
@@ -73,7 +73,7 @@ Option<std::string> ConversationModel::get_answer(const std::string& context, co
         return CFConversationModel::get_answer(context, prompt, system_prompt, model_config);
     } else if(model_namespace == "vllm") {
         return vLLMConversationModel::get_answer(context, prompt, system_prompt, model_config);
-    } else if(model_namespace == "gemini") {
+    } else if(model_namespace == "gcp") {
         return GeminiConversationModel::get_answer(context, prompt, system_prompt, model_config);
     }
 
@@ -101,7 +101,7 @@ Option<std::string> ConversationModel::get_answer_stream(const std::string& cont
         response_op =  CFConversationModel::get_answer_stream(context, prompt, system_prompt, model_config, req, res);
     } else if(model_namespace == "vllm") {
         response_op =  vLLMConversationModel::get_answer_stream(context, prompt, system_prompt, model_config, req, res);
-    } else if(model_namespace == "gemini") {
+    } else if(model_namespace == "gcp") {
         response_op =  GeminiConversationModel::get_answer_stream(context, prompt, system_prompt, model_config, req, res);
     } else {
         async_conversations.erase(req);
@@ -123,7 +123,7 @@ Option<std::string> ConversationModel::get_standalone_question(const nlohmann::j
         return CFConversationModel::get_standalone_question(conversation_history, question, model_config);
     } else if(model_namespace == "vllm") {
         return vLLMConversationModel::get_standalone_question(conversation_history, question, model_config);
-    } else if(model_namespace == "gemini") {
+    } else if(model_namespace == "gcp") {
         return GeminiConversationModel::get_standalone_question(conversation_history, question, model_config);
     }
 
@@ -139,7 +139,7 @@ Option<nlohmann::json> ConversationModel::format_question(const std::string& mes
         return CFConversationModel::format_question(message);
     } else if(model_namespace == "vllm") {
         return vLLMConversationModel::format_question(message);
-    } else if(model_namespace == "gemini") {
+    } else if(model_namespace == "gcp") {
         return GeminiConversationModel::format_question(message);
     }
 
@@ -155,7 +155,7 @@ Option<nlohmann::json> ConversationModel::format_answer(const std::string& messa
         return CFConversationModel::format_answer(message);
     } else if(model_namespace == "vllm") {
         return vLLMConversationModel::format_answer(message);
-    } else if(model_namespace == "gemini") {
+    } else if(model_namespace == "gcp") {
         return GeminiConversationModel::format_answer(message);
     }
 
@@ -171,7 +171,7 @@ Option<size_t> ConversationModel::get_minimum_required_bytes(const nlohmann::jso
         return Option<size_t>(CFConversationModel::get_minimum_required_bytes());
     } else if(model_namespace == "vllm") {
         return Option<size_t>(vLLMConversationModel::get_minimum_required_bytes());
-    } else if(model_namespace == "gemini") {
+    } else if(model_namespace == "gcp") {
         return Option<size_t>(GeminiConversationModel::get_minimum_required_bytes());
     }
 

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -327,9 +327,10 @@ size_t HttpClient::curl_write_async(char *buffer, size_t size, size_t nmemb, voi
         CURLcode res = curl_easy_getinfo (curl, CURLINFO_RESPONSE_CODE, &http_code);
         char* content_type;
         res = curl_easy_getinfo (curl, CURLINFO_CONTENT_TYPE, &content_type);
+        std::string content_type_str = content_type ? content_type : "";
 
         if(req_res->req->async_res_set_headers_callback && res == CURLE_OK) {
-            auto output = req_res->req->async_res_set_headers_callback(resp_str, req_res->req, http_code, content_type);
+            auto output = req_res->req->async_res_set_headers_callback(resp_str, req_res->req, http_code, content_type_str);
             if(!output) {
                 // if the callback returns false, don't set headers, early return
                 return res_size;
@@ -341,7 +342,7 @@ size_t HttpClient::curl_write_async(char *buffer, size_t size, size_t nmemb, voi
         }
 
         if(res == CURLE_OK && content_type != nullptr) {
-            req_res->res->content_type_header = content_type;
+            req_res->res->content_type_header = content_type_str;
         }
     }
 


### PR DESCRIPTION
## Usage
```json
{
    "id": "conv-model",
    "model_name": "gcp/gemini-2.0-flash",
    "history_collection": "conversation_store",
    "api_key": "GEMINI_API_KEY",,
    "system_prompt": "You are an assistant for question-answering. You can only make conversations based on the provided context. If a response cannot be formed strictly using the provided context, politely say you do not have knowledge about that topic.",
    "max_bytes": 65536
}
```
