### PR TITLE
support dynamic facet return parent

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -998,6 +998,8 @@ public:
 
     Option<bool> parse_facet(const std::string& facet_field, std::vector<facet>& facets) const;
 
+    Option<bool> process_facet_return_parent(std::vector<std::string>& facet_return_parent) const;
+
     // Override operations
 
     Option<uint32_t> add_override(const override_t & override, bool write_to_store = true);

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -2295,6 +2295,13 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
         }
     }
 
+    if(!coll_args.facet_return_parent.empty()) {
+        auto op = process_facet_return_parent(coll_args.facet_return_parent);
+        if(!op.ok()) {
+            return op;
+        }
+    }
+
     std::vector<facet_index_type_t> facet_index_types;
     std::vector<std::string> facet_index_str_types;
     StringUtils::split(facet_index_type, facet_index_str_types, ",");
@@ -3170,8 +3177,15 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) c
             }
         } else {
             auto the_field = search_schema.at(a_facet.field_name);
-            bool should_return_parent = std::find(facet_return_parent.begin(), facet_return_parent.end(),
-                                                  the_field.name) != facet_return_parent.end();
+            bool should_return_parent;
+            if(facet_return_parent.size() == 1 && facet_return_parent[0] == "*") {
+                //wildcard match
+                should_return_parent = true;
+            } else {
+                should_return_parent = std::find(facet_return_parent.begin(), facet_return_parent.end(),
+                          the_field.name) != facet_return_parent.end();
+
+            }
 
             for(size_t fi = 0; fi < max_facets; fi++) {
                 // remap facet value hash with actual string
@@ -7247,6 +7261,41 @@ Option<bool> Collection::parse_facet(const std::string& facet_field, std::vector
                                   order, sort_field));
     }
 
+    return Option<bool>(true);
+}
+
+Option<bool> Collection::process_facet_return_parent(std::vector<std::string>& facet_return_parent) const {
+    std::vector<std::string> result;
+
+    for(auto val : facet_return_parent) {
+        if(val.back() == '*') {
+            if(val.size() == 1) { //pure wildcard
+                result.clear();
+                result.emplace_back("*");
+                facet_return_parent = result;
+                return Option<bool>(true);
+            } else { //fields ending with *
+                auto prefix = val.substr(0, val.size() - 1);
+                auto pair = search_schema.equal_prefix_range(prefix);
+
+                if(pair.first == pair.second) {
+                    // not found
+                    std::string error = "Could not find a facet_return_parent field for `" + val + "` in the schema.";
+                    return Option<bool>(404, error);
+                }
+
+                // Collect the fields that match the prefix and are marked as facet.
+                for(auto field = pair.first; field != pair.second; field++) {
+                    if(field->facet) {
+                        result.emplace_back(field->name);
+                    }
+                }
+            }
+        } else { //normal field name
+            result.emplace_back(val);
+        }
+    }
+    facet_return_parent = std::move(result);
     return Option<bool>(true);
 }
 

