### PR TITLE
show geo_distance_meters for filter queries

### DIFF
--- a/include/filter.h
+++ b/include/filter.h
@@ -86,6 +86,10 @@ struct filter {
     static Option<bool> tokenize_filter_query(const std::string& filter_query, std::queue<std::string>& tokens);
 
     static Option<bool> parse_filter_string(const std::string& filter_query, std::string& token, size_t& index);
+
+    static bool extract_geo_field_value(const std::string& expr, std::string& ref_coll,
+                                                      std::string& field_name, std::vector<std::string>& value,
+                                                      bool is_reference_filter);
 };
 
 struct filter_node_t {

--- a/include/index.h
+++ b/include/index.h
@@ -1176,7 +1176,14 @@ public:
                                                 const std::map<basic_string<char>, reference_filter_result_t>& references,
                                                 const S2LatLng& reference_lat_lng, const bool& round_distance = false) const;
 
+    Option<int64_t> get_referenced_geo_distance(const filter& filter_exp, const uint32_t& seq_id,
+                                                const std::map<basic_string<char>, reference_filter_result_t>& references,
+                                                const S2LatLng& reference_lat_lng, const bool& round_distance = false) const;
+
     Option<std::vector<uint32_t>> get_ref_seq_ids(const sort_by& sort_field, const uint32_t& seq_id,
+                                                  const std::map<std::string, reference_filter_result_t>& references) const;
+
+    Option<std::vector<uint32_t>> get_ref_seq_ids(const filter& filter_exp, const uint32_t& seq_id,
                                                   const std::map<std::string, reference_filter_result_t>& references) const;
 
     void get_top_k_result_ids(const std::vector<std::vector<KV*>>& raw_result_kvs, std::vector<uint32_t>& result_ids) const;

--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -385,4 +385,6 @@ struct StringUtils {
 
         return escaped.str();
     }
+
+    static bool isValidGeoDistanceFilter(const std::string& str);
 };

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -3227,6 +3227,56 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) c
                 }
             }
 
+            if(geo_distances.empty() && search_params->filter_tree_root_guard.get()) {
+                //sort params were not having geopoint, should check if filter params contain geopoint
+                auto filter_exp = search_params->filter_tree_root_guard.get()->filter_exp;
+                auto field_name = filter_exp.field_name;
+                auto values = filter_exp.values;
+                bool is_geopoint = false;
+                bool is_reference_filter = !filter_exp.referenced_collection_name.empty();
+
+                if(!field_name.empty()) {
+                    std::string full_expr = field_name;
+                    std::string coll = is_reference_filter ? filter_exp.referenced_collection_name : get_name();
+
+                    if(filter::extract_geo_field_value(full_expr, coll, field_name, values, is_reference_filter)) {
+                        is_geopoint = true;
+                        filter_exp.referenced_collection_name = coll;
+                        filter_exp.field_name = field_name;
+                    }
+                }
+
+                if(is_geopoint && values.size() == 1 && StringUtils::isValidGeoDistanceFilter(values[0])) {
+                    //only geopoint is supported, no geopolygon or arrays
+                    std::vector<std::string> tokens;
+
+                    StringUtils::split(values[0], tokens, ",");
+                    const auto& lat = std::stod(tokens[0]);
+                    const auto& lng = std::stod(tokens[1]);
+                    S2LatLng reference_lat_lng = S2LatLng::FromDegrees(lat, lng);
+
+                    if (is_reference_filter) {
+                        auto get_geo_distance_op = index->get_referenced_geo_distance(filter_exp,
+                                                                                      field_order_kv->key,
+                                                                                      field_order_kv->reference_filter_results,
+                                                                                      reference_lat_lng, true);
+                        if (!get_geo_distance_op.ok()) {
+                            return Option<nlohmann::json>(get_geo_distance_op.code(), get_geo_distance_op.error());
+                        }
+                        field_name = "$" + filter_exp.referenced_collection_name + "(" + field_name + ")";
+                        geo_distances[field_name] = get_geo_distance_op.get();
+                    } else {
+                        auto get_geo_distance_op = index->get_geo_distance_with_lock(field_name, false,
+                                                                                     {(uint32_t) field_order_kv->key},
+                                                                                     reference_lat_lng, true);
+                        if (!get_geo_distance_op.ok()) {
+                            return Option<nlohmann::json>(get_geo_distance_op.code(), get_geo_distance_op.error());
+                        }
+                        geo_distances[field_name] = get_geo_distance_op.get();
+                    }
+                }
+            }
+
             if(!geo_distances.empty()) {
                 wrapper_doc["geo_distance_meters"] = geo_distances;
             }

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -1072,3 +1072,51 @@ Option<bool> filter::parse_filter_string(const std::string& filter_query, std::s
     token += filter_query.substr(token_start_index, index - token_start_index);
     return Option<bool>(true);
 }
