### PR TITLE
Add task type support for GCP embedding models

### DIFF
--- a/include/text_embedder_remote.h
+++ b/include/text_embedder_remote.h
@@ -160,6 +160,8 @@ class GCPEmbedder : public RemoteEmbedder {
         std::string client_id;
         std::string client_secret;
         std::string model_name;
+        std::string document_task;
+        std::string query_task;
         bool has_custom_dims;
         size_t num_dims;
         inline static const std::string GCP_EMBEDDING_BASE_URL = "https://us-central1-aiplatform.googleapis.com/v1/projects/";
@@ -172,7 +174,8 @@ class GCPEmbedder : public RemoteEmbedder {
         }
     public: 
         GCPEmbedder(const std::string& project_id, const std::string& model_name, const std::string& access_token, 
-                    const std::string& refresh_token, const std::string& client_id, const std::string& client_secret, const bool has_custom_dims = false, const size_t num_dims = 0);
+                    const std::string& refresh_token, const std::string& client_id, const std::string& client_secret, const bool has_custom_dims = false, const size_t num_dims = 0,
+                    const std::string& document_task = "RETRIEVAL_DOCUMENT", const std::string& query_task = "RETRIEVAL_QUERY");
         static Option<bool> is_model_valid(const nlohmann::json& model_config, size_t& num_dims, const bool has_custom_dims);
         embedding_res_t embed_query(const std::string& text, const size_t remote_embedder_timeout_ms = 30000, const size_t remote_embedding_num_tries = 2) override;
         std::vector<embedding_res_t> embed_documents(const std::vector<std::string>& inputs, const size_t remote_embedding_batch_size = 200,

--- a/src/text_embedder.cpp
+++ b/src/text_embedder.cpp
@@ -83,8 +83,16 @@ TextEmbedder::TextEmbedder(const nlohmann::json& model_config, size_t num_dims, 
         auto refresh_token = model_config["refresh_token"].get<std::string>();
         auto client_id = model_config["client_id"].get<std::string>();
         auto client_secret = model_config["client_secret"].get<std::string>();
+        std::string document_task = "RETRIEVAL_DOCUMENT";
+        if(model_config.count("document_task") > 0) {
+            document_task = model_config["document_task"].get<std::string>();
+        }
+        std::string query_task = "RETRIEVAL_QUERY";
+        if(model_config.count("query_task") > 0) {
+            query_task = model_config["query_task"].get<std::string>();
+        }
 
-        remote_embedder_ = std::make_unique<GCPEmbedder>(project_id, model_name, access_token, refresh_token, client_id, client_secret, has_custom_dims, num_dims);
+        remote_embedder_ = std::make_unique<GCPEmbedder>(project_id, model_name, access_token, refresh_token, client_id, client_secret, has_custom_dims, num_dims, document_task, query_task);
     } else if(model_namespace == "azure") {
         auto azure_url = model_config["url"].get<std::string>();
         auto api_key = model_config["api_key"].get<std::string>();


### PR DESCRIPTION
## Usage

```json
{
        "name": "products",
        "fields": [
          {
            "name": "product_name",
            "type": "string"
          },
          {
            "name": "embedding",
            "type": "float[]",
            "embed": {
              "from": [
                "product_name"
              ],
              "model_config": {
                "model_name": "gcp/text-embedding-005",
                "access_token": "your_gcp_access_token",
                "refresh_token": "your_gcp_refresh_token",
                "client_id": "your_gcp_app_client_id",
                "client_secret": "your_gcp_client_secret",
                "project_id": "your_gcp_project_id",
                "document_task": "RETRIEVAL_DOCUMENT",
                "query_task": "RETRIEVAL_QUERY"
              }
            }
          }
        ]
      }
```
