### PR TITLE
feat(gcp): support service account auth for embeddings and add tests

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -381,6 +381,13 @@ nlohmann::json Collection::get_summary_json() const {
                 hide_credential(field_json[fields::embed][fields::model_config], "client_id");
                 hide_credential(field_json[fields::embed][fields::model_config], "client_secret");
                 hide_credential(field_json[fields::embed][fields::model_config], "project_id");
+                // hide nested service_account credentials if present
+                if(field_json[fields::embed][fields::model_config].contains("service_account") &&
+                   field_json[fields::embed][fields::model_config]["service_account"].is_object()) {
+                    nlohmann::json& sa = field_json[fields::embed][fields::model_config]["service_account"];
+                    hide_credential(sa, "private_key");
+                    hide_credential(sa, "client_email");
+                }
             }
         }
 
@@ -6441,6 +6448,12 @@ Option<bool> Collection::alter(nlohmann::json& alter_payload) {
             hide_credential(field_json[fields::embed][fields::model_config], "client_id");
             hide_credential(field_json[fields::embed][fields::model_config], "client_secret");
             hide_credential(field_json[fields::embed][fields::model_config], "project_id");
+            if(field_json[fields::embed][fields::model_config].contains("service_account") &&
+                field_json[fields::embed][fields::model_config]["service_account"].is_object()) {
+                nlohmann::json& sa = field_json[fields::embed][fields::model_config]["service_account"];
+                hide_credential(sa, "private_key");
+                hide_credential(sa, "client_email");
+            }
         }
     }
 


### PR DESCRIPTION
## Change Summary
- add service account flow: pem newline normalization, jwt rs256 signing, base64url encoding via string_utils, and token minting to gcp oauth
- introduce token management with ensure_access_token and update embed calls to refresh on 401; differentiate model keys for sa vs oauth
- mask nested service_account.private_key and client_email using hide_credential in collection summary and alter responses
- add skippable tests for gcp validation using service accounts and legacy oauth; assert embedder keys are registered as expected
- refactor text_embedder to construct gcp embedder via sa or oauth based on model_config


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