+
+bool filter::extract_geo_field_value(const std::string& expr, std::string& coll,
+                                                   std::string& field_name, std::vector<std::string>& values,
+                                                   bool is_reference_filter) {
+    if (is_reference_filter) {
+        auto full_expr = expr;
+        while (full_expr[0] == '$') {
+            //skip to inner most reference
+            auto pos = full_expr.find('(');
+            coll = full_expr.substr(1, pos - 1); //exclude '('
+            full_expr = full_expr.substr(pos + 1); //start after '('
+            full_expr.pop_back(); //remove trailing ')'
+        }
+
+        size_t colon_pos = full_expr.find(':');
+        auto count = std::count(full_expr.begin(), full_expr.end(), ':');
+        if (count == 1 && colon_pos != std::string::npos) { //avoid AND/OR filtering
+            std::string extracted_field_name = full_expr.substr(0, colon_pos);
+            std::string value_part = full_expr.substr(colon_pos + 1);
+
+            // Trim whitespace
+            extracted_field_name = StringUtils::trim(extracted_field_name);
+            value_part = StringUtils::trim(value_part);
+
+            if (value_part[0] == '(' || value_part[0] == '[') {
+                value_part = value_part.substr(1, value_part.size() - 2); //remove '(' ')' '[' ']'
+            }
+
+            field_name = extracted_field_name;
+            values.clear();
+            values.push_back(value_part);
+        } else {
+            return false;
+        }
+    }
+    //for normal geopoint filter, values , field are already processed
+    auto collection = CollectionManager::get_instance().get_collection(coll);
+    if (field_name != "id" && collection) {
+        const auto& schema = collection->get_schema();
+        if(schema.find(field_name) != schema.end()) {
+            return schema.at(field_name).is_geopoint();
+        } else {
+            LOG(ERROR) << "field_name not found in schema : " << field_name;
+        }
+    }
+
+    return false;
+}

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -8676,6 +8676,26 @@ Option<std::vector<uint32_t>> Index::get_ref_seq_ids(const sort_by& sort_field, 
     return get_ref_seq_ids_helper(ref_seq_ids, collection_name, references_ptr, ref_collection_name);;
 }
 
