### PR TITLE
feat(conversation): add Azure OpenAI support for conversation models

### DIFF
--- a/include/conversation_model.h
+++ b/include/conversation_model.h
@@ -195,6 +195,10 @@ class AzureConversationModel : public ConversationModel {
         // prevent instantiation
         AzureConversationModel() = delete;
         static bool async_res_set_headers_callback(const std::string& response, const std::shared_ptr<http_req> req, long status_code, std::string& content_type);
+        static void _async_write_callback(std::string& response, const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res) {
+            // for testing purposes
+            return async_res_write_callback(response, req, res);
+        }
     private:
         static const inline std::string DATA_STR = "<Data>\n";
         static const inline std::string QUESTION_STR = "\n\n<Question>\n";

--- a/include/conversation_model.h
+++ b/include/conversation_model.h
@@ -31,6 +31,7 @@ class ConversationModel {
         static Option<std::string> get_answer_stream(const std::string& context, const std::string& prompt, const nlohmann::json& model_config,
                                                     const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res, 
                                                     const std::string conversation_id);
+        static std::shared_ptr<ConversationModel> get_conversation_model(const std::string& model_namespace, const nlohmann::json& model_config);
         // for testing
         static inline void _add_async_conversation(std::shared_ptr<http_req> req, const std::string& conversation_id) {
             async_conversations[req].conversation_id = conversation_id;
@@ -166,6 +167,39 @@ class GeminiConversationModel : public ConversationModel {
         static const inline std::string ANSWER_STR = "\n\n<Answer>";
         static Option<std::string> get_gemini_url(const nlohmann::json& model_config, const bool stream);
         static bool async_res_set_headers_callback(const std::string& response, const std::shared_ptr<http_req> req, long status_code, std::string& content_type);
+        static void async_res_write_callback(std::string& response, const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res);
+        static bool async_res_done_callback(const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res);
+};
+
+class AzureConversationModel : public ConversationModel {
+    public:
+        static Option<std::string> get_answer(const std::string& context, const std::string& prompt, const std::string& system_prompt, const nlohmann::json& model_config);
+        static Option<bool> validate_model(const nlohmann::json& model_config);
+        static Option<std::string> get_standalone_question(const nlohmann::json& conversation_history, const std::string& question, const nlohmann::json& model_config);
+        static Option<nlohmann::json> format_question(const std::string& message);
+        static Option<nlohmann::json> format_answer(const std::string& message);
+        static Option<std::string> get_answer_stream(const nlohmann::json& model_config,
+                                                   const std::string& prompt,
+                                                   const std::string& context,
+                                                   const std::string& system_prompt,
+                                                   const std::shared_ptr<http_req> req,
+                                                   const std::shared_ptr<http_res> res,
+                                                   const std::string& conversation_id);
+        // max_bytes must be greater than or equal to the minimum required bytes
+        static const size_t get_minimum_required_bytes() {
+            return  DATA_STR.size() + QUESTION_STR.size() + ANSWER_STR.size();
+        }
+        static const inline std::string STANDALONE_QUESTION_PROMPT = R"(
+            Rewrite the follow-up question on top of a human-assistant conversation history as a standalone question that encompasses all pertinent context.
+        )";
+        // prevent instantiation
+        AzureConversationModel() = delete;
+        static bool async_res_set_headers_callback(const std::string& response, const std::shared_ptr<http_req> req, long status_code, std::string& content_type);
+    private:
+        static const inline std::string DATA_STR = "<Data>\n";
+        static const inline std::string QUESTION_STR = "\n\n<Question>\n";
+        static const inline std::string ANSWER_STR = "\n\n<Answer>";
+        static Option<std::string> get_azure_url(const nlohmann::json& model_config);
         static void async_res_write_callback(std::string& response, const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res);
         static bool async_res_done_callback(const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res);
 };

--- a/src/conversation_model.cpp
+++ b/src/conversation_model.cpp
@@ -6,6 +6,7 @@
 #include "conversation_manager.h"
 #include "typesense_server_utils.h"
 #include "http_proxy.h"
+#include "string_utils.h"
 
 
 const std::string get_model_namespace(const std::string& model_name) {
@@ -53,6 +54,8 @@ Option<bool> ConversationModel::validate_model(const nlohmann::json& model_confi
         return vLLMConversationModel::validate_model(model_config);
     } else if(model_namespace == "gcp") {
         return GeminiConversationModel::validate_model(model_config);
+    } else if(model_namespace == "azure") {
+        return AzureConversationModel::validate_model(model_config);
     }
 
     return Option<bool>(400, "Model namespace `" + model_namespace + "` is not supported.");
@@ -75,6 +78,8 @@ Option<std::string> ConversationModel::get_answer(const std::string& context, co
         return vLLMConversationModel::get_answer(context, prompt, system_prompt, model_config);
     } else if(model_namespace == "gcp") {
         return GeminiConversationModel::get_answer(context, prompt, system_prompt, model_config);
+    } else if(model_namespace == "azure") {
+        return AzureConversationModel::get_answer(context, prompt, system_prompt, model_config);
     }
 
     return Option<std::string>(400, "Model namespace " + model_namespace + " is not supported.");
@@ -103,6 +108,8 @@ Option<std::string> ConversationModel::get_answer_stream(const std::string& cont
         response_op =  vLLMConversationModel::get_answer_stream(context, prompt, system_prompt, model_config, req, res);
     } else if(model_namespace == "gcp") {
         response_op =  GeminiConversationModel::get_answer_stream(context, prompt, system_prompt, model_config, req, res);
+    } else if(model_namespace == "azure") {
+        response_op = AzureConversationModel::get_answer_stream(model_config, prompt, context, system_prompt, req, res, conversation_id);
     } else {
         async_conversations.erase(req);
         return Option<std::string>(400, "Model namespace " + model_namespace + " is not supported.");
@@ -125,6 +132,8 @@ Option<std::string> ConversationModel::get_standalone_question(const nlohmann::j
         return vLLMConversationModel::get_standalone_question(conversation_history, question, model_config);
     } else if(model_namespace == "gcp") {
         return GeminiConversationModel::get_standalone_question(conversation_history, question, model_config);
+    } else if(model_namespace == "azure") {
+        return AzureConversationModel::get_standalone_question(conversation_history, question, model_config);
     }
 
     return Option<std::string>(400, "Model namespace " + model_namespace + " is not supported.");
@@ -141,6 +150,8 @@ Option<nlohmann::json> ConversationModel::format_question(const std::string& mes
         return vLLMConversationModel::format_question(message);
     } else if(model_namespace == "gcp") {
         return GeminiConversationModel::format_question(message);
+    } else if(model_namespace == "azure") {
+        return AzureConversationModel::format_question(message);
     }
 
     return Option<nlohmann::json>(400, "Model namespace " + model_namespace + " is not supported.");
@@ -157,6 +168,8 @@ Option<nlohmann::json> ConversationModel::format_answer(const std::string& messa
         return vLLMConversationModel::format_answer(message);
     } else if(model_namespace == "gcp") {
         return GeminiConversationModel::format_answer(message);
+    } else if(model_namespace == "azure") {
+        return AzureConversationModel::format_answer(message);
     }
 
     return Option<nlohmann::json>(400, "Model namespace " + model_namespace + " is not supported.");
@@ -173,6 +186,8 @@ Option<size_t> ConversationModel::get_minimum_required_bytes(const nlohmann::jso
         return Option<size_t>(vLLMConversationModel::get_minimum_required_bytes());
     } else if(model_namespace == "gcp") {
         return Option<size_t>(GeminiConversationModel::get_minimum_required_bytes());
+    } else if(model_namespace == "azure") {
+        return Option<size_t>(AzureConversationModel::get_minimum_required_bytes());
     }
 
     return Option<size_t>(400, "Model namespace " + model_namespace + " is not supported.");
@@ -1756,4 +1771,354 @@ Option<std::string> GeminiConversationModel::get_standalone_question(const nlohm
     } catch (const std::exception& e) {
         return Option<std::string>(400, "Got malformed response from Gemini API.");
     }
+}
+
+Option<std::string> AzureConversationModel::get_azure_url(const nlohmann::json& model_config) {
+    if (!model_config.contains("url")) {
+        return Option<std::string>(400, "url is required for Azure models");
+    }
+    return Option<std::string>(model_config["url"].get<std::string>());
+}
+
+Option<bool> AzureConversationModel::validate_model(const nlohmann::json& model_config) {
+    if (!model_config.contains("api_key")) {
+        return Option<bool>(400, "api_key is required for Azure models");
+    }
+    if (!model_config.contains("url")) {
+        return Option<bool>(400, "url is required for Azure models");
+    }
+    return Option<bool>(true);
+}
+
+Option<std::string> AzureConversationModel::get_answer(const std::string& context, const std::string& prompt, const std::string& system_prompt, const nlohmann::json& model_config) {
+    auto url_op = get_azure_url(model_config);
+    if (!url_op.ok()) {
+        return Option<std::string>(url_op.code(), url_op.error());
+    }
+
+    std::string url = url_op.get();
+    std::string api_key = model_config["api_key"].get<std::string>();
+
+    // Extract model name by removing "azure/" prefix
+    auto model_name = EmbedderManager::get_model_name_without_namespace(model_config["model_name"].get<std::string>());
+
+    nlohmann::json request_body;
+    request_body["model"] = model_name;
+    request_body["messages"] = nlohmann::json::array();
+    
+    if (!system_prompt.empty()) {
+        request_body["messages"].push_back({
+            {"role", "system"},
+            {"content", system_prompt}
+        });
+    }
+
+    request_body["messages"].push_back({
+        {"role", "user"},
+        {"content", context + prompt}
+    });
+
+    std::string response;
+    std::map<std::string, std::string> res_headers;
+    std::unordered_map<std::string, std::string> headers;
+    headers["api-key"] = api_key;
+    headers["Content-Type"] = "application/json";
+
+    long status_code = HttpClient::post_response(url, request_body.dump(), response, res_headers, headers);
+
+    if (status_code != 200) {
+        return Option<std::string>(status_code, "Failed to get response from Azure API: " + response);
+    }
+
+    try {
+        nlohmann::json response_json = nlohmann::json::parse(response);
+        if (response_json.contains("choices") && !response_json["choices"].empty() && 
+            response_json["choices"][0].contains("message") && 
+            response_json["choices"][0]["message"].contains("content")) {
+            return Option<std::string>(response_json["choices"][0]["message"]["content"].get<std::string>());
+        }
+        return Option<std::string>(500, "Invalid response format from Azure API");
+    } catch (const std::exception& e) {
+        return Option<std::string>(500, "Failed to parse Azure API response: " + std::string(e.what()));
+    }
+}
+
+Option<std::string> AzureConversationModel::get_standalone_question(const nlohmann::json& conversation_history, const std::string& question, const nlohmann::json& model_config) {
+    auto url_op = get_azure_url(model_config);
+    if (!url_op.ok()) {
+        return Option<std::string>(url_op.code(), url_op.error());
+    }
+
+    std::string url = url_op.get();
+    std::string api_key = model_config["api_key"].get<std::string>();
+
+    // Extract model name by removing "azure/" prefix
+    auto model_name = EmbedderManager::get_model_name_without_namespace(model_config["model_name"].get<std::string>());
+
+    nlohmann::json request_body;
+    request_body["model"] = model_name;
+    request_body["messages"] = nlohmann::json::array();
+
+    for (const auto& message : conversation_history) {
+        request_body["messages"].push_back({
+            {"role", message["role"].get<std::string>()},
+            {"content", message["content"].get<std::string>()}
+        });
+    }
+
+    request_body["messages"].push_back({
+        {"role", "system"},
+        {"content", STANDALONE_QUESTION_PROMPT}
+    });
+
+    request_body["messages"].push_back({
+        {"role", "user"},
+        {"content", question}
+    });
+
+    std::string response;
+    std::map<std::string, std::string> res_headers;
+    std::unordered_map<std::string, std::string> headers;
+    headers["api-key"] = api_key;
+    headers["Content-Type"] = "application/json";
+
+    long status_code = HttpClient::post_response(url, request_body.dump(), response, res_headers, headers);
+
+    if (status_code != 200) {
+        return Option<std::string>(status_code, "Failed to get response from Azure API: " + response);
+    }
+
+    try {
+        nlohmann::json response_json = nlohmann::json::parse(response);
+        if (response_json.contains("choices") && !response_json["choices"].empty() && 
+            response_json["choices"][0].contains("message") && 
+            response_json["choices"][0]["message"].contains("content")) {
+            return Option<std::string>(response_json["choices"][0]["message"]["content"].get<std::string>());
+        }
+        return Option<std::string>(500, "Invalid response format from Azure API");
+    } catch (const std::exception& e) {
+        return Option<std::string>(500, "Failed to parse Azure API response: " + std::string(e.what()));
+    }
+}
+
+Option<nlohmann::json> AzureConversationModel::format_question(const std::string& message) {
+    nlohmann::json formatted;
+    formatted["role"] = "user";
+    formatted["content"] = message;
+    return Option<nlohmann::json>(formatted);
+}
+
+Option<nlohmann::json> AzureConversationModel::format_answer(const std::string& message) {
+    nlohmann::json formatted;
+    formatted["role"] = "assistant";
+    formatted["content"] = message;
+    return Option<nlohmann::json>(formatted);
+}
+
+bool AzureConversationModel::async_res_set_headers_callback(const std::string& response, 
+                                                           const std::shared_ptr<http_req> req, 
+                                                           long status_code, 
+                                                           std::string& content_type) {
+    auto& async_conversations = ConversationModel::async_conversations;
+    if(async_conversations.find(req) == async_conversations.end()) {
+        return false;
+    }
+    
+    async_conversations[req].status_code = status_code;
+    if(status_code != 200) {
+        async_conversations[req].response = response;
+        async_conversations[req].ready = true;
+        async_conversations[req].cv.notify_one();
+        return false;
+    }
+    
+    content_type = "text/event-stream";
+    return true;
+}
+
+void AzureConversationModel::async_res_write_callback(std::string& response, const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res) {
+    auto& async_conversations = ConversationModel::async_conversations;
+    if(async_conversations.find(req) == async_conversations.end()) {
+        return;
+    }
+
+    try {
+        bool found_done = false;
+        std::string parsed_response;
+        std::regex data_regex("data: (.*?)\\n\\n");
+        auto begin = std::sregex_iterator(response.begin(), response.end(), data_regex);
+        auto end = std::sregex_iterator();
+        
+        
+        // Track if we've seen any non-empty content
+        bool has_content = false;
+        
+        for (std::sregex_iterator i = begin; i != end; ++i) {
+            std::string substr_line = i->str().substr(6, i->str().size() - 8);
+            
+            // Handle [DONE] signal
+            if(substr_line.find("[DONE]") != std::string::npos) {
+                found_done = true;
+                continue;  
+            }
+            
+            // Skip empty messages
+            if(substr_line.empty() || substr_line == "{}") {
+                continue;
+            }
+            
+            nlohmann::json json_line;
+            try {
+                json_line = nlohmann::json::parse(substr_line);
+            } catch (const std::exception& e) {
+                LOG(ERROR) << "Azure callback: Failed to parse JSON: " << substr_line << " Error: " << e.what();
+                continue;
+            }
+            
+            // Skip content filter results and empty messages
+            if (json_line.contains("prompt_filter_results") || 
+                (json_line.contains("choices") && json_line["choices"].empty())) {
+                continue;
+            }
+
+            // Skip role assignment messages
+            if (json_line.contains("choices") && !json_line["choices"].empty() && 
+                json_line["choices"][0].contains("delta") && 
+                json_line["choices"][0]["delta"].contains("role")) {
+                continue;
+            }
+
+            // Handle content chunks
+            if (json_line.contains("choices") && !json_line["choices"].empty() && 
+                json_line["choices"][0].contains("delta") && 
+                json_line["choices"][0]["delta"].contains("content")) {
+                std::string content = json_line["choices"][0]["delta"]["content"].get<std::string>();
+                if (!content.empty()) {
+                    parsed_response += content;
+                    has_content = true;
+                }
+            }
+
+            // Handle finish reason
+            if (json_line.contains("choices") && !json_line["choices"].empty() && 
+                json_line["choices"][0].contains("finish_reason") && 
+                !json_line["choices"][0]["finish_reason"].is_null()) {
+                std::string finish_reason = json_line["choices"][0]["finish_reason"].get<std::string>();
+                if (finish_reason == "stop") {
+                    found_done = true;
+                }
+            }
+        }
+
+        // Only send response if we have content
+        if (has_content) {
+            async_conversations[req].response += parsed_response;
+            nlohmann::json json_res;
+            json_res["message"] = parsed_response;
+            json_res["conversation_id"] = async_conversations[req].conversation_id;
+            response = "data: " + json_res.dump(-1) + "\n\n";
+        } else {
+            response = "";  // Don't send empty responses
+        }
+
+        // Send [DONE] if we've found it and we have content
+        if(found_done && has_content) {
+            response += "data: [DONE]\n\n";
+            async_conversations[req].ready = true;
+            async_conversations[req].cv.notify_one();
+        } 
+
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "Azure callback: Exception caught: " << e.what();
+        LOG(ERROR) << "Azure callback: Response that caused error: " << response;
+        // Set error response
+        async_conversations[req].response = "{\"error\":{\"message\":\"" + std::string(e.what()) + "\"}}";
+        async_conversations[req].ready = true;
+        async_conversations[req].cv.notify_one();
+    }
+}
+
+
+bool AzureConversationModel::async_res_done_callback(const std::shared_ptr<http_req> req, const std::shared_ptr<http_res> res) {
+    auto& async_conversations = ConversationModel::async_conversations;
+    if(async_conversations.find(req) == async_conversations.end()) {
+        return false;
+    }
+
+    // Only mark as done if not already marked by write callback
+    if (!async_conversations[req].ready) {
+        async_conversations[req].ready = true;
+        async_conversations[req].cv.notify_one();
+    }
+    return false;
+}
+
+Option<std::string> AzureConversationModel::get_answer_stream(const nlohmann::json& model_config,
+                                                             const std::string& prompt,
+                                                             const std::string& context,
+                                                             const std::string& system_prompt,
+                                                             const std::shared_ptr<http_req> req,
+                                                             const std::shared_ptr<http_res> res,
+                                                             const std::string& conversation_id) {
+    const std::string model_name = EmbedderManager::get_model_name_without_namespace(model_config["model_name"].get<std::string>());
+    const std::string api_key = model_config["api_key"].get<std::string>();
+    const std::string azure_url = model_config["url"].get<std::string>();
+
+    std::unordered_map<std::string, std::string> headers;
+    headers["api-key"] = api_key;
+    headers["Content-Type"] = "application/json";
+
+    nlohmann::json req_body;
+    req_body["messages"] = nlohmann::json::array();
+
+    if(!system_prompt.empty()) {
+        nlohmann::json system_message = nlohmann::json::object();
+        system_message["role"] = "system";
+        system_message["content"] = system_prompt;
+        req_body["messages"].push_back(system_message);
+    }
+
+    nlohmann::json message = nlohmann::json::object();
+    message["role"] = "user";
+    message["content"] = DATA_STR + context + QUESTION_STR + prompt + ANSWER_STR;
+    req_body["messages"].push_back(message);
+    req_body["stream"] = true;
+
+    req->async_res_set_headers_callback = async_res_set_headers_callback;
+    req->async_res_write_callback = async_res_write_callback;
+    req->async_res_done_callback = async_res_done_callback;
+
+    auto raft_server = RemoteEmbedder::get_raft_server();
+    if(raft_server && !raft_server->get_leader_url().empty()) {
+        auto proxy_url = raft_server->get_leader_url() + "proxy_sse";
+        nlohmann::json proxy_req_body;
+        proxy_req_body["method"] = "POST";
+        proxy_req_body["url"] = azure_url;
+        proxy_req_body["body"] = req_body.dump();
+        proxy_req_body["headers"] = headers;
+        std::unordered_map<std::string, std::string> header_;
+        header_["x-typesense-api-key"] = HttpClient::get_api_key();
+
+        HttpClient::get_instance().post_response_sse(proxy_url, proxy_req_body.dump(), header_, HttpProxy::default_timeout_ms, req, res, server);
+    } else {
+        HttpClient::get_instance().post_response_sse(azure_url, req_body.dump(), headers, HttpProxy::default_timeout_ms, req, res, server);
+    }
+
+    auto& async_conversation = async_conversations[req];
+    std::unique_lock<std::mutex> lock(async_conversation.mutex);
+    async_conversation.cv.wait(lock, [&async_conversation] { return async_conversation.ready; });
+
+    if(async_conversation.status_code != 200) {
+        try {
+            nlohmann::json error_json = nlohmann::json::parse(async_conversation.response);
+            if (error_json.contains("error") && error_json["error"].contains("message")) {
+                return Option<std::string>(400, "Azure API error: " + error_json["error"]["message"].get<std::string>());
+            }
+        } catch (const std::exception& e) {
+            LOG(ERROR) << "AzureConversationModel::get_answer_stream: Error parsing JSON: " << e.what();
+        }
+        return Option<std::string>(400, "Azure API error: " + async_conversation.response);
+    }
+
+    return Option<std::string>(async_conversation.response);
 }

--- a/test/conversation_test.cpp
+++ b/test/conversation_test.cpp
@@ -398,7 +398,7 @@ TEST_F(ConversationTest, TestAzureStreamManipulation) {
     ConversationModel::_add_async_conversation(req, "test");
 
     // Test initial prompt filter results
-    std::string test = R"({"choices":[],"created":0,"id":"","model":"","object":"","prompt_filter_results":[{"prompt_index":0,"content_filter_results":{"hate":{"filtered":false,"severity":"safe"},"jailbreak":{"filtered":false,"detected":false},"self_harm":{"filtered":false,"severity":"safe"},"sexual":{"filtered":false,"severity":"safe"},"violence":{"filtered":false,"severity":"safe"}}}]})";
+    std::string test = "{\"choices\":[],\"created\":0,\"id\":\"\",\"model\":\"\",\"object\":\"\",\"prompt_filter_results\":[{\"prompt_index\":0,\"content_filter_results\":{\"hate\":{\"filtered\":false,\"severity\":\"safe\"},\"jailbreak\":{\"filtered\":false,\"detected\":false},\"self_harm\":{\"filtered\":false,\"severity\":\"safe\"},\"sexual\":{\"filtered\":false,\"severity\":\"safe\"},\"violence\":{\"filtered\":false,\"severity\":\"safe\"}}}]}";
 
     // This should be ignored as it has no content
     std::string expected = "";
@@ -412,12 +412,8 @@ TEST_F(ConversationTest, TestAzureStreamBasicContent) {
     ConversationModel::_add_async_conversation(req, "test");
 
     // Test basic content streaming
-    std::string test = R"(data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}
-
-)";
-    std::string expected = R"(data: {"conversation_id":"test","message":"Hello"}
-
-)";
+    std::string test = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n";
+    std::string expected = "data: {\"conversation_id\":\"test\",\"message\":\"Hello\"}\n\n";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);
 }
@@ -428,17 +424,13 @@ TEST_F(ConversationTest, TestAzureStreamEmptyMessages) {
     ConversationModel::_add_async_conversation(req, "test");
 
     // Test empty messages
-    std::string test = R"(data: {"choices":[]}
-
-)";
+    std::string test = "data: {\"choices\":[]}\n\n";
     std::string expected = "";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);
 
     // Test empty JSON object
