### PR TITLE
feat(collection): add document copying option to clone collection

### DIFF
--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -88,7 +88,8 @@ public:
                                         const std::atomic<bool>& quit,
                                         const std::map<std::string, std::map<std::string, reference_info_t>>& referenced_infos);
 
-    Option<Collection*> clone_collection(const std::string& existing_name, const nlohmann::json& req_json);
+    Option<Collection*> clone_collection(const std::string& existing_name, const nlohmann::json& req_json, 
+                                         const bool copy_documents = false);
 
     void add_to_collections(Collection* collection);
 

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -274,6 +274,7 @@ bool post_create_collection(const std::shared_ptr<http_req>& req, const std::sha
     }
 
     const std::string SRC_COLL_NAME = "src_name";
+    const std::string COPY_DOCUMENTS = "copy_documents";
 
     /*if(res->is_alive && req_json.is_object() && req_json.count("enable_nested_fields") == 0) {
         // This patch ensures that nested fields are only enabled for collections created on Typesense versions
@@ -285,7 +286,7 @@ bool post_create_collection(const std::shared_ptr<http_req>& req, const std::sha
 
     CollectionManager& collectionManager = CollectionManager::get_instance();
     const Option<Collection*> &collection_op = req->params.count(SRC_COLL_NAME) != 0 ?
-               collectionManager.clone_collection(req->params[SRC_COLL_NAME], req_json) :
+               collectionManager.clone_collection(req->params[SRC_COLL_NAME], req_json, req->params.count(COPY_DOCUMENTS) != 0) :
                CollectionManager::create_collection(req_json);
 
     if(collection_op.ok()) {

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -1959,3 +1959,92 @@ TEST_F(CollectionManagerTest, HideQueryFromAnalytics) {
 
     collectionManager.drop_collection("coll3");
 }
+
+TEST_F(CollectionManagerTest, CloneCollectionWithDocuments) {
+    // Create the source collection with schema and synonyms
+    nlohmann::json schema = R"({
+        "name": "source_collection",
+        "fields": [
+          {"name": "title", "type": "string"},
+          {"name": "points", "type": "int32"}
+        ]
+      })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(collection_create_op.ok());
+
+    Collection* src_collection = collection_create_op.get();
+
+    nlohmann::json doc1 = R"({
+        "id": "1",
+        "title": "First document",
+        "points": 100
+    })"_json;
+
+    nlohmann::json doc2 = R"({
+        "id": "2", 
+        "title": "Second document with query word",
+        "points": 200
+    })"_json;
+
+    nlohmann::json doc3 = R"({
+        "id": "3",
+        "title": "Third test document", 
+        "points": 150
+    })"_json;
+
+    ASSERT_TRUE(src_collection->add(doc1.dump()).ok());
+    ASSERT_TRUE(src_collection->add(doc2.dump()).ok());
+    ASSERT_TRUE(src_collection->add(doc3.dump()).ok());
+
+
+    // Verify source collection has 3 documents
+    ASSERT_EQ(3, src_collection->get_num_documents());
+
+    // Test 1: Clone collection WITHOUT copying documents (existing behavior)
+    nlohmann::json clone_req = R"({
+        "name": "cloned_collection_no_docs"
+    })"_json;
+
+    auto clone_op = collectionManager.clone_collection("source_collection", clone_req, false);
+    ASSERT_TRUE(clone_op.ok());
+    
+    Collection* cloned_collection_no_docs = clone_op.get();
+    ASSERT_EQ("cloned_collection_no_docs", cloned_collection_no_docs->get_name());
+    ASSERT_EQ(0, cloned_collection_no_docs->get_num_documents()); // No documents copied
+    
+    // Test 2: Clone collection WITH copying documents
+    nlohmann::json clone_req_with_docs = R"({
+        "name": "cloned_collection_with_docs"
+    })"_json;
+
+    auto clone_with_docs_op = collectionManager.clone_collection("source_collection", clone_req_with_docs, true);
+    ASSERT_TRUE(clone_with_docs_op.ok());
+    
+    Collection* cloned_collection_with_docs = clone_with_docs_op.get();
+    ASSERT_EQ("cloned_collection_with_docs", cloned_collection_with_docs->get_name());
+    ASSERT_EQ(3, cloned_collection_with_docs->get_num_documents()); // Documents copied
+
+    // Test 3: Verify documents are searchable in cloned collection
+    auto search_results = cloned_collection_with_docs->search("First", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}).get();
+    ASSERT_EQ(1, search_results["found"].get<size_t>());
+    ASSERT_EQ("1", search_results["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_EQ("First document", search_results["hits"][0]["document"]["title"].get<std::string>());
+
+    search_results = cloned_collection_with_docs->search("*", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}).get();
+    ASSERT_EQ(3, search_results["found"].get<size_t>());
+    
+    // Also search the source collection and dump results
+    auto src_search_results = src_collection->search("*", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}).get();
+    ASSERT_EQ(3, src_search_results["found"].get<size_t>());
+
+    // Test 6: Verify original collection is unchanged
+    ASSERT_EQ(3, src_collection->get_num_documents());
+    auto orig_search_results = src_collection->search("*", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}).get();
+    ASSERT_EQ(3, orig_search_results["found"].get<size_t>());
+
+    // Clean up
+    collectionManager.drop_collection("source_collection");
+    collectionManager.drop_collection("cloned_collection_no_docs");
+    collectionManager.drop_collection("cloned_collection_with_docs");
+}


### PR DESCRIPTION
### TLDR
Add optional document copying when cloning collections via API parameter.

## Change Summary

#### Added Features:
1. **New Parameter in `CollectionManager::clone_collection()`**:
   - `copy_documents`: Boolean parameter to enable document copying during collection cloning
   - Defaults to `false` to maintain backward compatibility

#### Code Changes:
1. **In `collection_manager.h`**:
   - Updated `clone_collection()` method signature to accept `copy_documents` parameter

2. **In `collection_manager.cpp`**:
   - Added document copying logic using RocksDB iterator to scan source collection
   - Implemented batch processing (1000 docs per batch) with memory threshold monitoring
   - Added progress logging for operations processing >10,000 documents
   - Uses `add_many()` method for efficient document indexing in target collection

3. **In `core_api.cpp`**:
   - Added support for `copy_documents` query parameter in collection creation endpoint
   - Parameter presence triggers document copying during clone operation

4. **In `collection_manager_test.cpp`**:
   - Added `CloneCollectionWithDocuments` test case
   - Tests both scenarios: cloning with and without document copying
   - Verifies document searchability in cloned collections

### Demo

Clone collection without documents (existing behavior):
```bash
curl -X POST 'http://localhost:8108/collections?src_name=source_collection' \
  -H 'Content-Type: application/json' \
  -d '{"name": "new_collection"}'
```

Clone collection with documents (new feature):
```bash
curl -X POST 'http://localhost:8108/collections?src_name=source_collection&copy_documents=true' \
  -H 'Content-Type: application/json' \
  -d '{"name": "new_collection_with_docs"}'
```

### Context
- Addresses use cases where users need to duplicate collections with their data intact (#621)
- Maintains backward compatibility by making document copying opt-in

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