+Option<std::vector<uint32_t>> Index::get_ref_seq_ids(const filter& filter_exp, const uint32_t& seq_id,
+                                                      const std::map<std::string, reference_filter_result_t>& references) const {
+    std::vector<uint32_t> ref_seq_ids;
+    std::string ref_collection_name = filter_exp.referenced_collection_name;
+
+    // For filter-based references, check if the referenced collection is in the references map
+    if (references.count(ref_collection_name) > 0) { // Join specified in filter_by.
+        const auto& ref_result = references.at(ref_collection_name);
+        ref_seq_ids = std::vector<uint32_t>(ref_result.docs, ref_result.docs + ref_result.count);
+        return Option<std::vector<uint32_t>>(ref_seq_ids);
+    }
+
+    auto collection_name = get_collection_name_with_lock();
+    auto const* references_ptr = &(references);
+    ref_seq_ids.emplace_back(seq_id);
+
+    // todo?: update references to include the ref_ids of the seq_id for future use.
+    return get_ref_seq_ids_helper(ref_seq_ids, collection_name, references_ptr, ref_collection_name);
+}
+
 Option<std::vector<uint32_t>> Index::get_ref_seq_ids_helper(const std::vector<uint32_t>& seq_ids_vec,
                                                             std::string& coll_name,
                                                             std::map<std::string, reference_filter_result_t> const*& references,
@@ -8775,6 +8795,30 @@ Option<int64_t> Index::get_referenced_geo_distance(const sort_by& sort_field, co
     return ref_collection->get_geo_distance_with_lock(sort_field.name, is_asc, get_ref_seq_id_op.get(), reference_lat_lng,
                                                       round_distance);
 }
+
+Option<int64_t> Index::get_referenced_geo_distance(const filter& filter_exp, const uint32_t& seq_id,
+                                                   const std::map<basic_string<char>, reference_filter_result_t>& references,
+                                                   const S2LatLng& reference_lat_lng, const bool& round_distance) const {
+    // Get reference sequence IDs using the filter expression
+    auto get_ref_seq_ids_op = get_ref_seq_ids(filter_exp, seq_id, references);
+    if (!get_ref_seq_ids_op.ok()) {
+        return Option<int64_t>(400, get_ref_seq_ids_op.error());
+    } else if (get_ref_seq_ids_op.get().empty()) { // No references found.
+        return Option<int64_t>(0);
+    }
+
+    auto& cm = CollectionManager::get_instance();
+    const auto& ref_collection_name = filter_exp.referenced_collection_name;
+    auto ref_collection = cm.get_collection(ref_collection_name);
+    if (ref_collection == nullptr) {
+        return Option<int64_t>(400, "Referenced collection `" + ref_collection_name + "` in filter not found.");
+    }
+
+    // Get the geo distance from the referenced collection
+    return ref_collection->get_geo_distance_with_lock(filter_exp.field_name, false, get_ref_seq_ids_op.get(), reference_lat_lng,
+                                                      round_distance);
+}
+
 
 void Index::get_top_k_result_ids(const std::vector<std::vector<KV*>>& raw_result_kvs,
                                  std::vector<uint32_t>& result_ids) const{

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -9,6 +9,7 @@
 #include <arpa/inet.h>
 #include <join.h>
 #include "logger.h"
+#include <regex>
 
 StringUtils::StringUtils() {
     UErrorCode errcode = U_ZERO_ERROR;
@@ -471,4 +472,10 @@ size_t StringUtils::split_facet(const std::string &s, std::vector<std::string> &
 
 size_t StringUtils::get_occurence_count(const std::string &str, char symbol) {
     return std::count(str.begin(), str.end(), symbol);
+}
+
+bool StringUtils::isValidGeoDistanceFilter(const std::string& str) {
+    static const std::regex re(
+            R"(^\s*([-+]?[0-9]*\.?[0-9]+)\s*,\s*([-+]?[0-9]*\.?[0-9]+)\s*,\s*(.+?)(?:\s*,\s*([A-Za-z]+))?\s*$)");
+    return std::regex_match(str, re);
 }

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -11637,3 +11637,236 @@ TEST_F(CollectionJoinTest, MutualReferences) {
 
     ASSERT_EQ(0, collection_create_op.get()->get_schema().count("reference_field"));
 }
+
+TEST_F(CollectionJoinTest, GeoFilterReferenceDistanceTest) {
+    nlohmann::json products_schema = R"({
+        "name": "Products",
+        "fields": [
+            {"name": "product_id", "type": "string"},
+            {"name": "product_name", "type": "string"},
+            {"name": "customer_id", "type": "string", "reference": "Customers.customer_id"}
+        ]
+    })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(products_schema);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto products_collection = collection_create_op.get();
+
+    nlohmann::json customers_schema = R"({
+        "name": "Customers",
+        "fields": [
+            {"name": "customer_id", "type": "string"},
+            {"name": "name", "type": "string"},
+            {"name": "product_location", "type": "geopoint"}
+        ]
+    })"_json;
+
+    collection_create_op = collectionManager.create_collection(customers_schema);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto customers_collection = collection_create_op.get();
+
+    std::vector<nlohmann::json> customers = {
+            R"({
+                "customer_id": "customer_a",
+                "name": "Joe",
+                "product_location": [48.87538726829884, 2.296113163780903]
+            })"_json,
+            R"({
+                "customer_id": "customer_b",
+                "name": "Jane",
+                "product_location": [48.85468534184446, 2.342317694452325]
+            })"_json,
+    };
+
+    for (const auto & customer : customers) {
+        auto add_op = customers_collection->add(customer.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    std::vector<nlohmann::json> products = {
+            R"({
+                "product_id": "product_a",
+                "product_name": "shampoo",
+                "customer_id": "customer_a"
+            })"_json,
+            R"({
+                "product_id": "product_b",
+                "product_name": "conditioner",
+                "customer_id": "customer_b"
+            })"_json,
+    };
+
+    for (const auto & product : products) {
+        auto add_op = products_collection->add(product.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    // Test: Use geo filter on reference collection and verify geo_distance_meters is populated
+    std::map<std::string, std::string> req_params = {
+            {"collection", "Products"},
+            {"q", "*"},
+            {"query_by", "product_name"},
+            {"filter_by", "$Customers(product_location:(48.87709, 2.33495, 25km))"},  // Geo filter on referenced collection
+    };
+
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+    nlohmann::json embedded_params;
+    std::string json_res;
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    auto res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, res_obj["found"].get<size_t>());
+    ASSERT_EQ(2, res_obj["hits"].size());
+
+    // Verify that geo_distance_meters is populated for the referenced geo filter
+    ASSERT_TRUE(res_obj["hits"][0].contains("geo_distance_meters"));
+    ASSERT_TRUE(res_obj["hits"][0]["geo_distance_meters"].contains("$Customers(product_location)"));
+    ASSERT_EQ(2548, res_obj["hits"][0]["geo_distance_meters"]["$Customers(product_location)"]);
+
+    ASSERT_TRUE(res_obj["hits"][1].contains("geo_distance_meters"));
+    ASSERT_TRUE(res_obj["hits"][1]["geo_distance_meters"].contains("$Customers(product_location)"));
+    ASSERT_EQ(2845, res_obj["hits"][1]["geo_distance_meters"]["$Customers(product_location)"]);
+}
+
+TEST_F(CollectionJoinTest, GeoFilterDeepNestedReferenceDistanceTest) {
+    // Create a nested reference scenario
+    nlohmann::json products_schema = R"({
+        "name": "Products",
+        "fields": [
+            {"name": "product_id", "type": "string"},
+            {"name": "product_name", "type": "string"},
+            {"name": "customer_id", "type": "string", "reference": "Customers.customer_id"}
+        ]
+    })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(products_schema);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto products_collection = collection_create_op.get();
+
+    nlohmann::json customers_schema = R"({
+        "name": "Customers",
+        "fields": [
+            {"name": "customer_id", "type": "string"},
+            {"name": "name", "type": "string"},
+            {"name": "address_id", "type": "string", "reference": "Addresses.address_id"}
+        ]
+    })"_json;
+
+    collection_create_op = collectionManager.create_collection(customers_schema);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto customers_collection = collection_create_op.get();
+
+    nlohmann::json addresses_schema = R"({
+        "name": "Addresses",
+        "fields": [
+            {"name": "address_id", "type": "string"},
+            {"name": "city", "type": "string"},
+            {"name": "location", "type": "geopoint"}
+        ]
+    })"_json;
+
+    collection_create_op = collectionManager.create_collection(addresses_schema);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto addresses_collection = collection_create_op.get();
+
+    // Add documents to Addresses (deepest level)
+    std::vector<nlohmann::json> addresses = {
+            R"({
+                "address_id": "addr_a",
+                "city": "Paris",
+                "location": [48.8566, 2.3522]
+            })"_json,
+            R"({
+                "address_id": "addr_b",
+                "city": "London",
+                "location": [51.5074, -0.1278]
+            })"_json,
+    };
+
+    for (const auto & address : addresses) {
+        auto add_op = addresses_collection->add(address.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    // Add documents to Customers
+    std::vector<nlohmann::json> customers = {
+            R"({
+                "customer_id": "customer_a",
+                "name": "Joe",
+                "address_id": "addr_a"
+            })"_json,
+            R"({
+                "customer_id": "customer_b",
+                "name": "Jane",
+                "address_id": "addr_b"
+            })"_json,
+    };
+
+    for (const auto & customer : customers) {
+        auto add_op = customers_collection->add(customer.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    // Add documents to Products
+    std::vector<nlohmann::json> products = {
+            R"({
+                "product_id": "product_a",
+                "product_name": "shampoo",
+                "customer_id": "customer_a"
+            })"_json,
+            R"({
+                "product_id": "product_b",
+                "product_name": "conditioner",
+                "customer_id": "customer_b"
+            })"_json,
+    };
+
+    for (const auto & product : products) {
+        auto add_op = products_collection->add(product.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    // Test: Use deep nested geo filter and verify geo_distance_meters is populated
+    std::map<std::string, std::string> req_params = {
+            {"collection", "Products"},
+            {"q", "*"},
+            {"query_by", "product_name"},
+            {"filter_by", "$Customers($Addresses(location:(48.85, 2.35, 50km)))"},  // Deep nested geo filter
+            {"include_fields", "product_id, $Customers(name, strategy:merge)"},
+    };
+
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+    nlohmann::json embedded_params;
+    std::string json_res;
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    auto res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, res_obj["found"].get<size_t>());
+    ASSERT_EQ(1, res_obj["hits"].size());
+
+    // Verify that geo_distance_meters is populated for the referenced geo filter
+    ASSERT_TRUE(res_obj["hits"][0].contains("geo_distance_meters"));
+    ASSERT_TRUE(res_obj["hits"][0]["geo_distance_meters"].contains("$Addresses(location)"));
+    ASSERT_EQ(751, res_obj["hits"][0]["geo_distance_meters"]["$Addresses(location)"]);
+}