--- a/test/collection_faceting_test.cpp
+++ b/test/collection_faceting_test.cpp
@@ -2295,6 +2295,72 @@ TEST_F(CollectionFacetingTest, FacetingReturnParent) {
     ASSERT_EQ("0", results["facet_counts"][3]["counts"][0]["value"]);
     ASSERT_EQ("{\"b\":255,\"color\":\"blue\",\"g\":0,\"r\":0}", results["facet_counts"][3]["counts"][1]["parent"].dump());
     ASSERT_EQ("255", results["facet_counts"][3]["counts"][1]["value"]);
+
+    //should support dynamic fields
+    search_op = coll1->search("*", {},"", {"value.color", "value.r"},
+                              {}, {2}, 10, 1,FREQUENCY, {true},
+                              1, spp::sparse_hash_set<std::string>(),
+                              spp::sparse_hash_set<std::string>(),10, "",
+                              30, 4, "",
+                              Index::TYPO_TOKENS_THRESHOLD, "", "",{},
+                              3, "<mark>", "</mark>", {},
+                              UINT32_MAX, true, false, true,
+                              "", false, 6000*1000, 4, 7,
+                              fallback, 4, {off}, INT16_MAX, INT16_MAX,
+                              2, 2, false, "",
+                              true, 0, max_score, 100,
+                              0, 0, "exhaustive", 30000,
+                              2, "", {"value.*"});
+
+    if(!search_op.ok()) {
+        LOG(ERROR) << search_op.error();
+        FAIL();
+    }
+    results = search_op.get();
+    ASSERT_EQ(2, results["facet_counts"].size());
+
+    ASSERT_EQ(2, results["facet_counts"][0]["counts"].size());
+    ASSERT_EQ("red", results["facet_counts"][0]["counts"][0]["value"]);
+    ASSERT_EQ("blue", results["facet_counts"][0]["counts"][1]["value"]);
+
+    ASSERT_EQ(2, results["facet_counts"][1]["counts"].size());
+    ASSERT_EQ("{\"b\":255,\"color\":\"blue\",\"g\":0,\"r\":0}", results["facet_counts"][1]["counts"][0]["parent"].dump());
+    ASSERT_EQ("0", results["facet_counts"][1]["counts"][0]["value"]);
+    ASSERT_EQ("{\"b\":0,\"color\":\"red\",\"g\":0,\"r\":255}", results["facet_counts"][1]["counts"][1]["parent"].dump());
+    ASSERT_EQ("255", results["facet_counts"][1]["counts"][1]["value"]);
+
+    //pure wildcard
+    search_op = coll1->search("*", {},"", {"value.color", "value.r"},
+                              {}, {2}, 10, 1,FREQUENCY, {true},
+                              1, spp::sparse_hash_set<std::string>(),
+                              spp::sparse_hash_set<std::string>(),10, "",
+                              30, 4, "",
+                              Index::TYPO_TOKENS_THRESHOLD, "", "",{},
+                              3, "<mark>", "</mark>", {},
+                              UINT32_MAX, true, false, true,
+                              "", false, 6000*1000, 4, 7,
+                              fallback, 4, {off}, INT16_MAX, INT16_MAX,
+                              2, 2, false, "",
+                              true, 0, max_score, 100,
+                              0, 0, "exhaustive", 30000,
+                              2, "", {"*"});
+
+    if(!search_op.ok()) {
+        LOG(ERROR) << search_op.error();
+        FAIL();
+    }
+    results = search_op.get();
+    ASSERT_EQ(2, results["facet_counts"].size());
+
+    ASSERT_EQ(2, results["facet_counts"][0]["counts"].size());
+    ASSERT_EQ("red", results["facet_counts"][0]["counts"][0]["value"]);
+    ASSERT_EQ("blue", results["facet_counts"][0]["counts"][1]["value"]);
+
+    ASSERT_EQ(2, results["facet_counts"][1]["counts"].size());
+    ASSERT_EQ("{\"b\":255,\"color\":\"blue\",\"g\":0,\"r\":0}", results["facet_counts"][1]["counts"][0]["parent"].dump());
+    ASSERT_EQ("0", results["facet_counts"][1]["counts"][0]["value"]);
+    ASSERT_EQ("{\"b\":0,\"color\":\"red\",\"g\":0,\"r\":255}", results["facet_counts"][1]["counts"][1]["parent"].dump());
+    ASSERT_EQ("255", results["facet_counts"][1]["counts"][1]["value"]);
 }
 
 TEST_F(CollectionFacetingTest, FacetingReturnParentDeepNested) {

--- a/test/collection_optimized_faceting_test.cpp
+++ b/test/collection_optimized_faceting_test.cpp
@@ -1885,6 +1885,72 @@ TEST_F(CollectionOptimizedFacetingTest, FacetingReturnParent) {
     ASSERT_EQ("0", results["facet_counts"][3]["counts"][0]["value"]);
     ASSERT_EQ("{\"b\":255,\"color\":\"blue\",\"g\":0,\"r\":0}", results["facet_counts"][3]["counts"][1]["parent"].dump());
     ASSERT_EQ("255", results["facet_counts"][3]["counts"][1]["value"]);
+
+    //should support dynamic fields
+    search_op = coll1->search("*", {},"", {"value.color", "value.r"},
+                              {}, {2}, 10, 1,FREQUENCY, {true},
+                              1, spp::sparse_hash_set<std::string>(),
+                              spp::sparse_hash_set<std::string>(),10, "",
+                              30, 4, "",
+                              Index::TYPO_TOKENS_THRESHOLD, "", "",{},
+                              3, "<mark>", "</mark>", {},
+                              UINT32_MAX, true, false, true,
+                              "", false, 6000*1000, 4, 7,
+                              fallback, 4, {off}, INT16_MAX, INT16_MAX,
+                              2, 2, false, "",
+                              true, 0, max_score, 100,
+                              0, 0, "exhaustive", 30000,
+                              2, "", {"value.*"});
+
+    if(!search_op.ok()) {
+        LOG(ERROR) << search_op.error();
+        FAIL();
+    }
+    results = search_op.get();
+    ASSERT_EQ(2, results["facet_counts"].size());
+
+    ASSERT_EQ(2, results["facet_counts"][0]["counts"].size());
+    ASSERT_EQ("red", results["facet_counts"][0]["counts"][0]["value"]);
+    ASSERT_EQ("blue", results["facet_counts"][0]["counts"][1]["value"]);
+
+    ASSERT_EQ(2, results["facet_counts"][1]["counts"].size());
+    ASSERT_EQ("{\"b\":255,\"color\":\"blue\",\"g\":0,\"r\":0}", results["facet_counts"][1]["counts"][0]["parent"].dump());
+    ASSERT_EQ("0", results["facet_counts"][1]["counts"][0]["value"]);
+    ASSERT_EQ("{\"b\":0,\"color\":\"red\",\"g\":0,\"r\":255}", results["facet_counts"][1]["counts"][1]["parent"].dump());
+    ASSERT_EQ("255", results["facet_counts"][1]["counts"][1]["value"]);
+
+    //pure wildcard
+    search_op = coll1->search("*", {},"", {"value.color", "value.r"},
+                              {}, {2}, 10, 1,FREQUENCY, {true},
+                              1, spp::sparse_hash_set<std::string>(),
+                              spp::sparse_hash_set<std::string>(),10, "",
+                              30, 4, "",
+                              Index::TYPO_TOKENS_THRESHOLD, "", "",{},
+                              3, "<mark>", "</mark>", {},
+                              UINT32_MAX, true, false, true,
+                              "", false, 6000*1000, 4, 7,
+                              fallback, 4, {off}, INT16_MAX, INT16_MAX,
+                              2, 2, false, "",
+                              true, 0, max_score, 100,
+                              0, 0, "exhaustive", 30000,
+                              2, "", {"*"});
+
+    if(!search_op.ok()) {
+        LOG(ERROR) << search_op.error();
+        FAIL();
+    }
+    results = search_op.get();
+    ASSERT_EQ(2, results["facet_counts"].size());
+
+    ASSERT_EQ(2, results["facet_counts"][0]["counts"].size());
+    ASSERT_EQ("red", results["facet_counts"][0]["counts"][0]["value"]);
+    ASSERT_EQ("blue", results["facet_counts"][0]["counts"][1]["value"]);
+
+    ASSERT_EQ(2, results["facet_counts"][1]["counts"].size());
+    ASSERT_EQ("{\"b\":255,\"color\":\"blue\",\"g\":0,\"r\":0}", results["facet_counts"][1]["counts"][0]["parent"].dump());
+    ASSERT_EQ("0", results["facet_counts"][1]["counts"][0]["value"]);
+    ASSERT_EQ("{\"b\":0,\"color\":\"red\",\"g\":0,\"r\":255}", results["facet_counts"][1]["counts"][1]["parent"].dump());
+    ASSERT_EQ("255", results["facet_counts"][1]["counts"][1]["value"]);
 }
 
 TEST_F(CollectionOptimizedFacetingTest, FacetingReturnParentDeepNested) {


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
### Dynamic fields in facet_return_parent
Just need to add '*' at some root object field like
`facet_return_parent=value.*` and it'll return parent for all matching facets like `value.color`, `value.r`, `value.g` etc.

One can pass pure wildcard too like 
`facet_return_parent=*`. it'll return parent object of all found faceted field.
## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
