### PR TITLE
Rename `collection` parameter in `union_request_params` to `collection_name`.

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -3689,7 +3689,7 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
         }
 
         nlohmann::json params;
-        params["collection"] = coll->get_name();
+        params["collection_name"] = coll->get_name();
         params["per_page"] = union_params.per_page;
         params["q"] = coll_args.raw_query;
         params["found"] = found;
@@ -3726,7 +3726,7 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
             for (size_t i = 0; i < first_search_sort_fields.size(); i++) {
                 if (this_search_sort_fields[i].type != first_search_sort_fields[i].type) {
                     std::string append_hint;
-                    const auto& first_search_collection_name = request_json_list[0]["collection"].get<std::string>();
+                    const auto& first_search_collection_name = request_json_list[0]["collection_name"].get<std::string>();
                     if (default_sorting_field_used && first_request_default_sorting_field_used) {
                         // Both the current and first search request have declared a default sorting field.
                         append_hint = " Both `" + coll->get_name() + "` and `" + first_search_collection_name +

--- a/test/union_test.cpp
+++ b/test/union_test.cpp
@@ -816,9 +816,9 @@ TEST_F(UnionTest, Pagination) {
     ASSERT_EQ(578730123365187705, json_res["hits"][1]["text_match"]);
 
     ASSERT_EQ(5, json_res["union_request_params"][0]["found"]);
-    ASSERT_EQ("coll_bool", json_res["union_request_params"][0]["collection"]);
+    ASSERT_EQ("coll_bool", json_res["union_request_params"][0]["collection_name"]);
     ASSERT_EQ(5, json_res["union_request_params"][1]["found"]);
-    ASSERT_EQ("coll_array_fields", json_res["union_request_params"][1]["collection"]);
+    ASSERT_EQ("coll_array_fields", json_res["union_request_params"][1]["collection_name"]);
     json_res.clear();
     req_params.clear();
 
@@ -859,9 +859,9 @@ TEST_F(UnionTest, Pagination) {
     ASSERT_EQ(578730123365187705, json_res["hits"][1]["text_match"]);
 
     ASSERT_EQ(2, json_res["union_request_params"][0]["per_page"]);
-    ASSERT_EQ("coll_bool", json_res["union_request_params"][0]["collection"]);
+    ASSERT_EQ("coll_bool", json_res["union_request_params"][0]["collection_name"]);
     ASSERT_EQ(2, json_res["union_request_params"][1]["per_page"]);
-    ASSERT_EQ("coll_array_fields", json_res["union_request_params"][1]["collection"]);
+    ASSERT_EQ("coll_array_fields", json_res["union_request_params"][1]["collection_name"]);
     json_res.clear();
     req_params.clear();
 


### PR DESCRIPTION
Ensures similarity with single search response.

## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