-    test = R"(data: {}
-
-)";
+    test = "data: {}\n\n";
     expected = "";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);
@@ -450,9 +442,7 @@ TEST_F(ConversationTest, TestAzureStreamRoleAssignment) {
     ConversationModel::_add_async_conversation(req, "test");
 
     // Test role assignment message
-    std::string test = R"(data: {"choices":[{"delta":{"role":"assistant"},"finish_reason":null}]}
-
-)";
+    std::string test = "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n";
     std::string expected = "";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);
@@ -464,14 +454,9 @@ TEST_F(ConversationTest, TestAzureStreamFinishReason) {
     ConversationModel::_add_async_conversation(req, "test");
 
     // Test finish reason with content
-    std::string test = R"(data: {"choices":[{"delta":{"content":"Goodbye"},"finish_reason":"stop"}]}
-
-)";
-    std::string expected = R"(data: {"conversation_id":"test","message":"Goodbye"}
-
-data: [DONE]
-
-)";
+    std::string test = "data: {\"choices\":[{\"delta\":{\"content\":\"Goodbye\"},\"finish_reason\":\"stop\"}]}\n\n";
+    std::string expected = "data: {\"conversation_id\":\"test\",\"message\":\"Goodbye\"}\n\n"
+                          "data: [DONE]\n\n";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);
 }
