### PR TITLE
feat(search): add support for multiple stopword sets

### DIFF
--- a/include/stopwords_manager.h
+++ b/include/stopwords_manager.h
@@ -57,6 +57,8 @@ public:
 
     Option<bool> get_stopword(const std::string&, stopword_struct_t&) const;
 
+    Option<bool> get_combined_stopwords(const std::string& stopwords_set, stopword_struct_t& combined_stopwords) const;
+
     Option<bool> upsert_stopword(const std::string&, const nlohmann::json&, bool write_to_store=false);
 
     Option<bool> delete_stopword(const std::string&);

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -106,6 +106,25 @@ struct StringUtils {
 
     static void split_to_values(const std::string& vals_str, std::vector<std::string>& filter_values);
 
+    // Parse comma-separated stopword set names with trimming
+    static std::vector<std::string> parse_stopword_set_names(const std::string& stopwords_param) {
+        std::vector<std::string> stopword_set_names;
+        std::stringstream ss(stopwords_param);
+        std::string set_name;
+        
+        while(std::getline(ss, set_name, ',')) {
+            // Trim whitespace from the set name
+            set_name.erase(0, set_name.find_first_not_of(" \t"));
+            set_name.erase(set_name.find_last_not_of(" \t") + 1);
+            
+            if(!set_name.empty()) {
+                stopword_set_names.push_back(set_name);
+            }
+        }
+        
+        return stopword_set_names;
+    }
+
     // Adapted from: http://stackoverflow.com/a/36000453/131050
     static std::string & trim(std::string & str) {
         // right trim

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -109,19 +109,7 @@ struct StringUtils {
     // Parse comma-separated stopword set names with trimming
     static std::vector<std::string> parse_stopword_set_names(const std::string& stopwords_param) {
         std::vector<std::string> stopword_set_names;
-        std::stringstream ss(stopwords_param);
-        std::string set_name;
-        
-        while(std::getline(ss, set_name, ',')) {
-            // Trim whitespace from the set name
-            set_name.erase(0, set_name.find_first_not_of(" \t"));
-            set_name.erase(set_name.find_last_not_of(" \t") + 1);
-            
-            if(!set_name.empty()) {
-                stopword_set_names.push_back(set_name);
-            }
-        }
-        
+        StringUtils::split(stopwords_param, stopword_set_names, ",", false, true);
         return stopword_set_names;
     }
 

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -4551,33 +4551,10 @@ void Collection::parse_search_query(const std::string &query, std::vector<std::s
         stopword_struct_t stopwordStruct;
         
         if(!stopwords_set.empty()) {
-            // Parse stopword set names from comma-separated string
-            auto stopword_set_names = StringUtils::parse_stopword_set_names(stopwords_set);
-            
-            if(stopword_set_names.size() == 1) {
-                // Single stopword set - use original logic
-                const auto &stopword_op = StopwordsManager::get_instance().get_stopword(stopword_set_names[0], stopwordStruct);
-                if (!stopword_op.ok()) {
-                    LOG(ERROR) << stopword_op.error();
-                    LOG(ERROR) << "Error fetching stopword_list for stopword " << stopword_set_names[0];
-                }
-            } else if(stopword_set_names.size() > 1) {
-                // Multiple stopword sets - create combined stopword struct
-                stopwordStruct.id = "combined";
-                stopwordStruct.stopwords.clear();
-                
-                // Merge all stopword sets
-                for(const auto& name : stopword_set_names) {
-                    stopword_struct_t individual_set;
-                    const auto &stopword_op = StopwordsManager::get_instance().get_stopword(name, individual_set);
-                    if (stopword_op.ok()) {
-                        // Add all stopwords from this set to the combined set
-                        stopwordStruct.stopwords.insert(individual_set.stopwords.begin(), individual_set.stopwords.end());
-                    } else {
-                        LOG(ERROR) << stopword_op.error();
-                        LOG(ERROR) << "Error fetching stopword_list for stopword " << name;
-                    }
-                }
+            const auto &stopword_op = StopwordsManager::get_instance().get_combined_stopwords(stopwords_set, stopwordStruct);
+            if (!stopword_op.ok()) {
+                LOG(ERROR) << stopword_op.error();
+                LOG(ERROR) << "Error fetching stopword_list for stopword set: " << stopwords_set;
             }
         }
 

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1366,26 +1366,12 @@ Option<bool> apply_preset(std::map<std::string, std::string>& req_params) {
 }
 
 Option<bool> get_stopword_set(const std::map<std::string, std::string>& req_params, std::string& stopwords_set) {
-    //check if stopword set is supplied
     const auto stopword_it = req_params.find("stopwords");
 
     if(stopword_it != req_params.end()) {
         const std::string& stopwords_param = stopword_it->second;
         
-        // Split the comma-separated string into individual stopword set names
-        std::vector<std::string> stopword_set_names;
-        std::stringstream ss(stopwords_param);
-        std::string set_name;
-        
-        while(std::getline(ss, set_name, ',')) {
-            // Trim whitespace from the set name
-            set_name.erase(0, set_name.find_first_not_of(" \t"));
-            set_name.erase(set_name.find_last_not_of(" \t") + 1);
-            
-            if(!set_name.empty()) {
-                stopword_set_names.push_back(set_name);
-            }
-        }
+        auto stopword_set_names = StringUtils::parse_stopword_set_names(stopwords_param);
         
         // Validate that all stopword sets exist
         for(const auto& name : stopword_set_names) {
@@ -1394,13 +1380,8 @@ Option<bool> get_stopword_set(const std::map<std::string, std::string>& req_para
             }
         }
         
-        // If only one stopword set, use it directly
-        if(stopword_set_names.size() == 1) {
-            stopwords_set = stopword_set_names[0];
-        } else if(stopword_set_names.size() > 1) {
-            // For multiple sets, create a combined identifier
-            stopwords_set = "##COMBINED##:" + stopwords_param;
-        }
+        // Store the original parameter value - parsing will be done in collection.cpp
+        stopwords_set = stopwords_param;
     }
 
     return Option<bool>(true);


### PR DESCRIPTION
## Change Summary
- Allow comma-separated stopword set names in search queries
- Merge all specified stopword sets into a single unified set
- Add validation to ensure all referenced stopword sets exist
- Add tests for multi-stopword set functionality


## Demo
```bash
❮ curl "http://localhost:8108/collections/test/documents/search?q=query&stopwords=set1,set2" \
  -H "X-TYPESENSE-API-KEY: xyz" \
  -H "Content-Type: application/json" \
  -X GET
```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
