### PR TITLE
fix(api): return a 201 when creating a conversational model / personalization model / natural language search model

### DIFF
--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -3207,7 +3207,7 @@ bool post_conversation_model(const std::shared_ptr<http_req>& req, const std::sh
 
     Collection::hide_credential(model_json, "api_key");
 
-    res->set_200(model_json.dump());
+    res->set_201(model_json.dump());
     return true;
 }
 

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -3553,7 +3553,7 @@ bool post_nl_search_model(const std::shared_ptr<http_req>& req, const std::share
     Collection::hide_credential(model_json, "refresh_token");
     Collection::hide_credential(model_json, "client_secret");
 
-    res->set_200(model_json.dump());
+    res->set_201(model_json.dump());
     return true;
 }
 

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -3327,7 +3327,7 @@ bool post_personalization_model(const std::shared_ptr<http_req>& req, const std:
     if (model.contains("model_path")) {
       model.erase("model_path");
     }
-    res->set_200(model.dump());
+    res->set_201(model.dump());
     
     return true;
 }


### PR DESCRIPTION
## Change Summary
Change the return code of the POST operation on nl search model creation, to follow the rest of the conventions of resource creation. Also needed to match the OpenAPI spec.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
