### PR TITLE
fix: unlock write lock while `validate_and_preprocess`

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -713,7 +713,6 @@ private:
 
     std::string get_facet_str_val(const std::string& field_name, uint32_t facet_id);
 
-
 public:
 
     enum {MAX_ARRAY_MATCHES = 5};

--- a/include/collection.h
+++ b/include/collection.h
@@ -713,6 +713,18 @@ private:
 
     std::string get_facet_str_val(const std::string& field_name, uint32_t facet_id);
 
+    Option<bool> index_preprocess(Index* index, std::vector<index_record>&  iter_batch,
+                                        const std::string& default_sorting_field,
+                                        const tsl::htrie_map<char, field> & actual_search_schema,
+                                        const tsl::htrie_map<char, field> & embedding_fields,
+                                        const std::string& fallback_field_type,
+                                        const std::vector<char>& token_separators,
+                                        const std::vector<char>& symbols_to_index,
+                                        const bool do_validation,
+                                        const size_t remote_embedding_batch_size = 200,
+                                        const size_t remote_embedding_timeout_ms = 60000,
+                                        const size_t remote_embedding_num_tries = 2, const bool generate_embeddings = true) const;
+
 public:
 
     enum {MAX_ARRAY_MATCHES = 5};

--- a/include/collection.h
+++ b/include/collection.h
@@ -408,6 +408,8 @@ private:
 
     // Auto incrementing record ID used internally for indexing - not exposed to the client
     std::atomic<uint32_t> next_seq_id;
+    
+    std::atomic<uint32_t> schema_version = 0;
 
     Store* store;
 

--- a/include/collection.h
+++ b/include/collection.h
@@ -713,17 +713,6 @@ private:
 
     std::string get_facet_str_val(const std::string& field_name, uint32_t facet_id);
 
-    Option<bool> index_preprocess(Index* index, std::vector<index_record>&  iter_batch,
-                                        const std::string& default_sorting_field,
-                                        const tsl::htrie_map<char, field> & actual_search_schema,
-                                        const tsl::htrie_map<char, field> & embedding_fields,
-                                        const std::string& fallback_field_type,
-                                        const std::vector<char>& token_separators,
-                                        const std::vector<char>& symbols_to_index,
-                                        const bool do_validation,
-                                        const size_t remote_embedding_batch_size = 200,
-                                        const size_t remote_embedding_timeout_ms = 60000,
-                                        const size_t remote_embedding_num_tries = 2, const bool generate_embeddings = true) const;
 
 public:
 

--- a/include/index.h
+++ b/include/index.h
@@ -828,6 +828,7 @@ public:
                                      const std::vector<char>& symbols_to_index,
                                      const bool do_validation,
                                      std::unordered_set<std::string>& found_fields,
+                                     std::unique_lock<std::shared_mutex>& coll_write_lock,
                                      const size_t remote_embedding_batch_size = 200,
                                      const size_t remote_embedding_timeout_ms = 60000,
                                      const size_t remote_embedding_num_tries = 2, const bool generate_embeddings = true,

--- a/include/index.h
+++ b/include/index.h
@@ -817,7 +817,19 @@ public:
                                           const std::vector<char>& symbols_to_index,
                                           const bool do_validation, const size_t remote_embedding_batch_size = 200,
                                           const size_t remote_embedding_timeout_ms = 60000, const size_t remote_embedding_num_tries = 2, const bool generate_embeddings = true);
