### PR TITLE
fix(filter): support id:![...] filter syntax

### DIFF
--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -443,6 +443,11 @@ Option<bool> toFilter(const std::string& expression,
             filter_exp.apply_not_equals = true;
             filter_value_index++;
             while (++filter_value_index < raw_value.size() && raw_value[filter_value_index] == ' ');
+        } else if (raw_value.size() >= 1 && raw_value[0] == '!' && 
+                   (raw_value.size() == 1 || raw_value[1] != '=')) {
+            id_comparator = NOT_EQUALS;
+            filter_exp.apply_not_equals = true;
+            while (++filter_value_index < raw_value.size() && raw_value[filter_value_index] == ' ');
         }
         if (filter_value_index != 0) {
             raw_value = raw_value.substr(filter_value_index);

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -1746,6 +1746,14 @@ TEST_F(CollectionFilteringTest, FilteringViaDocumentIds) {
     ASSERT_EQ(1, results["hits"].size());
     ASSERT_STREQ("127", results["hits"][0]["document"]["id"].get<std::string>().c_str());
 
+    results = coll1->search("*",
+                           {}, "id:![123,125] && num_employees: <300",
+                           {}, sort_fields, {0}, 10, 1, FREQUENCY, {true}).get();
+
+    ASSERT_EQ(1, results["found"].get<size_t>());
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_STREQ("127", results["hits"][0]["document"]["id"].get<std::string>().c_str());
+
     // empty id list not allowed
     auto res_op = coll1->search("*", {}, "id:=", {}, sort_fields, {0}, 10, 1, FREQUENCY, {true});
     ASSERT_FALSE(res_op.ok());


### PR DESCRIPTION
## Change Summary
- add handling for `!` operator (without `=`) before array values in id field filtering
- enables `id:![...]` syntax to work consistently
- add test case to verify the fix works correctly
fixes #2700 

<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
