### PR TITLE
fix: include num_dim in remote embedder cache key for matryoshka models

### DIFF
--- a/include/embedder_manager.h
+++ b/include/embedder_manager.h
@@ -42,7 +42,7 @@ public:
     EmbedderManager(const EmbedderManager&) = delete;
     EmbedderManager& operator=(const EmbedderManager&) = delete;
 
-    Option<TextEmbedder*> get_text_embedder(const nlohmann::json& model_config);
+    Option<TextEmbedder*> get_text_embedder(const nlohmann::json& model_config, size_t num_dims = 0);
     Option<ImageEmbedder*> get_image_embedder(const nlohmann::json& model_config);
 
     void delete_text_embedder(const std::string& model_path);

--- a/include/text_embedder_remote.h
+++ b/include/text_embedder_remote.h
@@ -59,7 +59,7 @@ class RemoteEmbedder {
         virtual embedding_res_t embed_query(const std::string& text, const size_t remote_embedder_timeout_ms = 30000, const size_t remote_embedding_num_tries = 2) = 0;
         virtual std::vector<embedding_res_t> embed_documents(const std::vector<std::string>& inputs, const size_t remote_embedding_batch_size = 200,
                                                          const size_t remote_embedding_timeout_ms = 60000, const size_t remote_embedding_num_tries = 2) = 0;
-        static const std::string get_model_key(const nlohmann::json& model_config);
+        static const std::string get_model_key(const nlohmann::json& model_config, size_t num_dims = 0);
         static void init(ReplicationState* rs) {
             raft_server = rs;
         }
@@ -83,7 +83,7 @@ class AzureEmbedder : public RemoteEmbedder {
         std::vector<embedding_res_t> embed_documents(const std::vector<std::string>& inputs, const size_t remote_embedding_batch_size = 200,
                                                  const size_t remote_embedding_timeout_ms = 60000, const size_t remote_embedding_num_tries = 2) override;
         nlohmann::json get_error_json(const nlohmann::json& req_body, long res_code, const std::string& res_body) override;
-        static std::string get_model_key(const nlohmann::json& model_config);
+        static std::string get_model_key(const nlohmann::json& model_config, size_t num_dims = 0);
         bool update_api_key(const std::string& api_key) override {
             std::lock_guard<std::shared_mutex> lock(mutex);
             this->api_key = api_key;
@@ -139,7 +139,7 @@ class OpenAIEmbedder : public RemoteEmbedder {
         std::vector<embedding_res_t> embed_documents(const std::vector<std::string>& inputs, const size_t remote_embedding_batch_size = 200,
                                                  const size_t remote_embedding_timeout_ms = 60000, const size_t remote_embedding_num_tries = 2) override;
         nlohmann::json get_error_json(const nlohmann::json& req_body, long res_code, const std::string& res_body) override;
-        static std::string get_model_key(const nlohmann::json& model_config);
+        static std::string get_model_key(const nlohmann::json& model_config, size_t num_dims = 0);
 
         bool update_api_key(const std::string& apikey) override {
             std::lock_guard<std::shared_mutex> lock(mutex);
@@ -163,7 +163,7 @@ class GoogleEmbedder : public RemoteEmbedder {
         std::vector<embedding_res_t> embed_documents(const std::vector<std::string>& inputs, const size_t remote_embedding_batch_size = 200,
                                                  const size_t remote_embedding_timeout_ms = 60000, const size_t remote_embedding_num_tries = 2) override;
         nlohmann::json get_error_json(const nlohmann::json& req_body, long res_code, const std::string& res_body) override;
-        static std::string get_model_key(const nlohmann::json& model_config);
+        static std::string get_model_key(const nlohmann::json& model_config, size_t num_dims = 0);
         bool update_api_key(const std::string& apikey) override {
             std::lock_guard<std::shared_mutex> lock(mutex);
             google_api_key = apikey;
@@ -220,7 +220,7 @@ class GCPEmbedder : public RemoteEmbedder {
         std::vector<embedding_res_t> embed_documents(const std::vector<std::string>& inputs, const size_t remote_embedding_batch_size = 200,
                                                  const size_t remote_embedding_timeout_ms = 60000, const size_t remote_embedding_num_tries = 2) override;
         nlohmann::json get_error_json(const nlohmann::json& req_body, long res_code, const std::string& res_body) override;
-        static std::string get_model_key(const nlohmann::json& model_config);
+        static std::string get_model_key(const nlohmann::json& model_config, size_t num_dims = 0);
         bool update_api_key(const std::string& api_key) override {
             return true;
         }

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -1378,7 +1378,7 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
                     std::vector<std::vector<float>> embeddings;
                     for(const auto& q: sort_field_std.vector_query.query.queries) {
                         EmbedderManager& embedder_manager = EmbedderManager::get_instance();
-                        auto embedder_op = embedder_manager.get_text_embedder(vector_field_it.value().embed[fields::model_config]);
+                        auto embedder_op = embedder_manager.get_text_embedder(vector_field_it.value().embed[fields::model_config], vector_field_it.value().num_dim);
                         if(!embedder_op.ok()) {
                             return Option<bool>(400, embedder_op.error());
                         }
@@ -1442,7 +1442,7 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
                     // generate embeddings for the query
 
                     EmbedderManager& embedder_manager = EmbedderManager::get_instance();
-                    auto embedder_op = embedder_manager.get_text_embedder(vector_field_it.value().embed[fields::model_config]);
+                    auto embedder_op = embedder_manager.get_text_embedder(vector_field_it.value().embed[fields::model_config], vector_field_it.value().num_dim);
                     if(!embedder_op.ok()) {
                         return Option<bool>(embedder_op.code(), embedder_op.error());
                     }
@@ -2253,7 +2253,7 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
                 }
 
                 EmbedderManager& embedder_manager = EmbedderManager::get_instance();
-                auto embedder_op = embedder_manager.get_text_embedder(search_field.embed[fields::model_config]);
+                auto embedder_op = embedder_manager.get_text_embedder(search_field.embed[fields::model_config], search_field.num_dim);
                 if(!embedder_op.ok()) {
                     return Option<bool>(400, embedder_op.error());
                 }
@@ -8366,7 +8366,7 @@ Option<bool> Collection::parse_and_validate_vector_query(const std::string& vect
         std::vector<std::vector<float>> embeddings;
         for(const auto& q: vector_query.queries) {
             EmbedderManager& embedder_manager = EmbedderManager::get_instance();
-            auto embedder_op = embedder_manager.get_text_embedder(vector_field_it.value().embed[fields::model_config]);
+            auto embedder_op = embedder_manager.get_text_embedder(vector_field_it.value().embed[fields::model_config], vector_field_it.value().num_dim);
             if(!embedder_op.ok()) {
                 return Option<bool>(400, embedder_op.error());
             }

--- a/src/embedder_manager.cpp
+++ b/src/embedder_manager.cpp
@@ -60,7 +60,7 @@ Option<bool> EmbedderManager::validate_and_init_remote_model(const nlohmann::jso
     }
 
     std::unique_lock<std::mutex> lock(text_embedders_mutex);
-    std::string model_key = is_remote_model(model_name) ? RemoteEmbedder::get_model_key(model_config) : model_name;
+    std::string model_key = is_remote_model(model_name) ? RemoteEmbedder::get_model_key(model_config, num_dims) : model_name;
     auto text_embedder_it = text_embedders.find(model_key);
     if(text_embedder_it == text_embedders.end()) {
         text_embedders.emplace(model_key, std::make_shared<TextEmbedder>(model_config, num_dims, has_custom_dims));
@@ -181,10 +181,10 @@ Option<bool> EmbedderManager::validate_and_init_local_model(const nlohmann::json
     return Option<bool>(true);
 }
 
-Option<TextEmbedder*> EmbedderManager::get_text_embedder(const nlohmann::json& model_config) {
+Option<TextEmbedder*> EmbedderManager::get_text_embedder(const nlohmann::json& model_config, size_t num_dims) {
     std::unique_lock<std::mutex> lock(text_embedders_mutex);
     const std::string& model_name = model_config.at("model_name");
-    std::string model_key = is_remote_model(model_name) ? RemoteEmbedder::get_model_key(model_config) : model_name;
+    std::string model_key = is_remote_model(model_name) ? RemoteEmbedder::get_model_key(model_config, num_dims) : model_name;
     auto text_embedder_it = text_embedders.find(model_key);
 
     if(text_embedder_it == text_embedders.end()) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -8293,7 +8293,7 @@ void Index::batch_embed_fields(std::vector<index_record*>& records,
         }
 
         if(!values_text.empty()) {
-            auto embedder_op = embedder_manager.get_text_embedder(field.embed[fields::model_config]);
+            auto embedder_op = embedder_manager.get_text_embedder(field.embed[fields::model_config], field.num_dim);
             if(!embedder_op.ok()) {
                 LOG(ERROR) << "Error while getting embedder for model: " << field.embed[fields::model_config];
                 LOG(ERROR) << "Error: " << embedder_op.error();


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
### Remote Embedder Cache Key Bug explained:
When using `matryoshka-compatible` embedding models (e.g., `text-embedding-3-large`, `text-embedding-3-small`) with different `num_dim` values across multiple _collections_ or _fields_, __all fields incorrectly share the same cached embedder instance__.

 This causes embeddings to be generated with the wrong dimensions => Wrong Cosine/dot distances.
 
For example:
Create field A with num_dim: 768 using openai/text-embedding-3-large
Create field B with num_dim: 512 using the same model
Field B's embeddings are incorrectly generated with 768 dimensions
Root Cause:
The embedder cache key was generated using only model_name:api_key, ignoring the requested dimensions:

```cpp
// src/text_embedder_remote.cpp
std::string OpenAIEmbedder::get_model_key(..)
return model_config["model_name"] + ":" + model_config["api_key"];
```

### Changes:

- Added optional `num_dims` parameter (default 0) to `get_model_key()` for all remote embedders
- Updated `get_text_embedder()` to accept and propagate `num_dims`
- Updated all call sites to pass the field's `num_dim`
- Added unit test to verify cache key behavior

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
