### PR TITLE
Related docs count

### DIFF
--- a/include/field.h
+++ b/include/field.h
@@ -506,6 +506,7 @@ namespace ref_include {
     static const std::string merge_string = "merge";
     static const std::string nest_string = "nest";
     static const std::string nest_array_string = "nest_array";
+    static const std::string related_docs_count = "related_docs_count";
 
     enum strategy_enum {merge = 0, nest, nest_array};
 
@@ -529,6 +530,7 @@ struct ref_include_exclude_fields {
     std::string exclude_fields;
     std::string alias;
     ref_include::strategy_enum strategy = ref_include::nest;
+    std::string related_docs_field;
 
     // In case we have nested join.
     std::vector<ref_include_exclude_fields> nested_join_includes = {};


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
## Related Docs Count
While joining the collection using references, one can get related doc count related to a document by mentioning the param `related_docs_count` in include_fields like below,

```json
{
  "collection": "authors",
  "q": "*",
  "filter_by": "$books(id:*)",
  "include_fields": "$books(*, related_docs_count: foo_related_count)"
}
```
Which will return the response like below,
```json
[
  {
    "document": {
      "id": "1",
      "first_name": "JK",
      "last_name": "Rowling",
      "books": {
        "author_id": "1",
        "id": "2",
        "title": "Harry Potter"
      },
      "foo_related_count": 1
    }
  },
  {
    "document": {
      "id": "0",
      "first_name": "Enid",
      "last_name": "Blyton",
      "books": [
        {
          "author_id": "0",
          "id": "0",
          "title": "Famous Five"
        },
        {
          "author_id": "0",
          "id": "1",
          "title": "Secret Seven"
        }
      ],
      "foo_related_count": 2
    }
  }
]
```
#### related docs count will be populated only if `related_docs_count` is given in include_fields param. 
## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
