### PR TITLE
Filter out duplicates with Union

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -969,7 +969,7 @@ public:
 
     static Option<bool> do_union(const std::vector<uint32_t>& collection_ids,
                                  std::vector<collection_search_args_t>& searches, std::vector<long>& searchTimeMillis,
-                                 const union_global_params_t& union_params, nlohmann::json& result);
+                                 const union_global_params_t& union_params, nlohmann::json& result, bool remove_duplicates);
 
     Option<bool> get_filter_ids(const std::string & filter_query, filter_result_t& filter_result,
                                 const bool& should_timeout = true, const bool& validate_field_names = true) const;

--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -162,7 +162,7 @@ public:
 
     static Option<bool> do_union(std::map<std::string, std::string>& req_params,
                                  std::vector<nlohmann::json>& embedded_params_vec, nlohmann::json searches,
-                                 nlohmann::json& response, uint64_t start_ts, bool remove_duplicates = false);
+                                 nlohmann::json& response, uint64_t start_ts, bool remove_duplicates = true);
 
     static bool parse_sort_by_str(std::string sort_by_str, std::vector<sort_by>& sort_fields);
 

--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -162,7 +162,7 @@ public:
 
     static Option<bool> do_union(std::map<std::string, std::string>& req_params,
                                  std::vector<nlohmann::json>& embedded_params_vec, nlohmann::json searches,
-                                 nlohmann::json& response, uint64_t start_ts);
+                                 nlohmann::json& response, uint64_t start_ts, bool remove_duplicates = false);
 
     static bool parse_sort_by_str(std::string sort_by_str, std::vector<sort_by>& sort_fields);
 

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -3599,7 +3599,7 @@ Option<bool> Collection::run_search_with_lock(search_args* search_params) const 
 
 Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
                                   std::vector<collection_search_args_t>& searches, std::vector<long>& searchTimeMillis,
