### PR TITLE
fix(search): use field-level token separators in highlighting

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -5036,7 +5036,10 @@ void Collection::highlight_result(const bool& enable_nested_fields, const std::v
             text = document[search_field.name][match_index.index];
         }
 
-        handle_highlight_text(text, normalise, search_field, false, symbols_to_index, token_separators,
+        const auto& field_symbols = search_field.symbols_to_index.empty() ? symbols_to_index : search_field.symbols_to_index;
+        const auto& field_separators = search_field.token_separators.empty() ? token_separators : search_field.token_separators;
+
+        handle_highlight_text(text, normalise, search_field, false, field_symbols, field_separators,
                               highlight, string_utils, use_word_tokenizer, highlight_affix_num_tokens,
                               qtoken_leaves, last_valid_offset_index, prefix_token_num_chars,
                               highlight_fully, snippet_threshold, is_infix_search, raw_query_tokens,


### PR DESCRIPTION
## Change Summary
• fixes issue where search highlighting used collection-level token separators instead of field-specific ones
• ensures highlighting tokenizer matches indexing tokenizer configuration for consistent behavior
• resolves incorrect highlighting of domain extensions (com, org, net) when searching for "example" in email fields
• adds test case to verify proper highlighting with field-level token separators including @ symbol


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
