### PR TITLE
feat: support average embeddings of multiple ids on vector search

### DIFF
--- a/include/vector_query_ops.h
+++ b/include/vector_query_ops.h
@@ -15,6 +15,7 @@ struct vector_query_t {
     std::vector<float> values;
 
     uint32_t seq_id = 0;
+    std::vector<uint32_t> seq_ids;  // for multiple document IDs
     bool query_doc_given = false;
     float alpha = 0.3;
 
@@ -30,6 +31,7 @@ struct vector_query_t {
         distance_threshold = 2.01;
         values.clear();
         seq_id = 0;
+        seq_ids.clear();
         query_doc_given = false;
     }
 };

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3626,9 +3626,19 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
             VectorFilterFunctor filterFunctor(filter_result_iterator_no_groups, excluded_result_ids, excluded_result_ids_size);
             auto& field_vector_index = vector_index.at(vector_query.field_name);
 
-            if(vector_query.query_doc_given && filterFunctor(vector_query.seq_id)) {
-                // since query doc will be omitted from results, we will request for 1 more doc
-                k++;
+            if(vector_query.query_doc_given) {
+                // since query doc(s) will be omitted from results, we will request for more docs
+                if(!vector_query.seq_ids.empty()) {
+                    // multiple IDs provided
+                    for(const auto& query_seq_id : vector_query.seq_ids) {
+                        if(filterFunctor(query_seq_id)) {
+                            k++;
+                        }
+                    }
+                } else if(filterFunctor(vector_query.seq_id)) {
+                    // single ID
+                    k++;
+                }
             }
 
             filter_result_iterator_no_groups->reset();
@@ -3662,8 +3672,24 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                 auto& seq_id = dist_result.second.seq_id;
                 auto references = std::move(dist_result.second.reference_filter_results);
 
-                if(vector_query.query_doc_given && vector_query.seq_id == seq_id) {
-                    continue;
+                if(vector_query.query_doc_given) {
+                    bool is_source_doc = false;
+                    if(!vector_query.seq_ids.empty()) {
+                        // multiple IDs provided
+                        for(const auto& query_seq_id : vector_query.seq_ids) {
+                            if(query_seq_id == seq_id) {
+                                is_source_doc = true;
+                                break;
+                            }
+                        }
+                    } else if(vector_query.seq_id == seq_id) {
+                        // single ID
+                        is_source_doc = true;
+                    }
+                    
+                    if(is_source_doc) {
+                        continue;
+                    }
                 }
 
                 uint64_t distinct_id = seq_id;

--- a/src/vector_query_ops.cpp
+++ b/src/vector_query_ops.cpp
@@ -117,33 +117,85 @@ Option<bool> VectorQueryOps::parse_vector_query_str(const std::string& vector_qu
                                                  "and `id` parameter.");
                     }
 
-                    Option<uint32_t> id_op = coll->doc_id_to_seq_id(param_kv[1]);
-                    if(!id_op.ok()) {
-                        return Option<bool>(400, "Document id referenced in vector query is not found.");
+                    std::vector<std::string> doc_ids;
+                    bool is_array = false;
+                    
+                    // check for array syntax: [id1, id2, id3]
+                    if(param_kv[1].front() == '[' && param_kv[1].back() == ']') {
+                        is_array = true;
+                        std::string ids_str = param_kv[1].substr(1, param_kv[1].size() - 2);
+                        StringUtils::split(ids_str, doc_ids, ",");
+                        for(auto& doc_id : doc_ids) {
+                            StringUtils::trim(doc_id);
+                        }
+                    } else {
+                        // single ID
+                        doc_ids.push_back(param_kv[1]);
                     }
 
-                    nlohmann::json document;
-                    auto doc_op  = coll->get_document_from_store(id_op.get(), document);
-                    if(!doc_op.ok()) {
-                        return Option<bool>(400, "Document id referenced in vector query is not found.");
+                    if(doc_ids.empty()) {
+                        return Option<bool>(400, "Document id referenced in vector query is empty.");
                     }
 
-                    if(!document.contains(vector_query.field_name) || !document[vector_query.field_name].is_array()) {
-                        return Option<bool>(400, "Document referenced in vector query does not contain a valid "
-                                                 "vector field.");
-                    }
+                    std::vector<std::vector<float>> embeddings;
+                    
+                    for(const auto& doc_id : doc_ids) {
+                        Option<uint32_t> id_op = coll->doc_id_to_seq_id(doc_id);
+                        if(!id_op.ok()) {
+                            return Option<bool>(400, "Document id `" + doc_id + "` referenced in vector query is not found.");
+                        }
 
-                    for(auto& fvalue: document[vector_query.field_name]) {
-                        if(!fvalue.is_number()) {
-                            return Option<bool>(400, "Document referenced in vector query does not contain a valid "
+                        nlohmann::json document;
+                        auto doc_op = coll->get_document_from_store(id_op.get(), document);
+                        if(!doc_op.ok()) {
+                            return Option<bool>(400, "Document id `" + doc_id + "` referenced in vector query is not found.");
+                        }
+
+                        if(!document.contains(vector_query.field_name) || !document[vector_query.field_name].is_array()) {
+                            return Option<bool>(400, "Document `" + doc_id + "` referenced in vector query does not contain a valid "
                                                      "vector field.");
                         }
 
-                        vector_query.values.push_back(fvalue.get<float>());
+                        std::vector<float> doc_embedding;
+                        for(auto& fvalue: document[vector_query.field_name]) {
+                            if(!fvalue.is_number()) {
+                                return Option<bool>(400, "Document `" + doc_id + "` referenced in vector query does not contain a valid "
+                                                         "vector field.");
+                            }
+
+                            doc_embedding.push_back(fvalue.get<float>());
+                        }
+                        
+                        embeddings.push_back(doc_embedding);
+                        vector_query.seq_ids.push_back(id_op.get());
+                    }
+
+                    // average the embeddings if multiple IDs are provided
+                    if(embeddings.size() > 1) {
+                        size_t dim = embeddings[0].size();
+                        std::vector<float> avg_embedding(dim, 0.0f);
+                        
+                        for(const auto& embedding : embeddings) {
+                            if(embedding.size() != dim) {
+                                return Option<bool>(400, "All documents referenced in vector query must have the same embedding dimensions.");
+                            }
+                            for(size_t i = 0; i < dim; i++) {
+                                avg_embedding[i] += embedding[i];
+                            }
+                        }
+                        
+                        for(size_t i = 0; i < dim; i++) {
+                            avg_embedding[i] /= embeddings.size();
+                        }
+                        
+                        vector_query.values = avg_embedding;
+                    } else {
+                        // single ID
+                        vector_query.values = embeddings[0];
+                        vector_query.seq_id = vector_query.seq_ids[0];
                     }
 
                     vector_query.query_doc_given = true;
-                    vector_query.seq_id = id_op.get();
                 }
 
                 if(param_kv[0] == "k") {

--- a/test/collection_vector_search_test.cpp
+++ b/test/collection_vector_search_test.cpp
@@ -201,6 +201,84 @@ TEST_F(CollectionVectorTest, BasicVectorQuerying) {
     ASSERT_STREQ("0", results["hits"][0]["document"]["id"].get<std::string>().c_str());
     ASSERT_STREQ("2", results["hits"][1]["document"]["id"].get<std::string>().c_str());
 
+    // pass multiple IDs in array format, should average embeddings and exclude all source docs
+    results = coll1->search("*", {}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, Index::DROP_TOKENS_THRESHOLD,
+                            spp::sparse_hash_set<std::string>(),
+                            spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                            "", 10, {}, {}, {}, 0,
+                            "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7, fallback,
+                            4, {off}, 32767, 32767, 2,
+                            false, true, "vec:([], id: [0, 1])").get();
+
+    ASSERT_EQ(1, results["found"].get<size_t>());
+    ASSERT_EQ(1, results["hits"].size());
+    // doc 0 and 1 should be excluded, only doc 2 remains
+    ASSERT_STREQ("2", results["hits"][0]["document"]["id"].get<std::string>().c_str());
+
+    // test multiple IDs with all three documents - should return empty results
+    results = coll1->search("*", {}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, Index::DROP_TOKENS_THRESHOLD,
+                            spp::sparse_hash_set<std::string>(),
+                            spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                            "", 10, {}, {}, {}, 0,
+                            "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7, fallback,
+                            4, {off}, 32767, 32767, 2,
+                            false, true, "vec:([], id: [0, 1, 2])").get();
+
+    ASSERT_EQ(0, results["found"].get<size_t>());
+    ASSERT_EQ(0, results["hits"].size());
+
+    // test multiple IDs with k parameter
+    results = coll1->search("*", {}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, Index::DROP_TOKENS_THRESHOLD,
+                            spp::sparse_hash_set<std::string>(),
+                            spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                            "", 10, {}, {}, {}, 0,
+                            "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7, fallback,
+                            4, {off}, 32767, 32767, 2,
+                            false, true, "vec:([], id: [1, 2], k: 1)").get();
+
+    ASSERT_EQ(1, results["found"].get<size_t>());
+    ASSERT_EQ(1, results["hits"].size());
+    // doc 1 and 2 should be excluded, only doc 0 remains
+    ASSERT_STREQ("0", results["hits"][0]["document"]["id"].get<std::string>().c_str());
+
+    // test multiple IDs with filtering
+    results = coll1->search("*", {}, "points:[0,1]", {}, {}, {0}, 10, 1, FREQUENCY, {true}, Index::DROP_TOKENS_THRESHOLD,
+                            spp::sparse_hash_set<std::string>(),
+                            spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                            "", 10, {}, {}, {}, 0,
+                            "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7, fallback,
+                            4, {off}, 32767, 32767, 2,
+                            false, true, "vec:([], id: [0, 2])").get();
+
+    ASSERT_EQ(1, results["found"].get<size_t>());
+    ASSERT_EQ(1, results["hits"].size());
+    // doc 0 excluded by id param, doc 2 excluded by filter, only doc 1 remains
+    ASSERT_STREQ("1", results["hits"][0]["document"]["id"].get<std::string>().c_str());
+
+    // one of multiple IDs doesn't exist
+    res_op = coll1->search("*", {}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, Index::DROP_TOKENS_THRESHOLD,
+                           spp::sparse_hash_set<std::string>(),
+                           spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                           "", 10, {}, {}, {}, 0,
+                           "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7, fallback,
+                           4, {off}, 32767, 32767, 2,
+                           false, true, "vec:([], id: [0, 100])");
+
+    ASSERT_FALSE(res_op.ok());
+    ASSERT_EQ("Document id `100` referenced in vector query is not found.", res_op.error());
+
+    // test empty array of IDs
+    res_op = coll1->search("*", {}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, Index::DROP_TOKENS_THRESHOLD,
+                           spp::sparse_hash_set<std::string>(),
+                           spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                           "", 10, {}, {}, {}, 0,
+                           "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7, fallback,
+                           4, {off}, 32767, 32767, 2,
+                           false, true, "vec:([], id: [])");
+
+    ASSERT_FALSE(res_op.ok());
+    ASSERT_EQ("Document id referenced in vector query is empty.", res_op.error());
+
     // when id does not match filter, don't return k+1 hits
     results = coll1->search("*", {}, "id:!=1", {}, {}, {0}, 10, 1, FREQUENCY, {true}, Index::DROP_TOKENS_THRESHOLD,
                             spp::sparse_hash_set<std::string>(),
@@ -260,7 +338,7 @@ TEST_F(CollectionVectorTest, BasicVectorQuerying) {
                            false, true, "vec:([], id: 100)");
 
     ASSERT_FALSE(res_op.ok());
-    ASSERT_EQ("Document id referenced in vector query is not found.", res_op.error());
+    ASSERT_EQ("Document id `100` referenced in vector query is not found.", res_op.error());
 
     // support num_dim on only float array fields
     schema = R"({
@@ -925,6 +1003,57 @@ TEST_F(CollectionVectorTest, VecSearchWithFiltering) {
 
     ASSERT_EQ(1, results["found"].get<size_t>());
     ASSERT_EQ(1, results["hits"].size());
+
+    // test multiple IDs with filtering
+    results = coll1->search("*", {}, "points:<5", {}, {}, {0}, 10, 1, FREQUENCY, {true}, Index::DROP_TOKENS_THRESHOLD,
+                            spp::sparse_hash_set<std::string>(),
+                            spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                            "", 10, {}, {}, {}, 0,
+                            "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7,
+                            fallback,
+                            4, {off}, 32767, 32767, 2,
+                            false, true, "vec:([], id: [0, 1], flat_search_cutoff: 1000)").get();
+
+    ASSERT_EQ(3, results["hits"].size());
+    // Doc 0 and 1 are excluded, docs 2, 3, 4 match filter points:<5 (returned by vector similarity order)
+    std::set<std::string> returned_ids;
+    for(const auto& hit : results["hits"]) {
+        std::string id = hit["document"]["id"].get<std::string>();
+        returned_ids.insert(id);
+        // Ensure excluded docs 0 and 1 are not in results
+        ASSERT_NE("0", id);
+        ASSERT_NE("1", id);
+        // Ensure results match the filter points:<5
+        int points = hit["document"]["points"].get<int>();
+        ASSERT_LT(points, 5);
+    }
+    // Verify we got exactly docs 2, 3, 4 (in any order)
+    ASSERT_EQ(3, returned_ids.size());
+    ASSERT_TRUE(returned_ids.count("2") > 0);
+    ASSERT_TRUE(returned_ids.count("3") > 0);
+    ASSERT_TRUE(returned_ids.count("4") > 0);
+
+    // test multiple IDs with flat search disabled
+    results = coll1->search("*", {}, "points:<10", {}, {}, {0}, 5, 1, FREQUENCY, {true}, Index::DROP_TOKENS_THRESHOLD,
+                            spp::sparse_hash_set<std::string>(),
+                            spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                            "", 10, {}, {}, {}, 0,
+                            "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7,
+                            fallback,
+                            4, {off}, 32767, 32767, 2,
+                            false, true, "vec:([], id: [5, 9], flat_search_cutoff: 0)").get();
+
+    ASSERT_EQ(5, results["hits"].size());
+    // Doc 5 and 9 are excluded, should get 5 closest docs within points:<10 filter
+    for(const auto& hit : results["hits"]) {
+        std::string id = hit["document"]["id"].get<std::string>();
+        // Ensure excluded docs 5 and 9 are not in results
+        ASSERT_NE("5", id);
+        ASSERT_NE("9", id);
+        // Ensure results match the filter points:<10
+        int points = hit["document"]["points"].get<int>();
+        ASSERT_LT(points, 10);
+    }
 }
 
 TEST_F(CollectionVectorTest, VecSearchWithFilteringWithMissingVectorValues) {

--- a/test/vector_query_ops_test.cpp
+++ b/test/vector_query_ops_test.cpp
@@ -78,4 +78,16 @@ TEST_F(VectorQueryOpsTest, ParseVectorQueryString) {
     parsed = VectorQueryOps::parse_vector_query_str("vec([0.34, 0.66, 0.12, 0.68], k: 10)", vector_query, false, nullptr, false);
     ASSERT_FALSE(parsed.ok());
     ASSERT_EQ("Malformed vector query string: `:` is missing after the vector field name.", parsed.error());
+
+    // empty ID array is detected
+    vector_query._reset();
+    parsed = VectorQueryOps::parse_vector_query_str("vec:([], id: [])", vector_query, false, nullptr, false);
+    ASSERT_FALSE(parsed.ok());
+    ASSERT_EQ("Document id referenced in vector query is empty.", parsed.error());
+
+    // cannot pass both vector array and id array
+    vector_query._reset();
+    parsed = VectorQueryOps::parse_vector_query_str("vec:([0.34, 0.66, 0.12, 0.68], id: [doc1, doc2])", vector_query, false, nullptr, false);
+    ASSERT_FALSE(parsed.ok());
+    ASSERT_EQ("Malformed vector query string: cannot pass both vector query and `id` parameter.", parsed.error());
 }


### PR DESCRIPTION
## Change Summary
- add array syntax for id parameter: `vec:([], id: [doc1, doc2, doc3])`
- maintain backwards compatibility with single id syntax
- average embeddings when multiple document ids provided
- exclude all source documents from search results
- validate all embeddings have same dimensions before averaging


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
