### PR TITLE
support dynamic sort with overrides

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -597,13 +597,14 @@ private:
                                         std::vector<field>& update_fields,
                                         std::string& fallback_field_type);
 
-    void process_filter_overrides(std::vector<const override_t*>& filter_overrides,
+    void process_filter_sort_overrides(std::vector<const override_t*>& filter_overrides,
                                   std::vector<std::string>& q_include_tokens,
                                   token_ordering token_order,
                                   std::unique_ptr<filter_node_t>& filter_tree_root,
                                   std::vector<std::pair<uint32_t, uint32_t>>& included_ids,
                                   std::vector<uint32_t>& excluded_ids,
                                   nlohmann::json& override_metadata,
+                                  std::string& sort_by_clause,
                                   bool enable_typos_for_numerical_tokens=true,
                                   bool enable_typos_for_alpha_numerical_tokens=true,
                                   const bool& validate_field_names = true) const;

--- a/include/index.h
+++ b/include/index.h
@@ -524,7 +524,8 @@ private:
                           token_ordering token_order, std::set<std::string>& absorbed_tokens,
                           std::string& filter_by_clause,
                           bool enable_typos_for_numerical_tokens,
-                          bool enable_typos_for_alpha_numerical_tokens) const;
+                          bool enable_typos_for_alpha_numerical_tokens,
+                          std::string& sort_by_clause) const;
 
     bool check_for_overrides(const token_ordering& token_order, const string& field_name, bool slide_window,
                              bool exact_rule_match, std::vector<std::string>& tokens,
@@ -1087,12 +1088,13 @@ public:
                                      const int* sort_order,
                                      int64_t& out_best_field_match_score);
 