@@ -482,23 +467,14 @@ TEST_F(ConversationTest, TestAzureStreamMultipleChunks) {
     ConversationModel::_add_async_conversation(req, "test");
 
     // Test multiple content chunks
-    std::string test = R"(data: {"choices":[{"delta":{"content":"Hello "},"finish_reason":null}]}
-
-)";
-    std::string expected = R"(data: {"conversation_id":"test","message":"Hello "}
-
-)";
+    std::string test = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello \"},\"finish_reason\":null}]}\n\n";
+    std::string expected = "data: {\"conversation_id\":\"test\",\"message\":\"Hello \"}\n\n";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);
 
-    test = R"(data: {"choices":[{"delta":{"content":"World"},"finish_reason":"stop"}]}
-
-)";
-    expected = R"(data: {"conversation_id":"test","message":"World"}
-
-data: [DONE]
-
-)";
+    test = "data: {\"choices\":[{\"delta\":{\"content\":\"World\"},\"finish_reason\":\"stop\"}]}\n\n";
+    expected = "data: {\"conversation_id\":\"test\",\"message\":\"World\"}\n\n"
+               "data: [DONE]\n\n";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);
 }
@@ -509,17 +485,13 @@ TEST_F(ConversationTest, TestAzureStreamErrorHandling) {
     ConversationModel::_add_async_conversation(req, "test");
 
     // Test invalid JSON
-    std::string test = R"(data: {invalid json}
-
-)";
+    std::string test = "data: {invalid json}\n\n";
     std::string expected = "";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);
 
     // Test malformed content
