### PR TITLE
feat(nl): add azure openai support for natural language search

### DIFF
--- a/include/natural_language_search_model.h
+++ b/include/natural_language_search_model.h
@@ -55,6 +55,11 @@ public:
                                                         const std::string& client_id, 
                                                         const std::string& client_secret);
 
+    static Option<bool> validate_azure_model(const nlohmann::json& model_config);
+    static Option<nlohmann::json> azure_generate_search_params(const std::string& query, 
+                                                             const std::string& collection_schema_prompt,
+                                                             const nlohmann::json& model_config);
+
     static long post_response(const std::string& url, const std::string& body, std::string& response,
                                     std::map<std::string, std::string>& res_headers,
                                     const std::unordered_map<std::string, std::string>& headers = {},
@@ -78,6 +83,10 @@ private:
     static Option<nlohmann::json> call_gcp_api(const nlohmann::json& request_body,
                                                const nlohmann::json& model_config,
                                                long timeout_ms = DEFAULT_TIMEOUT_MS);
+
+    static Option<nlohmann::json> call_azure_api(const nlohmann::json& request_body,
+                                                 const nlohmann::json& model_config,
+                                                 long timeout_ms = DEFAULT_TIMEOUT_MS);
 
 public:
 


### PR DESCRIPTION
## Change Summary
Behaves similarly to how Conversational Search models work for Azure OpenAI
Example usage:
```sh
curl -X POST http://localhost:8108/nl_search_models \
      -H "X-TYPESENSE-API-KEY: xyz" \
      -H "Content-Type: application/json" \
      -d '{
  "id": "model-test",
  "model_name": "azure/gpt-35-turbo",
  "api_key": "<API_KEY>",
  "url": "https://myresource.openai.azure.com/openai/deployments/mygpt35deployment/chat/completions?api-version=2024-02-15-preview",
  "max_bytes": 16000
}'
```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