-    void process_filter_overrides(const std::vector<const override_t*>& filter_overrides,
+    void process_filter_sort_overrides(const std::vector<const override_t*>& filter_overrides,
                                   std::vector<std::string>& query_tokens,
                                   token_ordering token_order,
                                   std::unique_ptr<filter_node_t>& filter_tree_root,
                                   std::vector<const override_t*>& matched_dynamic_overrides,
                                   nlohmann::json& override_metadata,
+                                  std::string& sort_by_clause,
                                   bool enable_typos_for_numerical_tokens,
                                   bool enable_typos_for_alpha_numerical_tokens,
                                   const bool& validate_field_names = true) const;

--- a/include/index.h
+++ b/include/index.h
@@ -523,9 +523,9 @@ private:
                           const std::vector<std::string>& query_tokens,
                           token_ordering token_order, std::set<std::string>& absorbed_tokens,
                           std::string& filter_by_clause,
+                          std::string& sort_by_clause,
                           bool enable_typos_for_numerical_tokens,
-                          bool enable_typos_for_alpha_numerical_tokens,
-                          std::string& sort_by_clause) const;
+                          bool enable_typos_for_alpha_numerical_tokens) const;
 
     bool check_for_overrides(const token_ordering& token_order, const string& field_name, bool slide_window,
                              bool exact_rule_match, std::vector<std::string>& tokens,

--- a/include/override.h
+++ b/include/override.h
@@ -12,6 +12,7 @@ struct override_t {
         std::string normalized_query;       // not actually stored, used for lowercasing etc.
         std::string match;
         bool dynamic_query = false;
+        bool dynamic_filter = false;
         std::string filter_by;
         std::set<std::string> tags;
     };

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -883,12 +883,11 @@ bool Collection::does_override_match(const override_t& override, std::string& qu
     }
 
     // ID-based overrides are applied first as they take precedence over filter-based overrides
-    if(!override.filter_by.empty()) {
+    if(!override.filter_by.empty() || !override.sort_by.empty()) {
         filter_sort_overrides.push_back(&override);
     }
 
     if(!override.sort_by.empty()) {
-        filter_sort_overrides.push_back(&override);
         curated_sort_by = override.sort_by;
     }
 
@@ -4191,7 +4190,7 @@ void Collection::process_highlight_fields(const std::vector<search_field_t>& sea
     }
 }
 
-void Collection::process_filter_sort_overrides(std::vector<const override_t*>& filter_overrides,
+void Collection::process_filter_sort_overrides(std::vector<const override_t*>& filter_sort_overrides,
                                           std::vector<std::string>& q_include_tokens,
                                           token_ordering token_order,
                                           std::unique_ptr<filter_node_t>& filter_tree_root,
@@ -4204,7 +4203,7 @@ void Collection::process_filter_sort_overrides(std::vector<const override_t*>& f
                                           const bool& validate_field_names) const {
 
     std::vector<const override_t*> matched_dynamic_overrides;
-    index->process_filter_sort_overrides(filter_overrides, q_include_tokens, token_order,
+    index->process_filter_sort_overrides(filter_sort_overrides, q_include_tokens, token_order,
                                     filter_tree_root, matched_dynamic_overrides, override_metadata,
                                     sort_by_clause, enable_typos_for_numerical_tokens,
                                     enable_typos_for_alpha_numerical_tokens);

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -863,7 +863,7 @@ bool Collection::does_override_match(const override_t& override, std::string& qu
                                      const std::vector<std::string>& hidden_hits,
                                      std::vector<std::pair<uint32_t, uint32_t>>& included_ids,
                                      std::vector<uint32_t>& excluded_ids,
-                                     std::vector<const override_t*>& filter_overrides,
+                                     std::vector<const override_t*>& filter_sort_overrides,
                                      bool& filter_curated_hits,
                                      std::string& curated_sort_by,
                                      nlohmann::json& override_metadata) const {
@@ -884,7 +884,12 @@ bool Collection::does_override_match(const override_t& override, std::string& qu
 
     // ID-based overrides are applied first as they take precedence over filter-based overrides
     if(!override.filter_by.empty()) {
-        filter_overrides.push_back(&override);
+        filter_sort_overrides.push_back(&override);
+    }
+
+    if(!override.sort_by.empty()) {
+        filter_sort_overrides.push_back(&override);
+        curated_sort_by = override.sort_by;
     }
 
     if((wildcard_tag_matched || tags_matched) && override.rule.query.empty() && override.rule.filter_by.empty()) {
@@ -941,7 +946,6 @@ bool Collection::does_override_match(const override_t& override, std::string& qu
     }
 
     filter_curated_hits = override.filter_curated_hits;
-    curated_sort_by = override.sort_by;
     if(override_metadata.empty()) {
         override_metadata = override.metadata;
     }
@@ -955,7 +959,7 @@ void Collection::curate_results(string& actual_query, const string& filter_query
                                 const std::vector<std::string>& hidden_hits,
                                 std::vector<std::pair<uint32_t, uint32_t>>& included_ids,
                                 std::vector<uint32_t>& excluded_ids,
-                                std::vector<const override_t*>& filter_overrides,
+                                std::vector<const override_t*>& filter_sort_overrides,
                                 bool& filter_curated_hits,
                                 std::string& curated_sort_by,
                                 nlohmann::json& override_metadata) const {
@@ -1008,7 +1012,7 @@ void Collection::curate_results(string& actual_query, const string& filter_query
                             bool match_found = does_override_match(override, query, excluded_set, actual_query,
                                                                    filter_query, already_segmented, true, false,
                                                                    pinned_hits, hidden_hits, included_ids,
-                                                                   excluded_ids, filter_overrides, filter_curated_hits,
+                                                                   excluded_ids, filter_sort_overrides, filter_curated_hits,
                                                                    curated_sort_by, override_metadata);
 
                             if(match_found) {
@@ -1055,7 +1059,7 @@ void Collection::curate_results(string& actual_query, const string& filter_query
                         bool match_found = does_override_match(override, query, excluded_set, actual_query,
                                                                filter_query, already_segmented, true, false,
                                                                pinned_hits, hidden_hits, included_ids,
-                                                               excluded_ids, filter_overrides, filter_curated_hits,
+                                                               excluded_ids, filter_sort_overrides, filter_curated_hits,
                                                                curated_sort_by, override_metadata);
 
                         if(match_found) {
@@ -1075,7 +1079,7 @@ void Collection::curate_results(string& actual_query, const string& filter_query
                 bool match_found = does_override_match(override, query, excluded_set, actual_query, filter_query,
                                                        already_segmented, false, wildcard_tag,
                                                        pinned_hits, hidden_hits, included_ids,
-                                                       excluded_ids, filter_overrides, filter_curated_hits,
+                                                       excluded_ids, filter_sort_overrides, filter_curated_hits,
                                                        curated_sort_by, override_metadata);
                 if(match_found && override.stop_processing) {
                     break;
@@ -2417,7 +2421,7 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
     std::vector<std::string> hidden_hits;
     StringUtils::split(hidden_hits_str, hidden_hits, ",");
 
-    std::vector<const override_t*> filter_overrides;
+    std::vector<const override_t*> filter_sort_overrides;
     std::string curated_sort_by;
     std::set<std::string> override_tag_set;
 
@@ -2430,7 +2434,7 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
     bool filter_curated_hits_overrides = false;
 
     curate_results(query, filter_query, enable_overrides, pre_segmented_query, override_tag_set,
-                   pinned_hits, hidden_hits, included_ids, excluded_ids, filter_overrides, filter_curated_hits_overrides,
+                   pinned_hits, hidden_hits, included_ids, excluded_ids, filter_sort_overrides, filter_curated_hits_overrides,
                    curated_sort_by, override_metadata);
 
     bool filter_curated_hits = filter_curated_hits_option || filter_curated_hits_overrides;
@@ -2472,34 +2476,6 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
     bool is_group_by_query = group_by_fields.size() > 0;
     bool is_vector_query = !vector_query.field_name.empty();
 
-    if(curated_sort_by.empty()) {
-        auto sort_validation_op = validate_and_standardize_sort_fields(sort_fields,
-                                                                       sort_fields_std, is_wildcard_query, is_vector_query,
-                                                                       raw_query, is_group_by_query,
-                                                                       remote_embedding_timeout_ms, remote_embedding_num_tries,
-                                                                       validate_field_names, false, is_union_search,
-                                                                       union_search_index);
-        if(!sort_validation_op.ok()) {
-            return sort_validation_op;
-        }
-    } else {
-        std::vector<sort_by> curated_sort_fields;
-        bool parsed_sort_by = CollectionManager::parse_sort_by_str(curated_sort_by, curated_sort_fields);
-        if(!parsed_sort_by) {
-            return Option<bool>(400, "Parameter `sort_by` is malformed.");
-        }
-
-        auto sort_validation_op = validate_and_standardize_sort_fields(curated_sort_fields,
-                                                                       sort_fields_std, is_wildcard_query, is_vector_query,
-                                                                       raw_query, is_group_by_query,
-                                                                       remote_embedding_timeout_ms, remote_embedding_num_tries,
-                                                                       validate_field_names, false, is_union_search,
-                                                                       union_search_index);
-        if(!sort_validation_op.ok()) {
-            return sort_validation_op;
-        }
-    }
-
     //LOG(INFO) << "Num indices used for querying: " << indices.size();
     std::vector<query_tokens_t> field_query_tokens;
     std::vector<std::string> q_include_tokens;
@@ -2513,8 +2489,8 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
                                field_query_tokens[0].q_exclude_tokens, field_query_tokens[0].q_phrases, "",
                                false, stopwords_set);
 
-            process_filter_overrides(filter_overrides, q_include_tokens, token_order, filter_tree_root_guard,
-                                     included_ids, excluded_ids, override_metadata, enable_typos_for_numerical_tokens,
+            process_filter_sort_overrides(filter_sort_overrides, q_include_tokens, token_order, filter_tree_root_guard,
+                                     included_ids, excluded_ids, override_metadata, curated_sort_by, enable_typos_for_numerical_tokens,
                                      enable_typos_for_alpha_numerical_tokens, validate_field_names);
 
             for(size_t i = 0; i < q_include_tokens.size(); i++) {
@@ -2542,8 +2518,8 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
         // process filter overrides first, before synonyms (order is important)
 
         // included_ids, excluded_ids
-        process_filter_overrides(filter_overrides, q_include_tokens, token_order, filter_tree_root_guard,
-                                 included_ids, excluded_ids, override_metadata, enable_typos_for_numerical_tokens,
+        process_filter_sort_overrides(filter_sort_overrides, q_include_tokens, token_order, filter_tree_root_guard,
+                                 included_ids, excluded_ids, override_metadata, curated_sort_by, enable_typos_for_numerical_tokens,
                                  enable_typos_for_alpha_numerical_tokens, validate_field_names);
 
         for(size_t i = 0; i < q_include_tokens.size(); i++) {
@@ -2568,6 +2544,34 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
         for(size_t i = 1; i < weighted_search_fields.size(); i++) {
             field_query_tokens.emplace_back(query_tokens_t{});
             field_query_tokens[i] = field_query_tokens[0];
+        }
+    }
+
+    if(curated_sort_by.empty()) {
+        auto sort_validation_op = validate_and_standardize_sort_fields(sort_fields,
+                                                                       sort_fields_std, is_wildcard_query, is_vector_query,
+                                                                       raw_query, is_group_by_query,
+                                                                       remote_embedding_timeout_ms, remote_embedding_num_tries,
+                                                                       validate_field_names, false, is_union_search,
+                                                                       union_search_index);
+        if(!sort_validation_op.ok()) {
+            return sort_validation_op;
+        }
+    } else {
+        std::vector<sort_by> curated_sort_fields;
+        bool parsed_sort_by = CollectionManager::parse_sort_by_str(curated_sort_by, curated_sort_fields);
+        if(!parsed_sort_by) {
+            return Option<bool>(400, "Parameter `sort_by` is malformed.");
+        }
+
+        auto sort_validation_op = validate_and_standardize_sort_fields(curated_sort_fields,
+                                                                       sort_fields_std, is_wildcard_query, is_vector_query,
+                                                                       raw_query, is_group_by_query,
+                                                                       remote_embedding_timeout_ms, remote_embedding_num_tries,
+                                                                       validate_field_names, false, is_union_search,
+                                                                       union_search_index);
+        if(!sort_validation_op.ok()) {
+            return sort_validation_op;
         }
     }
 
@@ -4187,21 +4191,22 @@ void Collection::process_highlight_fields(const std::vector<search_field_t>& sea
     }
 }
 
-void Collection::process_filter_overrides(std::vector<const override_t*>& filter_overrides,
+void Collection::process_filter_sort_overrides(std::vector<const override_t*>& filter_overrides,
                                           std::vector<std::string>& q_include_tokens,
                                           token_ordering token_order,
                                           std::unique_ptr<filter_node_t>& filter_tree_root,
                                           std::vector<std::pair<uint32_t, uint32_t>>& included_ids,
                                           std::vector<uint32_t>& excluded_ids,
                                           nlohmann::json& override_metadata,
+                                          std::string& sort_by_clause,
                                           bool enable_typos_for_numerical_tokens,
                                           bool enable_typos_for_alpha_numerical_tokens,
                                           const bool& validate_field_names) const {
 
     std::vector<const override_t*> matched_dynamic_overrides;
-    index->process_filter_overrides(filter_overrides, q_include_tokens, token_order,
+    index->process_filter_sort_overrides(filter_overrides, q_include_tokens, token_order,
                                     filter_tree_root, matched_dynamic_overrides, override_metadata,
-                                    enable_typos_for_numerical_tokens,
+                                    sort_by_clause, enable_typos_for_numerical_tokens,
                                     enable_typos_for_alpha_numerical_tokens);
 
     // we will check the dynamic overrides to see if they also have include/exclude

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2808,7 +2808,7 @@ bool Index::resolve_override(const std::vector<std::string>& rule_tokens, const 
                              const std::vector<std::string>& query_tokens,
                              token_ordering token_order, std::set<std::string>& absorbed_tokens,
                              std::string& filter_by_clause, bool enable_typos_for_numerical_tokens,
-                             bool enable_typos_for_alpha_numerical_tokens) const {
+                             bool enable_typos_for_alpha_numerical_tokens, std::string& sort_by_clause) const {
 
     bool resolved_override = false;
     size_t i = 0, j = 0;
@@ -2892,18 +2892,26 @@ bool Index::resolve_override(const std::vector<std::string>& rule_tokens, const 
     for(const auto& kv: field_placeholder_tokens) {
         std::string pattern = "{" + kv.first + "}";
         std::string replacement = StringUtils::join(kv.second, " ");
-        StringUtils::replace_all(filter_by_clause, pattern, replacement);
+
+        if (!filter_by_clause.empty()) {
+            StringUtils::replace_all(filter_by_clause, pattern, replacement);
+        }
+
+        if (!sort_by_clause.empty()) {
+            StringUtils::replace_all(sort_by_clause, pattern, replacement);
+        }
     }
 
     return true;
 }
 
-void Index::process_filter_overrides(const std::vector<const override_t*>& filter_overrides,
+void Index::process_filter_sort_overrides(const std::vector<const override_t*>& filter_overrides,
                                      std::vector<std::string>& query_tokens,
                                      token_ordering token_order,
                                      std::unique_ptr<filter_node_t>& filter_tree_root,
                                      std::vector<const override_t*>& matched_dynamic_overrides,
                                      nlohmann::json& override_metadata,
+                                     std::string& sort_by_clause,
                                      bool enable_typos_for_numerical_tokens,
                                      bool enable_typos_for_alpha_numerical_tokens,
                                      const bool& validate_field_names) const {
@@ -2945,7 +2953,7 @@ void Index::process_filter_overrides(const std::vector<const override_t*>& filte
             bool resolved_override = resolve_override(rule_parts, exact_rule_match, query_tokens,
                                                       token_order, absorbed_tokens, filter_by_clause,
                                                       enable_typos_for_numerical_tokens,
-                                                      enable_typos_for_alpha_numerical_tokens);
+                                                      enable_typos_for_alpha_numerical_tokens, sort_by_clause);
 
             if (resolved_override) {
                 if(override_metadata.empty()) {

--- a/src/override.cpp
+++ b/src/override.cpp
@@ -147,6 +147,25 @@ Option<bool> override_t::parse(const nlohmann::json& override_json, const std::s
         }
 
         override.rule.filter_by = override_json["rule"]["filter_by"].get<std::string>();
+
+        //check if it is dynamic filter rule
+        size_t i = 0;
+        while(i < override.rule.filter_by.size()) {
+            if(override.rule.filter_by[i] == '{') {
+                // look for closing curly
+                i++;
+                while(i < override.rule.filter_by.size()) {
+                    if(override.rule.filter_by[i] == '}') {
+                        override.rule.dynamic_filter = true;
+                        // remove spaces around curlies
+                        override.rule.filter_by = StringUtils::trim_curly_spaces(override.rule.filter_by);
+                        break;
+                    }
+                    i++;
+                }
+            }
+            i++;
+        }
     }
 
     if (override_json.count("includes") != 0) {


### PR DESCRIPTION
Feature request: #2373

## Change Summary
<!--- Described your changes here -->
### Dynamic sorting using overrides
Like dynamic filtering, typesense supports dynamic sorting with overrides.

Consider below schema,
```json
{
    "name": "products",
    "fields":
    [
        {"name": "title", "type": "string"},
        {"name": "store", "type": "string[]"},
        {"name": "unitssold", "type": "object"},
        {"name": "unitssold.store01", "type": "int32"},
        {"name": "unitssold.store02", "type": "int32"},
        {"name": "stockonhand", "type": "object"},
        {"name": "stockonhand.store01", "type": "int32"},
        {"name": "stockonhand.store02", "type": "int32"},
    ]
}
```
See following override for query based dynamic sorting,

```json
{
            {"id",   "dynamic-sort"},
            {
             "rule", {
                             {"query", "{store}"},
                             {"match", "exact"}
                     }
            },
            {"remove_matched_tokens", true},
            {"sort_by", "unitssold.{store}:desc, stockonhand.{store}:desc"}
    }
```

Now we can also do dynamic sorting using override filter rule.
See following override,

```json
{
            {"id",   "dynamic-sort"},
            {
             "rule", {
                             {"filter_by", "store:={store}"},
                             {"match", "exact"}
                     }
            },
            {"remove_matched_tokens", true},
            {"sort_by", "unitssold.{store}:desc, stockonhand.{store}:desc"}
    }
```
## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