-    test = R"(data: {"choices":[{"delta":{},"finish_reason":null}]}
-
-)";
+    test = "data: {\"choices\":[{\"delta\":{},\"finish_reason\":null}]}\n\n";
     expected = "";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);

--- a/test/conversation_test.cpp
+++ b/test/conversation_test.cpp
@@ -412,8 +412,8 @@ TEST_F(ConversationTest, TestAzureStreamBasicContent) {
     ConversationModel::_add_async_conversation(req, "test");
 
     // Test basic content streaming
-    std::string test = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello\"},\"finish_reason\":null}]}\n\n";
-    std::string expected = "data: {\"conversation_id\":\"test\",\"message\":\"Hello\"}\n\n";
+    std::string test = std::string(R"(data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]})") + "\n\n";
+    std::string expected = std::string(R"(data: {"conversation_id":"test","message":"Hello"})") + "\n\n";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);
 }
@@ -424,13 +424,13 @@ TEST_F(ConversationTest, TestAzureStreamEmptyMessages) {
     ConversationModel::_add_async_conversation(req, "test");
 
     // Test empty messages
-    std::string test = "data: {\"choices\":[]}\n\n";
+    std::string test = std::string(R"(data: {"choices":[]})") + "\n\n";
     std::string expected = "";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);
 
     // Test empty JSON object
