### PR TITLE
chore: added a slighly more descritive error message for collection no…

### DIFF
--- a/docker/development-macos.Dockerfile
+++ b/docker/development-macos.Dockerfile
@@ -78,7 +78,7 @@ RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 30 && \
     update-alternatives --set c++ /usr/bin/g++
 
 # Install pip
-RUN curl -sSL https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py \
+RUN curl -sSL https://bootstrap.pypa.io/pip/3.8/get-pip.py -o /tmp/get-pip.py \
     && python3 /tmp/get-pip.py \
     && rm /tmp/get-pip.py
 

--- a/include/http_data.h
+++ b/include/http_data.h
@@ -128,10 +128,11 @@ struct http_res {
         body = "{\"message\": \"Forbidden\"}";
     }
 
-    void set_404() {
-        status_code = 404;
-        body = "{\"message\": \"Not Found\"}";
+    void set_404(const std::string & message = "Not Found") {
+        status_code = 400;
+        body = "{\"message\": \"" + message + "\"}";
     }
+
 
     void set_405(const std::string & message) {
         status_code = 405;

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1391,7 +1391,7 @@ Option<bool> CollectionManager::do_search(std::map<std::string, std::string>& re
     auto collection = collectionManager.get_collection(orig_coll_name);
 
     if(collection == nullptr) {
-        return Option<bool>(404, "Not found.");
+        return Option<bool>(404, "Collection not found");
     }
 
     collection_search_args_t args;

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -328,7 +328,7 @@ bool patch_update_collection(const std::shared_ptr<http_req>& req, const std::sh
     auto collection = collectionManager.get_collection(req->params["collection"]);
 
     if(collection == nullptr) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 
@@ -1240,7 +1240,7 @@ bool get_collection_summary(const std::shared_ptr<http_req>& req, const std::sha
     auto collection = collectionManager.get_collection(req->params["collection"]);
 
     if(collection == nullptr) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 
@@ -1258,7 +1258,7 @@ bool get_export_documents(const std::shared_ptr<http_req>& req, const std::share
     if(collection == nullptr) {
         req->last_chunk_aggregate = true;
         res->final = true;
-        res->set_404();
+        res->set_404("Collection not found");
         stream_response(req, res);
         return false;
     }
@@ -1553,7 +1553,7 @@ bool post_import_documents(const std::shared_ptr<http_req>& req, const std::shar
     if(collection == nullptr) {
         //LOG(INFO) << "collection == nullptr, for collection: " << req->params["collection"];
         res->final = true;
-        res->set_404();
+        res->set_404("Collection not found");
         stream_response(req, res);
         return false;
     }
@@ -1662,7 +1662,7 @@ bool post_add_document(const std::shared_ptr<http_req>& req, const std::shared_p
     auto collection = collectionManager.get_collection(req->params["collection"]);
 
     if(collection == nullptr) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 
@@ -1728,7 +1728,7 @@ bool patch_update_document(const std::shared_ptr<http_req>& req, const std::shar
     auto collection = collectionManager.get_collection(req->params["collection"]);
 
     if(collection == nullptr) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 
@@ -1763,7 +1763,7 @@ bool patch_update_documents(const std::shared_ptr<http_req>& req, const std::sha
     CollectionManager & collectionManager = CollectionManager::get_instance();
     auto collection = collectionManager.get_collection(req->params["collection"]);
     if(collection == nullptr) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 
@@ -1802,7 +1802,7 @@ bool get_fetch_document(const std::shared_ptr<http_req>& req, const std::shared_
     CollectionManager & collectionManager = CollectionManager::get_instance();
     auto collection = collectionManager.get_collection(req->params["collection"]);
     if(collection == nullptr) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 
@@ -1855,7 +1855,7 @@ bool del_remove_document(const std::shared_ptr<http_req>& req, const std::shared
     CollectionManager & collectionManager = CollectionManager::get_instance();
     auto collection = collectionManager.get_collection(req->params["collection"]);
     if(collection == nullptr) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 
@@ -1905,7 +1905,7 @@ bool del_remove_documents(const std::shared_ptr<http_req>& req, const std::share
     if(collection == nullptr) {
         req->last_chunk_aggregate = true;
         res->final = true;
-        res->set_404();
+        res->set_404("Collection not found");
         stream_response(req, res);
         return false;
     }
@@ -2105,7 +2105,7 @@ bool get_alias(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_
     Option<std::string> collection_name_op = collectionManager.resolve_symlink(alias);
 
     if(!collection_name_op.ok()) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 
@@ -2155,7 +2155,7 @@ bool del_alias(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_
 
     Option<std::string> collection_name_op = collectionManager.resolve_symlink(alias);
     if(!collection_name_op.ok()) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 
@@ -2178,7 +2178,7 @@ bool get_overrides(const std::shared_ptr<http_req>& req, const std::shared_ptr<h
     auto collection = collectionManager.get_collection(req->params["collection"]);
 
     if(collection == nullptr) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 
@@ -2225,7 +2225,7 @@ bool get_override(const std::shared_ptr<http_req>& req, const std::shared_ptr<ht
     auto collection = collectionManager.get_collection(req->params["collection"]);
 
     if(collection == nullptr) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 
@@ -2249,7 +2249,7 @@ bool put_override(const std::shared_ptr<http_req>& req, const std::shared_ptr<ht
     std::string override_id = req->params["id"];
 
     if(collection == nullptr) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 
@@ -2290,7 +2290,7 @@ bool del_override(const std::shared_ptr<http_req>& req, const std::shared_ptr<ht
     auto collection = collectionManager.get_collection(req->params["collection"]);
 
     if(collection == nullptr) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 
@@ -2542,7 +2542,7 @@ bool get_synonyms(const std::shared_ptr<http_req>& req, const std::shared_ptr<ht
     auto collection = collectionManager.get_collection(req->params["collection"]);
 
     if(collection == nullptr) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 
@@ -2588,7 +2588,7 @@ bool get_synonym(const std::shared_ptr<http_req>& req, const std::shared_ptr<htt
     auto collection = collectionManager.get_collection(req->params["collection"]);
 
     if(collection == nullptr) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 
@@ -2614,7 +2614,7 @@ bool put_synonym(const std::shared_ptr<http_req>& req, const std::shared_ptr<htt
     std::string synonym_id = req->params["id"];
 
     if(collection == nullptr) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 
@@ -2671,7 +2671,7 @@ bool del_synonym(const std::shared_ptr<http_req>& req, const std::shared_ptr<htt
     auto collection = collectionManager.get_collection(req->params["collection"]);
 
     if(collection == nullptr) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 
@@ -3300,7 +3300,7 @@ bool get_stemming_dictionary(const std::shared_ptr<http_req>& req, const std::sh
     nlohmann::json dictionary;
 
     if(!StemmerManager::get_instance().get_stemming_dictionary(id, dictionary)) {
-        res->set_404();
+        res->set_404("Collection not found");
         return false;
     }
 

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -98,6 +98,22 @@ TEST_F(CollectionTest, VerifyCountOfDocuments) {
     ASSERT_EQ(DIRTY_VALUES::REJECT, collection->parse_dirty_values_option(empty_dirty_values));
 }
 
+TEST_F(CollectionTest, CollectionNotFoundError) {
+    // Try to get a non-existent collection
+    auto non_existent_collection = collectionManager.get_collection("non_existent_collection");
+    ASSERT_FALSE(non_existent_collection.ok());
+    ASSERT_EQ(404, non_existent_collection.code());
+    ASSERT_STREQ("Collection not found", non_existent_collection.error().c_str());
+
+    // Try to search in a non-existent collection
+    std::vector<std::string> query_fields = {"title"};
+    std::vector<sort_by> sort_fields = { sort_by("points", "DESC") };
+    auto search_op = non_existent_collection.get()->search("test", query_fields, "", {}, sort_fields, {0}, 10);
+    ASSERT_FALSE(search_op.ok());
+    ASSERT_EQ(404, search_op.code());
+    ASSERT_STREQ("Collection not found", search_op.error().c_str());
+}
+
 TEST_F(CollectionTest, RetrieveADocumentById) {
     Option<nlohmann::json> doc_option = collection->get("1");
     ASSERT_TRUE(doc_option.ok());


### PR DESCRIPTION
## Change Summary
Added a slighly more descriptive when the error Not Found is for when a collection wasnt found.

When playing with curls, it was a bit frustrating what exactly triggered the 404 error. This aims to make it a little more clear and provide a slightly better developing experience.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
