### PR TITLE
feat(field): add per-field truncate option to control token truncation (port of #2549)

### DIFF
--- a/include/field.h
+++ b/include/field.h
@@ -86,6 +86,7 @@ namespace fields {
     static const std::string REFERENCE_HELPER_FIELD_SUFFIX = "_sequence_id";
 
     static const std::string store = "store";
+    static const std::string truncate_len = "truncate_len";
     
     static const std::string hnsw_params = "hnsw_params";
 }
@@ -124,6 +125,7 @@ struct field {
     bool nested;        // field inside an object
 
     bool store = true;        // store the field in disk
+    uint32_t truncate_len = 100;       // truncate string tokens at this many chars (0 = no truncation)
 
     // field inside an array of objects that is forced to be an array
     // integer to handle tri-state: true (1), false (0), not known yet (2)
@@ -161,10 +163,10 @@ struct field {
           std::string reference = "", const nlohmann::json& embed = nlohmann::json(), const bool range_index = false,
           const bool store = true, const bool stem = false, const std::string& stem_dictionary = "", const nlohmann::json hnsw_params = nlohmann::json(),
           const bool async_reference = false, const nlohmann::json& token_separators = {}, const nlohmann::json& symbols_to_index = {},
-          const bool cascade_delete = true) :
+          const bool cascade_delete = true, const uint32_t truncate_len = 100) :
             name(name), type(type), facet(facet), optional(optional), index(index), locale(locale),
             nested(nested), nested_array(nested_array), num_dim(num_dim), vec_dist(vec_dist), reference(reference),
-            embed(embed), range_index(range_index), store(store), stem(stem), stem_dictionary(stem_dictionary),
+            embed(embed), range_index(range_index), store(store), truncate_len(truncate_len), stem(stem), stem_dictionary(stem_dictionary),
             hnsw_params(hnsw_params), is_async_reference(async_reference), cascade_delete(cascade_delete) {
 
         set_computed_defaults(sort, infix);
@@ -412,7 +414,8 @@ struct field {
                      json[fields::async_reference].get<bool>(),
                      json[fields::token_separators].get<nlohmann::json>(),
                      json[fields::symbols_to_index].get<nlohmann::json>(),
-                     json[fields::cascade_delete].get<bool>());
+                     json[fields::cascade_delete].get<bool>(),
+                     json[fields::truncate_len].get<uint32_t>());
     }
 
     static Option<bool> fields_to_json_fields(const std::vector<field> & fields,

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -359,6 +359,7 @@ nlohmann::json Collection::get_summary_json() const {
         field_json[fields::locale] = coll_field.locale;
         field_json[fields::stem] = coll_field.stem;
         field_json[fields::store] = coll_field.store;
+        field_json[fields::truncate_len] = coll_field.truncate_len;
         field_json[fields::stem_dictionary] = coll_field.stem_dictionary;
 
         if(coll_field.range_index) {

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -101,6 +101,10 @@ Option<Collection*> CollectionManager::init_collection(const nlohmann::json & co
         if(field_obj.count(fields::store) == 0) {
             field_obj[fields::store] = true;
         }
+        
+        if(field_obj.count(fields::truncate_len) == 0) {
+            field_obj[fields::truncate_len] = 100;
+        }
 
         if(field_obj.count(fields::token_separators) == 0) {
             field_obj[fields::token_separators] = nlohmann::json::array();
@@ -149,7 +153,7 @@ Option<Collection*> CollectionManager::init_collection(const nlohmann::json & co
                 field_obj[fields::num_dim], vec_dist_type, field_obj[fields::reference], field_obj[fields::embed],
                 field_obj[fields::range_index], field_obj[fields::store], field_obj[fields::stem], field_obj[fields::stem_dictionary],
                 field_obj[fields::hnsw_params], field_obj[fields::async_reference], field_obj[fields::token_separators],
-                field_obj[fields::symbols_to_index], field_obj[fields::cascade_delete]);
+                field_obj[fields::symbols_to_index], field_obj[fields::cascade_delete], field_obj[fields::truncate_len]);
 
         // value of `sort` depends on field type
         if(field_obj.count(fields::sort) == 0) {

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -72,6 +72,9 @@ void field::add_default_json_values(nlohmann::json& json) {
     if (json.count(fields::store) == 0) {
         json[fields::store] = true;
     }
+    if (json.count(fields::truncate_len) == 0) {
+        json[fields::truncate_len] = (uint32_t) 100;
+    }
     if (json.count(fields::stem) == 0) {
         json[fields::stem] = false;
     }
@@ -147,6 +150,12 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
         return Option<bool>(400, std::string("The `infix` property of the field `") +
                                  field_json[fields::name].get<std::string>() + std::string("` should be a boolean."));
     }
+
+    if(!field_json.at(fields::truncate_len).is_number_unsigned()) {
+        return Option<bool>(400, std::string("The `truncate_len` property of the field `") +
+                                 field_json[fields::name].get<std::string>() + std::string("` should be a non-negative integer."));
+    }
+
 
     if(!field_json.at(fields::locale).is_string()) {
         return Option<bool>(400, std::string("The `locale` property of the field `") +
@@ -460,7 +469,7 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
                   field_json[fields::reference], field_json[fields::embed], field_json[fields::range_index], 
                   field_json[fields::store], field_json[fields::stem], field_json[fields::stem_dictionary],
                   field_json[fields::hnsw_params], field_json[fields::async_reference], field_json[fields::token_separators],
-                  field_json[fields::symbols_to_index], field_json[fields::cascade_delete])
+                  field_json[fields::symbols_to_index], field_json[fields::cascade_delete], field_json[fields::truncate_len])
     );
 
     if (!field_json[fields::reference].get<std::string>().empty()) {
@@ -889,6 +898,7 @@ nlohmann::json field::field_to_json_field(const struct field& field) {
     field_val[fields::locale] = field.locale;
 
     field_val[fields::store] = field.store;
+    field_val[fields::truncate_len] = field.truncate_len;
     field_val[fields::stem] = field.stem;
     field_val[fields::range_index] = field.range_index;
     field_val[fields::stem_dictionary] = field.stem_dictionary;

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -1753,8 +1753,8 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
             auto approx_filter_value_match = UINT32_MAX;
 
             while (tokenizer.next(str_token, token_index)) {
-                if (str_token.size() > 100) {
-                    str_token.erase(100);
+                if (str_token.size() > f.truncate_len && f.truncate_len > 0) {
+                    str_token.erase(f.truncate_len);
                 }
                 str_tokens.push_back(str_token);
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1282,8 +1282,8 @@ void Index::tokenize_string(const std::string& text, const field& a_field,
             continue;
         }
 
-        if(token.size() > 100) {
-            token.erase(100);
+        if(token.size() > a_field.truncate_len && a_field.truncate_len > 0) {
+            token.erase(a_field.truncate_len);
         }
         
         token_to_offsets[token].push_back(token_index + 1);

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -137,7 +137,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"string",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate_len": 100
             },
             {
               "facet":false,
@@ -152,7 +153,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"string",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate_len": 100
             },
             {
               "facet":true,
@@ -167,7 +169,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"string[]",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate_len": 100
             },
             {
               "facet":true,
@@ -182,7 +185,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"int32",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate_len": 100
             },
             {
               "facet":false,
@@ -197,7 +201,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"geopoint",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate_len": 100
             },
             {
               "facet":false,
@@ -212,7 +217,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"string",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate_len": 100
             },
             {
               "facet":false,
@@ -227,7 +233,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"int32",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate_len": 100
             },
             {
               "facet":false,
@@ -243,7 +250,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"object",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate_len": 100
             },
             {
               "facet":false,
@@ -261,7 +269,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "vec_dist":"cosine",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate_len": 100
             },
             {
               "async_reference":true,
@@ -279,7 +288,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "reference":"Products.product_id",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate_len": 100
             },
             {
               "facet":false,
@@ -294,7 +304,8 @@ TEST_F(CollectionManagerTest, CollectionCreation) {
               "type":"int64",
               "range_index":false,
               "stem":false,
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate_len": 100
             }
           ],
           "id":0,
@@ -1686,7 +1697,8 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
                     "type":"string",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate_len": 100
                 },
                 {
                     "facet":true,
@@ -1702,7 +1714,8 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate_len": 100
                 },{
                     "facet":true,
                     "index":true,
@@ -1717,7 +1730,8 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate_len": 100
                 },{
                     "facet":true,
                     "index":true,
@@ -1732,7 +1746,8 @@ TEST_F(CollectionManagerTest, CollectionCreationWithMetadata) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate_len": 100
                 }
             ],
             "id":1,

--- a/test/collection_specific_test.cpp
+++ b/test/collection_specific_test.cpp
@@ -3201,3 +3201,202 @@ TEST_F(CollectionSpecificTest, ExactMatchWithoutClosingSymbol) {
     ASSERT_EQ("1", result["hits"][1]["document"]["id"]);
     ASSERT_EQ("Mahabalipuram", result["hits"][1]["document"]["title"]);
 }
+
+TEST_F(CollectionSpecificTest, TruncationFilteringTest) {
+    std::vector<field> fields = {
+        field("url", field_types::STRING, false, false, true, "", -1, -1, false, 0, 0, cosine, "", nlohmann::json(), false, true, false, "", nlohmann::json(), false, nlohmann::json(), nlohmann::json(), 100), // truncate at 100 (default)
+        field("long_url", field_types::STRING, false, false, true, "", -1, -1, false, 0, 0, cosine, "", nlohmann::json(), false, true, false, "", nlohmann::json(), false, nlohmann::json(), nlohmann::json(), 0), // no truncation
+        field("short_url", field_types::STRING, false, false, true, "", -1, -1, false, 0, 0, cosine, "", nlohmann::json(), false, true, false, "", nlohmann::json(), false, nlohmann::json(), nlohmann::json(), 50) // truncate at 50
+    };
+
+    Collection* coll1 = collectionManager.create_collection("coll1", 1, fields, "").get();
+
+    std::vector<nlohmann::json> docs = {
+        {
+            {"id", "1"},
+            {"url", "https://www.nothing.com/en/products/transducers/force/c10"},
+            {"long_url", "https://www.nothing.com/en/products/transducers/force/c10"},
+            {"short_url", "https://www.nothing.com/en/products/transducers/force/c10"}
+        },
+        {
+            {"id", "2"},
+            {"url", "https://www.nothing.com/en/products/transducers/inertial-sensors/inertial-measurement-units--imu-/3dm-cv5-imu/p-34523-23423"},
+            {"long_url", "https://www.nothing.com/en/products/transducers/inertial-sensors/inertial-measurement-units--imu-/3dm-cv5-imu/p-34523-23423"},
+            {"short_url", "https://www.nothing.com/en/products/transducers/inertial-sensors/inertial-measurement-units--imu-/3dm-cv5-imu/p-34523-23423"}
+        },
+        {
+            {"id", "3"},
+            {"url", "https://www.example.com/very/long/url/path/that/goes/on/and/on/and/should/be/truncated/at/100/characters"},
+            {"long_url", "https://www.example.com/very/long/url/path/that/goes/on/and/on/and/should/be/truncated/at/100/characters"},
+            {"short_url", "https://www.example.com/very/long/url/path/that/goes/on/and/on/and/should/be/truncated/at/100/characters"}
+        }
+    };
+
+    for(const auto& doc : docs) {
+        ASSERT_TRUE(coll1->add(doc.dump()).ok());
+    }
+
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    // filter by exact URL match with truncation (should find only exact match)
+    std::map<std::string, std::string> req_params = {
+        {"collection", "coll1"},
+        {"q", "*"},
+        {"filter_by", "url:=`https://www.nothing.com/en/products/transducers/force/c10`"},
+    };
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    nlohmann::json result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, result["hits"].size());
+    ASSERT_EQ("1", result["hits"][0]["document"]["id"]);
+
+    // filter by exact URL match with longer URL (should find only exact match)
+    req_params = {
+        {"collection", "coll1"},
+        {"q", "*"},
+        {"filter_by", "url:=`https://www.nothing.com/en/products/transducers/inertial-sensors/inertial-measurement-units--imu-/3dm-cv5-imu/p-34523-23423`"},
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, result["hits"].size());
+    ASSERT_EQ("2", result["hits"][0]["document"]["id"]);
+
+    // filter by exact URL match with no truncation (should find exact match)
+    req_params = {
+        {"collection", "coll1"},
+        {"q", "*"},
+        {"filter_by", "long_url:=`https://www.nothing.com/en/products/transducers/force/c10`"},
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, result["hits"].size());
+    ASSERT_EQ("1", result["hits"][0]["document"]["id"]);
+
+    // filter by exact URL match with aggressive truncation (should find exact match)
+    req_params = {
+        {"collection", "coll1"},
+        {"q", "*"},
+        {"filter_by", "short_url:=`https://www.nothing.com/en/products/transducers/force/c10`"},
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, result["hits"].size());
+    ASSERT_EQ("1", result["hits"][0]["document"]["id"]);
+
+    // filter by very long URL that gets truncated (should find exact match)
+    req_params = {
+        {"collection", "coll1"},
+        {"q", "*"},
+        {"filter_by", "url:=`https://www.example.com/very/long/url/path/that/goes/on/and/on/and/should/be/truncated/at/100/characters`"},
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, result["hits"].size());
+    ASSERT_EQ("3", result["hits"][0]["document"]["id"]);
+}
+
+TEST_F(CollectionSpecificTest, TruncationEdgeCasesTest) {
+    std::vector<field> fields = {
+        field("text", field_types::STRING, false, false, true, "", -1, -1, false, 0, 0, cosine, "", nlohmann::json(), false, true, false, "", nlohmann::json(), false, nlohmann::json(), nlohmann::json(), 5) // truncate at 5
+    };
+
+    Collection* coll1 = collectionManager.create_collection("coll1", 1, fields, "").get();
+
+    // exactly 5 characters (should not be truncated)
+    nlohmann::json doc1 = {
+        {"id", "1"},
+        {"text", "Hello"}
+    };
+
+    // 6 characters (should be truncated to 5)
+    nlohmann::json doc2 = {
+        {"id", "2"},
+        {"text", "Hello World"}
+    };
+
+    // very long text
+    nlohmann::json doc3 = {
+        {"id", "3"},
+        {"text", "This is a very long text that should definitely be truncated at 5 characters"}
+    };
+
+    ASSERT_TRUE(coll1->add(doc1.dump()).ok());
+    ASSERT_TRUE(coll1->add(doc2.dump()).ok());
+    ASSERT_TRUE(coll1->add(doc3.dump()).ok());
+
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    // exact match for 5-character text (should find only doc1)
+    std::map<std::string, std::string> req_params = {
+        {"collection", "coll1"},
+        {"q", "*"},
+        {"filter_by", "text:=`Hello`"},
+    };
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    nlohmann::json result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, result["hits"].size());
+    ASSERT_EQ("1", result["hits"][0]["document"]["id"]);
+
+    // exact match for 6-character text (should find only doc2, even though it gets truncated)
+    req_params = {
+        {"collection", "coll1"},
+        {"q", "*"},
+        {"filter_by", "text:=`Hello World`"},
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, result["hits"].size());
+    ASSERT_EQ("2", result["hits"][0]["document"]["id"]);
+
+    // exact match for very long text (should find only doc3, even though it gets truncated)
+    req_params = {
+        {"collection", "coll1"},
+        {"q", "*"},
+        {"filter_by", "text:=`This is a very long text that should definitely be truncated at 5 characters`"},
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, result["hits"].size());
+    ASSERT_EQ("3", result["hits"][0]["document"]["id"]);
+}

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -1994,7 +1994,8 @@ TEST_F(CoreAPIUtilsTest, CollectionsPagination) {
               "stem":false,
               "store": true,
               "type":"string",
-              "stem_dictionary": ""
+              "stem_dictionary": "",
+              "truncate_len": 100
             }
           ],
           "name":"cp2",
@@ -2208,7 +2209,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"string",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate_len": 100
                 },
                 {
                     "facet":true,
@@ -2224,7 +2226,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate_len": 100
                 },{
                     "facet":true,
                     "index":true,
@@ -2239,7 +2242,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate_len": 100
                 },{
                     "facet":true,
                     "index":true,
@@ -2254,7 +2258,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate_len": 100
                 }
             ],
             "id":1,
@@ -2307,7 +2312,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"string",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate_len": 100
                 },
                 {
                     "facet":true,
@@ -2323,7 +2329,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate_len": 100
                 },{
                     "facet":true,
                     "index":true,
@@ -2338,7 +2345,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate_len": 100
                 },{
                     "facet":true,
                     "index":true,
@@ -2353,7 +2361,8 @@ TEST_F(CoreAPIUtilsTest, CollectionMetadataUpdate) {
                     "type":"int32",
                     "range_index":false,
                     "stem":false,
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate_len": 100
                 }
             ],
             "id":1,
