### PR TITLE
fix(override): add support for nested object fields in overrides

### DIFF
--- a/src/override.cpp
+++ b/src/override.cpp
@@ -132,6 +132,9 @@ Option<bool> override_t::parse(const nlohmann::json& override_json, const std::s
         symbols.push_back('{');
         symbols.push_back('}');
         symbols.push_back('*');
+        symbols.push_back('.');
+
+
         Tokenizer tokenizer(override.rule.query, true, false, locale, symbols, token_separators);
         std::vector<std::string> tokens;
         tokenizer.tokenize(tokens);


### PR DESCRIPTION
### TLDR

Add support for filtering with nested object fields in collection overrides.
## Change Summary
### Code Changes:

*    In **`src/override.cpp`**:
        - Added support for the `.` symbol in the tokenizer to handle nested field notation
        - Updated the token parsing logic to properly process nested object fields
        - Now doesn't break concat the field name into `nested.field -> nestedfield`.

 *  In test/collection_override_test.cpp:
     -  Added test case `NestedObjectOverride` that validates the behavior
     - When searching for "nike shoes", the override will:

       1. Extract "nike" as the value for nested.brand
       1. Apply the filter nested.brand:nike && nested.category:shoes
       1. Remove the matched tokens from the query



### Context

Previously, the override tokenizer didn't recognize the dot (`.`) character, which prevented using nested field notation in dynamic filters.

## PR Checklist

 - [x]    I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
