### PR TITLE
FEATURE: `POST /health {"shutdown":true}` sets failing health

### DIFF
--- a/include/http_server.h
+++ b/include/http_server.h
@@ -138,6 +138,8 @@ private:
 
     std::atomic<bool> exit_loop;
 
+    std::atomic<bool> unhealthy;
+
     std::string version;
 
     // must be a vector since order of routes entered matter
@@ -217,6 +219,10 @@ public:
     ReplicationState* get_replication_state() const;
 
     bool is_alive() const;
+
+    bool unhealthy_set() const;
+
+    bool set_unhealthy();
 
     bool is_leader() const;
 

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -371,7 +371,7 @@ bool patch_update_collection(const std::shared_ptr<http_req>& req, const std::sh
             res->set_400("The `curation_sets` value should be an array.");
             return false;
         }
-        
+
         auto curation_sets = req_json["curation_sets"].get<std::vector<std::string>>();
         auto op = CollectionManager::get_instance().update_collection_curation_sets(req->params["collection"], curation_sets);
         if(!op.ok()) {
@@ -444,7 +444,7 @@ bool get_debug(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_
 
 bool get_health_with_resource_usage(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     nlohmann::json result;
-    bool alive = server->is_alive();
+    bool alive = server->is_alive() && !server->unhealthy_set();
 
     auto resource_check = cached_resource_stat_t::get_instance().has_enough_resources(
         Config::get_instance().get_data_dir(),
@@ -485,7 +485,7 @@ bool get_health_with_resource_usage(const std::shared_ptr<http_req>& req, const 
 
 bool get_health(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     nlohmann::json result;
-    bool alive = server->is_alive();
+    bool alive = server->is_alive() && !server->unhealthy_set();
     result["ok"] = alive;
 
     auto resource_check = cached_resource_stat_t::get_instance().has_enough_resources(
@@ -509,7 +509,30 @@ bool get_health(const std::shared_ptr<http_req>& req, const std::shared_ptr<http
 
 bool post_health(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     nlohmann::json result;
-    bool alive = server->is_alive();
+    bool alive = server->is_alive() && !server->unhealthy_set();
+    if (!req->body.empty()) {
+        // check if the request body is a JSON object with a "shutdown" key
+        nlohmann::json req_json;
+        try {
+            req_json = nlohmann::json::parse(req->body);
+        } catch(const std::exception& e) {
+            // return 400 with the error message
+            // but also return the alive status
+            LOG(ERROR) << "JSON error: " << e.what();
+            result["ok"] = alive;
+            result["error"] = "Bad JSON.";
+            res->set_body(400, result.dump());
+            return alive;
+        }
+        if(req_json.contains("shutdown") && req_json["shutdown"] == true) {
+            server->set_unhealthy();
+            result["ok"] = false;
+            result["msg"] = "Shutdown requested.";
+            res->set_body(200, result.dump());
+            return false;
+        }
+    }
+    // default behavior
     result["ok"] = alive;
 
     if(alive) {
@@ -1258,7 +1281,7 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
         std::vector<std::string> exclude_fields;
         StringUtils::split(req->params["exclude_fields"], exclude_fields, ",");
         bool exclude_conversation_history = std::find(exclude_fields.begin(), exclude_fields.end(), "conversation_history") != exclude_fields.end();
-        
+
         auto new_conversation_op = ConversationManager::get_last_n_messages(conversation_history["conversation"], 2);
         if(!new_conversation_op.ok()) {
             res->set_400(new_conversation_op.error());
@@ -3026,7 +3049,7 @@ bool post_proxy(const std::shared_ptr<http_req>& req, const std::shared_ptr<http
         return false;
     }
 
-    try {        
+    try {
         if(req_json.count("body") != 0 && !req_json["body"].is_string()) {
             res->set_400("Body must be a string.");
             return false;
@@ -3050,7 +3073,7 @@ bool post_proxy(const std::shared_ptr<http_req>& req, const std::shared_ptr<http
     }
 
     auto response = proxy.send(url, method, body, headers);
-    
+
     if(response.status_code != 200) {
         int code = response.status_code;
         res->set_body(code, response.body);
@@ -3181,7 +3204,7 @@ bool put_conversation_model(const std::shared_ptr<http_req>& req, const std::sha
 
 bool post_personalization_model(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     nlohmann::json req_json;
-    
+
     if (!req->params.count("name") || !req->params.count("type")) {
         res->set_400("Missing required parameters 'name' and 'type'.");
         return false;
@@ -3204,19 +3227,19 @@ bool post_personalization_model(const std::shared_ptr<http_req>& req, const std:
         res->set(create_op.code(), create_op.error());
         return false;
     }
-    
+
     auto model = create_op.get();
     if (model.contains("model_path")) {
       model.erase("model_path");
     }
     res->set_201(model.dump());
-    
+
     return true;
 }
 
 bool get_personalization_model(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     const std::string& model_id = req->params["id"];
-    
+
     auto model_op = PersonalizationModelManager::get_model(model_id);
     if (!model_op.ok()) {
         res->set(model_op.code(), model_op.error());
@@ -3252,7 +3275,7 @@ bool get_personalization_models(const std::shared_ptr<http_req>& req, const std:
 
 bool del_personalization_model(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     const std::string& model_id = req->params["id"];
-    
+
     auto delete_op = PersonalizationModelManager::delete_model(model_id);
     if (!delete_op.ok()) {
         res->set(delete_op.code(), delete_op.error());
@@ -3269,7 +3292,7 @@ bool del_personalization_model(const std::shared_ptr<http_req>& req, const std::
 
 bool put_personalization_model(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     nlohmann::json req_json;
-    
+
     if (req->params.count("name") && !req->params["name"].empty()) {
         req_json["name"] = req->params["name"];
     }

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -19,7 +19,7 @@ HttpServer::HttpServer(const std::string & version, const std::string & listen_a
                        const uint64_t ssl_refresh_interval_ms, bool cors_enabled,
                        const std::set<std::string>& cors_domains, ThreadPool* thread_pool):
         SSL_REFRESH_INTERVAL_MS(ssl_refresh_interval_ms),
-        exit_loop(false), version(version), listen_address(listen_address), listen_port(listen_port),
+        exit_loop(false), unhealthy(false), version(version), listen_address(listen_address), listen_port(listen_port),
         ssl_cert_path(ssl_cert_path), ssl_cert_key_path(ssl_cert_key_path),
         cors_enabled(cors_enabled), cors_domains(cors_domains), thread_pool(thread_pool) {
     accept_ctx = new h2o_accept_ctx_t();
@@ -1092,6 +1092,15 @@ ReplicationState* HttpServer::get_replication_state() const {
 
 bool HttpServer::is_alive() const {
     return replication_state->is_alive();
+}
+
+bool HttpServer::unhealthy_set() const {
+    return unhealthy;
+}
+
+bool HttpServer::set_unhealthy() {
+    unhealthy = true;
+    return unhealthy;
 }
 
 bool HttpServer::get_route(uint64_t hash, route_path** found_rpath) {


### PR DESCRIPTION
## Change Summary
this would add a `POST /health {"shutdown": true}` endpoint

in systems that determine traffic routing based on healthchecks (e.g. kubernetes),

typesense responding quickly to sigterm before healthchecks have time to fail results in traffic being routed to down nodes

this PR seeks to add a `shutdown` request that would mark the system as unhealthy but allow it to continue serving traffic still routed at it


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
