### PR TITLE
refactor: conditionally add dash symbol only when a token starts with it

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -4712,7 +4712,6 @@ void Collection::parse_search_query(const std::string &query, std::vector<std::s
             std::string word;
             while(iss >> word) {
                 if(!word.empty() && word[0] == '-') {
-                    LOG(INFO) << "Found hyphen-prefixed word: '" << word << "'";
                     has_hyphen_prefix = true;
                     break;
                 }

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -3,6 +3,7 @@
 #include <numeric>
 #include <chrono>
 #include <unordered_set>
+#include <sstream>
 #include <match_score.h>
 #include <string_utils.h>
 #include <art.h>
@@ -4701,11 +4702,26 @@ void Collection::parse_search_query(const std::string &query, std::vector<std::s
             StringUtils::split(query, tokens, " ");
         } else {
             std::vector<char> custom_symbols = curation_symbols_to_index.empty() ? symbols_to_index : curation_symbols_to_index;
-            custom_symbols.push_back('-');
             custom_symbols.push_back('"');
 
             const auto& separators = curation_token_separators.empty() ? token_separators : curation_token_separators;
 
+            bool has_hyphen_prefix = false;
+            
+            std::istringstream iss(query);
+            std::string word;
+            while(iss >> word) {
+                if(!word.empty() && word[0] == '-') {
+                    LOG(INFO) << "Found hyphen-prefixed word: '" << word << "'";
+                    has_hyphen_prefix = true;
+                    break;
+                }
+            }
+            
+            if(has_hyphen_prefix) {
+                custom_symbols.push_back('-');
+            }
+            
             Tokenizer(query, true, false, locale, custom_symbols, separators, stemmer).tokenize(tokens);
             if(stemmer) {
                 Tokenizer(query, true, false, locale, custom_symbols, separators, nullptr).tokenize(tokens_non_stemmed);


### PR DESCRIPTION
## Change Summary
The previous implementation lead to problems when using `-` inside the token separator list, causing the tokenizer to always index the `-` character on search queries. Now, negation search will only take place when a query token starts with the hyphen, just as it did on the search logic, but not enforce the tokenization of the symbol regardless of the place of the hyphen.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
