### PR TITLE
add param shutdown-delay-seconds

### DIFF
--- a/include/http_server.h
+++ b/include/http_server.h
@@ -162,6 +162,8 @@ private:
 
     ThreadPool* meta_thread_pool;
 
+    bool is_shutdown_triggered = false;
+
     bool (*auth_handler)(std::map<std::string, std::string>& params,
                          std::vector<nlohmann::json>& embedded_params_vec,
                          const std::string& body, const route_path& rpath,
@@ -297,4 +299,6 @@ public:
     void decr_pending_writes();
 
     static bool curl_only_http1(std::string_view ua);
+
+    void set_shutdown_triggered();
 };

--- a/include/tsconfig.h
+++ b/include/tsconfig.h
@@ -99,6 +99,8 @@ private:
 
     uint32_t max_indexing_concurrency;
 
+    uint32_t shutdown_delay_seconds;
+
 protected:
 
     Config() {
@@ -217,6 +219,10 @@ public:
         this->max_indexing_concurrency = val;
     }
 
+    void set_shutdown_delay_seconds(uint32_t val) {
+        this->shutdown_delay_seconds = val;
+    }
+
     // @deprecated
     void set_search_only_api_key(const std::string & search_only_api_key) {
         this->search_only_api_key = search_only_api_key;
@@ -326,6 +332,9 @@ public:
         return this->api_key;
     }
 
