### PR TITLE
add stemming support for curations

### DIFF
--- a/include/curation.h
+++ b/include/curation.h
@@ -16,6 +16,9 @@ struct curation_t {
         bool dynamic_filter = false;
         std::string filter_by;
         std::set<std::string> tags;
+        std::string locale="";
+        std::string stemming_dictionary="";
+        bool stem = false;
     };
 
     struct add_hit_t {

--- a/test/collection_curation_test.cpp
+++ b/test/collection_curation_test.cpp
@@ -5827,24 +5827,32 @@ TEST_F(CollectionCurationTest, StemmingWithCuration) {
     coll1->set_curation_sets({"index"});
 
     // Add test documents
-    ASSERT_TRUE(coll1->add(R"({"id":"1","title":"Office Chargers","categoryType":"Electronics","region":"act","popularity":50})").ok());
-    ASSERT_TRUE(coll1->add(R"({"id":"2","title":"Office Staplers","categoryType":"Office","region":"act","popularity":30})").ok());
-    ASSERT_TRUE(coll1->add(R"({"id":"3","title":"Notebook","categoryType":"Office","region":"nsw","popularity":70})").ok());
-    ASSERT_TRUE(coll1->add(R"({"id":"4","title":"Bluetooth Speakers","categoryType":"Electronics","region":"act","popularity":90})").ok());
-    ASSERT_TRUE(coll1->add(R"({"id":"5","title":"Office Notebooks","categoryType":"Electronics","region":"act","popularity":90})").ok());
-    ASSERT_TRUE(coll1->add(R"({"id":"6","title":"Person Info","categoryType":"Office","region":"nsw","popularity":60})").ok());
-    ASSERT_TRUE(coll1->add(R"({"id":"7","title":"People Info","categoryType":"Office","region":"nsw","popularity":60})").ok());
+    ASSERT_TRUE(coll1->add(R"({"id":"1","title":"Bluetooth Speakers","categoryType":"Electronics","region":"act","popularity":90})").ok());
+    ASSERT_TRUE(coll1->add(R"({"id":"2","title":"Child Play","categoryType":"Electronics","region":"act","popularity":90})").ok());
+    ASSERT_TRUE(coll1->add(R"({"id":"3","title":"Children Notebooks","categoryType":"Electronics","region":"act","popularity":90})").ok());
+    ASSERT_TRUE(coll1->add(R"({"id":"4","title":"Person Info","categoryType":"Office","region":"nsw","popularity":60})").ok());
+    ASSERT_TRUE(coll1->add(R"({"id":"5","title":"People Info","categoryType":"Office","region":"nsw","popularity":60})").ok());
+
+    //check with stemming dictionary for irregular plurals
+    std::vector<std::string> json_lines;
+    std::string json_line = "{\"word\": \"people\", \"root\":\"person\"}";
+    json_lines.push_back(json_line);
+    json_line = "{\"word\": \"children\", \"root\":\"child\"}";
+    json_lines.push_back(json_line);
+
+    ASSERT_TRUE(stemmerManager.upsert_stemming_dictionary("set1", json_lines).ok());
 
     nlohmann::json curation_json = R"OVR(
         {
         "id": "stemmer",
         "rule": {
-            "query": "Notebooks",
+            "query": "Children",
             "match": "exact",
-            "stem" : true
+            "stem" : true,
+            "stemming_dictionary": "set1"
           },
           "includes": [
-                {"id": "4", "position": 1}
+                {"id": "1", "position": 1}
          ]
         }
     )OVR"_json;
@@ -5854,30 +5862,21 @@ TEST_F(CollectionCurationTest, StemmingWithCuration) {
     ASSERT_TRUE(parse_op.ok());
     ov_manager.upsert_curation_item("index", curation_json);
 
-    auto res_op = coll1->search("Notebook", {"title"}, "", {}, {}, {0});
+    auto res_op = coll1->search("Children", {"title"}, "", {}, {}, {0});
     ASSERT_TRUE(res_op.ok());
     auto results = res_op.get();
-    ASSERT_EQ(3, results["found"].get<size_t>());
-    ASSERT_EQ("4", results["hits"][0]["document"]["id"].get<std::string>()); //added by curation rule
+    ASSERT_EQ(2, results["found"].get<size_t>());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"].get<std::string>()); //added by curation rule
     ASSERT_EQ("3", results["hits"][1]["document"]["id"].get<std::string>());
-    ASSERT_EQ("5", results["hits"][2]["document"]["id"].get<std::string>());
 
     results.clear();
-    res_op = coll1->search("Notebooks", {"title"}, "", {}, {}, {0});
+    res_op = coll1->search("Child", {"title"}, "", {}, {}, {0});
     ASSERT_TRUE(res_op.ok());
     results = res_op.get();
     ASSERT_EQ(3, results["found"].get<size_t>());
-    ASSERT_EQ("4", results["hits"][0]["document"]["id"].get<std::string>()); //added by curation rule
-    ASSERT_EQ("3", results["hits"][1]["document"]["id"].get<std::string>());
-    ASSERT_EQ("5", results["hits"][2]["document"]["id"].get<std::string>());
-
-
-    //check with stemming dictionary for irregular plurals
-    std::string json_line = "{\"word\": \"people\", \"root\":\"person\"}";
-    std::vector<std::string> json_lines;
-    json_lines.push_back(json_line);
-
-    ASSERT_TRUE(stemmerManager.upsert_stemming_dictionary("set1", json_lines).ok());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"].get<std::string>()); //added by curation rule
+    ASSERT_EQ("2", results["hits"][1]["document"]["id"].get<std::string>());
+    ASSERT_EQ("3", results["hits"][2]["document"]["id"].get<std::string>());
 
     curation_json = R"OVR(
         {
@@ -5889,7 +5888,7 @@ TEST_F(CollectionCurationTest, StemmingWithCuration) {
             "stemming_dictionary": "set1"
           },
           "includes": [
-                {"id": "4", "position": 1}
+                {"id": "1", "position": 1}
          ]
         }
     )OVR"_json;
@@ -5902,14 +5901,14 @@ TEST_F(CollectionCurationTest, StemmingWithCuration) {
     ASSERT_TRUE(res_op.ok());
     results = res_op.get();
     ASSERT_EQ(2, results["found"].get<size_t>());
-    ASSERT_EQ("4", results["hits"][0]["document"]["id"].get<std::string>()); //added by curation rule
-    ASSERT_EQ("6", results["hits"][1]["document"]["id"].get<std::string>());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"].get<std::string>()); //added by curation rule
+    ASSERT_EQ("4", results["hits"][1]["document"]["id"].get<std::string>());
 
     results.clear();
     res_op = coll1->search("People", {"title"}, "", {}, {}, {0});
     ASSERT_TRUE(res_op.ok());
     results = res_op.get();
     ASSERT_EQ(2, results["found"].get<size_t>());
-    ASSERT_EQ("4", results["hits"][0]["document"]["id"].get<std::string>()); //added by curation rule
-    ASSERT_EQ("7", results["hits"][1]["document"]["id"].get<std::string>());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"].get<std::string>()); //added by curation rule
+    ASSERT_EQ("5", results["hits"][1]["document"]["id"].get<std::string>());
 }

--- a/test/collection_curation_test.cpp
+++ b/test/collection_curation_test.cpp
@@ -15,6 +15,7 @@ protected:
     CollectionManager & collectionManager = CollectionManager::get_instance();
     std::atomic<bool> quit = false;
     Collection *coll_mul_fields;
+    StemmerManager& stemmerManager = StemmerManager::get_instance();
     std::string state_dir_path = "/tmp/typesense_test/collection_curation";
 
     void setupCollection() {
@@ -22,6 +23,7 @@ protected:
         system(("rm -rf "+state_dir_path+" && mkdir -p "+state_dir_path).c_str());
 
         store = new Store(state_dir_path);
+        stemmerManager.init(store);
         collectionManager.init(store, 1.0, "auth_key", quit);
         collectionManager.load(8, 1000);
 
@@ -5783,7 +5785,7 @@ TEST_F(CollectionCurationTest, DiversityOverride) {
     };
     search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
     ASSERT_TRUE(search_op.ok());
-    res_obj = nlohmann::json::parse(json_res);LOG(INFO) << res_obj.dump(2);
+    res_obj = nlohmann::json::parse(json_res);
     ASSERT_EQ(6, res_obj["found"].get<size_t>());
     ASSERT_EQ(6, res_obj["hits"].size());
     for (uint32_t i = 0; i < 6; i++) {
@@ -5805,4 +5807,109 @@ TEST_F(CollectionCurationTest, DiversityOverride) {
     ASSERT_EQ("3", res_obj["hits"][3]["document"]["id"]);
     ASSERT_EQ("1", res_obj["hits"][4]["document"]["id"]);
     ASSERT_EQ("0", res_obj["hits"][5]["document"]["id"]);
+}
+
+TEST_F(CollectionCurationTest, StemmingWithCuration) {
+    auto& ov_manager = CurationIndexManager::get_instance();
+    nlohmann::json schema = R"({
+          "name": "products",
+          "fields": [
+              {"name": "title", "type": "string", "stem": true},
+              {"name": "categoryType", "type": "string"},
+              {"name": "region", "type": "string"},
+              {"name": "popularity", "type": "int32", "sort": true}
+          ]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+    Collection* coll1 = op.get();
+    coll1->set_curation_sets({"index"});
+
+    // Add test documents
+    ASSERT_TRUE(coll1->add(R"({"id":"1","title":"Office Chargers","categoryType":"Electronics","region":"act","popularity":50})").ok());
+    ASSERT_TRUE(coll1->add(R"({"id":"2","title":"Office Staplers","categoryType":"Office","region":"act","popularity":30})").ok());
+    ASSERT_TRUE(coll1->add(R"({"id":"3","title":"Notebook","categoryType":"Office","region":"nsw","popularity":70})").ok());
+    ASSERT_TRUE(coll1->add(R"({"id":"4","title":"Bluetooth Speakers","categoryType":"Electronics","region":"act","popularity":90})").ok());
+    ASSERT_TRUE(coll1->add(R"({"id":"5","title":"Office Notebooks","categoryType":"Electronics","region":"act","popularity":90})").ok());
+    ASSERT_TRUE(coll1->add(R"({"id":"6","title":"Person Info","categoryType":"Office","region":"nsw","popularity":60})").ok());
+    ASSERT_TRUE(coll1->add(R"({"id":"7","title":"People Info","categoryType":"Office","region":"nsw","popularity":60})").ok());
+
+    nlohmann::json curation_json = R"OVR(
+        {
+        "id": "stemmer",
+        "rule": {
+            "query": "Notebooks",
+            "match": "exact",
+            "stem" : true
+          },
+          "includes": [
+                {"id": "4", "position": 1}
+         ]
+        }
+    )OVR"_json;
+
+    curation_t ov;
+    auto parse_op = curation_t::parse(curation_json, "stemming", ov);
+    ASSERT_TRUE(parse_op.ok());
+    ov_manager.upsert_curation_item("index", curation_json);
+
+    auto res_op = coll1->search("Notebook", {"title"}, "", {}, {}, {0});
+    ASSERT_TRUE(res_op.ok());
+    auto results = res_op.get();
+    ASSERT_EQ(3, results["found"].get<size_t>());
+    ASSERT_EQ("4", results["hits"][0]["document"]["id"].get<std::string>()); //added by curation rule
+    ASSERT_EQ("3", results["hits"][1]["document"]["id"].get<std::string>());
+    ASSERT_EQ("5", results["hits"][2]["document"]["id"].get<std::string>());
+
+    results.clear();
+    res_op = coll1->search("Notebooks", {"title"}, "", {}, {}, {0});
+    ASSERT_TRUE(res_op.ok());
+    results = res_op.get();
+    ASSERT_EQ(3, results["found"].get<size_t>());
+    ASSERT_EQ("4", results["hits"][0]["document"]["id"].get<std::string>()); //added by curation rule
+    ASSERT_EQ("3", results["hits"][1]["document"]["id"].get<std::string>());
+    ASSERT_EQ("5", results["hits"][2]["document"]["id"].get<std::string>());
+
+
+    //check with stemming dictionary for irregular plurals
+    std::string json_line = "{\"word\": \"people\", \"root\":\"person\"}";
+    std::vector<std::string> json_lines;
+    json_lines.push_back(json_line);
+
+    ASSERT_TRUE(stemmerManager.upsert_stemming_dictionary("set1", json_lines).ok());
+
+    curation_json = R"OVR(
+        {
+        "id": "stemmer2",
+        "rule": {
+            "query": "People",
+            "match": "exact",
+            "stem" : true,
+            "stemming_dictionary": "set1"
+          },
+          "includes": [
+                {"id": "4", "position": 1}
+         ]
+        }
+    )OVR"_json;
+
+    parse_op = curation_t::parse(curation_json, "stemming2", ov);
+    ASSERT_TRUE(parse_op.ok());
+    ov_manager.upsert_curation_item("index", curation_json);
+
+    res_op = coll1->search("Person", {"title"}, "", {}, {}, {0});
+    ASSERT_TRUE(res_op.ok());
+    results = res_op.get();
+    ASSERT_EQ(2, results["found"].get<size_t>());
+    ASSERT_EQ("4", results["hits"][0]["document"]["id"].get<std::string>()); //added by curation rule
+    ASSERT_EQ("6", results["hits"][1]["document"]["id"].get<std::string>());
+
+    results.clear();
+    res_op = coll1->search("People", {"title"}, "", {}, {}, {0});
+    ASSERT_TRUE(res_op.ok());
+    results = res_op.get();
+    ASSERT_EQ(2, results["found"].get<size_t>());
+    ASSERT_EQ("4", results["hits"][0]["document"]["id"].get<std::string>()); //added by curation rule
+    ASSERT_EQ("7", results["hits"][1]["document"]["id"].get<std::string>());
 }


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->

### Stemming with Curations
Stemming can be enabled optionally for curations.
To enable stemming with any curation rule, one need to set `"stem":true` like following,
```json
{      "id": "stemmer2",
        "rule": {
            "query": "People",
            "match": "exact",
            "stem" : true,
            "stemming_dictionary": "set1"
          },
          "includes": [
                {"id": "4", "position": 1}
         ]
 }
```
additionally, one can reference already added stemming dictionary too with `stemming_dictionary`
## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
