### PR TITLE
fix(docker): bootstrap python version to 3.8

### DIFF
--- a/docker/development-macos.Dockerfile
+++ b/docker/development-macos.Dockerfile
@@ -1,13 +1,13 @@
 # Build & Run:
-#    docker run -p 8108:8108 \
-#                 -v "$(pwd)":/build/typesense \
-#                 -v typesense-bazel-cache:/root/.cache/bazel \
-#                 -v"$(pwd)"/typesense-data:/data \
-#                 -e TYPESENSE_TARGET=typesense-server \
-#                 typesense-builder \
-#                 --data-dir=/data \
-#                 --api-key=xyz \
-#                 --enable-cors
+   docker run -p 8108:8108 \
+                -v "$(pwd)":/build/typesense \
+                -v typesense-bazel-cache:/root/.cache/bazel \
+                -v"$(pwd)"/typesense-data:/data \
+                -e TYPESENSE_TARGET=typesense-server \
+                typesense-builder \
+                --data-dir=/data \
+                --api-key=xyz \
+                --enable-cors
 #
 # Build & Test:
 #    docker run -v "$(pwd)":/build/typesense \
@@ -71,7 +71,7 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 30 && \
     update-alternatives --set c++ /usr/bin/g++
 
 # Install pip
-RUN curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py \
+RUN curl -sSL https://bootstrap.pypa.io/pip/3.8/get-pip.py -o /tmp/get-pip.py \
     && python3 /tmp/get-pip.py \
     && rm /tmp/get-pip.py
 

--- a/docker/development-macos.Dockerfile
+++ b/docker/development-macos.Dockerfile
@@ -1,13 +1,13 @@
 # Build & Run:
-   docker run -p 8108:8108 \
-                -v "$(pwd)":/build/typesense \
-                -v typesense-bazel-cache:/root/.cache/bazel \
-                -v"$(pwd)"/typesense-data:/data \
-                -e TYPESENSE_TARGET=typesense-server \
-                typesense-builder \
-                --data-dir=/data \
-                --api-key=xyz \
-                --enable-cors
+#    docker run -p 8108:8108 \
+#                 -v "$(pwd)":/build/typesense \
+#                 -v typesense-bazel-cache:/root/.cache/bazel \
+#                 -v"$(pwd)"/typesense-data:/data \
+#                 -e TYPESENSE_TARGET=typesense-server \
+#                 typesense-builder \
+#                 --data-dir=/data \
+#                 --api-key=xyz \
+#                 --enable-cors
 #
 # Build & Test:
 #    docker run -v "$(pwd)":/build/typesense \

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -151,6 +151,27 @@ struct StringUtils {
         return escaped.str();
     }
 
+    static std::string url_encode(const std::string& text) {
+        std::ostringstream escaped;
+        escaped.fill('0');
+        escaped << std::hex;
+
+        for (auto i = text.begin(), n = text.end(); i != n; ++i) {
+            std::string::value_type c = (*i);
+
+            // Keep alphanumeric and other accepted characters intact
+            if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+                escaped << c;
+                continue;
+            }
+
+            // Any other characters are percent-encoded
+            escaped << '%' << std::setw(2) << int((unsigned char)c);
+        }
+
+        return escaped.str();
+    }
+
     static bool is_float(const std::string &s) {
         try {
             size_t num_chars_processed = 0;

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -485,7 +485,7 @@ int HttpServer::catch_all_handler(h2o_handler_t *_h2o_handler, h2o_req_t *req) {
             // ignore params map of multi_search since it is mutated for every search object in the POST body
             for(const auto& kv: query_map) {
                 if(kv.first != http_req::AUTH_HEADER) {
-                    query_string += kv.first + "=" + kv.second + "&";
+                    query_string += kv.first + "=" + StringUtils::url_encode(kv.second) + "&";
                 }
             }
 


### PR DESCRIPTION
## Change Summary
When building the docker image using `development-macos.Dockerfile` it would trigger an error saying python version should be 3.9. This fixes it by using the error message suggestion.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
