### PR TITLE
fix(collection): avoid duplicate dynamic fields after resolution (#2651)

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -607,6 +607,11 @@ nlohmann::json Collection::add_many(std::vector<std::string>& json_lines, nlohma
                 if(search_schema.find(new_field.name) == search_schema.end()) {
                     found_new_field = true;
                     found_batch_new_field = true;
+                    // Remove existing auto field with same name if present
+                    auto it = std::remove_if(fields.begin(), fields.end(),
+                                                [&new_field](const field& f) { return f.name == new_field.name &&
+                                                                               f.is_auto(); });
+                    fields.erase(it, fields.end());
                     search_schema.emplace(new_field.name, new_field);
                     fields.emplace_back(new_field);
                     if(new_field.nested) {

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -546,22 +546,32 @@ bool field::flatten_obj(nlohmann::json& doc, nlohmann::json& value, bool has_arr
         bool found_dynamic_field = false;
         field dyn_field(the_field.name, field_types::STRING, false);
 
-        for(auto dyn_field_it = dyn_fields.begin(); dyn_field_it != dyn_fields.end(); dyn_field_it++) {
-            auto& dynamic_field = dyn_field_it->second;
-
-            if(dynamic_field.is_auto() || dynamic_field.is_string_star()) {
-                continue;
+        auto exact_match_it = dyn_fields.find(flat_name);
+        if(exact_match_it != dyn_fields.end()) {
+            found_dynamic_field = true;
+            dyn_field = exact_match_it->second;
+            if(!dyn_field.is_auto() && !dyn_field.is_string_star()) {
+                detected_type = dyn_field.type;
             }
+        } else {
+            for(auto dyn_field_it = dyn_fields.begin(); dyn_field_it != dyn_fields.end(); dyn_field_it++) {
+                auto& dynamic_field = dyn_field_it->second;
 
-            if(std::regex_match(flat_name, std::regex(dynamic_field.name))) {
-                detected_type = dynamic_field.type;
-                found_dynamic_field = true;
-                dyn_field = dynamic_field;
-                break;
+                if(dynamic_field.is_auto() || dynamic_field.is_string_star()) {
+                    continue;
+                }
+
+                if(std::regex_match(flat_name, std::regex(dynamic_field.name))) {
+                    detected_type = dynamic_field.type;
+                    found_dynamic_field = true;
+                    dyn_field = dynamic_field;
+                    break;
+                }
             }
         }
 
-        if(!found_dynamic_field) {
+        if(!found_dynamic_field || dyn_field.is_auto() || dyn_field.is_string_star()) {
+            // Detect type from value if no match found or if the matched field is auto
             if(!field::get_type(value, detected_type)) {
                 return false;
             }

--- a/test/collection_all_fields_test.cpp
+++ b/test/collection_all_fields_test.cpp
@@ -1990,3 +1990,32 @@ TEST_F(CollectionAllFieldsTest, FieldNameEmpty) {
     ASSERT_FALSE(create_op.ok());
     ASSERT_EQ("Field name cannot be empty.", create_op.error());
 }
+
+TEST_F(CollectionAllFieldsTest, AvoidDuplicateDynamicFields) {
+    nlohmann::json schema = R"({
+        "name": "test",
+        "fields": [
+            {"name": "product", "type": "auto"},
+            {"name": "title", "type": "auto"},
+            {"name": "description", "type": "string"}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+
+    Collection* collection = create_op.get();
+    auto fields = collection->get_fields();
+    ASSERT_EQ(3, fields.size());
+
+    nlohmann::json doc;
+    doc["id"] = "0";
+    doc["product"] = "Running Shoes";
+    doc["title"] = "Nike Shoes";
+    doc["description"] = "A nice pair of running shoes.";
+    
+    auto add_op = collection->add(doc.dump(), CREATE);
+    ASSERT_TRUE(add_op.ok());
+    fields = collection->get_fields();
+    ASSERT_EQ(3, fields.size());
+}

--- a/test/collection_all_fields_test.cpp
+++ b/test/collection_all_fields_test.cpp
@@ -607,11 +607,14 @@ TEST_F(CollectionAllFieldsTest, NormalFieldWithAutoType) {
     ASSERT_EQ(1, results["hits"].size());
 
     auto schema = coll1->get_fields();
-    ASSERT_EQ("city", schema[2].name);
-    ASSERT_EQ(field_types::STRING, schema[2].type);
+    ASSERT_EQ("city", schema[0].name);
+    ASSERT_EQ(field_types::STRING, schema[0].type);
 
-    ASSERT_EQ("publication_year", schema[3].name);
-    ASSERT_EQ(field_types::INT64, schema[3].type);
+    ASSERT_EQ("publication_year", schema[1].name);
+    ASSERT_EQ(field_types::INT64, schema[1].type);
+
+    ASSERT_EQ("title", schema[2].name);
+    ASSERT_EQ(field_types::STRING, schema[2].type);
 
     collectionManager.drop_collection("coll1");
 }
@@ -1015,19 +1018,19 @@ TEST_F(CollectionAllFieldsTest, AutoAndStringStarFieldsShouldAcceptNullValues) {
     ASSERT_TRUE(add_op.ok());
 
     schema = coll1->get_fields();
-    ASSERT_EQ(8, schema.size());
+    ASSERT_EQ(7, schema.size());
 
-    ASSERT_EQ("bar_one", schema[4].name);
-    ASSERT_EQ(field_types::STRING, schema[4].type);
+    ASSERT_EQ("bar_one", schema[3].name);
+    ASSERT_EQ(field_types::STRING, schema[3].type);
 
-    ASSERT_EQ("baz_one", schema[5].name);
-    ASSERT_EQ(field_types::BOOL, schema[5].type);
+    ASSERT_EQ("baz_one", schema[4].name);
+    ASSERT_EQ(field_types::BOOL, schema[4].type);
 
-    ASSERT_EQ("buzz", schema[6].name);
-    ASSERT_EQ(field_types::INT64, schema[6].type);
+    ASSERT_EQ("buzz", schema[5].name);
+    ASSERT_EQ(field_types::INT64, schema[5].type);
 
-    ASSERT_EQ("foo", schema[7].name);
-    ASSERT_EQ(field_types::STRING_ARRAY, schema[7].type);
+    ASSERT_EQ("foo", schema[6].name);
+    ASSERT_EQ(field_types::STRING_ARRAY, schema[6].type);
 
     collectionManager.drop_collection("coll1");
 }

--- a/test/collection_all_fields_test.cpp
+++ b/test/collection_all_fields_test.cpp
@@ -2000,8 +2000,11 @@ TEST_F(CollectionAllFieldsTest, AvoidDuplicateDynamicFields) {
         "fields": [
             {"name": "product", "type": "auto"},
             {"name": "title", "type": "auto"},
-            {"name": "description", "type": "string"}
-        ]
+            {"name": "description", "type": "string"},
+            {"name": "nested.price", "type": "auto", "facet": true},
+            {"name": ".*", "type": "auto"}
+        ],
+        "enable_nested_fields": true
     })"_json;
 
     auto create_op = collectionManager.create_collection(schema);
@@ -2009,16 +2012,44 @@ TEST_F(CollectionAllFieldsTest, AvoidDuplicateDynamicFields) {
 
     Collection* collection = create_op.get();
     auto fields = collection->get_fields();
-    ASSERT_EQ(3, fields.size());
+    ASSERT_EQ(5, fields.size());
 
     nlohmann::json doc;
     doc["id"] = "0";
     doc["product"] = "Running Shoes";
     doc["title"] = "Nike Shoes";
     doc["description"] = "A nice pair of running shoes.";
+    doc["nested"] = R"({"price": 100})"_json;
     
     auto add_op = collection->add(doc.dump(), CREATE);
     ASSERT_TRUE(add_op.ok());
     fields = collection->get_fields();
-    ASSERT_EQ(3, fields.size());
+    // it's going to add the parent `nested` field as well
+    ASSERT_EQ(6, fields.size());
+    ASSERT_EQ(field_types::INT64, fields[5].type);
+    ASSERT_TRUE(fields[5].facet);
+
+    auto search_results = collection->search("*", {}, "nested.price: 100", {}, {}, {0}, 10, 1, FREQUENCY, {false});
+    ASSERT_TRUE(search_results.ok());
+    auto results = search_results.get();
+    ASSERT_EQ(1, results["found"].get<size_t>());
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_STREQ("0", results["hits"][0]["document"]["id"].get<std::string>().c_str());
+    
+    auto& document = results["hits"][0]["document"];
+    ASSERT_TRUE(document.contains("nested"));
+    ASSERT_TRUE(document["nested"].is_object());
+    ASSERT_TRUE(document["nested"].contains("price"));
+    ASSERT_EQ(100, document["nested"]["price"].get<int64_t>());
+
+    search_results = collection->search("*", {}, "", {"nested.price"}, {}, {0}, 10, 1, FREQUENCY, {false});
+    ASSERT_TRUE(search_results.ok());
+    results = search_results.get();
+    ASSERT_EQ(1, results["facet_counts"].size());
+    ASSERT_STREQ("nested.price", results["facet_counts"][0]["field_name"].get<std::string>().c_str());
+    ASSERT_EQ(1, results["facet_counts"][0]["counts"].size());
+    ASSERT_STREQ("100", results["facet_counts"][0]["counts"][0]["value"].get<std::string>().c_str());
+    ASSERT_EQ(1, (int)results["facet_counts"][0]["counts"][0]["count"]);
+
+    collectionManager.drop_collection("test");
 }

--- a/test/collection_schema_change_test.cpp
+++ b/test/collection_schema_change_test.cpp
@@ -231,14 +231,14 @@ TEST_F(CollectionSchemaChangeTest, AddNewFieldsToCollection) {
     ASSERT_EQ("Field `id` cannot be altered.", alter_op.error());
 
     ASSERT_EQ(9, coll1->get_schema().size());
-    ASSERT_EQ(12, coll1->get_fields().size());
+    ASSERT_EQ(11, coll1->get_fields().size());
     ASSERT_EQ(5, coll1->_get_index()->_get_numerical_index().size());
 
     // fields should also be persisted properly on disk
     std::string collection_meta_json;
     store->get(Collection::get_meta_key("coll1"), collection_meta_json);
     nlohmann::json collection_meta = nlohmann::json::parse(collection_meta_json);
-    ASSERT_EQ(12, collection_meta["fields"].size());
+    ASSERT_EQ(11, collection_meta["fields"].size());
 
     // try restoring collection from disk: all fields should be preserved
     collectionManager.dispose();
@@ -250,7 +250,7 @@ TEST_F(CollectionSchemaChangeTest, AddNewFieldsToCollection) {
     coll1 = collectionManager.get_collection("coll1").get();
 
     ASSERT_EQ(9, coll1->get_schema().size());
-    ASSERT_EQ(12, coll1->get_fields().size());
+    ASSERT_EQ(11, coll1->get_fields().size());
     ASSERT_EQ(5, coll1->_get_index()->_get_numerical_index().size());
 
     collectionManager.drop_collection("coll1");


### PR DESCRIPTION
## Change Summary
- extend #2651 to ensure the properties of dynamic nested fields are kept after resolution
```json
{
        "name": "companies",
        "fields": [
          {
            "name": ".*",
            "type": "auto"
          },
          {
            "name": "manufacturer",
            "type": "auto",
            "facet": true
          },
          {
            "name": "offer.price",
            "type": "auto",
            "facet": true
          }
        ],
        "enable_nested_fields": true
}
```

Used to report `offer.price` as:
```json
    {
      "facet": false, // <-- when it is actually true
      "index": true,
      "infix": false,
      "locale": "",
      "name": "offer.price",
      "optional": true,
      "sort": true,
      "stem": false,
      "stem_dictionary": "",
      "store": true,
      "truncate_len": 100,
      "type": "int64"
    }
```
fixes #2647 
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
