### PR TITLE
fix: retrieve NL query parameters from preset

### DIFF
--- a/src/natural_language_search_model_manager.cpp
+++ b/src/natural_language_search_model_manager.cpp
@@ -348,6 +348,27 @@ Option<uint64_t> NaturalLanguageSearchModelManager::process_nl_query_and_augment
     bool has_nl_query = false;
     auto start_time = std::chrono::high_resolution_clock::now();
 
+    if(req_params.count("preset") != 0) {
+        nlohmann::json preset_json;
+        auto preset_op = CollectionManager::get_instance().get_preset(req_params["preset"], preset_json);
+        if(preset_op.ok()) {
+            if(preset_json.is_object() && preset_json.count("value") != 0 && preset_json["value"].is_object()) {
+                preset_json = preset_json["value"];
+                if(preset_json.contains("nl_query") && preset_json["nl_query"].is_boolean()) {
+                    req_params["nl_query"] = preset_json["nl_query"].get<bool>() ? "true" : "false";
+                }
+
+                if(preset_json.contains("q") && preset_json["q"].is_string() && !preset_json["q"].get<std::string>().empty()) {
+                    req_params["q"] = preset_json["q"].get<std::string>();
+                }
+
+                if(preset_json.contains("nl_model_id") && preset_json["nl_model_id"].is_string() && !preset_json["nl_model_id"].get<std::string>().empty()) {
+                    req_params["nl_model_id"] = preset_json["nl_model_id"].get<std::string>();
+                }
+            }
+        }
+    }
+
     if(req_params.count("nl_query") != 0 && req_params["nl_query"] == "true" && req_params.count("q") != 0 && !req_params["q"].empty()) {
         nl_query = req_params["q"];
         req_params["_original_nl_query"] = nl_query;


### PR DESCRIPTION
## Change Summary
CUrrently NL query params are not retrieved from the selected preset, because NL query augmentation happens before preset resolution. This PR fixes the problem by resolving the NL query params inside the preset in the request params augmentation function.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
