### PR TITLE
fix(api): process results before parsing the convo stream

### DIFF
--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -786,15 +786,15 @@ bool get_search(const std::shared_ptr<http_req>& req, const std::shared_ptr<http
         return false;
     }
 
+    nlohmann::json results_json = nlohmann::json::parse(results_json_str);
+    NaturalLanguageSearchModelManager::add_nl_query_data_to_results(results_json, &(req->params), nl_search_time_ms);
+    results_json_str = results_json.dump();
 
     // if the response is an event stream, we need to add the data: prefix
     if(conversation_stream) {
         results_json_str = "data: " + results_json_str + "\n\n";
     }
 
-    nlohmann::json results_json = nlohmann::json::parse(results_json_str);
-    NaturalLanguageSearchModelManager::add_nl_query_data_to_results(results_json, &(req->params), nl_search_time_ms);
-    results_json_str = results_json.dump();
 
     res->set_200(results_json_str);
     res->final = true;


### PR DESCRIPTION
## Change Summary
The natural language feature introduced in the refactor in 778256b introduced a JSON parsing error in streaming responses (SSE).

It [added](https://github.com/typesense/typesense/commit/778256bb5f9a42e5c310a2c1a6a10a97733e2cf7#diff-6d6e083ae99f609f8f834df870444aa8a7168ebd9ebfc8c5119a8f8c4bb52c6cR777-R780) the `data: <convo>` before parsing it. This PR just parses the string beforehand. This wasn't an issue in multisearch, as the parsing already happened before appending the `data:` prefix to the convo response.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
