### PR TITLE
fix(convo-nl): handle conversation & nl model id changes during update

### DIFF
--- a/src/conversation_model_manager.cpp
+++ b/src/conversation_model_manager.cpp
@@ -95,13 +95,42 @@ Option<nlohmann::json> ConversationModelManager::update_model(const std::string&
         return Option<nlohmann::json>(validate_res.code(), validate_res.error());
     }
 
-    auto model_key = get_model_key(model_id);
-    bool insert_op = store->insert(model_key, model_copy.dump(0));
-    if(!insert_op) {
-        return Option<nlohmann::json>(500, "Error while inserting model into the store");
-    }
+    std::string new_model_id = model_copy["id"].get<std::string>();
+    bool id_changed = (new_model_id != model_id);
 
-    models[model_id] = model_copy;
+    if (id_changed) {
+        if (models.find(new_model_id) != models.end()) {
+            return Option<nlohmann::json>(409, "Model id already exists");
+        }
+
+        nlohmann::json old_model = it->second;
+
+        models.erase(it);
+
+        auto old_model_key = get_model_key(model_id);
+        bool remove_op = store->remove(old_model_key);
+        if(!remove_op) {
+            models[model_id] = old_model;
+            return Option<nlohmann::json>(500, "Error while removing old model from the store");
+        }
+
+        models[new_model_id] = model_copy;
+        auto new_model_key = get_model_key(new_model_id);
+        bool insert_op = store->insert(new_model_key, model_copy.dump(0));
+        if(!insert_op) {
+            models.erase(new_model_id);
+            models[model_id] = old_model;
+            return Option<nlohmann::json>(500, "Error while inserting model into the store");
+        }
+    } else {
+        auto model_key = get_model_key(model_id);
+        bool insert_op = store->insert(model_key, model_copy.dump(0));
+        if(!insert_op) {
+            return Option<nlohmann::json>(500, "Error while inserting model into the store");
+        }
+
+        models[model_id] = model_copy;
+    }
 
     return Option<nlohmann::json>(model_copy);
 }


### PR DESCRIPTION
## Change Summary
- add logic to handle model id change during the update process
- check for model id duplication and return appropriate error
- ensure old model is removed from store if id changes and insertion fails
- restore old model on error during model removal or insertion


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