-
+    
+    static void batch_validate_and_preprocess(Index* index, std::vector<index_record>&  iter_batch,
+                                        const std::string& default_sorting_field,
+                                        const tsl::htrie_map<char, field> & actual_search_schema,
+                                        const tsl::htrie_map<char, field> & embedding_fields,
+                                        const std::string& fallback_field_type,
+                                        const std::vector<char>& token_separators,
+                                        const std::vector<char>& symbols_to_index,
+                                        const bool do_validation,
+                                        const size_t remote_embedding_batch_size = 200,
+                                        const size_t remote_embedding_timeout_ms = 60000,
+                                        const size_t remote_embedding_num_tries = 2, const bool generate_embeddings = true);
+                
     static size_t batch_memory_index(Index *index,
                                      std::vector<index_record>& iter_batch,
                                      const std::string& default_sorting_field,
@@ -826,12 +838,7 @@ public:
                                      const std::string& fallback_field_type,
                                      const std::vector<char>& token_separators,
                                      const std::vector<char>& symbols_to_index,
-                                     const bool do_validation,
                                      std::unordered_set<std::string>& found_fields,
-                                     std::unique_lock<std::shared_mutex>& coll_write_lock,
-                                     const size_t remote_embedding_batch_size = 200,
-                                     const size_t remote_embedding_timeout_ms = 60000,
-                                     const size_t remote_embedding_num_tries = 2, const bool generate_embeddings = true,
                                      const bool use_addition_fields = false,
                                      const tsl::htrie_map<char, field>& addition_fields = tsl::htrie_map<char, field>(),
                                      const std::string& collection_name = "");

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -6390,12 +6390,12 @@ Option<bool> Collection::batch_alter_data(const std::vector<field>& alter_fields
             do {
                 ulock.unlock();
                 shlock.lock();
-                auto validation_schema_version = schema_version;
+                auto validation_schema_version = schema_version.load()
                 Index::batch_validate_and_preprocess(index, iter_batch, default_sorting_field, search_schema, embedding_fields,
                                     fallback_field_type, token_separators, symbols_to_index, true, 200, 60000, 2, found_embedding_field);
                 shlock.unlock();
                 ulock.lock();
-            } while(validation_schema_version != schema_version);
+            } while(validation_schema_version != schema_version.load());
             ++schema_version;
 
             Index::batch_memory_index(index, iter_batch, default_sorting_field, search_schema, embedding_fields,

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -6390,7 +6390,7 @@ Option<bool> Collection::batch_alter_data(const std::vector<field>& alter_fields
             do {
                 ulock.unlock();
                 shlock.lock();
-                auto validation_schema_version = schema_version.load()
+                auto validation_schema_version = schema_version.load();
                 Index::batch_validate_and_preprocess(index, iter_batch, default_sorting_field, search_schema, embedding_fields,
                                     fallback_field_type, token_separators, symbols_to_index, true, 200, 60000, 2, found_embedding_field);
                 shlock.unlock();

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -6385,10 +6385,19 @@ Option<bool> Collection::batch_alter_data(const std::vector<field>& alter_fields
             }
 
             std::unordered_set<std::string> dummy;
-            Index::batch_validate_and_preprocess(index, iter_batch, default_sorting_field, search_schema, embedding_fields,
-                                    fallback_field_type, token_separators, symbols_to_index, true, 200, 60000, 2, found_embedding_field);
             shlock.unlock();
             ulock.lock();
+            do {
+                ulock.unlock();
+                shlock.lock();
+                auto validation_schema_version = schema_version;
+                Index::batch_validate_and_preprocess(index, iter_batch, default_sorting_field, search_schema, embedding_fields,
+                                    fallback_field_type, token_separators, symbols_to_index, true, 200, 60000, 2, found_embedding_field);
+                shlock.unlock();
+                ulock.lock();
+            } while(validation_schema_version != schema_version);
+            ++schema_version;
+
             Index::batch_memory_index(index, iter_batch, default_sorting_field, search_schema, embedding_fields,
                                       fallback_field_type, token_separators, symbols_to_index, dummy, true, schema_additions);
             ulock.unlock();

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -6385,12 +6385,13 @@ Option<bool> Collection::batch_alter_data(const std::vector<field>& alter_fields
             }
 
             std::unordered_set<std::string> dummy;
+            uint32_t validation_schema_version;
             shlock.unlock();
             ulock.lock();
             do {
                 ulock.unlock();
                 shlock.lock();
-                auto validation_schema_version = schema_version.load();
+                validation_schema_version = schema_version.load();
                 Index::batch_validate_and_preprocess(index, iter_batch, default_sorting_field, search_schema, embedding_fields,
                                     fallback_field_type, token_separators, symbols_to_index, true, 200, 60000, 2, found_embedding_field);
                 shlock.unlock();

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -901,7 +901,6 @@ size_t Collection::batch_index_in_memory(std::vector<index_record>& index_record
     lock.unlock();
 
     Index::update_async_references(collection_name, index_records, found_async_referenced_ins);
-    LOG(INFO) << "Releasing the lock to batch index in memory";
     return num_indexed;
 }
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -452,6 +452,61 @@ bool validate_object_field(nlohmann::json& doc, const field& a_field) {
     return false;
 }
 
+void Index::batch_validate_and_preprocess(Index* index, std::vector<index_record>&  iter_batch,
+                                        const std::string& default_sorting_field,
+                                        const tsl::htrie_map<char, field> & actual_search_schema,
+                                        const tsl::htrie_map<char, field> & embedding_fields,
+                                        const std::string& fallback_field_type,
+                                        const std::vector<char>& token_separators,
+                                        const std::vector<char>& symbols_to_index,
+                                        const bool do_validation,
+                                        const size_t remote_embedding_batch_size,
+                                        const size_t remote_embedding_timeout_ms,
+                                        const size_t remote_embedding_num_tries, const bool generate_embeddings) {
+    const size_t concurrency = Config::get_instance().get_max_indexing_concurrency();
+    const size_t num_threads = std::min(concurrency, iter_batch.size());
+    const size_t window_size = (num_threads == 0) ? 0 :
+                               (iter_batch.size() + num_threads - 1) / num_threads;  // rounds up
+
+    size_t num_indexed = 0;
+    size_t num_processed = 0;
+    std::mutex m_process;
+    std::condition_variable cv_process;
+
+    size_t num_queued = 0;
+    size_t batch_index = 0;
+
+    // local is need to propogate the thread local inside threads launched below
+    auto local_write_log_index = write_log_index;
+    for(size_t thread_id = 0; thread_id < num_threads && batch_index < iter_batch.size(); thread_id++) {
+        size_t batch_len = window_size;
+
+        if(batch_index + window_size > iter_batch.size()) {
+            batch_len = iter_batch.size() - batch_index;
+        }
+
+        num_queued++;
+
+        index->thread_pool->enqueue([&, batch_index, batch_len]() {
+            write_log_index = local_write_log_index;
+            Index::validate_and_preprocess(index, iter_batch, batch_index, batch_len, default_sorting_field, actual_search_schema,
+                                    embedding_fields, fallback_field_type, token_separators, symbols_to_index, do_validation, remote_embedding_batch_size, remote_embedding_timeout_ms, remote_embedding_num_tries, generate_embeddings);
+
+            std::unique_lock<std::mutex> lock(m_process);
+            num_processed++;
+
+            cv_process.notify_one();
+        });
+
+        batch_index += batch_len;
+    }
+
+    {
+        std::unique_lock<std::mutex> lock_process(m_process);
+        cv_process.wait(lock_process, [&](){ return num_processed == num_queued; });
+    }
+}
+
 void Index::validate_and_preprocess(Index *index,
                                     std::vector<index_record>& iter_batch,
                                     const size_t batch_start_index, const size_t batch_size,
@@ -580,12 +635,7 @@ size_t Index::batch_memory_index(Index *index,
                                  const std::string& fallback_field_type,
                                  const std::vector<char>& token_separators,
                                  const std::vector<char>& symbols_to_index,
-                                 const bool do_validation,
                                  std::unordered_set<std::string>& found_fields,
-                                 std::unique_lock<std::shared_mutex>& coll_write_lock,
-                                 const size_t remote_embedding_batch_size,
-                                 const size_t remote_embedding_timeout_ms, const size_t remote_embedding_num_tries,
-                                 const bool generate_embeddings,
                                  const bool use_addition_fields, const tsl::htrie_map<char, field>& addition_fields,
                                  const std::string& collection_name) {
     const size_t concurrency = Config::get_instance().get_max_indexing_concurrency();
@@ -600,40 +650,10 @@ size_t Index::batch_memory_index(Index *index,
     std::condition_variable cv_process;
 
     size_t num_queued = 0;
-    size_t batch_index = 0;
 
     // local is need to propogate the thread local inside threads launched below
     auto local_write_log_index = write_log_index;
-    coll_write_lock.unlock();
-    for(size_t thread_id = 0; thread_id < num_threads && batch_index < iter_batch.size(); thread_id++) {
-        size_t batch_len = window_size;
-
-        if(batch_index + window_size > iter_batch.size()) {
-            batch_len = iter_batch.size() - batch_index;
-        }
-
-        num_queued++;
-
-        index->thread_pool->enqueue([&, batch_index, batch_len]() {
-            write_log_index = local_write_log_index;
-            validate_and_preprocess(index, iter_batch, batch_index, batch_len, default_sorting_field, actual_search_schema,
-                                    embedding_fields, fallback_field_type, token_separators, symbols_to_index, do_validation, remote_embedding_batch_size, remote_embedding_timeout_ms, remote_embedding_num_tries, generate_embeddings);
-
-            std::unique_lock<std::mutex> lock(m_process);
-            num_processed++;
-
-            cv_process.notify_one();
-        });
-
-        batch_index += batch_len;
-    }
-
-    {
-        std::unique_lock<std::mutex> lock_process(m_process);
-        cv_process.wait(lock_process, [&](){ return num_processed == num_queued; });
-    }
-
-    coll_write_lock.lock();
+    
     for(size_t i = 0; i < iter_batch.size(); i++) {
         auto& index_rec = iter_batch[i];
 
@@ -653,7 +673,6 @@ size_t Index::batch_memory_index(Index *index,
         }
     }
 
-    num_queued = num_processed = 0;
     std::unique_lock ulock(index->mutex);
 
     for(const auto& field_name: found_fields) {


### PR DESCRIPTION
## Change Summary
Locking the write lock for the collection when indexing documents blocks other operations for a long time if a large batch of documents needs embedding generation.

This PR proposes fine-grain the lock mechanism by unlocking the write lock while `validate_and_preprocess` jobs are running.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
