### PR TITLE
fix(filter): tokenize strings on nested field filters

### DIFF
--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -3172,9 +3172,20 @@ bool filter_result_iterator_t::validate_object_filter_helper(Index const* const 
                     val.pop_back();
                 }
 
-                filter_val = val;
-                doc_val = doc[nested_field].get<std::string>();
-
+                const auto& symbols = f.symbols_to_index.empty() ? index->symbols_to_index : f.symbols_to_index;
+                const auto& separators = f.token_separators.empty() ? index->token_separators : f.token_separators;
+                Tokenizer tokenizer(val, true, false, f.locale, symbols, separators, f.get_stemmer());
+                
+                std::string tokenized_filter_val;
+                size_t token_index = 0;
+                filter_val = tokenizer.next(tokenized_filter_val, token_index) ? tokenized_filter_val : val;
+                
+                std::string doc_str = doc[nested_field].get<std::string>();
+                Tokenizer doc_tokenizer(doc_str, true, false, f.locale, symbols, separators, f.get_stemmer());
+                
+                std::string tokenized_doc_val;
+                size_t doc_token_index = 0;
+                doc_val = doc_tokenizer.next(tokenized_doc_val, doc_token_index) ? tokenized_doc_val : doc_str;
             } else if (f.is_float()) {
                 filter_val = std::stof(val);
                 doc_val = doc[nested_field].get<float>();

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -3686,12 +3686,12 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
     std::vector<nlohmann::json> documents = {
             R"({
                 "name": "Pasta",
-                "ingredients": [{"name": "Cheese", "concentration": 40}, {"name" : "spinach", "concentration": 10},
+                "ingredients": [{"name": "Che,ese", "concentration": 40}, {"name" : "spinach", "concentration": 10},
                                 {"name": "jalepeno", "concentration": 20}]
             })"_json,
             R"({
                 "name": "Pizza",
-                "ingredients": [{"name": "CHEESE", "concentration": 30}, {"name": "pizza sauce", "concentration": 30},
+                "ingredients": [{"name": "chee.se", "concentration": 30}, {"name": "pizza sauce", "concentration": 30},
                                 {"name": "olives", "concentration": 30}]
             })"_json,
             R"({
@@ -3701,11 +3701,11 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
             })"_json,
             R"({
                 "name": "Popcorn",
-                "ingredients": [{"name": "CHEESE", "concentration": 30}]
+                "ingredients": [{"name": "chee.se", "concentration": 30}]
             })"_json,
             R"({
                 "name": "Pizza Rolls",
-                "ingredients": [{"name": "cheese", "concentration": 60}, {"name": "pizza sauce", "concentration": 5},
+                "ingredients": [{"name": "chee/se", "concentration": 60}, {"name": "pizza sauce", "concentration": 5},
                                 {"name" : "corn", "concentration": 40}]
             })"_json
     };

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -3686,22 +3686,22 @@ TEST_F(CollectionFilteringTest, NestedObjectFieldsFiltering) {
     std::vector<nlohmann::json> documents = {
             R"({
                 "name": "Pasta",
-                "ingredients": [{"name": "cheese", "concentration": 40}, {"name" : "spinach", "concentration": 10},
+                "ingredients": [{"name": "Cheese", "concentration": 40}, {"name" : "spinach", "concentration": 10},
                                 {"name": "jalepeno", "concentration": 20}]
             })"_json,
             R"({
                 "name": "Pizza",
-                "ingredients": [{"name": "cheese", "concentration": 30}, {"name": "pizza sauce", "concentration": 30},
+                "ingredients": [{"name": "CHEESE", "concentration": 30}, {"name": "pizza sauce", "concentration": 30},
                                 {"name": "olives", "concentration": 30}]
             })"_json,
             R"({
                 "name": "Lasagna",
-                "ingredients": [{"name": "cheese", "concentration": 60}, {"name": "jalepeno", "concentration": 20},
+                "ingredients": [{"name": "Cheese", "concentration": 60}, {"name": "jalepeno", "concentration": 20},
                                 {"name": "olives", "concentration": 20}]
             })"_json,
             R"({
                 "name": "Popcorn",
-                "ingredients": [{"name": "cheese", "concentration": 30}]
+                "ingredients": [{"name": "CHEESE", "concentration": 30}]
             })"_json,
             R"({
                 "name": "Pizza Rolls",


### PR DESCRIPTION
## Change Summary
On nested object filters, if the condition includes AND or OR logical operands, string equality happens without tokenization, leading to issues where the value could be case-sensitive:

```sh
curl -s "$TYPESENSE_HOST/collections" \
       -X POST \
       -H "Content-Type: application/json" \
       -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
	-d '
	   {
  	     "name": "recipes",
  	     "enable_nested_fields": true,
	    "fields": [
	      { "name": "name", "type": "string" },
	      { "name": "ingredients", "type": "object[]" },
	      { "name": "ingredients.name", "type": "string[]" },
	      { "name": "ingredients.weight", "type": "int32[]" }
	    ]
	   }' | jq

curl -s "$TYPESENSE_HOST/collections/recipes/documents/import?action=create" \
        -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
        -H "Content-Type: text/plain" \
        -X POST \
        -d '{"id": "1","name": "Pizza","ingredients": [{ "name": "cheese", "weight": 30 }, { "name": "milk", "weight": 100 }] }
	    {"id": "2","name": "Pasta","ingredients": [{ "name": "Cheese", "weight": 50 }, { "name": "chili", "weight": 20 }] }
	    {"id": "3","name": "Muffin","ingredients": [{ "name": "CHEESE", "weight": 10 }, { "name": "milk", "weight": 200 }] }'  | jq
	    
	    
curl -s "$TYPESENSE_HOST/multi_search" \
        -X POST \
        -H "Content-Type: application/json" \
        -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
        -d '
          {
            "searches": [
              {
                "collection": "recipes",
                "q": "*",
                "query_by": "name",
		"filter_by": "ingredients.{name:=cheese && weight:>20}"
              }
            ]
          }'  | jq

```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
