### PR TITLE
Fix issue with rocksdb build

### DIFF
--- a/bazel/foreign_cc.patch
+++ b/bazel/foreign_cc.patch
@@ -307,3 +307,20 @@ index 5288b27..a193021 100755
      "1.10.2",
      "1.10.1",
      "1.10.0",
+
+diff --git a/foreign_cc/private/cmake_script.bzl b/foreign_cc/private/cmake_script.bzl
+--- foreign_cc/private/cmake_script.bzl
++++ foreign_cc/private/cmake_script.bzl
+@@ -84,12 +84,5 @@
+     # CMAKE_BUILD_TYPE will not be passed to CMake
+     _wipe_empty_values(params.cache, keys_with_empty_values_in_user_cache)
+
+-    # However, if no CMAKE_RANLIB was passed, pass the empty value for it explicitly,
+-    # as it is legacy and autodetection of ranlib made by CMake automatically
+-    # breaks some cross compilation builds,
+-    # see https://github.com/envoyproxy/envoy/pull/6991
+-    if not params.cache.get("CMAKE_RANLIB"):
+-        params.cache.update({"CMAKE_RANLIB": ""})
+-
+     set_env_vars = [
+         "export {}=\"{}\"".format(key, _escape_dquote_bash(params.env[key]))

--- a/bazel/rocksdb.BUILD
+++ b/bazel/rocksdb.BUILD
@@ -28,6 +28,7 @@ cmake(
         "//conditions:default": CMAKE_CACHE_ENTRIES,
     }),
     generate_args = [
+        "-UCMAKE_RANLIB",
         "-DWITH_GFLAGS=OFF",
         "-DWITH_ALL_TESTS=OFF",
         "-DPORTABLE=1",


### PR DESCRIPTION
## Issue

Locally I am seeing the following issue when doing a bazel build. It's totally bizarre, I am wondering if anyone else is seeing this.

```
$ bazel build @rocksdb//:rocksdb
...
ccache: error: Could not find compiler ":" in PATH
```

Its very strange because previously I could build fine, maybe something changed in my environment, and now I hit it.

The issue is caused by this: https://github.com/bazel-contrib/rules_foreign_cc/issues/1394, see also https://github.com/bazel-contrib/rules_foreign_cc/issues/252#issuecomment-2832630126

In a nutshell:
- The problem is related to the detection of `CMAKE_RANLIB`
- AFAIK bazel does not load `CMAKE_RANLIB` from the system env, nor do we set it in `.bazelrc` or anywhere else.
- `foreign_cc/private/cmake_script.bzl` adds a hack which explicitly sets `CMAKE_RANLIB=""` (empty string) if it is nil.
- As per [rules_foreign_cc#1394](https://github.com/bazel-contrib/rules_foreign_cc/issues/1394) the Ninja generator (?) is converting "" to ":" which is intended to mean "no-op"
- rocksdb's build then chokes on it with `Could not find compiler ":" in PATH`

## The Fix

I've included two possible solutions to this, we only need one or the other:
1. `bazel/foreign_cc.patch` --> patch out the foreign_cc hack which sets `CMAKE_RANLIB=""`
2. `bazel/rocksdb.BUILD` --> explictly unset `CMAKE_RANLIB` flag

In either solution, the rocksdb build will have `CMAKE_RANLIB` unset, which will cause **CMake to correctly autodetect ranlib**.

## Build Log

```
$ bazel build @rocksdb//:rocksdb

...
[100%] Building CXX object CMakeFiles/rocksdb.dir/build_version.cc.o
[100%] Linking CXX static library librocksdb.a
ccache: error: Could not find compiler ":" in PATH
make[3]: *** [CMakeFiles/rocksdb.dir/build.make:5250: librocksdb.a] Error 1
make[3]: *** Deleting file 'librocksdb.a'
make[2]: *** [CMakeFiles/Makefile2:141: CMakeFiles/rocksdb.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:148: CMakeFiles/rocksdb.dir/rule] Error 2
make: *** [Makefile:169: rocksdb] Error 2
_____ END BUILD LOGS _____
rules_foreign_cc: Build wrapper script location: bazel-out/k8-fastbuild/bin/external/rocksdb/rocksdb_foreign_cc/wrapper_build_script.sh
rules_foreign_cc: Build script location: bazel-out/k8-fastbuild/bin/external/rocksdb/rocksdb_foreign_cc/build_script.sh
rules_foreign_cc: Build log location: bazel-out/k8-fastbuild/bin/external/rocksdb/rocksdb_foreign_cc/CMake.log

Target @rocksdb//:rocksdb failed to build
Use --verbose_failures to see the command lines of failed build steps.                                  
INFO: Elapsed time: 80.862s, Critical Path: 72.35s
INFO: 17 processes: 9 internal, 8 linux-sandbox.                                                        
FAILED: Build did NOT complete successfully    
```

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).

