### PR TITLE
feat(field): add per-field truncate option to control token truncation

### DIFF
--- a/include/field.h
+++ b/include/field.h
@@ -85,6 +85,7 @@ namespace fields {
     static const std::string REFERENCE_HELPER_FIELD_SUFFIX = "_sequence_id";
 
     static const std::string store = "store";
+    static const std::string truncate = "truncate";
     
     static const std::string hnsw_params = "hnsw_params";
 }
@@ -123,6 +124,7 @@ struct field {
     bool nested;        // field inside an object
 
     bool store = true;        // store the field in disk
+    bool truncate = true;     // truncate string tokens at 100 chars
 
     // field inside an array of objects that is forced to be an array
     // integer to handle tri-state: true (1), false (0), not known yet (2)
@@ -158,10 +160,10 @@ struct field {
           int nested_array = 0, size_t num_dim = 0, vector_distance_type_t vec_dist = cosine,
           std::string reference = "", const nlohmann::json& embed = nlohmann::json(), const bool range_index = false,
           const bool store = true, const bool stem = false, const std::string& stem_dictionary = "", const nlohmann::json hnsw_params = nlohmann::json(),
-          const bool async_reference = false, const nlohmann::json& token_separators = {}, const nlohmann::json& symbols_to_index = {}) :
+          const bool async_reference = false, const nlohmann::json& token_separators = {}, const nlohmann::json& symbols_to_index = {}, const bool truncate = true) :
             name(name), type(type), facet(facet), optional(optional), index(index), locale(locale),
             nested(nested), nested_array(nested_array), num_dim(num_dim), vec_dist(vec_dist), reference(reference),
-            embed(embed), range_index(range_index), store(store), stem(stem), stem_dictionary(stem_dictionary),
+            embed(embed), range_index(range_index), store(store), truncate(truncate), stem(stem), stem_dictionary(stem_dictionary),
             hnsw_params(hnsw_params), is_async_reference(async_reference) {
 
         set_computed_defaults(sort, infix);
@@ -408,7 +410,8 @@ struct field {
                      json[fields::hnsw_params].get<nlohmann::json>(),
                      json[fields::async_reference].get<bool>(),
                      json[fields::token_separators].get<nlohmann::json>(),
-                     json[fields::symbols_to_index].get<nlohmann::json>());
+                     json[fields::symbols_to_index].get<nlohmann::json>(),
+                     json[fields::truncate].get<bool>());
     }
 
     static Option<bool> fields_to_json_fields(const std::vector<field> & fields,

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -361,6 +361,7 @@ nlohmann::json Collection::get_summary_json() const {
         field_json[fields::locale] = coll_field.locale;
         field_json[fields::stem] = coll_field.stem;
         field_json[fields::store] = coll_field.store;
+        field_json[fields::truncate] = coll_field.truncate;
         field_json[fields::stem_dictionary] = coll_field.stem_dictionary;
 
         if(coll_field.range_index) {

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -99,6 +99,10 @@ Collection* CollectionManager::init_collection(const nlohmann::json & collection
         if(field_obj.count(fields::store) == 0) {
             field_obj[fields::store] = true;
         }
+        
+        if(field_obj.count(fields::truncate) == 0) {
+            field_obj[fields::truncate] = true;
+        }
 
         if(field_obj.count(fields::token_separators) == 0) {
             field_obj[fields::token_separators] = nlohmann::json::array();
@@ -140,7 +144,7 @@ Collection* CollectionManager::init_collection(const nlohmann::json & collection
                 -1, field_obj[fields::infix], field_obj[fields::nested], field_obj[fields::nested_array],
                 field_obj[fields::num_dim], vec_dist_type, field_obj[fields::reference], field_obj[fields::embed],
                 field_obj[fields::range_index], field_obj[fields::store], field_obj[fields::stem], field_obj[fields::stem_dictionary],
-                field_obj[fields::hnsw_params], field_obj[fields::async_reference], field_obj[fields::token_separators], field_obj[fields::symbols_to_index]);
+                field_obj[fields::hnsw_params], field_obj[fields::async_reference], field_obj[fields::token_separators], field_obj[fields::symbols_to_index], field_obj[fields::truncate]);
 
         // value of `sort` depends on field type
         if(field_obj.count(fields::sort) == 0) {

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -69,6 +69,9 @@ void field::add_default_json_values(nlohmann::json& json) {
     if (json.count(fields::store) == 0) {
         json[fields::store] = true;
     }
+    if (json.count(fields::truncate) == 0) {
+        json[fields::truncate] = true;
+    }
     if (json.count(fields::stem) == 0) {
         json[fields::stem] = false;
     }
@@ -143,6 +146,11 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
 
     if(!field_json.at(fields::infix).is_boolean()) {
         return Option<bool>(400, std::string("The `infix` property of the field `") +
+                                 field_json[fields::name].get<std::string>() + std::string("` should be a boolean."));
+    }
+
+    if(!field_json.at(fields::truncate).is_boolean()) {
+        return Option<bool>(400, std::string("The `truncate` property of the field `") +
                                  field_json[fields::name].get<std::string>() + std::string("` should be a boolean."));
     }
 
@@ -443,7 +451,7 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
                   field_json[fields::reference], field_json[fields::embed], field_json[fields::range_index], 
                   field_json[fields::store], field_json[fields::stem], field_json[fields::stem_dictionary],
                   field_json[fields::hnsw_params], field_json[fields::async_reference], field_json[fields::token_separators],
-                  field_json[fields::symbols_to_index])
+                  field_json[fields::symbols_to_index], field_json[fields::truncate])
     );
 
     if (!field_json[fields::reference].get<std::string>().empty()) {
@@ -868,6 +876,7 @@ nlohmann::json field::field_to_json_field(const struct field& field) {
     field_val[fields::locale] = field.locale;
 
     field_val[fields::store] = field.store;
+    field_val[fields::truncate] = field.truncate;
     field_val[fields::stem] = field.stem;
     field_val[fields::range_index] = field.range_index;
     field_val[fields::stem_dictionary] = field.stem_dictionary;

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -1761,7 +1761,7 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
             auto approx_filter_value_match = UINT32_MAX;
 
             while (tokenizer.next(str_token, token_index)) {
-                if (str_token.size() > 100) {
+                if (str_token.size() > 100 && f.truncate) {
                     str_token.erase(100);
                 }
                 str_tokens.push_back(str_token);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1334,7 +1334,7 @@ void Index::tokenize_string(const std::string& text, const field& a_field,
             continue;
         }
 
-        if(token.size() > 100) {
+        if(token.size() > 100 && a_field.truncate) {
             token.erase(100);
         }
         

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -148,7 +148,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"string",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate": true
             },
             {
               "facet":false,
@@ -163,7 +164,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"string",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate": true
             },
             {
               "facet":true,
@@ -178,7 +180,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"string[]",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate": true
             },
             {
               "facet":true,
@@ -193,7 +196,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"int32",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate": true
             },
             {
               "facet":false,
@@ -208,7 +212,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"geopoint",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate": true
             },
             {
               "facet":false,
@@ -223,7 +228,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"string",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate": true
             },
             {
               "facet":false,
@@ -238,7 +244,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"int32",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate": true
             },
             {
               "facet":false,
@@ -254,7 +261,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"object",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate": true
             },
             {
               "facet":false,
@@ -272,7 +280,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "vec_dist":"cosine",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate": true
             },
             {
               "async_reference":true,
@@ -289,7 +298,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "reference":"Products.product_id",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate": true
             },
             {
               "facet":false,
@@ -304,7 +314,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"int64",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate": true
             }
           ],
           "id":0,
@@ -1696,7 +1707,8 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
                     "type":"string",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate": true
                 },
                 {
                     "facet":true,
@@ -1712,7 +1724,8 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate": true
                 },{
                     "facet":true,
                     "index":true,
@@ -1727,7 +1740,8 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate": true
                 },{
                     "facet":true,
                     "index":true,
@@ -1742,7 +1756,8 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate": true
                 }
             ],
             "id":1,

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -1995,7 +1995,8 @@ TEST_F(CoreAPIUtilsTest, CollectionsPagination) {
               "stem":false,
               "store": true,
               "type":"string",
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate": true
             }
           ],
           "name":"cp2",
@@ -2203,7 +2204,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"string",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate": true
                 },
                 {
                     "facet":true,
@@ -2219,7 +2221,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate": true
                 },{
                     "facet":true,
                     "index":true,
@@ -2234,7 +2237,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate": true
                 },{
                     "facet":true,
                     "index":true,
@@ -2249,7 +2253,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate": true
                 }
             ],
             "id":1,
@@ -2303,7 +2308,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"string",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate": true
                 },
                 {
                     "facet":true,
@@ -2319,7 +2325,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate": true
                 },{
                     "facet":true,
                     "index":true,
@@ -2334,7 +2341,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate": true
                 },{
                     "facet":true,
                     "index":true,
@@ -2349,7 +2357,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate": true
                 }
             ],
             "id":1,
