### PR TITLE
fix(sort): fix non-deterministic sorting in bucketing with group_by

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -2962,7 +2962,7 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) c
             }
 
             // sort again based on bucketed match score
-            std::partial_sort(raw_result_kvs.begin(), raw_result_kvs.begin() + max_kvs_bucketed, raw_result_kvs.end(),
+            std::stable_sort(raw_result_kvs.begin(), raw_result_kvs.begin() + max_kvs_bucketed,
                               KV::is_greater_kv_group);
 
             // restore original scores
@@ -3009,7 +3009,7 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) c
             }
 
             // sort again based on bucketed match score
-            std::partial_sort(raw_result_kvs.begin(), raw_result_kvs.begin() + max_kvs_bucketed, raw_result_kvs.end(),
+            std::stable_sort(raw_result_kvs.begin(), raw_result_kvs.begin() + max_kvs_bucketed,
                               KV::is_greater_kv_group);
 
             // restore original scores


### PR DESCRIPTION
## Change Summary


When using `_text_match(buckets: N)` with `group_by`, the same group could appear on different pages across separate search requests. This occurred because:

1. `std::partial_sort` used for bucketing is not stable - it doesn't preserve relative order of equivalent elements
2. The group comparator didn't include `distinct_key` as a tie-breaker, making ordering non-deterministic when groups had identical scores


- **Extended group comparator**: Added `distinct_key` to `KV::is_greater_kv_group` comparison function to ensure deterministic ordering even when scores are identical
- **Replaced `partial_sort` with `stable_sort`**: Changed sorting algorithm for both text match and vector distance bucketing to maintain stability and preserve relative order


Added `BucketingWithGroupByNoDuplicates` test that:
- Creates 500 unique groups (exceeding `DEFAULT_TOPSTER_SIZE` of 250)
- Performs multiple paginated searches with bucketing and grouping
- Verifies each group appears on exactly one page and remains stable across iterations

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
