### PR TITLE
fix upsert bug with stemming dictionary

### DIFF
--- a/src/stemmer_manager.cpp
+++ b/src/stemmer_manager.cpp
@@ -110,7 +110,6 @@ Option<bool> StemmerManager::upsert_stemming_dictionary(const std::string& dicti
     nlohmann::json dictionary_json;
     dictionary_json["id"] = dictionary_name;
     dictionary_json["words"] = nlohmann::json::array();
-    spp::sparse_hash_map<std::string, std::string> dictionary;
 
     for(const auto& line_str : json_lines) {
         try {
@@ -122,11 +121,10 @@ Option<bool> StemmerManager::upsert_stemming_dictionary(const std::string& dicti
         if(!json_line.contains("word") || !json_line.contains("root")) {
             return Option<bool>(400, "dictionary lines should contain `word` and `root` values.");
         }
-        dictionary[json_line["word"]] = json_line["root"];
+
+        stem_dictionaries[dictionary_name][json_line["word"]] = json_line["root"];
         dictionary_json["words"].push_back(json_line);
     }
-
-    stem_dictionaries[dictionary_name] = dictionary;
 
     if(write_to_store) {
         bool inserted = store->insert(get_stemming_dictionary_key(dictionary_name), dictionary_json.dump());

--- a/src/stemmer_manager.cpp
+++ b/src/stemmer_manager.cpp
@@ -110,6 +110,7 @@ Option<bool> StemmerManager::upsert_stemming_dictionary(const std::string& dicti
     nlohmann::json dictionary_json;
     dictionary_json["id"] = dictionary_name;
     dictionary_json["words"] = nlohmann::json::array();
+    spp::sparse_hash_map<std::string, std::string> dictionary;
 
     for(const auto& line_str : json_lines) {
         try {
@@ -121,9 +122,11 @@ Option<bool> StemmerManager::upsert_stemming_dictionary(const std::string& dicti
         if(!json_line.contains("word") || !json_line.contains("root")) {
             return Option<bool>(400, "dictionary lines should contain `word` and `root` values.");
         }
-        stem_dictionaries[dictionary_name].emplace(json_line["word"], json_line["root"]);
+        dictionary[json_line["word"]] = json_line["root"];
         dictionary_json["words"].push_back(json_line);
     }
+
+    stem_dictionaries[dictionary_name] = dictionary;
 
     if(write_to_store) {
         bool inserted = store->insert(get_stemming_dictionary_key(dictionary_name), dictionary_json.dump());

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -3514,7 +3514,7 @@ TEST_F(CollectionSpecificMoreTest, StemmingDictionaryBasics) {
     ASSERT_EQ("qualities", dictionary["words"][0]["word"]);
     ASSERT_EQ("quality", dictionary["words"][0]["root"]);
 
-    //add another line to same set and get
+    //upsert to same set
     json_lines.clear();
     json_line = "{\"word\": \"mangoes\", \"root\":\"mango\"}";
     json_lines.push_back(json_line);
@@ -3522,11 +3522,9 @@ TEST_F(CollectionSpecificMoreTest, StemmingDictionaryBasics) {
 
     ASSERT_TRUE(stemmerManager.get_stemming_dictionary("set2", dictionary));
     ASSERT_EQ("set2", dictionary["id"]);
-    ASSERT_EQ(2, dictionary["words"].size());
-    ASSERT_EQ("qualities", dictionary["words"][0]["word"]);
-    ASSERT_EQ("quality", dictionary["words"][0]["root"]);
-    ASSERT_EQ("mangoes", dictionary["words"][1]["word"]);
-    ASSERT_EQ("mango", dictionary["words"][1]["root"]);
+    ASSERT_EQ(1, dictionary["words"].size());
+    ASSERT_EQ("mangoes", dictionary["words"][0]["word"]);
+    ASSERT_EQ("mango", dictionary["words"][0]["root"]);
 
     //get all dictionary sets
     nlohmann::json dictionary_sets;

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -3522,9 +3522,23 @@ TEST_F(CollectionSpecificMoreTest, StemmingDictionaryBasics) {
 
     ASSERT_TRUE(stemmerManager.get_stemming_dictionary("set2", dictionary));
     ASSERT_EQ("set2", dictionary["id"]);
-    ASSERT_EQ(1, dictionary["words"].size());
-    ASSERT_EQ("mangoes", dictionary["words"][0]["word"]);
-    ASSERT_EQ("mango", dictionary["words"][0]["root"]);
+    ASSERT_EQ(2, dictionary["words"].size());
+    ASSERT_EQ("qualities", dictionary["words"][0]["word"]);
+    ASSERT_EQ("quality", dictionary["words"][0]["root"]);
+    ASSERT_EQ("mangoes", dictionary["words"][1]["word"]);
+    ASSERT_EQ("mango", dictionary["words"][1]["root"]);
+
+    json_lines.clear();
+    json_line = "{\"word\": \"mangoes\", \"root\":\"mangotree\"}";
+    json_lines.push_back(json_line);
+    ASSERT_TRUE(stemmerManager.upsert_stemming_dictionary("set2", json_lines).ok());
+    ASSERT_TRUE(stemmerManager.get_stemming_dictionary("set2", dictionary));
+    ASSERT_EQ("set2", dictionary["id"]);
+    ASSERT_EQ(2, dictionary["words"].size());
+    ASSERT_EQ("qualities", dictionary["words"][0]["word"]);
+    ASSERT_EQ("quality", dictionary["words"][0]["root"]);
+    ASSERT_EQ("mangoes", dictionary["words"][1]["word"]);
+    ASSERT_EQ("mangotree", dictionary["words"][1]["root"]);
 
     //get all dictionary sets
     nlohmann::json dictionary_sets;


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
### Bug Description
#### import Endpoint Duplicates Entries, Contradicting upsert in SDK
The `POST /stemming/dictionaries/import?id=` endpoint (named upsert in the JS SDK) does not update existing entries. Importing a new alternate for an existing root creates a duplicate entry instead of overwriting the original one. This makes the upsert method name in the SDK misleading.

### Fix
Update the root if word is already in the dictionary else emplace new word-root to dictionary


## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
