### PR TITLE
fix(nl-search): update temperature and max tokens params usage for the o-series models

### DIFF
--- a/src/natural_language_search_model.cpp
+++ b/src/natural_language_search_model.cpp
@@ -112,24 +112,34 @@ Option<bool> NaturalLanguageSearchModel::validate_openai_model(const nlohmann::j
        model_config["api_key"].get<std::string>().empty()) {
         return Option<bool>(400, "Property `api_key` is missing or is not a non-empty string.");
     }
-
-    if(model_config.count("temperature") != 0 && 
-       (!model_config["temperature"].is_number() || 
-        model_config["temperature"].get<float>() < 0 || 
-        model_config["temperature"].get<float>() > 2)) {
-        return Option<bool>(400, "Property `temperature` must be a number between 0 and 2.");
-    }
-
     // Validate API key by making a test API call
     const std::string& model_name = model_config["model_name"].get<std::string>();
     const std::string& model_name_without_namespace = model_name.substr(model_name.find('/') + 1);
+    bool is_o_model = (model_name_without_namespace.size() >= 2 && model_name_without_namespace[0] == 'o' 
+                        && isdigit(model_name_without_namespace[1]));
+
+    if(model_config.count("temperature") != 0) {
+        if(is_o_model) {
+            return Option<bool>(400, "Property `temperature` is not supported for the o-series models.");
+        }
+        if(!model_config["temperature"].is_number() || 
+           model_config["temperature"].get<float>() < 0 || 
+           model_config["temperature"].get<float>() > 2) {
+            return Option<bool>(400, "Property `temperature` must be a number between 0 and 2.");
+        }
+    }
+
 
     nlohmann::json test_request;
     test_request["model"] = model_name_without_namespace;
     test_request["messages"] = R"([{"role":"user","content":"hello"}])"_json;
-    test_request["max_tokens"] = 10;
-    test_request["temperature"] = 0;
-
+    if(is_o_model) {
+        test_request["max_completion_tokens"] = 10;
+    } else {
+        test_request["max_tokens"] = 10;
+        test_request["temperature"] = 0;
+    }
+    
     auto result = call_openai_api(test_request, model_config, VALIDATION_TIMEOUT_MS);
     if(!result.ok()) {
         return Option<bool>(400, result.error());
@@ -150,10 +160,17 @@ Option<nlohmann::json> NaturalLanguageSearchModel::openai_vllm_generate_search_p
     size_t max_bytes = model_config["max_bytes"].get<size_t>();
     std::string api_url = model_config.value("api_url", std::string("https://api.openai.com/v1/chat/completions"));
 
+    bool is_o_model = (model_name_without_namespace.size() >= 2 && model_name_without_namespace[0] == 'o' 
+                        && isdigit(model_name_without_namespace[1]));
+
     nlohmann::json request_body;
     request_body["model"] = model_name_without_namespace;
-    request_body["temperature"] = temperature;
-    request_body["max_tokens"] = max_bytes;
+    if(is_o_model) {
+        request_body["max_completion_tokens"] = max_bytes;
+    } else {
+        request_body["max_tokens"] = max_bytes;
+        request_body["temperature"] = temperature;
+    }
     request_body["messages"] = {
         {{"role", "system"}, {"content", system_prompt}},
         {{"role", "user"}, {"content", query}}


### PR DESCRIPTION
## Change Summary
The o-series models use `max_completion_tokens` param instead of `max_tokens` and do not support temperature setting. This PR handles the validation and fixes the param usage for max_tokens.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
