### PR TITLE
Use `google` instead of `gcp` for a namespace in conversation models

### DIFF
--- a/src/conversation_model.cpp
+++ b/src/conversation_model.cpp
@@ -76,7 +76,7 @@ Option<std::string> ConversationModel::get_answer(const std::string& context, co
         return CFConversationModel::get_answer(context, prompt, system_prompt, model_config);
     } else if(model_namespace == "vllm") {
         return vLLMConversationModel::get_answer(context, prompt, system_prompt, model_config);
-    } else if(model_namespace == "gcp") {
+    } else if(model_namespace == "google") {
         return GeminiConversationModel::get_answer(context, prompt, system_prompt, model_config);
     } else if(model_namespace == "azure") {
         return AzureConversationModel::get_answer(context, prompt, system_prompt, model_config);


### PR DESCRIPTION
Related to #2297

Historically, for text embeddings we've used:

- `google` namespace for calls to `https://generativelanguage.googleapis.com/` which is Google AI Studio
- `gcp` namespace for calls to `https://<region>-aiplatform.googleapis.com/` which is Vertex AI

This PR updates the new model we've added for conversation search in v29 in https://github.com/typesense/typesense/pull/2297, to use the existing convention, since it's making calls out to `https://generativelanguage.googleapis.com/`