### PR TITLE
refactor: rename `curation_*` to `most_weighted_field_*` on `parse_search_query`

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -849,8 +849,8 @@ public:
                             std::vector<std::vector<std::string>>& q_exclude_tokens,
                             std::vector<std::vector<std::string>>& q_phrases,
                             const std::string& locale, const bool already_segmented, const std::string& stopword_set="", std::shared_ptr<Stemmer> stemmer = nullptr,
-                            const std::vector<char>& curation_symbols_to_index = std::vector<char>(),
-                            const std::vector<char>& curation_token_separators = std::vector<char>()) const;
+                            const std::vector<char>& most_weighted_field_symbols_to_index = std::vector<char>(),
+                            const std::vector<char>& most_weighted_field_token_separators = std::vector<char>()) const;
     
     void process_tokens(std::vector<std::string>& tokens, std::vector<std::string>& q_include_tokens,
                        std::vector<std::vector<std::string>>& q_exclude_tokens,

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -4682,8 +4682,8 @@ void Collection::parse_search_query(const std::string &query, std::vector<std::s
                                     std::vector<std::vector<std::string>>& q_exclude_tokens,
                                     std::vector<std::vector<std::string>>& q_phrases,
                                     const std::string& locale, const bool already_segmented, const std::string& stopwords_set, std::shared_ptr<Stemmer> stemmer,
-                                    const std::vector<char>& curation_symbols_to_index,
-                                    const std::vector<char>& curation_token_separators) const {
+                                    const std::vector<char>& most_weighted_field_symbols_to_index,
+                                    const std::vector<char>& most_weighted_field_token_separators) const {
     if(query == "*") {
         q_exclude_tokens = {};
         q_include_tokens = {query};
@@ -4702,10 +4702,10 @@ void Collection::parse_search_query(const std::string &query, std::vector<std::s
         if(already_segmented) {
             StringUtils::split(query, tokens, " ");
         } else {
-            std::vector<char> custom_symbols = curation_symbols_to_index.empty() ? symbols_to_index : curation_symbols_to_index;
+            std::vector<char> custom_symbols = most_weighted_field_symbols_to_index.empty() ? symbols_to_index : most_weighted_field_symbols_to_index;
             custom_symbols.push_back('"');
 
-            const auto& separators = curation_token_separators.empty() ? token_separators : curation_token_separators;
+            const auto& separators = most_weighted_field_token_separators.empty() ? token_separators : most_weighted_field_token_separators;
 
             bool has_hyphen_prefix = false;
             


### PR DESCRIPTION
**Change Summary**
During the curation refactor, this was changed from `override_symbols` and `override_token` respectively. This didn't match what this variable was actually about, the field-level symbols and separators. This changes this to a more appropriate name, since it's the most weighted field's separators and symbols


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
