### PR TITLE
fix(collection): avoid duplicate dynamic fields after resolution

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -607,6 +607,11 @@ nlohmann::json Collection::add_many(std::vector<std::string>& json_lines, nlohma
                 if(search_schema.find(new_field.name) == search_schema.end()) {
                     found_new_field = true;
                     found_batch_new_field = true;
+                    // Remove existing auto field with same name if present
+                    auto it = std::remove_if(fields.begin(), fields.end(),
+                                                [&new_field](const field& f) { return f.name == new_field.name &&
+                                                                               f.is_auto(); });
+                    fields.erase(it, fields.end());
                     search_schema.emplace(new_field.name, new_field);
                     fields.emplace_back(new_field);
                     if(new_field.nested) {

--- a/test/collection_all_fields_test.cpp
+++ b/test/collection_all_fields_test.cpp
@@ -1990,3 +1990,32 @@ TEST_F(CollectionAllFieldsTest, FieldNameEmpty) {
     ASSERT_FALSE(create_op.ok());
     ASSERT_EQ("Field name cannot be empty.", create_op.error());
 }
+
+TEST_F(CollectionAllFieldsTest, AvoidDuplicateDynamicFields) {
+    nlohmann::json schema = R"({
+        "name": "test",
+        "fields": [
+            {"name": "product", "type": "auto"},
+            {"name": "title", "type": "auto"},
+            {"name": "description", "type": "string"}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+
+    Collection* collection = create_op.get();
+    auto fields = collection->get_fields();
+    ASSERT_EQ(3, fields.size());
+
+    nlohmann::json doc;
+    doc["id"] = "0";
+    doc["product"] = "Running Shoes";
+    doc["title"] = "Nike Shoes";
+    doc["description"] = "A nice pair of running shoes.";
+    
+    auto add_op = collection->add(doc.dump(), CREATE);
+    ASSERT_TRUE(add_op.ok());
+    fields = collection->get_fields();
+    ASSERT_EQ(3, fields.size());
+}


### PR DESCRIPTION
## Change Summary
When we create a collection that has `auto` as type:

```json
{
    "name": "test",
    "fields": [
        {"name": "title", "type": "auto"}
    ]
}

```

Indexing a document that has `title` key results having the same field twice in the collection: one with `auto` type and one with the original type after indexing. We should remove the one with the auto type while resolving the field in indexing.

This PR fixes #2647 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