@@ -2660,7 +2669,8 @@ TEST_F(CoreAPIUtilsTest, CollectionSchemaResponseWithStoreValue) {
                     "stem":false,
                     "store":false,
                     "type":"string",
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate_len":100
                 },
                 {
                     "facet":false,
@@ -2673,7 +2683,8 @@ TEST_F(CoreAPIUtilsTest, CollectionSchemaResponseWithStoreValue) {
                     "stem":false,
                     "store":true,
                     "type":"int32",
-                    "stem_dictionary": ""
+                    "stem_dictionary": "",
+                    "truncate_len":100
                 }],
                 "name":"collection3",
                 "num_documents":0,
@@ -2683,6 +2694,33 @@ TEST_F(CoreAPIUtilsTest, CollectionSchemaResponseWithStoreValue) {
 
     expected_json["created_at"] = res_json["created_at"];
     ASSERT_EQ(expected_json, res_json);
+}
+
+TEST_F(CoreAPIUtilsTest, TruncateFieldValidation) {
+    // `truncate_len` must be an integer
+    nlohmann::json schema = R"({
+        "name": "truncate_validation",
+        "fields": [
+            {"name": "title", "type": "string", "truncate_len": "false"}
+        ]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_FALSE(op.ok());
+    ASSERT_EQ("The `truncate_len` property of the field `title` should be a non-negative integer.", op.error());
+}
+
+TEST_F(CoreAPIUtilsTest, TruncateFieldValidationNegative) {
+    nlohmann::json schema = R"({
+        "name": "truncate_validation_negative",
+        "fields": [
+            {"name": "title", "type": "string", "truncate_len": -1}
+        ]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_FALSE(op.ok());
+    ASSERT_EQ("The `truncate_len` property of the field `title` should be a non-negative integer.", op.error());
 }
 
 TEST_F(CoreAPIUtilsTest, StatefulRemoveDocsWithReturnValues) {


### PR DESCRIPTION
## Change Summary
**Port** of #2549 

* feat(field): add per-field truncate option to control token truncation

- add `truncate` to field model and json schema; default to true
- validate `truncate` is boolean during collection creation
- include `truncate` in schema and summary responses
- conditionally truncate tokens to 100 chars in index and filter paths
- set missing `truncate` to true in collection manager
- update tests and add validation test for `truncate`

* feat(field): make truncate option a number instead of a boolean

* test: add tests for truncation on filters

* refactor(field): rename `truncate` to `truncate_len` and make it unsigned


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
