### PR TITLE
feat: add field-level token separators and symbols override support (temp branch)

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -837,7 +837,9 @@ public:
     void parse_search_query(const std::string &query, std::vector<std::string>& q_include_tokens, std::vector<std::string>& q_include_tokens_non_stemmed,
                             std::vector<std::vector<std::string>>& q_exclude_tokens,
                             std::vector<std::vector<std::string>>& q_phrases,
-                            const std::string& locale, const bool already_segmented, const std::string& stopword_set="", std::shared_ptr<Stemmer> stemmer = nullptr) const;
+                            const std::string& locale, const bool already_segmented, const std::string& stopword_set="", std::shared_ptr<Stemmer> stemmer = nullptr,
+                            const std::vector<char>& most_weighted_field_symbols_to_index = std::vector<char>(),
+                            const std::vector<char>& most_weighted_field_token_separators = std::vector<char>()) const;
     
     void process_tokens(std::vector<std::string>& tokens, std::vector<std::string>& q_include_tokens,
                        std::vector<std::vector<std::string>>& q_exclude_tokens,

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -2579,7 +2579,8 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
         parse_search_query(query, q_include_tokens, q_unstemmed_tokens,
                            field_query_tokens[0].q_exclude_tokens,
                            field_query_tokens[0].q_phrases,
-                           field_locale, pre_segmented_query, stopwords_set, most_weighted_field.get_stemmer());
+                           field_locale, pre_segmented_query, stopwords_set, most_weighted_field.get_stemmer(),
+                           most_weighted_field.symbols_to_index, most_weighted_field.token_separators);
 
         // process filter overrides first, before synonyms (order is important)
 
@@ -4562,7 +4563,9 @@ void Collection::process_tokens(std::vector<std::string>& tokens, std::vector<st
 void Collection::parse_search_query(const std::string &query, std::vector<std::string>& q_include_tokens, std::vector<std::string>& q_unstemmed_tokens,
                                     std::vector<std::vector<std::string>>& q_exclude_tokens,
                                     std::vector<std::vector<std::string>>& q_phrases,
-                                    const std::string& locale, const bool already_segmented, const std::string& stopwords_set, std::shared_ptr<Stemmer> stemmer) const {
+                                    const std::string& locale, const bool already_segmented, const std::string& stopwords_set, std::shared_ptr<Stemmer> stemmer,
+                                    const std::vector<char>& most_weighted_field_symbols_to_index,
+                                    const std::vector<char>& most_weighted_field_token_separators) const {
     if(query == "*") {
         q_exclude_tokens = {};
         q_include_tokens = {query};
@@ -4581,10 +4584,10 @@ void Collection::parse_search_query(const std::string &query, std::vector<std::s
         if(already_segmented) {
             StringUtils::split(query, tokens, " ");
         } else {
-            std::vector<char> custom_symbols = symbols_to_index;
+            std::vector<char> custom_symbols = most_weighted_field_symbols_to_index.empty() ? symbols_to_index : most_weighted_field_symbols_to_index;
             custom_symbols.push_back('"');
 
-            const auto& separators = token_separators;
+            const auto& separators = most_weighted_field_token_separators.empty() ? token_separators : most_weighted_field_token_separators;
             bool has_hyphen_prefix = false;
             
             std::istringstream iss(query);
@@ -4602,7 +4605,7 @@ void Collection::parse_search_query(const std::string &query, std::vector<std::s
             
             Tokenizer(query, true, false, locale, custom_symbols, separators, stemmer).tokenize(tokens);
             if(stemmer) {
-                Tokenizer(query, true, false, locale, custom_symbols, token_separators, nullptr).tokenize(tokens_non_stemmed);
+                Tokenizer(query, true, false, locale, custom_symbols, separators, nullptr).tokenize(tokens_non_stemmed);
             }
         }
 


### PR DESCRIPTION
* test: add per-field token separators test for example email field

* feat: add field-level token separators and symbols override support

* add override parameters for symbols_to_index and token_separators
* modify parse_search_query to use field-specific tokenization settings
* enable per-field customization of tokenization behavior
* maintain backward compatibility with collection-level settings

## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