@@ -2657,7 +2666,8 @@ TEST_F(CoreAPIUtilsTest, CollectionSchemaResponseWithStoreValue) {
                     "stem":false,
                     "store":false,
                     "type":"string",
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate":true
                 },
                 {
                     "facet":false,
@@ -2670,7 +2680,8 @@ TEST_F(CoreAPIUtilsTest, CollectionSchemaResponseWithStoreValue) {
                     "stem":false,
                     "store":true,
                     "type":"int32",
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate":true
                 }],
                 "name":"collection3",
                 "num_documents":0,
@@ -2681,6 +2692,20 @@ TEST_F(CoreAPIUtilsTest, CollectionSchemaResponseWithStoreValue) {
 
     expected_json["created_at"] = res_json["created_at"];
     ASSERT_EQ(expected_json, res_json);
+}
+
+TEST_F(CoreAPIUtilsTest, TruncateFieldValidation) {
+    // `truncate` must be a boolean
+    nlohmann::json schema = R"({
+        "name": "truncate_validation",
+        "fields": [
+            {"name": "title", "type": "string", "truncate": "false"}
+        ]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_FALSE(op.ok());
+    ASSERT_EQ("The `truncate` property of the field `title` should be a boolean.", op.error());
 }
 
 TEST_F(CoreAPIUtilsTest, StatefulRemoveDocsWithReturnValues) {


### PR DESCRIPTION
## Change Summary
- add `truncate` to field model and json schema; default to true
- validate `truncate` is boolean during collection creation
- include `truncate` in schema and summary responses
- conditionally truncate tokens to 100 chars in index and filter paths
- set missing `truncate` to true in collection manager
- update tests and add validation test for `truncate`
- fix #2548 

<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
