### PR TITLE
fix: python bootstrap version should be 3.8

### DIFF
--- a/docker/development-macos.Dockerfile
+++ b/docker/development-macos.Dockerfile
@@ -71,7 +71,7 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 30 && \
     update-alternatives --set c++ /usr/bin/g++
 
 # Install pip
-RUN curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py \
+RUN curl -sSL https://bootstrap.pypa.io/pip/3.8/get-pip.py -o /tmp/get-pip.py \
     && python3 /tmp/get-pip.py \
     && rm /tmp/get-pip.py
 


### PR DESCRIPTION
## Change Summary
When building the docker image using `development-macos.Dockerfile` it would trigger an error saying python version should be 3.9. This fixes it by using the error message suggestion.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
