### PR TITLE
Fix an edge case for not equals `!= []` filter returning matches for equals filter.

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -407,6 +407,10 @@ struct pair_hash {
     }
 };
 
+#ifdef TEST_BUILD
+    extern bool testing_not_equals_bug;
+#endif
+
 class Index {
 private:
     mutable std::shared_mutex mutex;

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -576,9 +576,14 @@ Option<bool> toFilter(const std::string& expression,
                                      "`: Filter value cannot be empty.");
         }
         if (raw_value[0] == '[' && raw_value[raw_value.size() - 1] == ']') {
+            filter_exp = {field_name, {}, {}};
+            if (bool_comparator == NOT_EQUALS) {
+                filter_exp.apply_not_equals = true;
+                bool_comparator = EQUALS;
+            }
+
             std::vector<std::string> filter_values;
             StringUtils::split(raw_value.substr(1, raw_value.size() - 2), filter_values, ",");
-            filter_exp = {field_name, {}, {}};
             for (std::string& filter_value: filter_values) {
                 if (filter_value != "true" && filter_value != "false") {
                     return Option<bool>(400, "Values of filter field `" + _field.name +

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -1001,6 +1001,8 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
             filter_result = op.get();
         }
 
+        is_filter_result_initialized = true;
+
         if (filter_result.count == 0) {
             validity = invalid;
             return;
@@ -1012,7 +1014,6 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
             reference.insert(ref.begin(), ref.end());
         }
 
-        is_filter_result_initialized = true;
         approx_filter_ids_length = filter_result.count;
         return;
     }
@@ -1059,6 +1060,7 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
         }
 
         is_filter_result_initialized = true;
+
         if (filter_result.count == 0) {
             validity = invalid;
             return;
@@ -1122,13 +1124,14 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
                                  filter_result.docs, filter_result.count);
             }
 
+            is_filter_result_initialized = true;
+
             if (filter_result.count == 0) {
                 validity = invalid;
                 return;
             }
 
             seq_id = filter_result.docs[result_index];
-            is_filter_result_initialized = true;
             approx_filter_ids_length = filter_result.count;
         } else {
             auto const& filter_values_count = a_filter.values.size();
@@ -1225,13 +1228,14 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
                                      filter_result.docs, filter_result.count);
                 }
 
+                is_filter_result_initialized = true;
+
                 if (filter_result.count == 0) {
                     validity = invalid;
                     return;
                 }
 
                 seq_id = filter_result.docs[result_index];
-                is_filter_result_initialized = true;
                 approx_filter_ids_length = filter_result.count;
             }
         }
@@ -1277,13 +1281,14 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
                                  filter_result.docs, filter_result.count);
             }
 
+            is_filter_result_initialized = true;
+
             if (filter_result.count == 0) {
                 validity = invalid;
                 return;
             }
 
             seq_id = filter_result.docs[result_index];
-            is_filter_result_initialized = true;
             approx_filter_ids_length = filter_result.count;
         } else {
             auto const& filter_values_count = a_filter.values.size();
@@ -1381,13 +1386,14 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
                                      filter_result.docs, filter_result.count);
                 }
 
+                is_filter_result_initialized = true;
+
                 if (filter_result.count == 0) {
                     validity = invalid;
                     return;
                 }
 
                 seq_id = filter_result.docs[result_index];
-                is_filter_result_initialized = true;
                 approx_filter_ids_length = filter_result.count;
             }
         }
@@ -1457,13 +1463,14 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
                              filter_result.docs, filter_result.count);
         }
 
+        is_filter_result_initialized = true;
+
         if (filter_result.count == 0) {
             validity = invalid;
             return;
         }
 
         seq_id = filter_result.docs[result_index];
-        is_filter_result_initialized = true;
         approx_filter_ids_length = filter_result.count;
         return;
     } else if (f.is_geopoint()) {
@@ -1608,13 +1615,14 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
             filter_result.docs = out;
         }
 
+        is_filter_result_initialized = true;
+
         if (filter_result.count == 0) {
             validity = invalid;
             return;
         }
 
         seq_id = filter_result.docs[result_index];
-        is_filter_result_initialized = true;
         approx_filter_ids_length = filter_result.count;
         return;
     } else if (f.is_geopolygon()) {

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -1615,13 +1615,13 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
             filter_result.docs = out;
         }
 
-        is_filter_result_initialized = true;
 
         if (filter_result.count == 0) {
             validity = invalid;
             return;
         }
 
+        is_filter_result_initialized = true;
         seq_id = filter_result.docs[result_index];
         approx_filter_ids_length = filter_result.count;
         return;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3290,6 +3290,10 @@ void process_results_hnsw_index(filter_result_iterator_t* filter_result_iterator
     }
 }
 
+#ifdef TEST_BUILD
+    bool testing_not_equals_bug = false;
+#endif
+
 Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, const std::vector<search_field_t>& the_fields,
                    const text_match_type_t match_type,
                    std::unique_ptr<filter_node_t>& filter_tree_root, std::vector<facet>& facets, facet_query_t facet_query,
@@ -3350,7 +3354,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
 
 #ifdef TEST_BUILD
 
-    if (filter_result_iterator->approx_filter_ids_length > 20) {
+    if (testing_not_equals_bug || filter_result_iterator->approx_filter_ids_length > 20) {
         filter_result_iterator->compute_iterators();
     }
 #else


### PR DESCRIPTION
## Change Summary
#2350
Fixes an edge case only appearing in Typesense binary. 

If we have two documents having:
```json
[
  {"field": 1},
  {"field": 2}
]
```
and the query:
```json
{
  "q": "*",
  "filter_by": "field: !=[1, 2]"
}
```
Typesense matched both the docs due to the bug whereas it should've matched none.

[Here](https://github.com/typesense/typesense/blob/f4fd7e017b23eac5888a88e109f88346bc98357d/src/filter_result_iterator.cpp#L1125-L1132) we returned early when filter didn't match any docs but didn't mark `is_filter_result_initialized = true;`. The bug only appeared in binary since it took [this code path](https://github.com/typesense/typesense/blob/f4fd7e017b23eac5888a88e109f88346bc98357d/src/index.cpp#L3351) and called `filter_result_iterator_t::compute_iterators()` which called `apply_not_equals()` once again since `is_filter_result_initialized` was not initialized and hence returned the wrong result.


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
