### PR TITLE
Fix `group_by` performance regression due to two-pass approach.

### DIFF
--- a/include/filter_result_iterator.h
+++ b/include/filter_result_iterator.h
@@ -330,7 +330,8 @@ private:
 
     /// Collects n doc ids while advancing the iterator. The iterator may become invalid during this operation.
     /// **The references are moved from filter_result_iterator_t.
-    void get_n_ids(const uint32_t& n, filter_result_t*& result, const bool& override_timeout = false);
+    void get_n_ids(const uint32_t& n, filter_result_t*& result, const bool& override_timeout = false,
+                   const bool& is_group_by_first_pass = false);
 
     /// Updates `validity` of the iterator to `timed_out` if condition is met. Assumes `timeout_info` is not null.
     inline bool is_timed_out(const bool& override_function_call_counter = false);
@@ -373,6 +374,10 @@ public:
                                       uint64_t search_begin_us = 0, uint64_t search_stop_us = UINT64_MAX,
                                       const bool& validate_field_names = true);
 
+    explicit filter_result_iterator_t(FILTER_OPERATOR filter_operator, filter_result_iterator_t* filter_result_iterator,
+                                      filter_result_iterator_t* new_iterator,
+                                      std::unique_ptr<filter_node_t>& filter_root, filter_node_t* new_filter_tree_root);
+
     ~filter_result_iterator_t();
 
     filter_result_iterator_t& operator=(filter_result_iterator_t&& obj) noexcept;
@@ -402,7 +407,8 @@ public:
     void get_n_ids(const uint32_t& n,
                    uint32_t& excluded_result_index,
                    uint32_t const* const excluded_result_ids, const size_t& excluded_result_ids_size,
-                   filter_result_t*& result, const bool& override_timeout = false);
+                   filter_result_t*& result, const bool& override_timeout = false,
+                   const bool& is_group_by_first_pass = false);
 
     /// Returns true if at least one id from the posting list object matches the filter.
     bool contains_atleast_one(const void* obj);

--- a/include/index.h
+++ b/include/index.h
@@ -765,7 +765,7 @@ public:
 
     Option<bool> search(std::vector<query_tokens_t>& field_query_tokens, const std::vector<search_field_t>& the_fields,
                 const text_match_type_t match_type,
-                std::unique_ptr<filter_node_t>& filter_tree_root, std::vector<facet>& facets, facet_query_t facet_query,
+                filter_result_iterator_t*& filter_result_iterator, std::vector<facet>& facets, facet_query_t facet_query,
                 const int max_facet_values,
                 const std::vector<std::pair<uint32_t, uint32_t>>& included_ids,
                 const std::vector<uint32_t>& excluded_ids, std::vector<sort_by>& sort_fields_std,
@@ -872,8 +872,7 @@ public:
 
     // the following methods are not synchronized because their parent calls are synchronized or they are const/static
 
-    Option<bool> search_wildcard(filter_node_t const* const& filter_tree_root,
-                                 const std::vector<sort_by>& sort_fields, Topster<KV>*& topster,
+    Option<bool> search_wildcard(const std::vector<sort_by>& sort_fields, Topster<KV>*& topster,
                                  spp::sparse_hash_map<uint64_t, uint32_t>& groups_processed,
                                  std::vector<std::vector<art_leaf*>>& searched_queries, const size_t group_limit,
                                  const std::vector<std::string>& group_by_fields,
@@ -948,7 +947,6 @@ public:
 
     [[nodiscard]] Option<bool> do_synonym_search(const std::vector<search_field_t>& the_fields,
                                                  const text_match_type_t match_type,
-                                                 filter_node_t const* const& filter_tree_root,
                                                  const std::vector<sort_by>& sort_fields_std,
                                                  const token_ordering& token_order,
                                                  const size_t typo_tokens_threshold, const size_t group_limit,


### PR DESCRIPTION
Initialize `filter_result_iterator` in `Index::run_search` so it can be reused in the second group_by pass.

## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
