### PR TITLE
fix: ensure stemming dictionaries apply when created after collections

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -1179,6 +1179,8 @@ public:
     bool check_store_alter_status_msg(bool success, const std::string& msg = "");
 
     std::string get_facet_str_val_with_lock(const std::string& field_name, uint32_t facet_id);
+
+    void refresh_stemmers();
 };
 
 template<class T>

--- a/include/stemmer_manager.h
+++ b/include/stemmer_manager.h
@@ -79,4 +79,6 @@ class StemmerManager {
         Option<bool> del_stemming_dictionary(const std::string& id);
 
         void delete_all_stemming_dictionaries();
+
+        void refresh_collection_stemmers(const std::string& dictionary_name);
 };

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -8372,6 +8372,7 @@ Option<bool> collection_search_args_t::init(std::map<std::string, std::string>& 
     size_t snippet_threshold = 30;
     size_t highlight_affix_num_tokens = 4;
     std::string highlight_full_fields;
+    std::string highlight_fields;
     std::string pinned_hits_str;
     std::string hidden_hits_str;
     std::vector<std::string> group_by_fields;
@@ -8391,7 +8392,6 @@ Option<bool> collection_search_args_t::init(std::map<std::string, std::string>& 
     std::vector<std::string> synonym_sets;
 
     bool filter_curated_hits_option = false;
-    std::string highlight_fields;
     bool exhaustive_search = false;
     size_t search_cutoff_ms = 30 * 1000;
     enable_t split_join_tokens = fallback;
@@ -8762,4 +8762,20 @@ void collection_search_args_t::override_union_global_params(union_global_params_
     per_page = global_params.per_page;
     offset = global_params.offset;
     limit_hits = global_params.limit_hits;
+}
+
+void Collection::refresh_stemmers() {
+    std::unique_lock lock(mutex);
+    
+    
+    size_t schema_refreshed = 0;
+    size_t total_schema_fields = 0;
+    
+    for(auto& field : search_schema) {
+        total_schema_fields++;
+        if(!field.stem_dictionary.empty()) {
+            field.stemmer = StemmerManager::get_instance().get_stemmer(field.locale, field.stem_dictionary);
+            schema_refreshed++;
+        }
+    }
 }

--- a/src/stemmer_manager.cpp
+++ b/src/stemmer_manager.cpp
@@ -1,4 +1,5 @@
 #include "stemmer_manager.h"
+#include "collection_manager.h"
 
 
 Stemmer::Stemmer(const char * language, const std::string& dictionary_name) {
@@ -92,32 +93,57 @@ Option<bool> StemmerManager::upsert_stemming_dictionary(const std::string& dicti
         return Option<bool>(400, "Invalid dictionary format.");
     }
 
-    std::lock_guard<std::mutex> lock(mutex);
+    bool needs_refresh = false;
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        
+        nlohmann::json dictionary_json;
+        dictionary_json["id"] = dictionary_name;
+        dictionary_json["words"] = nlohmann::json::array();
 
-    nlohmann::json json_line;
-    nlohmann::json dictionary_json;
-    dictionary_json["id"] = dictionary_name;
-    dictionary_json["words"] = nlohmann::json::array();
-
-    for(const auto& line_str : json_lines) {
-        try {
-            json_line = nlohmann::json::parse(line_str);
-        } catch(...) {
-            return Option<bool>(400, "Invalid dictionary format.");
+        for(const auto& kv : stem_dictionaries[dictionary_name]) {
+            nlohmann::json existing_word;
+            existing_word["word"] = kv.first;
+            existing_word["root"] = kv.second;
+            dictionary_json["words"].push_back(existing_word);
         }
 
-        if(!json_line.contains("word") || !json_line.contains("root")) {
-            return Option<bool>(400, "dictionary lines should contain `word` and `root` values.");
-        }
-        stem_dictionaries[dictionary_name].emplace(json_line["word"], json_line["root"]);
-        dictionary_json["words"].push_back(json_line);
-    }
+        for(const auto& line_str : json_lines) {
+            nlohmann::json json_line;
+            try {
+                json_line = nlohmann::json::parse(line_str);
+            } catch(const nlohmann::json::exception& e) {
+                return Option<bool>(400, "Invalid JSON format.");
+            }
 
-    if(write_to_store) {
-        bool inserted = store->insert(get_stemming_dictionary_key(dictionary_name), dictionary_json.dump());
-        if (!inserted) {
-            return Option<bool>(500, "Unable to insert into store.");
+            if(!json_line.contains("word") || !json_line.contains("root")) {
+                return Option<bool>(400, "Dictionary lines must contain both 'word' and 'root' values.");
+            }
+            
+            const std::string& word = json_line["word"];
+            const std::string& root = json_line["root"];
+            
+            if(word.empty() || root.empty()) {
+                return Option<bool>(400, "Word and root values cannot be empty.");
+            }
+            
+            stem_dictionaries[dictionary_name].emplace(word, root);
+            dictionary_json["words"].push_back(json_line);
         }
+
+        if(write_to_store) {
+            bool inserted = store->insert(get_stemming_dictionary_key(dictionary_name), dictionary_json.dump());
+            if (!inserted) {
+                return Option<bool>(500, "Unable to insert dictionary into store.");
+            }
+        }
+
+        // refresh collection after successfully inserting the dictionary
+        needs_refresh = true;
+    } 
+    
+    if(needs_refresh) {
+        refresh_collection_stemmers(dictionary_name);
     }
 
     return Option<bool>(true);
@@ -207,6 +233,40 @@ void StemmerManager::delete_all_stemming_dictionaries() {
         store->remove(get_stemming_dictionary_key(kv.first));
     }
     stem_dictionaries.clear();
+}
+
+void StemmerManager::refresh_collection_stemmers(const std::string& dictionary_name) {
+    auto& collectionManager = CollectionManager::get_instance();
+    auto collections_op = collectionManager.get_collections();
+    
+    if(!collections_op.ok()) {
+        return;
+    }
+    
+    auto collections = collections_op.get();
+    
+    size_t refreshed_count = 0;
+    for(auto& collection : collections) {
+        if(collection == nullptr) {
+            continue;
+        }
+        
+        const auto& search_schema = collection->get_schema();
+        bool needs_refresh = false;
+        std::vector<std::string> matching_fields;
+        
+        for(const auto& field : search_schema) {
+            if(field.stem_dictionary == dictionary_name) {
+                needs_refresh = true;
+                matching_fields.push_back(field.name);
+            }
+        }
+        
+        if(needs_refresh) {
+            collection->refresh_stemmers();
+            refreshed_count++;
+        }
+    }
 }
 
 std::string StemmerManager::get_stemming_dictionary_key(const std::string &dictionary_name) {


### PR DESCRIPTION
## Change Summary
- add refresh_stemmers() method to collection class
- add refresh_collection_stemmers() method to stemmer manager
- trigger collection refresh after dictionary upsert

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
