### PR TITLE
feat: add validation for the type when sort enabled

### DIFF
--- a/src/field.cpp
+++ b/src/field.cpp
@@ -279,17 +279,9 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
                                      "setting` enable_nested_fields` to true.");
         }
     }
-
-    bool is_sortable_type = (field_json["type"] == field_types::INT32 || field_json["type"] == field_types::INT32_ARRAY ||
-                                 field_json["type"] == field_types::INT64 || field_json["type"] == field_types::INT64_ARRAY ||
-                                 field_json["type"] == field_types::FLOAT || field_json["type"] == field_types::FLOAT_ARRAY ||
-                                 field_json["type"] == field_types::BOOL ||
-                                 field_json["type"] == field_types::GEOPOINT || field_json["type"] == field_types::GEOPOINT_ARRAY ||
-                                 field_json["type"] == field_types::GEOPOLYGON || field_json["type"] == field_types::STRING ||
-                                 field_json["type"] == field_types::STRING_ARRAY);
-    if(field_json[fields::sort].get<bool>() && !is_sortable_type) {
-        return Option<bool>(400, std::string("The type `") +
-                                 field_json["type"].get<std::string>() + std::string("` is not sortable."));
+    // Auto fields are not sortable
+    if(field_json[fields::sort].get<bool>() && field_json[fields::type] == field_types::AUTO) {
+        return Option<bool>(400, std::string("The type `auto` is not sortable."));
     }
 
     if(!field_json[fields::embed].empty()) {

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -280,6 +280,18 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
         }
     }
 
+    bool is_sortable_type = (field_json["type"] == field_types::INT32 || field_json["type"] == field_types::INT32_ARRAY ||
+                                 field_json["type"] == field_types::INT64 || field_json["type"] == field_types::INT64_ARRAY ||
+                                 field_json["type"] == field_types::FLOAT || field_json["type"] == field_types::FLOAT_ARRAY ||
+                                 field_json["type"] == field_types::BOOL ||
+                                 field_json["type"] == field_types::GEOPOINT || field_json["type"] == field_types::GEOPOINT_ARRAY ||
+                                 field_json["type"] == field_types::GEOPOLYGON || field_json["type"] == field_types::STRING ||
+                                 field_json["type"] == field_types::STRING_ARRAY);
+    if(field_json[fields::sort].get<bool>() && !is_sortable_type) {
+        return Option<bool>(400, std::string("The type `") +
+                                 field_json["type"].get<std::string>() + std::string("` is not sortable."));
+    }
+
     if(!field_json[fields::embed].empty()) {
         if(field_json[fields::type] != field_types::FLOAT_ARRAY) {
             return Option<bool>(400, "Fields with the `embed` parameter can only be of type `float[]`.");

--- a/test/collection_schema_change_test.cpp
+++ b/test/collection_schema_change_test.cpp
@@ -2002,7 +2002,7 @@ TEST_F(CollectionSchemaChangeTest, EmbeddingFieldAlterUpdateOldDocs) {
     ASSERT_EQ(0, search_res.get()["hits"][0]["document"].count("nested.hello"));
 }
 
-TEST_F(CollectionSchemaChangeTest,AlterAddSameFieldTwice) {
+TEST_F(CollectionSchemaChangeTest, AlterAddSameFieldTwice) {
     nlohmann::json schema = R"({
             "name": "objects",
             "fields": [


### PR DESCRIPTION
## Change Summary
Currently we don't validate if the type of the new field is sortable before adding the field actually to the collection. This PR fixes the issue.

Fixes #1573 
## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