-    test = "data: {}\n\n";
+    test = std::string(R"(data: {})") + "\n\n";
     expected = "";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);
@@ -442,7 +442,7 @@ TEST_F(ConversationTest, TestAzureStreamRoleAssignment) {
     ConversationModel::_add_async_conversation(req, "test");
 
     // Test role assignment message
-    std::string test = "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n";
+    std::string test = std::string(R"(data: {"choices":[{"delta":{"role":"assistant"},"finish_reason":null}]})") + "\n\n";
     std::string expected = "";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);
@@ -454,9 +454,8 @@ TEST_F(ConversationTest, TestAzureStreamFinishReason) {
     ConversationModel::_add_async_conversation(req, "test");
 
     // Test finish reason with content
-    std::string test = "data: {\"choices\":[{\"delta\":{\"content\":\"Goodbye\"},\"finish_reason\":\"stop\"}]}\n\n";
-    std::string expected = "data: {\"conversation_id\":\"test\",\"message\":\"Goodbye\"}\n\n"
-                          "data: [DONE]\n\n";
+    std::string test = std::string(R"(data: {"choices":[{"delta":{"content":"Goodbye"},"finish_reason":"stop"}]})") + "\n\n";
+    std::string expected = std::string(R"(data: {"conversation_id":"test","message":"Goodbye"})") + "\n\n" + "data: [DONE]\n\n";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);
 }
