### PR TITLE
feat(filter): add array count filtering with `_count()` syntax

### DIFF
--- a/include/filter.h
+++ b/include/filter.h
@@ -50,6 +50,9 @@ struct filter {
 
     bool is_ignored_filter = false;
 
+    std::string array_field_name{};
+    bool is_array_count_filter = false;
+
     /// For searching places within a given radius of a given latlong (mi for miles and km for kilometers)
     static constexpr const char* GEO_FILTER_RADIUS_KEY = "radius";
 


### PR DESCRIPTION
### TLDR
Add support for filtering documents by array element count using `_count(fieldname)` syntax

## Change Summary

#### Added Features:
1. **New Array Count Filter Syntax**:
   - `_count(fieldname)`: Filter documents based on the number of elements in array fields
   - Support for all comparison operators: `:=`, `:>`, `:<`, `:>=`, `:<=`, `:!=`
   - Range filtering with `[1..3]` syntax for inclusive ranges
   - Multiple value filtering with `[0,2,5]` syntax for OR logic

#### Code Changes:
1. **In `filter.h`**:
   - Added `array_field_name` and `is_array_count_filter` properties to track array count filters

2. **In `filter.cpp`**:
   - `toFilter()`: Added parsing logic for `_count(fieldname)` syntax
   - Added validation to ensure `_count()` is only used on array fields
   - Added support for bracket notation with ranges and multiple values
   - Added integer validation for count values

3. **In `filter_result_iterator.cpp`**:
   - `init()`: Added specialized handling for array count filters
   - Implemented document iteration to count array elements and apply comparisons
   - Added support for all comparison operators including ranges

4. **In `string_utils.cpp`**:
   - `tokenize_filter_query()`: Enhanced tokenizer to properly parse `_count()` expressions
   - Added special handling for parentheses and colon parsing within count expressions

#### Test Coverage:
1. **In `collection_filtering_test.cpp`**:
   - Added `FilterByArrayCount` test suite with 15+ test cases
   - Tests for basic equality, comparison operators, ranges, and multiple values
   - Error handling tests for invalid syntax, non-array fields, and non-integer values

### Demo
For a `tags` field

```
{
	"name": "tags",
	"type": "string[]"
}
```

```
// Filter documents with exactly 2 tags
_count(tags):2

// Filter documents with more than 1 category
_count(categories):>1

// Filter documents with 1-3 scores (inclusive range)
_count(scores):[1..3]

// Filter documents with 0 or 2 tags (multiple values)
_count(tags):[0,2]

// Combine with other filters
name:John && _count(tags):>0
```

### Context
Addresses #2346 