--- a/test/geo_filtering_test.cpp
+++ b/test/geo_filtering_test.cpp
@@ -906,3 +906,57 @@ TEST_F(GeoFilteringTest, GeoPolygonTestRealCoordinates) {
         ASSERT_EQ("Geopolygon for seq_id 3 is invalid: Loop 0: empty loops are not allowed", op.error());
     }
 }
+
+TEST_F(GeoFilteringTest, GeoDistanceMeters) {
+    nlohmann::json schema = R"({
+            "name": "companies",
+            "fields": [
+                {"name": "company_name", "type": "string" },
+                {"name": "num_employees", "type": "int32" },
+                {"name": "location", "type": "geopoint" }
+            ],
+            "default_sorting_field": "num_employees"
+    })"_json;
+
+    auto coll_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(coll_op.ok());
+    Collection* coll1 = coll_op.get();
+
+    std::vector<std::vector<std::string>> records = {
+            {"Stark Industries", "5215", "48.8, 2.3"},
+            {"Acme Corp", "2133", "48.8, 2.4"}
+    };
+
+    for(size_t i=0; i<records.size(); i++) {
+        nlohmann::json doc;
+
+        std::vector<std::string> lat_lng;
+        StringUtils::split(records[i][2], lat_lng, ", ");
+
+        double lat = std::stod(lat_lng[0]);
+        double lng = std::stod(lat_lng[1]);
+
+        doc["id"] = std::to_string(i);
+        doc["company_name"] = records[i][0];
+        doc["location"] = {lat, lng};
+        doc["num_employees"] = std::stoul(records[i][1]);
+
+        ASSERT_TRUE(coll1->add(doc.dump()).ok());
+    }
+
+    auto results = coll1->search("*",
+                                 {}, "location:(48.9, 2.3, 25.0 km)",
+                                 {}, {}, {0}, 10, 1, FREQUENCY).get();
+
+    ASSERT_EQ(2, results["found"].get<size_t>());
+    ASSERT_EQ(2, results["hits"].size());
+    ASSERT_EQ("0", results["hits"][0]["document"]["id"]);
+    ASSERT_EQ(1, results["hits"][0].count("geo_distance_meters"));
+    ASSERT_EQ(1, results["hits"][0]["geo_distance_meters"].count("location"));
+    ASSERT_EQ(11117, results["hits"][0]["geo_distance_meters"]["location"]);
+
+    ASSERT_EQ("1", results["hits"][1]["document"]["id"]);
+    ASSERT_EQ(1, results["hits"][1].count("geo_distance_meters"));
+    ASSERT_EQ(1, results["hits"][1]["geo_distance_meters"].count("location"));
+    ASSERT_EQ(13308, results["hits"][1]["geo_distance_meters"]["location"]);
+}


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- compute and show geo_distance_meters for filter queries with geopints
- only supports geopoints, not geopolygon or geopoint arrays
- supports references and joins

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