+    uint32_t get_shutdown_delay_seconds() const {
+        return this->shutdown_delay_seconds;
+    }
     // @deprecated
     std::string get_search_only_api_key() const {
         return this->search_only_api_key;

--- a/include/typesense_server_utils.h
+++ b/include/typesense_server_utils.h
@@ -24,5 +24,3 @@ int init_root_logger(Config& config, const std::string& server_version);
 
 int run_server(const Config& config, const std::string& version,
                void (*master_server_routes)());
-
-void trigger_shutdown();

--- a/include/typesense_server_utils.h
+++ b/include/typesense_server_utils.h
@@ -24,3 +24,5 @@ int init_root_logger(Config& config, const std::string& server_version);
 
 int run_server(const Config& config, const std::string& version,
                void (*master_server_routes)());
+
+void trigger_shutdown();

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -1091,7 +1091,7 @@ ReplicationState* HttpServer::get_replication_state() const {
 }
 
 bool HttpServer::is_alive() const {
-    return replication_state->is_alive();
+    return !is_shutdown_triggered && replication_state->is_alive();
 }
 
 bool HttpServer::get_route(uint64_t hash, route_path** found_rpath) {
@@ -1258,4 +1258,8 @@ ThreadPool* HttpServer::get_meta_thread_pool() const {
 
 void HttpServer::decr_pending_writes() {
     return replication_state->decr_pending_writes();
+}
+
+void HttpServer::set_shutdown_triggered() {
+    is_shutdown_triggered = true;
 }

--- a/src/main/typesense_server.cpp
+++ b/src/main/typesense_server.cpp
@@ -230,6 +230,7 @@ int main(int argc, char **argv) {
     // we can install new signal handlers only after overriding above
     signal(SIGINT, catch_interrupt);
     signal(SIGTERM, catch_interrupt);
+    signal(SIGHUP, catch_interrupt);
 
     init_api(config.get_cache_num_entries());
 

--- a/src/tsconfig.cpp
+++ b/src/tsconfig.cpp
@@ -313,6 +313,10 @@ void Config::load_config_env() {
     if(!get_env("TYPESENSE_MAX_INDEXING_CONCURRENCY").empty()) {
         this->max_indexing_concurrency = std::stoi(get_env("TYPESENSE_MAX_INDEXING_CONCURRENCY"));
     }
+
+    if(!get_env("TYPESENSE_SHUTDOWN_DELAY_SECONDS").empty()) {
+        this->shutdown_delay_seconds = std::stoi(get_env("TYPESENSE_SHUTDOWN_DELAY_SECONDS"));
+    }
 }
 
 void Config::load_config_file(cmdline::parser& options) {
@@ -556,6 +560,10 @@ void Config::load_config_file(cmdline::parser& options) {
     if(reader.Exists("server", "max-indexing-concurrency")) {
         this->max_indexing_concurrency = reader.GetInteger("server", "max-indexing-concurrency", 4);
     }
+
+    if(reader.Exists("server", "shutdown-delay-seconds")) {
+        this->shutdown_delay_seconds = reader.GetInteger("server", "shutdown-delay-seconds", 0);
+    }
 }
 
 void Config::load_config_cmd_args(cmdline::parser& options)  {
@@ -771,6 +779,10 @@ void Config::load_config_cmd_args(cmdline::parser& options)  {
 
     if(options.exist("max-indexing-concurrency")) {
         this->max_indexing_concurrency = options.get<uint32_t>("max-indexing-concurrency");
+    }
+
+    if(options.exist("shutdown-delay-seconds")) {
+        this->shutdown_delay_seconds = options.get<uint32_t>("shutdown-delay-seconds");
     }
 }
 

--- a/src/typesense_server_utils.cpp
+++ b/src/typesense_server_utils.cpp
@@ -61,8 +61,8 @@ bool using_jemalloc() {
 
 void catch_interrupt(int sig) {
     LOG(INFO) << "Stopping Typesense server...";
+    trigger_shutdown();
     signal(sig, SIG_IGN);  // ignore for now as we want to shut down elegantly
-    quit_raft_service = true;
 }
 
 void init_cmdline_options(cmdline::parser & options, int argc, char **argv) {
@@ -75,7 +75,7 @@ void init_cmdline_options(cmdline::parser & options, int argc, char **argv) {
     options.add<std::string>("analytics-dir", '\0', "Directory where Analytics will be stored.", false);
     options.add<uint32_t>("analytics-db-ttl", '\0', "TTL in seconds for events stored in analytics db", false);
     options.add<uint32_t>("analytics-minute-rate-limit", '\0', "per minute rate limit for /events endpoint", false);
-
+    options.add<uint32_t>("shutdown-delay-seconds", '\0', "delay in seconds after which server will shutdown on receiving signal");
 
     options.add<std::string>("api-address", '\0', "Address to which Typesense API service binds.", false, "0.0.0.0");
     options.add<uint32_t>("api-port", '\0', "Port on which Typesense API service listens.", false, 8108);
@@ -761,3 +761,12 @@ int run_server(const Config & config, const std::string & version, void (*master
     return ret_code;
 }
 
+
+void trigger_shutdown() {
+    auto secs = Config::get_instance().get_shutdown_delay_seconds();
+    server->set_shutdown_triggered();
+    //sleep till delay timeout
+    sleep(secs);
+
+    quit_raft_service.store(true);
+}

--- a/src/typesense_server_utils.cpp
+++ b/src/typesense_server_utils.cpp
@@ -61,7 +61,19 @@ bool using_jemalloc() {
 
 void catch_interrupt(int sig) {
     LOG(INFO) << "Stopping Typesense server...";
-    trigger_shutdown();
+    if(sig == SIGHUP) {
+        LOG(INFO) << "shutdown is triggered.";
+        server->set_shutdown_triggered(); //inform http server
+        auto secs = Config::get_instance().get_shutdown_delay_seconds();
+        std::thread shutdown_thread([&]() {
+            std::this_thread::sleep_for(std::chrono::seconds(secs));
+            quit_raft_service.store(true);
+        });
+        shutdown_thread.detach();
+    } else {
+        quit_raft_service.store(true);
+    }
+
     signal(sig, SIG_IGN);  // ignore for now as we want to shut down elegantly
 }
 
@@ -422,7 +434,7 @@ int start_raft_server(ReplicationState& replication_state, Store& store,
 
     // Wait until 'CTRL-C' is pressed. then Stop() and Join() the service
     size_t raft_counter = 0;
-    while (!brpc::IsAskedToQuit() && !quit_raft_service.load()) {
+    while (!quit_raft_service.load()) {
         if(raft_counter % 10 == 0) {
             // reset peer configuration periodically to identify change in cluster membership
             const Option<std::string> & refreshed_nodes_op = Config::fetch_nodes_config(path_to_nodes);
@@ -759,14 +771,4 @@ int run_server(const Config & config, const std::string & version, void (*master
     LOG(INFO) << "Bye.";
 
     return ret_code;
-}
-
-
-void trigger_shutdown() {
-    auto secs = Config::get_instance().get_shutdown_delay_seconds();
-    server->set_shutdown_triggered();
-    //sleep till delay timeout
-    sleep(secs);
-
-    quit_raft_service.store(true);
 }


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
### Delayed Shutdown
One can set the param `shutdown-delay-seconds=<seconds>` as command line param or put in config file to set the delayed shutdown seconds.
#### purpose
- in case of terminating server, any in-flight ongoing requests going on gets terminated immediately.
- with the above param, system gets some time to finish up inflight on going requests before shutting down.

#### behavior
- One need to send `SIGHUP` signal to typesense-server for triggering this delayed shutdown countdown. After which typesense server will be shut.
- after successfully triggering shutdown, /health endpoint will be returning error `503`.
- in-flight requests will not be terminated and gets time till the timeout.
- one can adjust delayed seconds as per their need.
- other signals like `SIGINT`, `SIGTERM` dont handle above param and will behave as usual.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
