### PR TITLE
feat(search): add `max_dropped_tokens` limit to prevent excessive token removal

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -69,6 +69,7 @@ struct collection_search_args_t {
 
     static constexpr auto PREFIX = "prefix";
     static constexpr auto DROP_TOKENS_THRESHOLD = "drop_tokens_threshold";
+    static constexpr auto MAX_DROPPED_TOKENS = "max_dropped_tokens";
     static constexpr auto TYPO_TOKENS_THRESHOLD = "typo_tokens_threshold";
     static constexpr auto FILTER = "filter_by";
     static constexpr auto QUERY = "q";
@@ -195,6 +196,7 @@ struct collection_search_args_t {
     token_ordering token_order;
     std::vector<bool> prefixes;
     size_t drop_tokens_threshold;
+    size_t max_dropped_tokens;
     spp::sparse_hash_set<std::string> include_fields;
     spp::sparse_hash_set<std::string> exclude_fields;
     size_t max_facet_values;
@@ -306,7 +308,7 @@ struct collection_search_args_t {
                              std::string personalization_type, std::string personalization_user_field,
                              std::string personalization_item_field, std::string personalization_event_name,
                              size_t personalization_n_events, std::vector<std::string> synonym_sets,
-                             float diversity_lamda, size_t group_max_candidates) :
+                             float diversity_lamda, size_t group_max_candidates, size_t max_dropped_tokens) :
             raw_query(std::move(raw_query)), search_fields(std::move(search_fields)), filter_query(std::move(filter_query)),
             facet_fields(std::move(facet_fields)), sort_fields(std::move(sort_fields)),
             num_typos(std::move(num_typos)), per_page(per_page), page(page), token_order(token_order),
@@ -338,7 +340,7 @@ struct collection_search_args_t {
             personalization_user_id(personalization_user_id), personalization_model_id(personalization_model_id),
             personalization_type(personalization_type), personalization_user_field(personalization_user_field),
             personalization_item_field(personalization_item_field), personalization_event_name(personalization_event_name), personalization_n_events(personalization_n_events),
-            synonym_sets(synonym_sets), diversity_lamda(diversity_lamda), group_max_candidates(group_max_candidates) {}
+            synonym_sets(synonym_sets), diversity_lamda(diversity_lamda), group_max_candidates(group_max_candidates), max_dropped_tokens(max_dropped_tokens) {}
 
     collection_search_args_t() = default;
 
@@ -974,7 +976,8 @@ public:
                                   size_t personalization_n_events = 0,
                                   const std::vector<std::string>& search_synonym_sets = {},
                                   float diversity_lamda = 0.5,
-                                  size_t group_max_candidates = Index::DEFAULT_TOPSTER_SIZE) const;
+                                  size_t group_max_candidates = Index::DEFAULT_TOPSTER_SIZE,
+                                  size_t max_dropped_tokens = Index::MAX_DROPPED_TOKENS) const;
 
     Option<bool> parse_and_validate_personalization_query(const std::string& personalization_user_id,
                                                           const std::string& personalization_model_id,

--- a/include/index.h
+++ b/include/index.h
@@ -151,6 +151,7 @@ struct search_args {
     token_ordering token_order;
     std::vector<bool> prefixes;
     size_t drop_tokens_threshold;
+    size_t max_dropped_tokens;
     size_t typo_tokens_threshold;
     std::vector<std::string> group_by_fields;
     size_t group_limit;
@@ -212,7 +213,7 @@ struct search_args {
                 std::vector<std::pair<uint32_t, uint32_t>>& included_ids, std::vector<uint32_t> excluded_ids,
                 std::vector<sort_by>& sort_fields_std, facet_query_t facet_query, const std::vector<uint32_t>& num_typos,
                 size_t max_facet_values, size_t fetch_size, size_t per_page, size_t offset, token_ordering token_order,
-                const std::vector<bool>& prefixes, size_t drop_tokens_threshold, size_t typo_tokens_threshold,
+                const std::vector<bool>& prefixes, size_t drop_tokens_threshold, size_t max_dropped_tokens, size_t typo_tokens_threshold,
                 const std::vector<std::string>& group_by_fields, size_t group_limit,
                 const bool group_missing_values,
                 const string& default_sorting_field, bool prioritize_exact_match,
@@ -234,7 +235,7 @@ struct search_args {
             facet_query(facet_query), num_typos(num_typos), max_facet_values(max_facet_values),
             fetch_size(fetch_size), per_page(per_page),
             offset(offset), token_order(token_order), prefixes(prefixes),
-            drop_tokens_threshold(drop_tokens_threshold), typo_tokens_threshold(typo_tokens_threshold),
+            drop_tokens_threshold(drop_tokens_threshold), max_dropped_tokens(max_dropped_tokens), typo_tokens_threshold(typo_tokens_threshold),
             group_by_fields(group_by_fields), group_limit(group_limit),
             group_missing_values(group_missing_values),
             default_sorting_field(default_sorting_field),
@@ -676,6 +677,9 @@ public:
     // If the number of results found is less than this threshold, Typesense will attempt to drop the tokens
     // in the query that have the least individual hits one by one until enough results are found.
     static const int DROP_TOKENS_THRESHOLD = 1;
+    
+    // Maximum number of tokens that can be dropped during search to prevent infinite loops
+    static const int MAX_DROPPED_TOKENS = 20;
 
     enum {DEFAULT_TOPSTER_SIZE = 250};
 
@@ -768,7 +772,7 @@ public:
                 const size_t fetch_size,
                 const size_t per_page,
                 const size_t offset, const token_ordering token_order, const std::vector<bool>& prefixes,
-                const size_t drop_tokens_threshold, size_t& all_result_ids_len,
+                const size_t drop_tokens_threshold, const size_t max_dropped_tokens, size_t& all_result_ids_len,
                 spp::sparse_hash_map<uint64_t, uint32_t>& groups_processed,
                 std::vector<std::vector<art_leaf*>>& searched_queries,
                 tsl::htrie_map<char, token_leaf>& qtoken_set,

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -2704,7 +2704,7 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
                                                match_type, facets, included_ids, excluded_ids,
                                                sort_fields_std, facet_query, num_typos, max_facet_values,
                                                fetch_size, per_page, offset, token_order, prefixes,
-                                               drop_tokens_threshold, typo_tokens_threshold,
+                                               drop_tokens_threshold, coll_args.max_dropped_tokens, typo_tokens_threshold,
                                                group_by_fields, group_limit, group_missing_values,
                                                default_sorting_field,
                                                prioritize_exact_match, prioritize_token_position,
@@ -2805,7 +2805,8 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
                                           size_t personalization_n_events,
                                           const std::vector<std::string>& search_synonym_sets,
                                           float diversity_lamda,
-                                          size_t group_max_candidates) const {
+                                          size_t group_max_candidates,
+                                          size_t max_dropped_tokens) const {
     std::shared_lock lock(mutex);
 
     auto args = collection_search_args_t(query, search_fields, filter_query,
@@ -2837,7 +2838,7 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
                                          rerank_hybrid_matches, enable_analytics, validate_field_names, analytics_tags,
                                          personalization_user_id, personalization_model_id, personalization_type,
                                          personalization_user_field, personalization_item_field, personalization_event_name,
-                                         personalization_n_events, search_synonym_sets, diversity_lamda, group_max_candidates);
+                                         personalization_n_events, search_synonym_sets, diversity_lamda, group_max_candidates, max_dropped_tokens);
     return search(args);
 }
 
@@ -3310,7 +3311,7 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) c
                 auto facet_range_iter = a_facet.facet_range_map.find(kv.first);
                 if(facet_range_iter != a_facet.facet_range_map.end()){
                     auto & facet_count = kv.second;
-                    facet_value_t facet_value = {facet_range_iter->second.range_label, std::string(), facet_count.count};
+                    facet_value_t facet_value = {facet_range_iter->second.range_label, std::string(), facet_count.count, 0, nlohmann::json(), std::string()};
 
                     if(!a_facet.reference_collection_name.empty()) {
                         std::string facet_filter = "$" + a_facet.reference_collection_name + "(" + a_facet.field_name + ": ";
@@ -3459,7 +3460,7 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) c
 
                 const auto& highlighted_text = highlight.snippets.empty() ? value : highlight.snippets[0];
                 facet_value_t facet_value = {value, highlighted_text, facet_count.count,
-                                             facet_count.sort_field_val, parent};
+                                             facet_count.sort_field_val, parent, std::string()};
 
                 if(!a_facet.reference_collection_name.empty()) {
                     std::string facet_filter = "$" + a_facet.reference_collection_name + "(" + a_facet.field_name + ": ";
@@ -8477,6 +8478,7 @@ Option<bool> collection_search_args_t::init(std::map<std::string, std::string>& 
     size_t min_len_2typo = 7;
     std::vector<bool> prefixes = {true};
     size_t drop_tokens_threshold = Index::DROP_TOKENS_THRESHOLD;
+    size_t max_dropped_tokens = Index::MAX_DROPPED_TOKENS;
     size_t typo_tokens_threshold = Index::TYPO_TOKENS_THRESHOLD;
 
     std::vector<std::string> search_fields;
@@ -8577,6 +8579,7 @@ Option<bool> collection_search_args_t::init(std::map<std::string, std::string>& 
             {MIN_LEN_1TYPO, &min_len_1typo},
             {MIN_LEN_2TYPO, &min_len_2typo},
             {DROP_TOKENS_THRESHOLD, &drop_tokens_threshold},
+            {MAX_DROPPED_TOKENS, &max_dropped_tokens},
             {TYPO_TOKENS_THRESHOLD, &typo_tokens_threshold},
             {MAX_FACET_VALUES, &max_facet_values},
             {LIMIT_HITS, &limit_hits},
@@ -8847,7 +8850,7 @@ Option<bool> collection_search_args_t::init(std::map<std::string, std::string>& 
                                     rerank_hybrid_matches, enable_analytics, validate_field_names, analytics_tags,
                                     personalization_user_id, personalization_model_id, personalization_type,
                                     personalization_user_field, personalization_item_field, personalization_event_name,
-                                    personalization_n_events, synonym_sets, diversity_lamda, group_max_candidates);
+                                    personalization_n_events, synonym_sets, diversity_lamda, group_max_candidates, max_dropped_tokens);
     return Option<bool>(true);
 }
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2503,7 +2503,7 @@ Option<bool> Index::run_search(search_args* search_params) {
                           search_params->topster, search_params->curated_topster,
                           search_params->fetch_size,
                           search_params->per_page, search_params->offset, search_params->token_order,
-                          search_params->prefixes, search_params->drop_tokens_threshold,
+                          search_params->prefixes, search_params->drop_tokens_threshold, search_params->max_dropped_tokens,
                           search_params->all_result_ids_len, search_params->groups_processed,
                           search_params->searched_queries,
                           search_params->qtoken_set,
@@ -2680,7 +2680,7 @@ Option<bool> Index::run_search(search_args* search_params) {
                   search_params->topster, search_params->curated_topster,
                   search_params->fetch_size,
                   search_params->per_page, search_params->offset, search_params->token_order,
-                  search_params->prefixes, search_params->drop_tokens_threshold,
+                  search_params->prefixes, search_params->drop_tokens_threshold, search_params->max_dropped_tokens,
                   search_params->all_result_ids_len, search_params->groups_processed,
                   search_params->searched_queries,
                   search_params->qtoken_set,
@@ -3435,7 +3435,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                    const size_t fetch_size,
                    const size_t per_page,
                    const size_t offset, const token_ordering token_order, const std::vector<bool>& prefixes,
-                   const size_t drop_tokens_threshold, size_t& all_result_ids_len,
+                   const size_t drop_tokens_threshold, const size_t max_dropped_tokens, size_t& all_result_ids_len,
                    spp::sparse_hash_map<uint64_t, uint32_t>& groups_processed,
                    std::vector<std::vector<art_leaf*>>& searched_queries,
                    tsl::htrie_map<char, token_leaf>& qtoken_set,
@@ -3908,7 +3908,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
 
                 auto curr_direction = drop_tokens_mode.mode;
                 bool drop_both_sides = false;
-                size_t orig_tokens_size = std::min<size_t>(orig_tokens.size(), 20);  // drop only upto N tokens
+                size_t orig_tokens_size = orig_tokens.size();  // Use original token count, not limited by max_dropped_tokens
 
                 if(drop_tokens_mode.mode == both_sides) {
                     if(orig_tokens_size <= drop_tokens_mode.token_limit) {
@@ -3918,7 +3918,8 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                     }
                 }
 
-                while(exhaustive_search || all_result_ids_len < drop_tokens_threshold || drop_both_sides) {
+                while((exhaustive_search || all_result_ids_len < drop_tokens_threshold || drop_both_sides) && 
+                      num_tokens_dropped < max_dropped_tokens) {
                     // When atleast two tokens from the query are available we can drop one
                     std::vector<token_t> truncated_tokens;
                     std::vector<token_t> dropped_tokens;

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -3089,6 +3089,84 @@ TEST_F(CollectionSpecificMoreTest, NumDroppedTokensTest) {
     ASSERT_EQ(1, res["hits"][0]["text_match_info"]["num_tokens_dropped"]);
 }
 
+TEST_F(CollectionSpecificMoreTest, MaxDroppedTokensTest) {
+    nlohmann::json schema = R"({
+        "name": "coll1",
+        "fields": [
+            {"name": "title", "type": "string"}
+        ]
+    })"_json;
+
+    Collection *coll1 = collectionManager.create_collection(schema).get();
+
+    nlohmann::json doc;
+    doc["title"] = "alpha beta";
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    doc["title"] = "beta gamma";
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    doc["title"] = "gamma delta";
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    doc["title"] = "delta epsilon";
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    doc["title"] = "epsilon alpha";
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    std::cout << "DEBUG: Added documents:" << std::endl;
+    std::cout << "  - alpha beta" << std::endl;
+    std::cout << "  - beta gamma" << std::endl;
+    std::cout << "  - gamma delta" << std::endl;
+    std::cout << "  - delta epsilon" << std::endl;
+    std::cout << "  - epsilon alpha" << std::endl;
+
+    // Test with max_dropped_tokens = 1, should only drop 1 token maximum
+    // Use a query that can match with only 1 token dropped: "alpha beta" matches "alpha zeta" (drop "zeta")
+    auto res = coll1->search("alpha zeta", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true},
+                             5, spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(), 10, "", 30, 4, "", 1, "", "", {}, 3, "<mark>", "</mark>", {}, 1000000, true, false, true, "", false, 6000000, 4, 7, fallback, 4, {off}, INT16_MAX, INT16_MAX, 2, false, false, "", true, 0, max_score, 100, 0, 0, 0, "exhaustive", 30000, 2, "", {}, {}, "right_to_left", true, true, false, "", "", "", "", true, true, false, false, 0, false, true, 100000, false, true, true, "", "", "", "", "", "", "", 0, {}, 0.5, 250, 1).get();
+    // Should find results but with limited token dropping
+    ASSERT_GT(res["hits"].size(), 0);
+    
+    // Check that no result has more than 1 dropped token
+    for (const auto& hit : res["hits"]) {
+        if (hit.contains("text_match_info") && hit["text_match_info"].contains("num_tokens_dropped")) {
+            ASSERT_LE(hit["text_match_info"]["num_tokens_dropped"].get<int>(), 1);
+        }
+    }
+
+    // Test with max_dropped_tokens = 0, should not drop any tokens
+    // Use a query that exactly matches a document: "alpha beta" matches "alpha beta" exactly
+    res = coll1->search("alpha beta", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true},
+                        5, spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(), 10, "", 30, 4, "", 1, "", "", {}, 3, "<mark>", "</mark>", {}, 1000000, true, false, true, "", false, 6000000, 4, 7, fallback, 4, {off}, INT16_MAX, INT16_MAX, 2, false, false, "", true, 0, max_score, 100, 0, 0, 0, "exhaustive", 30000, 2, "", {}, {}, "right_to_left", true, true, false, "", "", "", "", true, true, false, false, 0, false, true, 100000, false, true, true, "", "", "", "", "", "", "", 0, {}, 0.5, 250, 0).get();
+
+    // Should find results but with no token dropping
+    ASSERT_GT(res["hits"].size(), 0);
+    
+    // Check that no result has any dropped tokens
+    for (const auto& hit : res["hits"]) {
+        if (hit.contains("text_match_info") && hit["text_match_info"].contains("num_tokens_dropped")) {
+            ASSERT_EQ(hit["text_match_info"]["num_tokens_dropped"].get<int>(), 0);
+        }
+    }
+
+    // Test with max_dropped_tokens = 3, should allow up to 3 dropped tokens
+    // Use the original query that needs 2 tokens dropped to match documents
+    res = coll1->search("alpha zeta gamma", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true},
+                        5, spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(), 10, "", 30, 4, "", 1, "", "", {}, 3, "<mark>", "</mark>", {}, 1000000, true, false, true, "", false, 6000000, 4, 7, fallback, 4, {off}, INT16_MAX, INT16_MAX, 2, false, false, "", true, 0, max_score, 100, 0, 0, 0, "exhaustive", 30000, 2, "", {}, {}, "right_to_left", true, true, false, "", "", "", "", true, true, false, false, 0, false, true, 100000, false, true, true, "", "", "", "", "", "", "", 0, {}, 0.5, 250, 3).get();
+
+    // Should find results with up to 3 dropped tokens
+    ASSERT_GT(res["hits"].size(), 0);
+    
+    // Check that no result has more than 3 dropped tokens
+    for (const auto& hit : res["hits"]) {
+        if (hit.contains("text_match_info") && hit["text_match_info"].contains("num_tokens_dropped")) {
+            ASSERT_LE(hit["text_match_info"]["num_tokens_dropped"].get<int>(), 3);
+        }
+    }
+}
+
 TEST_F(CollectionSpecificMoreTest, TestStemming2) {
     nlohmann::json schema = R"({
          "name": "words",


### PR DESCRIPTION


## Change Summary
- introduces `max_dropped_tokens` param to cap token drops during search
- prevents excessive  token dropping loops in fallback searches
- adds tests verifying token drop limits at various threshold values
-


## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
