### PR TITLE
fix(curation): add check for `match` existing alongside `query`

### DIFF
--- a/src/curation.cpp
+++ b/src/curation.cpp
@@ -20,6 +20,10 @@ Option<bool> curation_t::parse(const nlohmann::json& curation_json, const std::s
         return Option<bool>(400, "The `rule` definition must contain either a `tags` or a `query` and `match`.");
     }
 
+    if (curation_json["rule"].count("match") != 0 && curation_json["rule"].count("query") == 0) {
+        return Option<bool>(400, "The `match` field requires a `query` field to be present.");
+    }
+
     if(curation_json.count("includes") == 0 && curation_json.count("excludes") == 0 &&
        curation_json.count("filter_by") == 0 && curation_json.count("sort_by") == 0 &&
        curation_json.count("remove_matched_tokens") == 0 && curation_json.count("metadata") == 0 &&

--- a/test/collection_curation_test.cpp
+++ b/test/collection_curation_test.cpp
@@ -3599,8 +3599,7 @@ TEST_F(CollectionCurationTest, DynamicSorting) {
             {"id",   "dynamic-sort2"},
             {
              "rule", {
-                             {"filter_by", "store:={store}"},
-                             {"match", curation_t::MATCH_CONTAINS}
+                             {"filter_by", "store:={store}"}
                      }
             },
             {"remove_matched_tokens", true},
@@ -3636,7 +3635,6 @@ TEST_F(CollectionCurationTest, DynamicSorting) {
             {
              "rule",                {
                                             {"filter_by", "store:={store} && size:={size}"},
-                                            {"match", curation_t::MATCH_CONTAINS},
                                             {"tags", {"size"}}
                                     }
             },
@@ -4499,6 +4497,36 @@ TEST_F(CollectionCurationTest, MetadataValidation) {
     ov_manager.upsert_curation_item("index", curation_json1);
 
     collectionManager.drop_collection("coll1");
+}
+
+TEST_F(CollectionCurationTest, MatchRequiresQuery) {
+    nlohmann::json curation_json = R"({
+       "id": "ov-1",
+       "rule": {
+            "match": "exact",
+            "tags": ["tag_id"]
+        },
+        "includes": [{"id": "0", "position": 0}]
+    })"_json;
+
+    curation_t curation;
+    auto op = curation_t::parse(curation_json, "ov-1", curation);
+    ASSERT_FALSE(op.ok());
+    ASSERT_EQ("The `match` field requires a `query` field to be present.", op.error());
+
+    // both query and match - should succeed
+    curation_json = R"({
+       "id": "ov-3",
+       "rule": {
+            "query": "test",
+            "match": "exact"
+        },
+        "includes": [{"id": "0", "position": 0}]
+    })"_json;
+
+    curation_t curation3;
+    op = curation_t::parse(curation_json, "ov-3", curation3);
+    ASSERT_TRUE(op.ok());
 }
 
 TEST_F(CollectionCurationTest, WildcardSearchOverride) {


### PR DESCRIPTION
## Change Summary
`match` always has to be defined with a `query`. The current implementation let `match` be defined alongside a `tags` or a `filter_by` parameter, leading to misleading curation set creation

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
