### PR TITLE
fix(tokenizer): improve separator handling for non-English locales

### DIFF
--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -15,6 +15,11 @@ Tokenizer::Tokenizer(const std::string& input, bool normalize, bool no_op, const
 
     for(char c: separators) {
         separator_symbols[uint8_t(c)] = 1;
+        
+        // Only enforce separator precedence when using locale-specific tokenization
+        if(!locale.empty() && locale != "en") {
+            index_symbols[uint8_t(c)] = 0;
+        }
     }
 
     UErrorCode errcode = U_ZERO_ERROR;


### PR DESCRIPTION
## Change Summary
Addresses #2313 
- add special handling for separator precedence in non-English locales
- only enforce separator symbol indexing rules when locale is specified
- add test case for German street names with hyphenated tokens and typos

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
