### PR TITLE
Add Bazel Dockerfile for Local Development

### DIFF
--- a/docker/bazel_dev.Dockerfile
+++ b/docker/bazel_dev.Dockerfile
@@ -1,13 +1,10 @@
-# $ docker build --file docker/bazel_dev.Dockerfile --tag  typesense/bazel_dev:DDMMYYYY ./docker
-# NOTE: Default build image is bloated. Before publishing, export from a container to squash the image:
-# $ docker run -it typesense/bazel_dev:DDMMYYYY bash -c "exit"
-# $ docker ps -a | grep bazel_dev
-# $ docker export <container_id> | docker import - typesense/bazel_dev:latest
-# $ docker push typesense/bazel_dev:latest
+# Base image
+FROM ubuntu:20.04
 
-FROM ubuntu:14.10
+# Prevent interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
+# Install dependencies
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	tar \
@@ -16,50 +13,55 @@ RUN apt-get update && apt-get install -y \
 	libmpc-dev \
 	flex \
 	bison \
-	zlib1g-dev
+	zlib1g-dev \
+	libssl-dev \
+	git \
+	locales \
+	wget \
+	curl && \
+	rm -rf /var/lib/apt/lists/*
 
-ADD https://ftp.gnu.org/gnu/gcc/gcc-10.3.0/gcc-10.3.0.tar.gz /opt/
-RUN tar -C /opt -xf /opt/gcc-10.3.0.tar.gz
-
-RUN mkdir /opt/gcc-10.3.0/build && cd /opt/gcc-10.3.0/build && ../configure --disable-checking --enable-languages=c,c++ \
-      --enable-multiarch --disable-multilib --enable-shared --enable-threads=posix \
-      --with-gmp=/usr/lib --with-mpc=/usr/lib --with-mpfr=/usr/lib \
-      --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu \
-      --without-included-gettext --with-tune=generic --prefix=/usr/local/gcc-10.3.0
-RUN cd /opt/gcc-10.3.0/build && make -j8
-RUN cd /opt/gcc-10.3.0/build && make install
-
-RUN apt-get remove -y gcc
-RUN rm -rf /opt/gcc-10.3.0 /opt/gcc-10.3.0.tar.gz
-
-ADD https://github.com/bazelbuild/bazel/releases/download/5.2.0/bazel-5.2.0-linux-x86_64 /opt/
-RUN chmod 777 /opt/bazel-5.2.0-linux-x86_64
-RUN mv /opt/bazel-5.2.0-linux-x86_64 /usr/bin/bazel
-
-# To force extraction of installation
-RUN /usr/bin/bazel --version
-
-RUN apt-get -y install git
-
-#RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-
-ENV CC /usr/local/gcc-10.3.0/bin/gcc
-ENV CXX /usr/local/gcc-10.3.0/bin/g++
-ENV PATH /usr/local/gcc-10.3.0/bin/:$PATH
-ENV LD_LIBRARY_PATH /usr/local/gcc-10.3.0/lib64
-
+# Set up UTF-8 locale
 RUN locale-gen en_US.UTF-8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 
-RUN apt install -y libssl-dev
+# Install GCC 10.3.0
+ADD https://ftp.gnu.org/gnu/gcc/gcc-10.3.0/gcc-10.3.0.tar.gz /opt/
+RUN tar -C /opt -xf /opt/gcc-10.3.0.tar.gz && \
+	mkdir /opt/gcc-10.3.0/build && \
+	cd /opt/gcc-10.3.0/build && \
+	../configure --disable-checking --enable-languages=c,c++ \
+	--disable-multilib --enable-shared --enable-threads=posix \
+	--with-gmp=/usr/lib --with-mpc=/usr/lib --with-mpfr=/usr/lib \
+	--without-included-gettext --prefix=/usr/local/gcc-10.3.0 && \
+	make -j8 && make install && \
+	rm -rf /opt/gcc-10.3.0 /opt/gcc-10.3.0.tar.gz
 
+# Set GCC as default compiler
+ENV CC=/usr/local/gcc-10.3.0/bin/gcc \
+	CXX=/usr/local/gcc-10.3.0/bin/g++ \
+	PATH=/usr/local/gcc-10.3.0/bin/:$PATH \
+	LD_LIBRARY_PATH=/usr/local/gcc-10.3.0/lib64
+
+# Install Bazel (ARM64 version)
+ADD https://github.com/bazelbuild/bazel/releases/download/5.2.0/bazel-5.2.0-linux-arm64 /opt/
+RUN chmod +x /opt/bazel-5.2.0-linux-arm64 && \
+	mv /opt/bazel-5.2.0-linux-arm64 /usr/bin/bazel && \
+	bazel --version
+
+# Install Python 3.6.3 (fast version without optimizations)
 ADD https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tgz /opt
-RUN tar -C /opt -xf /opt/Python-3.6.3.tgz
-RUN cd /opt/Python-3.6.3 && ./configure --enable-optimizations && make install
+RUN tar -C /opt -xf /opt/Python-3.6.3.tgz && \
+	cd /opt/Python-3.6.3 && \
+	./configure && \
+	make -j8 && make install && \
+	rm -rf /opt/Python-3.6.3 /opt/Python-3.6.3.tgz
 
+# Install pip for Python 3.6
 ADD https://bootstrap.pypa.io/pip/3.6/get-pip.py /opt
-RUN /usr/local/bin/python3.6 /opt/get-pip.py
+RUN /usr/local/bin/python3.6 /opt/get-pip.py && \
+	update-alternatives --install /usr/bin/python python /usr/local/bin/python3.6 1 && \
+	rm -f /opt/get-pip.py
 
-RUN update-alternatives --install /usr/bin/python python /usr/local/bin/python3.6 1
-
-
+# Set working directory
+WORKDIR /app


### PR DESCRIPTION
## Change Summary
This PR introduces a bazel_dev.Dockerfile in the docker/ directory, intended to simplify local Typesense development using Bazel. It includes:

GCC 10.3.0 built from source

Python 3.6.3 built from source

Bazel 5.2.0 binary install

Ubuntu 20.04 base image

Cleaned up image (removed temp build files)

## PR Checklist

 I have read and signed the Contributor License Agreement.

 Tested the Docker image by running bazel --version and building the project inside the container

 Verified Python and GCC versions work as expected

 The Dockerfile is non-intrusive and lives only under docker/

- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
