### PR TITLE
fix(stemmer): bypass stemming check for `de_en` locales (#2546)

### DIFF
--- a/src/stemmer_manager.cpp
+++ b/src/stemmer_manager.cpp
@@ -57,7 +57,13 @@ void StemmerManager::dispose() {
 std::shared_ptr<Stemmer> StemmerManager::get_stemmer(const std::string& language, const std::string& dictionary_name) {
     std::unique_lock<std::mutex> lock(mutex);
     // use english as default language
-    const std::string language_ = language.empty() ? "english" : language;
+    std::string language_ = language.empty() ? "english" : language;
+    
+    // Treat de_en the same as en
+    if (language_ == "de_en") {
+        language_ = "english";
+    }
+    
     if (stemmers.find(language_) == stemmers.end()) {
         stemmers[language] = std::make_shared<Stemmer>(language_.c_str(), dictionary_name);
     }
@@ -77,7 +83,13 @@ void StemmerManager::delete_all_stemmers() {
 }
 
 const bool StemmerManager::validate_language(const std::string& language) {
-    const std::string language_ = language.empty() ? "english" : language;
+    std::string language_ = language.empty() ? "english" : language;
+
+    // Treat de_en the same as en
+    if (language_ == "de_en") {
+        language_ = "english";
+    }
+
     auto stemmer = sb_stemmer_new(language_.c_str(), nullptr);
     if (stemmer == nullptr) {
         return false;

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -3662,3 +3662,78 @@ TEST_F(CollectionSpecificMoreTest, StemmingPhraseSearch) {
     results = coll1->search(R"(" achievements of ")", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 10).get();
     ASSERT_EQ(0, results["hits"].size());
 }
+
+TEST_F(CollectionSpecificMoreTest, CustomStemmingDictionaryOverridesDeEnLocale) {
+    nlohmann::json schema = R"({
+        "name": "custom_stemming_test",
+        "fields": [
+          {"name": "title_de_en", "type": "string", "locale": "de_en", "stem_dictionary": "absurd_stems"},
+          {"name": "title_en", "type": "string", "locale": "en", "stem": true}
+        ]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+    Collection* coll = op.get();
+
+    std::vector<std::string> json_lines;
+    json_lines.push_back("{\"word\": \"running\", \"root\": \"foo\"}");
+    json_lines.push_back("{\"word\": \"walking\", \"root\": \"bar\"}");
+    json_lines.push_back("{\"word\": \"playing\", \"root\": \"baz\"}");
+    json_lines.push_back("{\"word\": \"swimming\", \"root\": \"qux\"}");
+    json_lines.push_back("{\"word\": \"dancing\", \"root\": \"xyz\"}");
+
+    ASSERT_TRUE(stemmerManager.upsert_stemming_dictionary("absurd_stems", json_lines).ok());
+
+    nlohmann::json doc1;
+    doc1["id"] = "1";
+    doc1["title_de_en"] = "running";
+    doc1["title_en"] = "running";
+    ASSERT_TRUE(coll->add(doc1.dump()).ok());
+
+    nlohmann::json doc2;
+    doc2["id"] = "2";
+    doc2["title_de_en"] = "walking";
+    doc2["title_en"] = "walking";
+    ASSERT_TRUE(coll->add(doc2.dump()).ok());
+
+    nlohmann::json doc3;
+    doc3["id"] = "3";
+    doc3["title_de_en"] = "playing";
+    doc3["title_en"] = "playing";
+    ASSERT_TRUE(coll->add(doc3.dump()).ok());
+
+    nlohmann::json doc4;
+    doc4["id"] = "4";
+    doc4["title_de_en"] = "swimming";
+    doc4["title_en"] = "swimming";
+    ASSERT_TRUE(coll->add(doc4.dump()).ok());
+
+    nlohmann::json doc5;
+    doc5["id"] = "5";
+    doc5["title_de_en"] = "dancing";
+    doc5["title_en"] = "dancing";
+    ASSERT_TRUE(coll->add(doc5.dump()).ok());
+
+    auto res = coll->search("foo", {"title_de_en"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, 0).get();
+    ASSERT_EQ(1, res["hits"].size()) << "Custom stem 'foo' should find 'running' in de_en field";
+    ASSERT_EQ("1", res["hits"][0]["document"]["id"].get<std::string>());
+
+    res = coll->search("bar", {"title_de_en"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, 0).get();
+    ASSERT_EQ(1, res["hits"].size()) << "Custom stem 'bar' should find 'walking' in de_en field";
+    ASSERT_EQ("2", res["hits"][0]["document"]["id"].get<std::string>());
+
+    res = coll->search("baz", {"title_de_en"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, 0).get();
+    ASSERT_EQ(1, res["hits"].size()) << "Custom stem 'baz' should find 'playing' in de_en field";
+    ASSERT_EQ("3", res["hits"][0]["document"]["id"].get<std::string>());
+
+    res = coll->search("qux", {"title_de_en"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, 0).get();
+    ASSERT_EQ(1, res["hits"].size()) << "Custom stem 'qux' should find 'swimming' in de_en field";
+    ASSERT_EQ("4", res["hits"][0]["document"]["id"].get<std::string>());
+
+    res = coll->search("xyz", {"title_de_en"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, 0).get();
+    ASSERT_EQ(1, res["hits"].size()) << "Custom stem 'xyz' should find 'dancing' in de_en field";
+    ASSERT_EQ("5", res["hits"][0]["document"]["id"].get<std::string>());
+
+    collectionManager.drop_collection("custom_stemming_test");
+}


### PR DESCRIPTION
* fix(stemmer): bypass stemming check for `de_en` locales

* test(stemmer): test stemming behavior of `de_en` locale with stem true

## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