-                                  const union_global_params_t& union_params, nlohmann::json& result) {
+                                  const union_global_params_t& union_params, nlohmann::json& result, bool remove_duplicates) {
     if (searches.size() != collection_ids.size()) {
         return Option<bool>(400, "Expected `collection_ids` and `searches` size to be equal.");
     }
@@ -3791,24 +3791,22 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
     std::vector<std::vector<Union_KV*>> override_result_kvs;
 
     auto union_topster = std::make_unique<Topster<Union_KV, Union_KV::get_key, Union_KV::get_distinct_key,
-                                                        Union_KV::is_greater, Union_KV::is_smaller>>(
-                                                            std::max<size_t>(union_params.fetch_size, Index::DEFAULT_TOPSTER_SIZE));
+            Union_KV::is_greater, Union_KV::is_smaller>>(std::max<size_t>(union_params.fetch_size, Index::DEFAULT_TOPSTER_SIZE));
 
     auto overrides_topster = std::make_unique<Topster<Union_KV, Union_KV::get_key, Union_KV::get_distinct_key,
-            Union_KV::is_greater, Union_KV::is_smaller>>(
-            std::max<size_t>(union_params.fetch_size, Index::DEFAULT_TOPSTER_SIZE));
+            Union_KV::is_greater, Union_KV::is_smaller>>(std::max<size_t>(union_params.fetch_size, Index::DEFAULT_TOPSTER_SIZE));
 
     for (size_t search_index = 0; search_index < searches.size(); search_index++) {
         auto& search_param = search_params_guards[search_index];
 
         for (auto& kvs: search_param->raw_result_kvs) {
-            Union_KV kv(*kvs[0], search_index);
+            Union_KV kv(*kvs[0], search_index, collection_ids[search_index], remove_duplicates);
             union_topster->add(&kv);
         }
 
         //populate overrides
         for(auto& kvs : search_param->override_result_kvs) {
-            Union_KV kv(*kvs[0], search_index);
+            Union_KV kv(*kvs[0], search_index, collection_ids[search_index], remove_duplicates);
             overrides_topster->add(&kv);
         }
     }

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -3801,13 +3801,19 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
 
         for (auto& kvs: search_param->raw_result_kvs) {
             Union_KV kv(*kvs[0], search_index, collection_ids[search_index], remove_duplicates);
-            union_topster->add(&kv);
+            auto ret = union_topster->add(&kv);
+            if(remove_duplicates && ret == 0) { //duplicate doc
+                total--;
+            }
         }
 
         //populate overrides
         for(auto& kvs : search_param->override_result_kvs) {
             Union_KV kv(*kvs[0], search_index, collection_ids[search_index], remove_duplicates);
-            overrides_topster->add(&kv);
+            auto ret = overrides_topster->add(&kv);
+            if(remove_duplicates && ret == 0) { //duplicate doc
+                total--;
+            }
         }
     }
 

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1510,7 +1510,7 @@ void remove_global_params(std::map<std::string, std::string>& req_params) {
 
 Option<bool> CollectionManager::do_union(std::map<std::string, std::string>& req_params,
                                          std::vector<nlohmann::json>& embedded_params_vec, nlohmann::json searches,
-                                         nlohmann::json& response, uint64_t start_ts) {
+                                         nlohmann::json& response, uint64_t start_ts, bool remove_duplicates) {
     union_global_params_t union_params(req_params);
     if (!union_params.init_op.ok()) {
         const auto& op = union_params.init_op;
@@ -1591,7 +1591,7 @@ Option<bool> CollectionManager::do_union(std::map<std::string, std::string>& req
 
     std::vector<long> searchTimeMillis;
 
-    auto union_op = Collection::do_union(collection_ids, coll_searches, searchTimeMillis, union_params, response);
+    auto union_op = Collection::do_union(collection_ids, coll_searches, searchTimeMillis, union_params, response, remove_duplicates);
 
     for (const auto& time: searchTimeMillis) {
         update_app_metrics(time);

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -956,7 +956,7 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
     const char* UNION_RESULT = "union";
     const char* UNION_REMOVE_DUPLICATES = "remove_duplicates";
     auto is_union = false;
-    auto union_remove_duplicates = false;
+    auto union_remove_duplicates = true;
     auto it = req_json.find(UNION_RESULT);
     if (it != req_json.end() && it.value().is_boolean()) {
         is_union = it.value();

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -954,10 +954,17 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
     }
 
     const char* UNION_RESULT = "union";
+    const char* UNION_REMOVE_DUPLICATES = "remove_duplicates";
     auto is_union = false;
+    auto union_remove_duplicates = false;
     auto it = req_json.find(UNION_RESULT);
     if (it != req_json.end() && it.value().is_boolean()) {
         is_union = it.value();
+    }
+
+    it = req_json.find(UNION_REMOVE_DUPLICATES);
+    if(it != req_json.end() && it.value().is_boolean()) {
+        union_remove_duplicates = it.value();
     }
 
     bool conversation = orig_req_params["conversation"] == "true" && !is_union;
@@ -1030,7 +1037,7 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
 
     if (is_union) {
         Option<bool> union_op = CollectionManager::do_union(req->params, req->embedded_params_vec, searches,
-                                                            response, req->conn_ts);
+                                                            response, req->conn_ts, union_remove_duplicates);
         if(!union_op.ok() && union_op.code() == 408) {
             res->set(union_op.code(), union_op.error());
             req->overloaded = true;

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -3017,7 +3017,7 @@ TEST_F(CoreAPIUtilsTest, UnionRemoveDuplicates) {
     add_op = coll1->add(doc.dump());
     ASSERT_TRUE(add_op.ok());
 
-    nlohmann::json  searches = R"([
+    nlohmann::json searches = R"([
                     {
                         "collection": "coll1",
                         "q": "shampoo",
@@ -3059,4 +3059,22 @@ TEST_F(CoreAPIUtilsTest, UnionRemoveDuplicates) {
     ASSERT_EQ(2, response["hits"].size());
     ASSERT_EQ("1", response["hits"][0]["document"]["id"]);
     ASSERT_EQ("0", response["hits"][1]["document"]["id"]);
+
+    //check setting remove_duplicates to false
+    req->params.clear();
+    body.clear();
+    body["searches"] = searches;
+    body["union"] = true;
+    body["remove_duplicates"] = false;
+    req->body = body.dump();
+
+    post_multi_search(req, res);
+    response = nlohmann::json::parse(res->body);
+    ASSERT_EQ(5, response["found"].get<size_t>());
+    ASSERT_EQ(5, response["hits"].size());
+    ASSERT_EQ("1", response["hits"][0]["document"]["id"]);
+    ASSERT_EQ("0", response["hits"][1]["document"]["id"]);
+    ASSERT_EQ("0", response["hits"][2]["document"]["id"]);
+    ASSERT_EQ("1", response["hits"][3]["document"]["id"]);
+    ASSERT_EQ("1", response["hits"][4]["document"]["id"]);
 }

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -3055,7 +3055,7 @@ TEST_F(CoreAPIUtilsTest, UnionRemoveDuplicates) {
 
     post_multi_search(req, res);
     nlohmann::json response = nlohmann::json::parse(res->body);
-    ASSERT_EQ(5, response["found"]);
+    ASSERT_EQ(2, response["found"]);
     ASSERT_EQ(2, response["hits"].size());
     ASSERT_EQ("1", response["hits"][0]["document"]["id"]);
     ASSERT_EQ("0", response["hits"][1]["document"]["id"]);

--- a/test/union_test.cpp
+++ b/test/union_test.cpp
@@ -1302,3 +1302,56 @@ TEST_F(UnionTest, HybridSearchHasVectorDistance) {
     ASSERT_TRUE(json_res["hits"][0].contains("vector_distance"));
     ASSERT_TRUE(json_res["hits"][1].contains("vector_distance"));
 }
+
+TEST_F(UnionTest, RemoveDuplicatesWithUnion) {
+    nlohmann::json schema = R"({
+        "name": "coll1",
+        "fields": [
+            {"name": "name", "type": "string"}
+        ]
+    })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto coll1 = collection_create_op.get();
+
+    nlohmann::json doc = R"({"name": "anti dandruff shampoo" })"_json;
+    auto add_op = coll1->add(doc.dump());
+    ASSERT_TRUE(add_op.ok());
+
+    doc = R"({"name": "sliky hair shampoo" })"_json;
+    add_op = coll1->add(doc.dump());
+    ASSERT_TRUE(add_op.ok());
+
+    req_params = {{"remove_duplicates", "true"}};
+    auto embedded_params = std::vector<nlohmann::json>(4, nlohmann::json::object());
+    searches = R"([
+                    {
+                        "collection": "coll1",
+                        "q": "shampoo",
+                        "query_by": "name"
+                    },
+                    {
+                        "collection": "coll1",
+                        "q": "dandruff",
+                        "query_by": "name"
+                    },
+                    {
+                        "collection": "coll1",
+                        "q": "silky",
+                        "query_by": "name"
+                    },
+                    {
+                        "collection": "coll1",
+                        "q": "hair",
+                        "query_by": "name"
+                    }
+                ])"_json;
+
+    auto search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts, true);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(5, json_res["found"].get<size_t>());
+    ASSERT_EQ(2, json_res["hits"].size());
+    ASSERT_EQ("1", json_res["hits"][0]["document"]["id"]);
+    ASSERT_EQ("0", json_res["hits"][1]["document"]["id"]);
+}

--- a/test/union_test.cpp
+++ b/test/union_test.cpp
@@ -1350,7 +1350,7 @@ TEST_F(UnionTest, RemoveDuplicatesWithUnion) {
 
     auto search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts, true);
     ASSERT_TRUE(search_op.ok());
-    ASSERT_EQ(5, json_res["found"].get<size_t>());
+    ASSERT_EQ(2, json_res["found"].get<size_t>());
     ASSERT_EQ(2, json_res["hits"].size());
     ASSERT_EQ("1", json_res["hits"][0]["document"]["id"]);
     ASSERT_EQ("0", json_res["hits"][1]["document"]["id"]);

--- a/test/union_test.cpp
+++ b/test/union_test.cpp
@@ -1348,10 +1348,23 @@ TEST_F(UnionTest, RemoveDuplicatesWithUnion) {
                     }
                 ])"_json;
 
-    auto search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts, true);
+    //default to remove duplicates
+    auto search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
     ASSERT_TRUE(search_op.ok());
     ASSERT_EQ(2, json_res["found"].get<size_t>());
     ASSERT_EQ(2, json_res["hits"].size());
     ASSERT_EQ("1", json_res["hits"][0]["document"]["id"]);
     ASSERT_EQ("0", json_res["hits"][1]["document"]["id"]);
+
+    //should explicitly set to false if not intending to remove duplicates
+    req_params = {{"remove_duplicates", "false"}};
+    search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts, false);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(5, json_res["found"].get<size_t>());
+    ASSERT_EQ(5, json_res["hits"].size());
+    ASSERT_EQ("1", json_res["hits"][0]["document"]["id"]);
+    ASSERT_EQ("0", json_res["hits"][1]["document"]["id"]);
+    ASSERT_EQ("0", json_res["hits"][2]["document"]["id"]);
+    ASSERT_EQ("1", json_res["hits"][3]["document"]["id"]);
+    ASSERT_EQ("1", json_res["hits"][4]["document"]["id"]);
 }


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
### Filter out duplicates with Union
When using `union` with multi-search, there might some instances when multiple keywords matched through different searches for same doc and those are duplicated in final response.
With optional flag `remove_duplicates`, one can enable/disable removal of these duplicated results.

#### By default this flag is set to `true` if not specified and has to be explicitly disabled by setting to `false` if required.

sample query :
```curl
curl 'http://localhost:8108/multi_search?page=1&per_page=2' -X POST \
     -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" -d '
{
  "union": true,
  "remove_duplicates": <true/false>,
  "searches": [
    {
      "collection": "posts",
      "q": "comment",
      "query_by": "title"
    },
    {
      "collection": "posts",
      "q": "post",
      "query_by": "title"
    }
  ]
}'
```
## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
