### PR TITLE
fix(collection): prevent adding duplicate field names in schema alterations

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -6842,8 +6842,14 @@ Option<bool> Collection::validate_alter_payload(nlohmann::json& schema_changes,
                 }
 
                 if(f.is_dynamic()) {
+                    if(new_dynamic_fields.find(f.name) != new_dynamic_fields.end()) {
+                        return Option<bool>(400, "There can be only one field named `" + f.name + "`.");
+                    }
                     new_dynamic_fields[f.name] = f;
                 } else {
+                    if(updated_search_schema.find(f.name) != updated_search_schema.end()) {
+                        return Option<bool>(400, "There can be only one field named `" + f.name + "`.");
+                    }
                     updated_search_schema[f.name] = f;
                 }
 

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -6842,12 +6842,12 @@ Option<bool> Collection::validate_alter_payload(nlohmann::json& schema_changes,
                 }
 
                 if(f.is_dynamic()) {
-                    if(new_dynamic_fields.find(f.name) != new_dynamic_fields.end()) {
+                    if(!f.is_reference_helper && new_dynamic_fields.find(f.name) != new_dynamic_fields.end()) {
                         return Option<bool>(400, "There can be only one field named `" + f.name + "`.");
                     }
                     new_dynamic_fields[f.name] = f;
                 } else {
-                    if(updated_search_schema.find(f.name) != updated_search_schema.end()) {
+                    if(!f.is_reference_helper && updated_search_schema.find(f.name) != updated_search_schema.end()) {
                         return Option<bool>(400, "There can be only one field named `" + f.name + "`.");
                     }
                     updated_search_schema[f.name] = f;

--- a/test/collection_schema_change_test.cpp
+++ b/test/collection_schema_change_test.cpp
@@ -2024,4 +2024,13 @@ TEST_F(CollectionSchemaChangeTest, AlterAddSameFieldTwice) {
     auto schema_change_op = coll->alter(schema_change);
     ASSERT_FALSE(schema_change_op.ok());
     ASSERT_EQ("There can be only one field named `title`.", schema_change_op.error());
+
+    schema_change = R"({
+            "fields": [
+                {"name": "title", "drop": true},
+                {"name": "title", "type": "string", "facet": true}
+            ]
+        })"_json;
+    schema_change_op = coll->alter(schema_change);
+    ASSERT_TRUE(schema_change_op.ok());
 }

--- a/test/collection_schema_change_test.cpp
+++ b/test/collection_schema_change_test.cpp
@@ -2001,3 +2001,27 @@ TEST_F(CollectionSchemaChangeTest, EmbeddingFieldAlterUpdateOldDocs) {
     ASSERT_EQ(0, search_res.get()["hits"][0]["document"].count(".flat"));
     ASSERT_EQ(0, search_res.get()["hits"][0]["document"].count("nested.hello"));
 }
+
+TEST_F(CollectionSchemaChangeTest, AlterAddSameFieldTwice) {
+    nlohmann::json schema = R"({
+            "name": "objects",
+            "fields": [
+                {"name": "title", "type": "string"}
+            ]
+        })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+    Collection* coll = op.get();
+
+    nlohmann::json schema_change = R"({
+            "fields": [
+                {"name": "title", "drop": true},
+                {"name": "title", "type": "string", "facet": true},
+                {"name": "title", "type": "string", "index": true}
+            ]
+        })"_json;
+    auto schema_change_op = coll->alter(schema_change);
+    ASSERT_FALSE(schema_change_op.ok());
+    ASSERT_EQ("There can be only one field named `title`.", schema_change_op.error());
+}


### PR DESCRIPTION
## Change Summary
Prevent adding or reindexing the same field twice or more in the alterations.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
