### PR TITLE
fix: remove trailing operands from filter query when group limit

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2642,6 +2642,11 @@ Option<bool> Index::run_search(search_args* search_params) {
                 filter_by += " && ";
             }
         }
+        
+        // Remove trailing " && " if exists.
+        if(filter_by.size() >= 4 && filter_by.substr(filter_by.size() - 4) == " && ") {
+            filter_by = filter_by.substr(0, filter_by.size() - 4);
+        }
 
         filter_node_t* new_filter_tree_root = nullptr;
         Option<bool> filter_op = filter::parse_filter_query(filter_by, search_schema, store, "", new_filter_tree_root,

--- a/test/collection_grouping_test.cpp
+++ b/test/collection_grouping_test.cpp
@@ -2044,3 +2044,39 @@ TEST_F(CollectionGroupingTest, GroupMaxCandidates) {
     res_obj = nlohmann::json::parse(json_res);
     ASSERT_EQ(991, res_obj["found"]);
 }
+
+TEST_F(CollectionGroupingTest, GroupByWithFilterBy) {
+    auto schema_json =
+            R"({
+                "name": "coll",
+                "fields": [
+                    {"name":"field1","facet":true,"type":"string"},
+                    {"name":"field2","facet":true,"type":"string", "optional": true}
+                ]
+            })"_json;
+    std::vector<nlohmann::json> documents = {
+            R"({"field1": "A"})"_json,
+            R"({"field1": "B"})"_json
+    };
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    for (auto const &json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    std::map<std::string, std::string> req_params = {
+            {"collection", "coll"},
+            {"q", "*"},
+            {"group_by", "field1,field2"},
+            {"group_limit", "1"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+}


### PR DESCRIPTION
## Change Summary
Filter by clause has redundant trailing operands when one of the fields in the `groupBy` is optional and doesn't have values when group limit applied. 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
