### PR TITLE
feat: url encoding in search_logs

### DIFF
--- a/docker/development-macos-entrypoint.sh
+++ b/docker/development-macos-entrypoint.sh
@@ -13,8 +13,17 @@ cd /build/typesense
 /bin/bash ci_build_v2.sh $BUILD_FLAGS
 
 if [ "$TYPESENSE_TARGET" = "typesense-test" ]; then
-    # Run the tests
-    bazel test --cache_test_results=no --test_output=all //:typesense-test
+    # Run the tests and pass any additional arguments to the test command
+    # Properly set up test arguments for Bazel
+    TEST_ARGS=""
+    for arg in "$@"; do
+        # Format each argument correctly for passing to the test binary
+        TEST_ARGS="$TEST_ARGS --test_arg=$arg"
+    done
+    
+    echo "Running test command: bazel test --cache_test_results=no --test_output=all $TEST_ARGS //:typesense-test"
+    
+    bazel test --cache_test_results=no --test_output=all $TEST_ARGS //:typesense-test
 else
     # Forward signals to the child process
     trap 'kill -TERM $child' TERM INT

--- a/docker/development-macos.Dockerfile
+++ b/docker/development-macos.Dockerfile
@@ -1,4 +1,9 @@
-# Build & Run:
+# First time setup:
+# 1) Note: If using Docker Desktop, increase memory limit in Docker Desktop > Settings > Resources > Memory (requires at least 16GB)
+# 2) docker volume create typesense-bazel-cache
+# 3) docker build -t typesense-builder -f docker/development-macos.Dockerfile .
+
+# Build & Run typesense-server:
 #    docker run -p 8108:8108 \
 #                 -v "$(pwd)":/build/typesense \
 #                 -v typesense-bazel-cache:/root/.cache/bazel \
@@ -9,17 +14,19 @@
 #                 --api-key=xyz \
 #                 --enable-cors
 #
-# Build & Test:
+# Build & Test entire test suite:
 #    docker run -v "$(pwd)":/build/typesense \
 #                 -v typesense-bazel-cache:/root/.cache/bazel \
 #                 -e TYPESENSE_TARGET=typesense-test \
 #                 typesense-builder
 #
-
-# First time setup:
-# Note: If using Docker Desktop, increase memory limit in Docker Desktop > Settings > Resources > Memory (requires at least 16GB)
-# docker volume create typesense-bazel-cache
-# docker build -t typesense-builder -f docker/development-macos.Dockerfile .
+# Build & Test single test:
+#    docker run -v "$(pwd)":/build/typesense \
+#                 -v typesense-bazel-cache:/root/.cache/bazel \
+#                 -e TYPESENSE_TARGET=typesense-test \
+#                 typesense-builder \
+#                 --gtest_filter="TestSuiteName.TestName"
+#
 
 FROM ubuntu:20.04
 

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -372,7 +372,7 @@ struct StringUtils {
             std::string::value_type c = (*i);
 
             // Keep alphanumeric and other accepted characters intact
-            if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+            if (std::isalnum(static_cast<unsigned char>(c)) || c=='-' || c=='_' || c=='.' || c=='~') {
                 escaped << c;
                 continue;
             }

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -8,6 +8,7 @@
 #include <random>
 #include <map>
 #include <queue>
+#include <iomanip>
 #include "wyhash_v5.h"
 #include <unicode/normalizer2.h>
 #include <set>
@@ -361,4 +362,27 @@ struct StringUtils {
                                                      std::vector<std::string>& tokens);
 
     static size_t get_occurence_count(const std::string& str, char symbol);
+
+    static std::string url_encode(const std::string& value) {
+        std::ostringstream escaped;
+        escaped.fill('0');
+        escaped << std::hex;
+
+        for (std::string::const_iterator i = value.begin(), n = value.end(); i != n; ++i) {
+            std::string::value_type c = (*i);
+
+            // Keep alphanumeric and other accepted characters intact
+            if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+                escaped << c;
+                continue;
+            }
+
+            // Any other characters are percent-encoded
+            escaped << std::uppercase;
+            escaped << '%' << std::setw(2) << int((unsigned char) c);
+            escaped << std::nouppercase;
+        }
+
+        return escaped.str();
+    }
 };

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -485,7 +485,7 @@ int HttpServer::catch_all_handler(h2o_handler_t *_h2o_handler, h2o_req_t *req) {
             // ignore params map of multi_search since it is mutated for every search object in the POST body
             for(const auto& kv: query_map) {
                 if(kv.first != http_req::AUTH_HEADER) {
-                    query_string += kv.first + "=" + kv.second + "&";
+                    query_string += kv.first + "=" + StringUtils::url_encode(kv.second) + "&";
                 }
             }
 

--- a/test/string_utils_test.cpp
+++ b/test/string_utils_test.cpp
@@ -499,3 +499,30 @@ TEST(StringUtilsTest, SplitReferenceIncludeExcludeFields) {
     ASSERT_EQ("$inventory(qty,sku,$retailer(id,title))", token);
     ASSERT_EQ(", foo)", exclude_fields.substr(index));
 }
+
+TEST(StringUtilsTest, ShouldURLEncode) {
+    // Test basic alphanumeric characters (should remain unchanged)
+    ASSERT_STREQ("abc123", StringUtils::url_encode("abc123").c_str());
+    
+    // Test special characters that should be percent-encoded
+    ASSERT_STREQ("Hello%20World%21", StringUtils::url_encode("Hello World!").c_str());
+    ASSERT_STREQ("test%40example.com", StringUtils::url_encode("test@example.com").c_str());
+    ASSERT_STREQ("path%2Fto%2Ffile", StringUtils::url_encode("path/to/file").c_str());
+    
+    // Test characters that should remain unchanged (-_.~)
+    ASSERT_STREQ("test-file.txt", StringUtils::url_encode("test-file.txt").c_str());
+    ASSERT_STREQ("user_name", StringUtils::url_encode("user_name").c_str());
+    ASSERT_STREQ("example.com", StringUtils::url_encode("example.com").c_str());
+    ASSERT_STREQ("~home", StringUtils::url_encode("~home").c_str());
+    
+    // Test empty string
+    ASSERT_STREQ("", StringUtils::url_encode("").c_str());
+    
+    // Test Unicode characters
+    ASSERT_STREQ("%E2%82%AC", StringUtils::url_encode("€").c_str());
+    ASSERT_STREQ("%E6%97%A5%E6%9C%AC%E8%AA%9E", StringUtils::url_encode("日本語").c_str());
+    
+    // Test mixed content
+    ASSERT_STREQ("Hello%20World%21%20%E2%82%AC%20test%40example.com", 
+                 StringUtils::url_encode("Hello World! € test@example.com").c_str());
+}


### PR DESCRIPTION
## Change Summary
search_requests logs weren't url encoded. This changes update it, creating a url_encode tool in StringUtils

![0ceeneJhQQ](https://github.com/user-attachments/assets/00b071a7-3626-454a-88a3-cbc821dd9570)


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