@@ -467,14 +466,13 @@ TEST_F(ConversationTest, TestAzureStreamMultipleChunks) {
     ConversationModel::_add_async_conversation(req, "test");
 
     // Test multiple content chunks
-    std::string test = "data: {\"choices\":[{\"delta\":{\"content\":\"Hello \"},\"finish_reason\":null}]}\n\n";
-    std::string expected = "data: {\"conversation_id\":\"test\",\"message\":\"Hello \"}\n\n";
+    std::string test = std::string(R"(data: {"choices":[{"delta":{"content":"Hello "},"finish_reason":null}]})") + "\n\n";
+    std::string expected = std::string(R"(data: {"conversation_id":"test","message":"Hello "})") + "\n\n";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);
 
-    test = "data: {\"choices\":[{\"delta\":{\"content\":\"World\"},\"finish_reason\":\"stop\"}]}\n\n";
-    expected = "data: {\"conversation_id\":\"test\",\"message\":\"World\"}\n\n"
-               "data: [DONE]\n\n";
+    test = std::string(R"(data: {"choices":[{"delta":{"content":"World"},"finish_reason":"stop"}]})") + "\n\n";
+    expected = std::string(R"(data: {"conversation_id":"test","message":"World"})") + "\n\n" + "data: [DONE]\n\n";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);
 }
