### PR TITLE
fix(index): correct curation handling in group-by queries

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3444,7 +3444,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
     }
     topster_size = std::max((size_t)1, topster_size);  // needs to be atleast 1 since scoring is mandatory
     topster = new Topster<KV>(topster_size, group_limit, is_group_by_first_pass, group_found_params);
-    curated_topster = new Topster<KV>(topster_size, group_limit, false);
+    curated_topster = new Topster<KV>(topster_size, group_limit, is_group_by_first_pass);
 
     std::set<uint32_t> curated_ids;
     std::map<size_t, std::map<size_t, uint32_t>> included_ids_map;  // outer pos => inner pos => list of IDs

--- a/test/collection_override_test.cpp
+++ b/test/collection_override_test.cpp
@@ -5013,3 +5013,103 @@ TEST_F(CollectionOverrideTest, NestedObjectOverride) {
 
     collectionManager.drop_collection("coll1");
 }
+TEST_F(CollectionOverrideTest, CurationWithGroupBy) {
+    
+    nlohmann::json schema = R"({
+        "name": "coll1",
+        "fields": [
+          {"name": "title", "index": true, "type": "string" },
+          {"name": "category", "index": true, "type": "string", "facet": true },
+          {"name": "brand", "index": true, "type": "string", "facet": true }
+        ]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+    Collection* coll1 = op.get();
+
+    // Add test documents
+    nlohmann::json doc1 = R"({"id": "1", "title": "winter dress", "category": "clothing", "brand": "brandA"})"_json;
+    nlohmann::json doc2 = R"({"id": "2", "title": "winter shoes", "category": "footwear", "brand": "brandB"})"_json;
+    nlohmann::json doc3 = R"({"id": "3", "title": "winter hat", "category": "accessories", "brand": "brandA"})"_json;
+    nlohmann::json doc4 = R"({"id": "4", "title": "winter coat", "category": "clothing", "brand": "brandB"})"_json;
+    nlohmann::json doc5 = R"({"id": "5", "title": "winter bag", "category": "something-else", "brand": "brandA"})"_json;
+
+    ASSERT_TRUE(coll1->add(doc1.dump()).ok());
+    ASSERT_TRUE(coll1->add(doc2.dump()).ok());
+    ASSERT_TRUE(coll1->add(doc3.dump()).ok());
+    ASSERT_TRUE(coll1->add(doc4.dump()).ok());
+    ASSERT_TRUE(coll1->add(doc5.dump()).ok());
+
+    // Create override rule that pins documents for exact query "summer"
+    nlohmann::json override_json = R"({
+       "id": "summer-curation",
+       "rule": {
+            "query": "summer",
+            "match": "exact"
+        },
+        "includes": [
+            {"id": "3", "position": 1},
+            {"id": "5", "position": 2}
+        ]
+    })"_json;
+
+    override_t override_rule;
+    auto parse_op = override_t::parse(override_json, "summer-curation", override_rule);
+    ASSERT_TRUE(parse_op.ok());
+    coll1->add_override(override_rule);
+
+    // Test 1: Search without group_by - should show curated results first
+    auto results_no_group = coll1->search("summer", {"title"}, "", {}, {},
+                                          {0}, 50, 1, FREQUENCY,
+                                          {false}, Index::DROP_TOKENS_THRESHOLD,
+                                          spp::sparse_hash_set<std::string>(),
+                                          spp::sparse_hash_set<std::string>(), 10,
+                                          "", 30, 5, "",
+                                         10, {}, {}, {}, 0).get();
+
+    ASSERT_EQ(2, results_no_group["hits"].size());
+    // First two should be curated (pinned) documents
+    ASSERT_EQ("3", results_no_group["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_EQ("5", results_no_group["hits"][1]["document"]["id"].get<std::string>());
+    ASSERT_EQ(true, results_no_group["hits"][0]["curated"].get<bool>());
+    ASSERT_EQ(true, results_no_group["hits"][1]["curated"].get<bool>());
+
+    // Test 2: Search with group_by category - should still show curated results
+    auto results_with_group = coll1->search("summer", {"title"}, "", {}, {},
+                                            {0}, 50, 1, FREQUENCY,
+                                            {false}, Index::DROP_TOKENS_THRESHOLD,
+                                            spp::sparse_hash_set<std::string>(),
+                                            spp::sparse_hash_set<std::string>(), 10,
+                                            "", 30, 5, "",
+                                            10, {}, {}, {"category"}, 2).get();
+
+    // Should have grouped results
+    ASSERT_TRUE(results_with_group.contains("grouped_hits"));
+    ASSERT_GE(results_with_group["grouped_hits"].size(), 1);
+
+    // Look for curated results in grouped hits
+    bool found_curated_doc3 = false;
+    bool found_curated_doc5 = false;
+    
+    
+    for (const auto& group : results_with_group["grouped_hits"]) {
+        for (const auto& hit : group["hits"]) {
+            std::string doc_id = hit["document"]["id"].get<std::string>();
+            bool is_curated = hit.contains("curated") && hit["curated"].get<bool>();
+            
+            if (doc_id == "3" && is_curated) {
+                found_curated_doc3 = true;
+            }
+            if (doc_id == "5" && is_curated) {
+                found_curated_doc5 = true;
+            }
+        }
+    }
+    
+    // Verify that curated documents are present and marked as curated
+    ASSERT_TRUE(found_curated_doc3) << "Document 3 should be marked as curated in grouped results";
+    ASSERT_TRUE(found_curated_doc5) << "Document 5 should be marked as curated in grouped results";
+
+    collectionManager.drop_collection("coll1");
+}


### PR DESCRIPTION


### TLDR
Fixes curated_topster initialization to properly handle group-by first pass.

## Change Summary

#### Bug Fixes:
1. **In `src/index.cpp`**:
   - **`Index::search()`**: Fixed `curated_topster` initialization on line 3447 to use `is_group_by_first_pass` parameter instead of hardcoded `false`
   - This ensures curated results are properly handled during the first pass of group-by operations

#### Test Coverage:
1. **In `test/collection_override_test.cpp`**:
   - **`CurationWithGroupBy()`**: Added new test method to verify curation works correctly with group-by queries
   - Tests both regular search and group-by search scenarios with pinned documents
   - Validates that curated documents maintain their `curated` flag in grouped results


### Context
The bug occurred when using curation (pinned documents) with group-by queries. The `curated_topster` was being initialized with `false` for the group-by first pass parameter, causing curated results to not be properly handled during grouped searches. This fix ensures that both the main `topster` and `curated_topster` use the same `is_group_by_first_pass` parameter, maintaining consistency in how results are processed and ensuring curated documents appear correctly in grouped search results.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
