### PR TITLE
feat: ram profiling for collections

### DIFF
--- a/include/art.h
+++ b/include/art.h
@@ -284,6 +284,12 @@ int art_int64_search(art_tree *t, int64_t value, NUM_COMPARATOR comparator, std:
 
 int art_float_search(art_tree *t, float value, NUM_COMPARATOR comparator, std::vector<const art_leaf *> &results);
 
+/**
+ * Calculate the total memory usage of an ART tree in bytes.
+ * This includes all nodes, leaves, and posting lists.
+ */
+uint64_t art_tree_memory_size(const art_tree* t);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/collection.h
+++ b/include/collection.h
@@ -1204,6 +1204,12 @@ public:
                                       const ref_include_exclude_fields& ref_include_exclude) const;
 
     void reset_async_reference_field(const std::string& field_name);
+
+    /**
+     * Get memory usage statistics for this collection.
+     * Returns a JSON object with per-field memory breakdown.
+     */
+    nlohmann::json get_memory_usage() const;
 };
 
 template<class T>

--- a/include/core_api.h
+++ b/include/core_api.h
@@ -23,6 +23,10 @@ bool del_drop_collection(const std::shared_ptr<http_req>& req, const std::shared
 
 bool get_collection_summary(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 
+bool get_collection_memory_usage(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+
+bool get_all_collections_memory_usage(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+
 // Documents
 
 bool get_search(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);

--- a/include/index.h
+++ b/include/index.h
@@ -1235,6 +1235,12 @@ public:
     static void update_async_references(const std::string& collection_name, std::vector<index_record>& iter_batch,
                                         const spp::sparse_hash_map<std::string, std::set<reference_pair_t>>& async_referenced_ins =
                                         spp::sparse_hash_map<std::string, std::set<reference_pair_t>>());
+
+    /**
+     * Get memory usage statistics for all index data structures.
+     * Returns a JSON object with per-field memory breakdown.
+     */
+    nlohmann::json get_memory_usage() const;
 };
 
 template<class T>

--- a/src/art.cpp
+++ b/src/art.cpp
@@ -2147,3 +2147,89 @@ int art_float_search(art_tree *t, float value, NUM_COMPARATOR comparator, std::v
     art_int_fuzzy_recurse(t->root, 0, chars, 8, comparator, results);
     return 0;
 }
+
+// Recursively calculate memory usage of an art_node and its children
+static uint64_t art_node_memory_size(const art_node* n) {
+    if (!n) return 0;
+
+    // Handle leaf nodes
+    if (IS_LEAF(n)) {
+        art_leaf* l = (art_leaf*)LEAF_RAW(n);
+        uint64_t leaf_size = sizeof(art_leaf) + l->key_len;
+        
+        // Add memory from posting list values
+        if (l->values) {
+            if (IS_COMPACT_POSTING(l->values)) {
+                compact_posting_list_t* clist = COMPACT_POSTING_PTR(l->values);
+                leaf_size += sizeof(compact_posting_list_t) + (clist->capacity * sizeof(uint32_t));
+            } else {
+                posting_list_t* plist = (posting_list_t*)l->values;
+                // Base posting_list_t structure
+                leaf_size += sizeof(posting_list_t);
+                // Each block in the posting list
+                for (auto& kv : plist->id_block_map) {
+                    posting_list_t::block_t* block = kv.second;
+                    if (block) {
+                        leaf_size += sizeof(posting_list_t::block_t);
+                        // sorted_array ids + offset_index + array offsets
+                        leaf_size += block->ids.getLength() * sizeof(uint32_t);
+                        leaf_size += block->offset_index.getLength() * sizeof(uint32_t);
+                        leaf_size += block->offsets.getLength() * sizeof(uint32_t);
+                    }
+                }
+            }
+        }
+        return leaf_size;
+    }
+
+    uint64_t size = 0;
+
+    // Calculate size based on node type
+    switch (n->type) {
+        case NODE4: {
+            size = sizeof(art_node4);
+            art_node4* p = (art_node4*)n;
+            for (int i = 0; i < n->num_children; i++) {
+                size += art_node_memory_size(p->children[i]);
+            }
+            break;
+        }
+        case NODE16: {
+            size = sizeof(art_node16);
+            art_node16* p = (art_node16*)n;
+            for (int i = 0; i < n->num_children; i++) {
+                size += art_node_memory_size(p->children[i]);
+            }
+            break;
+        }
+        case NODE48: {
+            size = sizeof(art_node48);
+            art_node48* p = (art_node48*)n;
+            for (int i = 0; i < 48; i++) {
+                if (p->children[i]) {
+                    size += art_node_memory_size(p->children[i]);
+                }
+            }
+            break;
+        }
+        case NODE256: {
+            size = sizeof(art_node256);
+            art_node256* p = (art_node256*)n;
+            for (int i = 0; i < 256; i++) {
+                if (p->children[i]) {
+                    size += art_node_memory_size(p->children[i]);
+                }
+            }
+            break;
+        }
+        default:
+            break;
+    }
+
+    return size;
+}
+
+uint64_t art_tree_memory_size(const art_tree* t) {
+    if (!t) return 0;
+    return sizeof(art_tree) + art_node_memory_size(t->root);
+}

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -9298,3 +9298,28 @@ void Collection::reset_async_reference_field(const std::string& field_name) {
 
     update_matching_filter("id: *", doc.dump(), req_dirty_values, true, 5000);
 }
+
+nlohmann::json Collection::get_memory_usage() const {
+    std::shared_lock lock(mutex);
+    
+    nlohmann::json result;
+    result["name"] = name;
+    result["num_documents"] = num_documents.load();
+    
+    // Get memory usage from the index
+    nlohmann::json index_memory = index->get_memory_usage();
+    result["index"] = index_memory;
+    
+    // Calculate field schema metadata size
+    uint64_t schema_bytes = 0;
+    for (const auto& f : fields) {
+        schema_bytes += sizeof(field) + f.name.size();
+    }
+    result["schema_bytes"] = schema_bytes;
+    
+    // Total bytes
+    uint64_t total_bytes = index_memory["total_bytes"].get<uint64_t>() + schema_bytes;
+    result["total_bytes"] = total_bytes;
+    
+    return result;
+}

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -1329,6 +1329,45 @@ bool get_collection_summary(const std::shared_ptr<http_req>& req, const std::sha
     return true;
 }
 
+bool get_collection_memory_usage(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
+    CollectionManager& collectionManager = CollectionManager::get_instance();
+    auto collection = collectionManager.get_collection(req->params["collection"]);
+
+    if(collection == nullptr) {
+        res->set_404("Collection not found");
+        return false;
+    }
+
+    nlohmann::json json_response = collection->get_memory_usage();
+    res->set_200(json_response.dump(2));
+
+    return true;
+}
+
+bool get_all_collections_memory_usage(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
+    CollectionManager& collectionManager = CollectionManager::get_instance();
+    std::vector<std::string> collection_names = collectionManager.get_collection_names();
+
+    nlohmann::json result = nlohmann::json::object();
+    nlohmann::json collections_json = nlohmann::json::array();
+    uint64_t total_bytes = 0;
+
+    for(const auto& collection_name : collection_names) {
+        auto collection = collectionManager.get_collection(collection_name);
+        if(collection != nullptr) {
+            nlohmann::json collection_memory = collection->get_memory_usage();
+            collections_json.push_back(collection_memory);
+            total_bytes += collection_memory["total_bytes"].get<uint64_t>();
+        }
+    }
+
+    result["collections"] = collections_json;
+    result["total_bytes"] = total_bytes;
+    res->set_200(result.dump(2));
+
+    return true;
+}
+
 Option<bool> populate_include_exclude(const std::shared_ptr<http_req>& req, std::shared_ptr<Collection>& collection,
                                       const std::string& filter_query,
                                       tsl::htrie_set<char>& include_fields, tsl::htrie_set<char>& exclude_fields,

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -9199,3 +9199,158 @@ void Index::transform_for_180th_meridian(GeoCoord &point, double offset) {
     point.lon = point.lon < 0.0 ? point.lon + offset : point.lon;
 }
 */
+
+nlohmann::json Index::get_memory_usage() const {
+    std::shared_lock lock(mutex);
+    
+    nlohmann::json result;
+    nlohmann::json fields = nlohmann::json::object();
+    uint64_t total_bytes = 0;
+
+    // Search index (art_tree for string fields)
+    for (const auto& kv : search_index) {
+        uint64_t field_bytes = art_tree_memory_size(kv.second);
+        fields[kv.first]["search_index_bytes"] = field_bytes;
+        total_bytes += field_bytes;
+    }
+
+    // Numerical index (num_tree_t)
+    for (const auto& kv : numerical_index) {
+        uint64_t field_bytes = sizeof(num_tree_t);
+        // Estimate memory for the int64map entries
+        field_bytes += kv.second->size() * (sizeof(int64_t) + sizeof(void*) + 64); // rough estimate per entry
+        
+        if (fields.contains(kv.first)) {
+            fields[kv.first]["numerical_index_bytes"] = field_bytes;
+        } else {
+            fields[kv.first] = nlohmann::json::object();
+            fields[kv.first]["numerical_index_bytes"] = field_bytes;
+        }
+        total_bytes += field_bytes;
+    }
+
+    // Range index (NumericTrie)
+    for (const auto& kv : range_index) {
+        // Estimate memory for NumericTrie - this is approximate
+        uint64_t field_bytes = sizeof(NumericTrie) + 1024; // base overhead
+        if (fields.contains(kv.first)) {
+            fields[kv.first]["range_index_bytes"] = field_bytes;
+        } else {
+            fields[kv.first] = nlohmann::json::object();
+            fields[kv.first]["range_index_bytes"] = field_bytes;
+        }
+        total_bytes += field_bytes;
+    }
+
+    // Geo range index
+    for (const auto& kv : geo_range_index) {
+        uint64_t field_bytes = sizeof(NumericTrie) + 1024;
+        if (fields.contains(kv.first)) {
+            fields[kv.first]["geo_range_index_bytes"] = field_bytes;
+        } else {
+            fields[kv.first] = nlohmann::json::object();
+            fields[kv.first]["geo_range_index_bytes"] = field_bytes;
+        }
+        total_bytes += field_bytes;
+    }
+
+    // Sort index
+    for (const auto& kv : sort_index) {
+        uint64_t field_bytes = sizeof(spp::sparse_hash_map<uint32_t, int64_t, Hasher32>);
+        field_bytes += kv.second->size() * (sizeof(uint32_t) + sizeof(int64_t) + 16); // entry overhead
+        
+        if (fields.contains(kv.first)) {
+            fields[kv.first]["sort_index_bytes"] = field_bytes;
+        } else {
+            fields[kv.first] = nlohmann::json::object();
+            fields[kv.first]["sort_index_bytes"] = field_bytes;
+        }
+        total_bytes += field_bytes;
+    }
+
+    // String sort index (adi_tree_t)
+    for (const auto& kv : str_sort_index) {
+        uint64_t field_bytes = sizeof(adi_tree_t) + 1024; // base + estimated overhead
+        if (fields.contains(kv.first)) {
+            fields[kv.first]["str_sort_index_bytes"] = field_bytes;
+        } else {
+            fields[kv.first] = nlohmann::json::object();
+            fields[kv.first]["str_sort_index_bytes"] = field_bytes;
+        }
+        total_bytes += field_bytes;
+    }
+
+    // Vector index (HNSW)
+    for (const auto& kv : vector_index) {
+        hnsw_index_t* hnsw = kv.second;
+        uint64_t field_bytes = sizeof(hnsw_index_t);
+        
+        if (hnsw && hnsw->vecdex) {
+            // Memory = num_elements * (dimensions * sizeof(float) + overhead for links)
+            size_t num_elements = hnsw->vecdex->getCurrentElementCount();
+            size_t num_dim = hnsw->num_dim;
+            // Each element stores: vector data + links to neighbors
+            // Links overhead is approximately M * 2 * sizeof(unsigned int) per layer
+            field_bytes += num_elements * (num_dim * sizeof(float) + 256); // 256 bytes overhead per element for links
+            field_bytes += hnsw->vecdex->getMaxElements() * sizeof(void*); // label lookup table
+        }
+        
+        if (fields.contains(kv.first)) {
+            fields[kv.first]["vector_index_bytes"] = field_bytes;
+        } else {
+            fields[kv.first] = nlohmann::json::object();
+            fields[kv.first]["vector_index_bytes"] = field_bytes;
+        }
+        total_bytes += field_bytes;
+    }
+
+    // Infix index
+    for (const auto& kv : infix_index) {
+        uint64_t field_bytes = 0;
+        for (const auto& trie_ptr : kv.second) {
+            if (trie_ptr) {
+                field_bytes += sizeof(tsl::htrie_set<char>) + 1024; // base + estimated content
+            }
+        }
+        if (field_bytes > 0) {
+            if (fields.contains(kv.first)) {
+                fields[kv.first]["infix_index_bytes"] = field_bytes;
+            } else {
+                fields[kv.first] = nlohmann::json::object();
+                fields[kv.first]["infix_index_bytes"] = field_bytes;
+            }
+            total_bytes += field_bytes;
+        }
+    }
+
+    // Geo array index
+    for (const auto& kv : geo_array_index) {
+        uint64_t field_bytes = sizeof(spp::sparse_hash_map<uint32_t, int64_t*>);
+        field_bytes += kv.second->size() * (sizeof(uint32_t) + sizeof(int64_t*) + 32);
+        
+        if (fields.contains(kv.first)) {
+            fields[kv.first]["geo_array_index_bytes"] = field_bytes;
+        } else {
+            fields[kv.first] = nlohmann::json::object();
+            fields[kv.first]["geo_array_index_bytes"] = field_bytes;
+        }
+        total_bytes += field_bytes;
+    }
+
+    // Calculate totals per field
+    for (auto& [field_name, field_data] : fields.items()) {
+        uint64_t field_total = 0;
+        for (auto& [key, value] : field_data.items()) {
+            if (value.is_number()) {
+                field_total += value.get<uint64_t>();
+            }
+        }
+        field_data["total_bytes"] = field_total;
+    }
+
+    result["fields"] = fields;
+    result["total_bytes"] = total_bytes;
+    result["num_documents"] = num_documents;
+
+    return result;
+}

--- a/src/main/typesense_server.cpp
+++ b/src/main/typesense_server.cpp
@@ -45,6 +45,10 @@ void master_server_routes() {
     server->del("/collections/:collection", del_drop_collection);
     server->get("/collections/:collection", get_collection_summary);
 
+    // memory usage
+    server->get("/collections/:collection/memory", get_collection_memory_usage);
+    server->get("/memory", get_all_collections_memory_usage);
+
     server->get("/aliases", get_aliases);
     server->get("/aliases/:alias", get_alias);
     server->put("/aliases/:alias", put_upsert_alias);


### PR DESCRIPTION
## Change Summary
Added endpoints to check how much RAM each collection and field it's using.

### New endpoints:

`/collections/:collection/memory`

Return a collection memory usage:

```
{
      "index": {
        "fields": {
          "company_name": {
            "search_index_bytes": 275,
            "total_bytes": 275
          },
          "foo": {
            "numerical_index_bytes": 48,
            "total_bytes": 48
          },
          "foo.field": {
            "numerical_index_bytes": 128,
            "sort_index_bytes": 144,
            "total_bytes": 272
          },
          "foo.unindexed_field": {
            "numerical_index_bytes": 128,
            "sort_index_bytes": 144,
            "total_bytes": 272
          }
        }
      },
      "name": "companies",
      "num_documents": 2,
      "schema_bytes": 1572,
      "total_bytes": 2439
    }
```

`/memory`

Return memory usage for all colections.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
