### PR TITLE
fix(analytics): use meta-fields in doc ID generation for query events

### DIFF
--- a/src/query_analytics.cpp
+++ b/src/query_analytics.cpp
@@ -67,7 +67,17 @@ void QueryAnalytics::serialize_as_docs(std::string& docs) {
             doc["analytics_tag"] = it->first.tag_str;
         }
 
-        doc["id"] = std::to_string(StringUtils::hash_wy(it->first.query.c_str(), it->first.query.size()));
+        std::string id_source = it->first.query;
+        
+        if (meta_fields.find("filter_by") != meta_fields.end() && !it->first.filter_str.empty()) {
+            id_source += "|filter:" + it->first.filter_str;
+        }
+        
+        if (meta_fields.find("analytics_tag") != meta_fields.end() && !it->first.tag_str.empty()) {
+            id_source += "|tag:" + it->first.tag_str;
+        }
+        
+        doc["id"] = std::to_string(StringUtils::hash_wy(id_source.c_str(), id_source.size()));
         doc["q"] = it->first.query;
         doc["$operations"]["increment"]["count"] = it->second;
         docs += doc.dump(-1, ' ', false, nlohmann::detail::error_handler_t::ignore) + "\n";


### PR DESCRIPTION
## TLDR
Ensure unique analytics IDs when queries differ by `filter_by` or `analytics_tag` metadata.

## Change summary

Previously, queries with different filters or tags could end up sharing the same analytics ID, causing aggregation issues in the destination collection. This pull request modifies how IDs are generated to include both `filter_by` and `analytics_tag` values (when applicable) to ensure queries are uniquely identified based on their full context.

### Changes

#### Code Changes:

1. **In `query_analytics.cpp`**:

   * Updated ID generation logic in `QueryAnalytics::serialize_as_docs`.
   * The ID hash now includes `filter_by` and `analytics_tag` values (if present in `meta_fields`) to distinguish between queries with similar text but different filtering/tagging contexts.
   * This prevents ID collisions when aggregating analytics data.

#### Added Features:

1. **New Tests in `analytics_manager_test.cpp`**:

   * `MetaFieldsGenerateUniqueIDs`: Verifies that two queries with the same base string but different tags generate distinct IDs.
   * `MetaFieldsGenerateUniqueIDsWithFilterAndTag`: Validates that combinations of different `filter_by` and `analytics_tag` values produce separate analytics records.
   * These tests confirm that the updated ID generation produces distinct entries under various metadata conditions.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
