### PR TITLE
feat: add STOPSIGNAL instruction to Dockerfile

### DIFF
--- a/docker/deployment.Dockerfile
+++ b/docker/deployment.Dockerfile
@@ -6,4 +6,5 @@ RUN mkdir -p /opt
 COPY typesense-server /opt
 RUN chmod +x /opt/typesense-server
 EXPOSE 8108
+STOPSIGNAL SIGINT
 ENTRYPOINT ["/opt/typesense-server"]


### PR DESCRIPTION
## Change Summary
This makes a regular shutdown a graceful shotdown. Useful for kubernetes and other deployment modes.

See https://docs.docker.com/reference/dockerfile/#stopsignal


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
