### PR TITLE
fix(process-manager): add fallbacks for local runs of the test suite

### DIFF
--- a/benchmark/src/global.ts
+++ b/benchmark/src/global.ts
@@ -93,6 +93,8 @@ function startTypesenseServer(options?: SetupNodesOptions): ResultAsync<NodeConf
  * @example
  */
 function restartTypesenseServer(): ResultAsync<NodeConfig[], ErrorWithMessage> {
+  const startTime = performance.now();
+
   const cleanupResults = Array.from(globalTypesenseManager.processes.values()).map((process) =>
     process.dispose().andThen(() => {
       globalTypesenseManager.processes.delete(process.http);
@@ -100,7 +102,14 @@ function restartTypesenseServer(): ResultAsync<NodeConfig[], ErrorWithMessage> {
     }),
   );
 
-  return ResultAsync.combine(cleanupResults).andThen(() => startTypesenseServer({ skipCleanup: true }));
+  return ResultAsync.combine(cleanupResults)
+    .andThen(() => startTypesenseServer({ skipCleanup: true }))
+    .map((nodes) => {
+      const endTime = performance.now();
+      const duration = endTime - startTime;
+      console.log(`Typesense server restart completed in ${duration.toFixed(2)}ms`);
+      return nodes;
+    });
 }
 
 function closeDownTypesenseServer(): ResultAsync<void[], ErrorWithMessage> {

--- a/benchmark/src/global.ts
+++ b/benchmark/src/global.ts
@@ -39,6 +39,7 @@ import { z } from "zod";
 import { OpenAIProxy } from "@/services/openai-mock";
 import { TypesenseProcessManager } from "@/services/typesense-process";
 import { constructUrl, delay } from "@/utils/base";
+import { logger } from "@/utils/logger";
 
 const env = createEnv({
   clientPrefix: "TYPESENSE_",
@@ -107,7 +108,7 @@ function restartTypesenseServer(): ResultAsync<NodeConfig[], ErrorWithMessage> {
     .map((nodes) => {
       const endTime = performance.now();
       const duration = endTime - startTime;
-      console.log(`Typesense server restart completed in ${duration.toFixed(2)}ms`);
+      logger.info(`Typesense server restart completed in ${duration.toFixed(2)}ms`);
       return nodes;
     });
 }

--- a/benchmark/src/services/typesense-process.ts
+++ b/benchmark/src/services/typesense-process.ts
@@ -71,8 +71,8 @@ export class TypesenseProcessController extends EventEmitter {
       logLevel: "DEBUG",
       apiKey: this.apiKey,
       connectionTimeoutSeconds: 100,
-      retryIntervalSeconds: 3,
-      numRetries: 20,
+      retryIntervalSeconds: 0.2,
+      numRetries: 20*30,
     });
 
     this.process.on("close", (code, signal) => {

--- a/benchmark/src/services/typesense-process.ts
+++ b/benchmark/src/services/typesense-process.ts
@@ -19,8 +19,6 @@ import { exists, safeEmptyDir, safeMakeOrEmptyDir } from "@/utils/fs";
 import { logger } from "@/utils/logger";
 import { isStringifiable } from "@/utils/stringifiable";
 
-export const DEFAULT_IP_ADDRESS = "192.168.2.25";
-
 interface AddressError {
   message: string;
   type: "address";
@@ -72,7 +70,7 @@ export class TypesenseProcessController extends EventEmitter {
       apiKey: this.apiKey,
       connectionTimeoutSeconds: 100,
       retryIntervalSeconds: 0.2,
-      numRetries: 20*30,
+      numRetries: 20 * 30,
     });
 
     this.process.on("close", (code, signal) => {
@@ -432,7 +430,19 @@ export class TypesenseProcessManager {
     const interfaces = networkInterfaces();
 
     if (!this.isInCi) {
-      return DEFAULT_IP_ADDRESS;
+      if (process.env.IP_ADDRESS) {
+        return process.env.IP_ADDRESS;
+      }
+
+      const networkAddress = Object.values(interfaces)
+        .flatMap((interfaceInfo) => interfaceInfo ?? [])
+        .find((info) => info.family === "IPv4" && !info.internal && !info.address.startsWith("127."))?.address;
+
+      if (networkAddress) {
+        return networkAddress;
+      }
+
+      return "127.0.0.1";
     }
 
     // First try to find a 10.1.0.* address


### PR DESCRIPTION


### TLDR
Add IP address fallback chain for local test runs: env var → first IPv4 → localhost

## Change Summary

#### Code Changes:
1. **In `benchmark/src/services/typesense-process.ts`**:
  - **Removed hardcoded `DEFAULT_IP_ADDRESS`**: Eliminated the static "192.168.2.25" constant
  - **Enhanced `getIpAddress()` method**: Added intelligent fallback chain for non-CI environments:
    - First checks `process.env.IP_ADDRESS` environment variable
    - Falls back to first available non-internal IPv4 address from network interfaces
    - Finally defaults to "127.0.0.1" (localhost) if no network address found
  - **Minor formatting fix**: Corrected spacing in `numRetries: 20 * 30`

<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