@@ -485,13 +483,13 @@ TEST_F(ConversationTest, TestAzureStreamErrorHandling) {
     ConversationModel::_add_async_conversation(req, "test");
 
     // Test invalid JSON
-    std::string test = "data: {invalid json}\n\n";
+    std::string test = std::string(R"(data: {invalid json})") + "\n\n";
     std::string expected = "";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);
 
     // Test malformed content
-    test = "data: {\"choices\":[{\"delta\":{},\"finish_reason\":null}]}\n\n";
+    test = std::string(R"(data: {"choices":[{"delta":{},"finish_reason":null}]})") + "\n\n";
     expected = "";
     AzureConversationModel::_async_write_callback(test, req, res);
     ASSERT_EQ(test, expected);


### PR DESCRIPTION
### TLDR
Adds Azure OpenAI support to conversation models with streaming response handling.

## Change Summary

#### Added Features:
1. **New Class in `conversation_model.h`**:
   - `AzureConversationModel`: Implements Azure OpenAI API integration with streaming support

3. **Updated Methods in `ConversationModel`**:
   - Added Azure namespace handling across all base class methods

#### Unit Tests:
1. **In `conversation_test.cpp`**:
   - Added test cases for Azure streaming response handling:
     - Initial prompt filter results handling
     - Basic content streaming
     - Empty message handling  
     - Role assignment message processing
     - Finish reason with content
     - Multiple content chunks processing
     - Error handling for invalid JSON and malformed content

### Demo
```bash
# Create a new conversation model using Azure OpenAI
curl 'http://localhost:8108/conversations/models' \
  -X POST \
  -H 'Content-Type: application/json' \
  -H "X-TYPESENSE-API-KEY: xyz" \
  -d '{
        "id": "conv-model-1",
        "model_name": "azure/gpt-35-turbo",
        "history_collection": "conversation_store",
        "api_key": "<your_api_key>",
        "url": "https://your_resource.openai.azure.com/openai/deployments/your_deployment/chat/completions?api-version=2025-01-01-preview",
        "system_prompt": "You are an assistant for question-answering. You can only make conversations based on the provided context. If a response cannot be formed strictly using the provided context, politely say you do not have knowledge about that topic.",
        "max_bytes": 16384
      }'
```

### Context
Issues #2276 and #1828

This PR adds support for Microsoft Azure's OpenAI service, allowing users to integrate Azure-hosted models like GPT-3.5 and GPT-4 with our conversation system.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
