### PR TITLE
fix: include num_dim in remote embedder cache key (port of #2721)

### DIFF
--- a/api_tests/tests/embedding.test.ts
+++ b/api_tests/tests/embedding.test.ts
@@ -1,44 +1,54 @@
 import { describe, it, expect } from "bun:test";
 import { Phases, Filters } from "../src/constants";
 import { z } from "zod";
-import { fetchSingleNode } from "../src/request";
+import { fetchSingleNode, fetchMultiNode } from "../src/request";
+
+const ModelConfig = z.object({
+  model_name: z.string(),
+  api_key: z.string(),
+  url: z.string().optional(),
+});
+
+const EmbedConfig = z.object({
+  from: z.array(z.string()),
+  model_config: ModelConfig,
+});
+
+const CollectionField = z.object({
+  facet: z.boolean(),
+  index: z.boolean(),
+  infix: z.boolean(),
+  locale: z.string(),
+  name: z.string(),
+  optional: z.boolean(),
+  sort: z.boolean(),
+  stem: z.boolean(),
+  stem_dictionary: z.string(),
+  store: z.boolean(),
+  type: z.string(),
+  num_dim: z.number().optional(),
+  embed: EmbedConfig.optional(),
+  vec_dist: z.string().optional(),
+  hnsw_params: z
+    .object({
+      M: z.number(),
+      ef_construction: z.number(),
+    })
+    .optional(),
+});
+
+const UpdateCollectionField = z.object({
+  name: z.string(),
+  type: z.string(),
+  num_dim: z.number().optional(),
+  embed: EmbedConfig.optional(),
+});
 
 const CreateCollectionResponse = z.object({
   created_at: z.number(),
   default_sorting_field: z.string(),
   enable_nested_fields: z.boolean(),
-  fields: z.array(
-    z.object({
-      facet: z.boolean(),
-      index: z.boolean(),
-      infix: z.boolean(),
-      locale: z.string(),
-      name: z.string(),
-      optional: z.boolean(),
-      sort: z.boolean(),
-      stem: z.boolean(),
-      stem_dictionary: z.string(),
-      store: z.boolean(),
-      type: z.string(),
-      num_dim: z.number().optional(),
-      embed: z
-        .object({
-          from: z.array(z.string()),
-          model_config: z.object({
-            model_name: z.string(),
-            api_key: z.string(),
-          }),
-        })
-        .optional(),
-      vec_dist: z.string().optional(),
-      hnsw_params: z
-        .object({
-          M: z.number(),
-          ef_construction: z.number(),
-        })
-        .optional(),
-    })
-  ),
+  fields: z.array(CollectionField),
   name: z.string(),
   num_documents: z.number(),
   symbols_to_index: z.array(z.string()),
@@ -46,27 +56,121 @@ const CreateCollectionResponse = z.object({
 });
 
 const UpdateCollectionResponse = z.object({
-  fields: z.array(
-    z.object({
-      name: z.string(),
-      type: z.string(),
-      num_dim: z.number().optional(),
-      embed: z
-        .object({
-          from: z.array(z.string()),
-          model_config: z.object({
-            model_name: z.string(),
-            api_key: z.string(),
-          }),
-        })
-        .optional(),
-    })
-  ),
+  fields: z.array(UpdateCollectionField),
 });
 
 const ErrorResponse = z.object({
   message: z.string(),
 });
+
+const DocumentBase = z.object({
+  id: z.string(),
+});
+
+const DocumentWithEmbedding = DocumentBase.extend({
+  embedding: z.array(z.number()).optional(),
+  title: z.string().optional(),
+  text: z.string().optional(),
+  product_name: z.string().optional(),
+}).passthrough();
+
+const SearchHitDocument = DocumentBase.extend({
+  embedding: z.array(z.number()).optional(),
+  title: z.string().optional(),
+  text: z.string().optional(),
+  product_name: z.string().optional(),
+}).passthrough();
+
+const SearchHit = z.object({
+  document: SearchHitDocument,
+  highlight: z.record(z.string()).optional(),
+  text_match: z.number().optional(),
+  text_match_info: z.record(z.unknown()).optional(),
+  curated: z.boolean().optional(),
+  hybrid_search_info: z.object({ rank_fusion_score: z.number().optional() }).optional(),
+  vector_distance: z.number().optional(),
+  geo_distance_meters: z.record(z.number()).optional(),
+});
+
+const FacetCountEntry = z.object({
+  value: z.union([z.string(), z.number(), z.boolean()]).optional(),
+  highlighted: z.string().optional(),
+  count: z.number(),
+  parent: z.union([z.string(), z.number(), z.boolean()]).optional(),
+  facet_filter: z.string().optional(),
+});
+
+const FacetResult = z.object({
+  field_name: z.string(),
+  sampled: z.boolean().optional(),
+  counts: z.array(FacetCountEntry),
+});
+
+const GroupedHits = z.object({
+  group_key: z.array(z.union([z.string(), z.number(), z.boolean()])),
+  found: z.number().optional(),
+  hits: z.array(SearchHit),
+});
+
+const SearchResponse = z.object({
+  found: z.number(),
+  out_of: z.number().optional(),
+  found_docs: z.number().optional(),
+  search_time_ms: z.number().optional(),
+  page: z.number().optional(),
+  hits: z.array(SearchHit).optional(),
+  grouped_hits: z.array(GroupedHits).optional(),
+  facet_counts: z.array(FacetResult),
+  request_params: z.record(z.unknown()).optional(),
+  parsed_nl_query: z.record(z.unknown()).optional(),
+  union_request_params: z.array(z.record(z.unknown())).optional(),
+});
+
+const MultiSearchHitDocument = DocumentBase.extend({
+  embedding: z.array(z.number()).optional(),
+  title: z.string().optional(),
+  text: z.string().optional(),
+  product_name: z.string().optional(),
+  content: z.string().optional(),
+}).passthrough();
+
+const MultiSearchResult = z.object({
+  facet_counts: z.array(z.unknown()),
+  found: z.number(),
+  hits: z.array(
+    z.object({
+      document: MultiSearchHitDocument,
+      highlight: z.record(z.string()).optional(),
+      highlights: z.array(z.unknown()).optional(),
+      vector_distance: z.number().optional(),
+    })
+  ),
+  out_of: z.number().optional(),
+  page: z.number().optional(),
+  request_params: z.record(z.unknown()).optional(),
+  search_cutoff: z.boolean().optional(),
+  search_time_ms: z.number().optional(),
+});
+
+const MultiSearchResponse = z.object({
+  results: z.array(MultiSearchResult),
+});
+
+const DocumentResponse = z.object({
+  id: z.string(),
+});
+
+const COLLECTION_DIMENSIONS = {
+  matryoshka_512: 512,
+  matryoshka_1024: 1024,
+  matryoshka_256: 256,
+  matryoshka_search_512: 512,
+  matryoshka_search_1024: 1024,
+  azure_matryoshka_512: 512,
+  azure_matryoshka_1024: 1024,
+  matryoshka_multi_512: 512,
+  matryoshka_multi_1024: 1024,
+} as const;
 
 describe(Phases.SINGLE_FRESH, () => {
   it(`${Filters.SECRETS} create a collection with openai embedding`, async () => {
@@ -99,7 +203,6 @@ describe(Phases.SINGLE_FRESH, () => {
     expect(res.ok).toBe(true);
     const resJson = await res.json();
     const data = CreateCollectionResponse.safeParse(resJson);
-    expect(data.success).toBe(true);
     expect(data.data?.name).toBe("openai_collection");
     expect(data.data?.num_documents).toBe(0);
     expect(data.data?.fields.length).toBe(2);
@@ -109,6 +212,8 @@ describe(Phases.SINGLE_FRESH, () => {
   });
 
   it(`${Filters.SECRETS} should reject update with no changes to embedding field`, async () => {
+    const checkRes = await fetchSingleNode("/collections/openai_collection");
+
     const res = await fetchSingleNode("/collections/openai_collection", {
       method: "PATCH",
       body: JSON.stringify({
@@ -236,6 +341,392 @@ describe(Phases.SINGLE_FRESH, () => {
     const startsWith = getData.data?.fields[1]?.embed?.model_config?.api_key.startsWith(newApiKey.slice(0, 5));
     expect(startsWith).toBe(true);
   });
+
+  it(`${Filters.SECRETS} should support multiple collections with same model but different dimensions`, async () => {
+    const apiKey = Bun.env.OPEN_AI_API_KEY ?? "sk-random";
+    const modelName = "openai/text-embedding-3-large";
+
+    const res1 = await fetchSingleNode("/collections", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "matryoshka_512",
+        fields: [
+          {
+            name: "text",
+            type: "string",
+          },
+          {
+            name: "embedding",
+            type: "float[]",
+            num_dim: 512,
+            embed: {
+              from: ["text"],
+              model_config: {
+                model_name: modelName,
+                api_key: apiKey,
+              },
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(res1.ok).toBe(true);
+    const res1Json = await res1.json();
+    const data1 = CreateCollectionResponse.safeParse(res1Json);
+    expect(data1.success).toBe(true);
+    expect(data1.data?.name).toBe("matryoshka_512");
+    expect(data1.data?.fields[1]?.num_dim).toBe(512);
+    expect(data1.data?.fields[1]?.embed?.model_config?.model_name).toBe(modelName);
+
+    const res2 = await fetchSingleNode("/collections", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "matryoshka_1024",
+        fields: [
+          {
+            name: "text",
+            type: "string",
+          },
+          {
+            name: "embedding",
+            type: "float[]",
+            num_dim: 1024,
+            embed: {
+              from: ["text"],
+              model_config: {
+                model_name: modelName,
+                api_key: apiKey,
+              },
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(res2.ok).toBe(true);
+    const res2Json = await res2.json();
+    const data2 = CreateCollectionResponse.safeParse(res2Json);
+    expect(data2.success).toBe(true);
+    expect(data2.data?.name).toBe("matryoshka_1024");
+    expect(data2.data?.fields[1]?.num_dim).toBe(1024);
+    expect(data2.data?.fields[1]?.embed?.model_config?.model_name).toBe(modelName);
+
+    const res3 = await fetchSingleNode("/collections", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "matryoshka_256",
+        fields: [
+          {
+            name: "text",
+            type: "string",
+          },
+          {
+            name: "embedding",
+            type: "float[]",
+            num_dim: 256,
+            embed: {
+              from: ["text"],
+              model_config: {
+                model_name: modelName,
+                api_key: apiKey,
+              },
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(res3.ok).toBe(true);
+    const res3Json = await res3.json();
+    const data3 = CreateCollectionResponse.safeParse(res3Json);
+    expect(data3.success).toBe(true);
+    expect(data3.data?.name).toBe("matryoshka_256");
+    expect(data3.data?.fields[1]?.num_dim).toBe(256);
+    expect(data3.data?.fields[1]?.embed?.model_config?.model_name).toBe(modelName);
+
+    const getRes1 = await fetchSingleNode("/collections/matryoshka_512");
+    expect(getRes1.ok).toBe(true);
+    const getData1 = CreateCollectionResponse.safeParse(await getRes1.json());
+    expect(getData1.success).toBe(true);
+    expect(getData1.data?.fields[1]?.num_dim).toBe(512);
+
+    const getRes2 = await fetchSingleNode("/collections/matryoshka_1024");
+    expect(getRes2.ok).toBe(true);
+    const getData2 = CreateCollectionResponse.safeParse(await getRes2.json());
+    expect(getData2.success).toBe(true);
+    expect(getData2.data?.fields[1]?.num_dim).toBe(1024);
+
+    const getRes3 = await fetchSingleNode("/collections/matryoshka_256");
+    expect(getRes3.ok).toBe(true);
+    const getData3 = CreateCollectionResponse.safeParse(await getRes3.json());
+    expect(getData3.success).toBe(true);
+    expect(getData3.data?.fields[1]?.num_dim).toBe(256);
+
+    const collectionsToTest = (["matryoshka_512", "matryoshka_1024", "matryoshka_256"] as const).map((name) => ({
+      name,
+      expectedDim: COLLECTION_DIMENSIONS[name],
+    }));
+
+    for (const { name, expectedDim } of collectionsToTest) {
+      const addRes = await fetchSingleNode(`/collections/${name}/documents`, {
+        method: "POST",
+        body: JSON.stringify({
+          id: "1",
+          text: "Test document for dimension verification",
+        }),
+      });
+
+      expect(addRes.ok).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      const getDocRes = await fetchSingleNode(`/collections/${name}/documents/1`);
+      expect(getDocRes.ok).toBe(true);
+      const docData = DocumentWithEmbedding.safeParse(await getDocRes.json());
+      expect(docData.success).toBe(true);
+      if (docData.success && docData.data.embedding) {
+        expect(Array.isArray(docData.data.embedding)).toBe(true);
+        expect(docData.data.embedding.length).toBe(expectedDim);
+      }
+    }
+  });
+
+  it(`${Filters.SECRETS} should index and search documents with different dimensions using same model`, async () => {
+    const apiKey = Bun.env.OPEN_AI_API_KEY ?? "sk-random";
+    const modelName = "openai/text-embedding-3-large";
+
+    const createRes = await fetchSingleNode("/collections", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "matryoshka_search_512",
+        fields: [
+          {
+            name: "title",
+            type: "string",
+          },
+          {
+            name: "embedding",
+            type: "float[]",
+            num_dim: 512,
+            embed: {
+              from: ["title"],
+              model_config: {
+                model_name: modelName,
+                api_key: apiKey,
+              },
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(createRes.ok).toBe(true);
+
+    const addRes = await fetchSingleNode("/collections/matryoshka_search_512/documents", {
+      method: "POST",
+      body: JSON.stringify({
+        id: "1",
+        title: "Machine learning and artificial intelligence",
+      }),
+    });
+
+    expect(addRes.ok).toBe(true);
+    const addData = DocumentResponse.safeParse(await addRes.json());
+    expect(addData.success).toBe(true);
+    if (addData.success) {
+      expect(addData.data.id).toBe("1");
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    const searchRes = await fetchSingleNode(
+      `/collections/matryoshka_search_512/documents/search?q=*&vector_query=${encodeURIComponent(
+        "embedding:([], k:1)"
+      )}`,
+      { method: "GET" }
+    );
+
+    expect(searchRes.ok).toBe(true);
+    const searchData = SearchResponse.safeParse(await searchRes.json());
+    expect(searchData.success).toBe(true);
+    if (searchData.success) {
+      expect(searchData.data.found).toBeGreaterThanOrEqual(0);
+    }
+
+    const getDocRes = await fetchSingleNode("/collections/matryoshka_search_512/documents/1");
+    expect(getDocRes.ok).toBe(true);
+    const docData = DocumentWithEmbedding.safeParse(await getDocRes.json());
+    expect(docData.success).toBe(true);
+    if (docData.success && docData.data.embedding) {
+      expect(Array.isArray(docData.data.embedding)).toBe(true);
+      expect(docData.data.embedding.length).toBe(512);
+    }
+
+    const createRes2 = await fetchSingleNode("/collections", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "matryoshka_search_1024",
+        fields: [
+          {
+            name: "title",
+            type: "string",
+          },
+          {
+            name: "embedding",
+            type: "float[]",
+            num_dim: 1024,
+            embed: {
+              from: ["title"],
+              model_config: {
+                model_name: modelName,
+                api_key: apiKey,
+              },
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(createRes2.ok).toBe(true);
+
+    const addRes2 = await fetchSingleNode("/collections/matryoshka_search_1024/documents", {
+      method: "POST",
+      body: JSON.stringify({
+        id: "1",
+        title: "Deep learning and neural networks",
+      }),
+    });
+
+    expect(addRes2.ok).toBe(true);
+    const addData2 = DocumentResponse.safeParse(await addRes2.json());
+    expect(addData2.success).toBe(true);
+    if (addData2.success) {
+      expect(addData2.data.id).toBe("1");
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    const searchRes2 = await fetchSingleNode(
+      `/collections/matryoshka_search_1024/documents/search?q=*&vector_query=${encodeURIComponent(
+        "embedding:([], k:1)"
+      )}`,
+      { method: "GET" }
+    );
+
+    expect(searchRes2.ok).toBe(true);
+    const searchData2 = SearchResponse.safeParse(await searchRes2.json());
+    expect(searchData2.success).toBe(true);
+    if (searchData2.success) {
+      expect(searchData2.data.found).toBeGreaterThanOrEqual(0);
+    }
+
+    const getDocRes2 = await fetchSingleNode("/collections/matryoshka_search_1024/documents/1");
+    expect(getDocRes2.ok).toBe(true);
+    const docData2 = DocumentWithEmbedding.safeParse(await getDocRes2.json());
+    expect(docData2.success).toBe(true);
+    if (docData2.success && docData2.data.embedding) {
+      expect(Array.isArray(docData2.data.embedding)).toBe(true);
+      expect(docData2.data.embedding.length).toBe(1024);
+    }
+
+    const getRes1 = await fetchSingleNode("/collections/matryoshka_search_512");
+    const getData1 = CreateCollectionResponse.safeParse(await getRes1.json());
+    expect(getData1.success).toBe(true);
+    expect(getData1.data?.fields[1]?.num_dim).toBe(512);
+
+    const getRes2 = await fetchSingleNode("/collections/matryoshka_search_1024");
+    const getData2 = CreateCollectionResponse.safeParse(await getRes2.json());
+    expect(getData2.success).toBe(true);
+    expect(getData2.data?.fields[1]?.num_dim).toBe(1024);
+  });
+
+  it(`${Filters.SECRETS} should support Azure embedder with different dimensions`, async () => {
+    const apiKey = Bun.env.AZURE_OPENAI_API_KEY ?? "test-azure-key";
+    const modelName = "azure/text-embedding-3-large";
+    const azureUrl = Bun.env.AZURE_OPENAI_URL;
+
+    const modelConfig1: z.infer<typeof ModelConfig> = {
+      model_name: modelName,
+      api_key: apiKey,
+      ...(azureUrl && { url: azureUrl }),
+    };
+
+    const res1 = await fetchSingleNode("/collections", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "azure_matryoshka_512",
+        fields: [
+          {
+            name: "text",
+            type: "string",
+          },
+          {
+            name: "embedding",
+            type: "float[]",
+            num_dim: 512,
+            embed: {
+              from: ["text"],
+              model_config: modelConfig1,
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(res1.ok).toBe(true);
+    const res1Json = await res1.json();
+    const data1 = CreateCollectionResponse.safeParse(res1Json);
+    expect(data1.success).toBe(true);
+    expect(data1.data?.name).toBe("azure_matryoshka_512");
+    expect(data1.data?.fields[1]?.num_dim).toBe(512);
+
+    const modelConfig2: z.infer<typeof ModelConfig> = {
+      model_name: modelName,
+      api_key: apiKey,
+      ...(azureUrl && { url: azureUrl }),
+    };
+
+    const res2 = await fetchSingleNode("/collections", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "azure_matryoshka_1024",
+        fields: [
+          {
+            name: "text",
+            type: "string",
+          },
+          {
+            name: "embedding",
+            type: "float[]",
+            num_dim: 1024,
+            embed: {
+              from: ["text"],
+              model_config: modelConfig2,
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(res2.ok).toBe(true);
+    const res2Json = await res2.json();
+    const data2 = CreateCollectionResponse.safeParse(res2Json);
+    expect(data2.success).toBe(true);
+    expect(data2.data?.name).toBe("azure_matryoshka_1024");
+    expect(data2.data?.fields[1]?.num_dim).toBe(1024);
+
+    const getRes1 = await fetchSingleNode("/collections/azure_matryoshka_512");
+    expect(getRes1.ok).toBe(true);
+    const getData1 = CreateCollectionResponse.safeParse(await getRes1.json());
+    expect(getData1.success).toBe(true);
+    expect(getData1.data?.fields[1]?.num_dim).toBe(512);
+
+    const getRes2 = await fetchSingleNode("/collections/azure_matryoshka_1024");
+    expect(getRes2.ok).toBe(true);
+    const getData2 = CreateCollectionResponse.safeParse(await getRes2.json());
+    expect(getData2.success).toBe(true);
+    expect(getData2.data?.fields[1]?.num_dim).toBe(1024);
+  });
 });
 
 describe(Phases.SINGLE_RESTARTED, () => {
@@ -254,5 +745,349 @@ describe(Phases.SINGLE_RESTARTED, () => {
     expect(data.data?.fields[1]?.num_dim).toBe(1536);
     expect(data.data?.fields[1]?.embed?.from).toEqual(["product_name"]);
     expect(data.data?.fields[1]?.embed?.model_config?.model_name).toBe("openai/text-embedding-3-small");
+  });
+
+  it(`${Filters.SECRETS} should persist matryoshka collections with different dimensions after restart`, async () => {
+    const collections = (["matryoshka_512", "matryoshka_1024", "matryoshka_256"] as const).reduce((acc, name) => {
+      acc[name] = COLLECTION_DIMENSIONS[name];
+      return acc;
+    }, {} as Record<string, number>);
+
+    for (const [collectionName, expectedDim] of Object.entries(collections)) {
+      const res = await fetchSingleNode(`/collections/${collectionName}`, {
+        method: "GET",
+      });
+
+      expect(res.ok).toBe(true);
+      const resJson = await res.json();
+      const data = CreateCollectionResponse.safeParse(resJson);
+      expect(data.success).toBe(true);
+      if (data.success) {
+        expect(data.data.name).toBe(collectionName);
+        const embeddingField = data.data.fields[1];
+        expect(embeddingField).toBeDefined();
+        if (embeddingField && embeddingField.num_dim !== undefined) {
+          expect(embeddingField.num_dim).toBe(expectedDim);
+        }
+      }
+    }
+  });
+
+  it(`${Filters.SECRETS} should persist search collections with different dimensions after restart`, async () => {
+    const collections = (["matryoshka_search_512", "matryoshka_search_1024"] as const).reduce((acc, name) => {
+      acc[name] = COLLECTION_DIMENSIONS[name];
+      return acc;
+    }, {} as Record<string, number>);
+
+    for (const [collectionName, expectedDim] of Object.entries(collections)) {
+      const res = await fetchSingleNode(`/collections/${collectionName}`, {
+        method: "GET",
+      });
+
+      expect(res.ok).toBe(true);
+      const resJson = await res.json();
+      const data = CreateCollectionResponse.safeParse(resJson);
+      expect(data.success).toBe(true);
+      if (data.success) {
+        expect(data.data.name).toBe(collectionName);
+        const embeddingField = data.data.fields[1];
+        expect(embeddingField).toBeDefined();
+        if (embeddingField && embeddingField.num_dim !== undefined) {
+          expect(embeddingField.num_dim).toBe(expectedDim);
+        }
+      }
+    }
+  });
+
+  it(`${Filters.SECRETS} should persist Azure matryoshka collections with different dimensions after restart`, async () => {
+    const collections = (["azure_matryoshka_512", "azure_matryoshka_1024"] as const).reduce((acc, name) => {
+      acc[name] = COLLECTION_DIMENSIONS[name];
+      return acc;
+    }, {} as Record<string, number>);
+
+    for (const [collectionName, expectedDim] of Object.entries(collections)) {
+      const res = await fetchSingleNode(`/collections/${collectionName}`, {
+        method: "GET",
+      });
+
+      expect(res.ok).toBe(true);
+      const resJson = await res.json();
+      const data = CreateCollectionResponse.safeParse(resJson);
+      expect(data.success).toBe(true);
+      if (data.success) {
+        expect(data.data.name).toBe(collectionName);
+        const embeddingField = data.data.fields[1];
+        expect(embeddingField).toBeDefined();
+        if (embeddingField && embeddingField.num_dim !== undefined) {
+          expect(embeddingField.num_dim).toBe(expectedDim);
+        }
+      }
+    }
+  });
+});
+
+describe(Phases.SINGLE_SNAPSHOT, () => {
+  it(`${Filters.SECRETS} should persist matryoshka collections with different dimensions after snapshot`, async () => {
+    const collections = (["matryoshka_512", "matryoshka_1024", "matryoshka_256"] as const).reduce((acc, name) => {
+      acc[name] = COLLECTION_DIMENSIONS[name];
+      return acc;
+    }, {} as Record<string, number>);
+
+    for (const [collectionName, expectedDim] of Object.entries(collections)) {
+      const res = await fetchSingleNode(`/collections/${collectionName}`, {
+        method: "GET",
+      });
+
+      expect(res.ok).toBe(true);
+      const resJson = await res.json();
+      const data = CreateCollectionResponse.safeParse(resJson);
+      expect(data.success).toBe(true);
+      if (data.success) {
+        expect(data.data.name).toBe(collectionName);
+        const embeddingField = data.data.fields[1];
+        expect(embeddingField).toBeDefined();
+        if (embeddingField && embeddingField.num_dim !== undefined) {
+          expect(embeddingField.num_dim).toBe(expectedDim);
+        }
+      }
+    }
+  });
+
+  it(`${Filters.SECRETS} should persist Azure matryoshka collections with different dimensions after snapshot`, async () => {
+    const collections = (["azure_matryoshka_512", "azure_matryoshka_1024"] as const).reduce((acc, name) => {
+      acc[name] = COLLECTION_DIMENSIONS[name];
+      return acc;
+    }, {} as Record<string, number>);
+
+    for (const [collectionName, expectedDim] of Object.entries(collections)) {
+      const res = await fetchSingleNode(`/collections/${collectionName}`, {
+        method: "GET",
+      });
+
+      expect(res.ok).toBe(true);
+      const resJson = await res.json();
+      const data = CreateCollectionResponse.safeParse(resJson);
+      expect(data.success).toBe(true);
+      if (data.success) {
+        expect(data.data.name).toBe(collectionName);
+        const embeddingField = data.data.fields[1];
+        expect(embeddingField).toBeDefined();
+        if (embeddingField && embeddingField.num_dim !== undefined) {
+          expect(embeddingField.num_dim).toBe(expectedDim);
+        }
+      }
+    }
+  });
+});
+
+describe(Phases.MULTI_FRESH, () => {
+  it(`${Filters.SECRETS} should create matryoshka collections with different dimensions in multi-node`, async () => {
+    const apiKey = Bun.env.OPEN_AI_API_KEY ?? "sk-random";
+    const modelName = "openai/text-embedding-3-large";
+
+    const res1 = await fetchMultiNode(1, "/collections", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "matryoshka_multi_512",
+        fields: [
+          {
+            name: "text",
+            type: "string",
+          },
+          {
+            name: "embedding",
+            type: "float[]",
+            num_dim: 512,
+            embed: {
+              from: ["text"],
+              model_config: {
+                model_name: modelName,
+                api_key: apiKey,
+              },
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(res1.ok).toBe(true);
+    const res1Json = await res1.json();
+    const data1 = CreateCollectionResponse.safeParse(res1Json);
+    expect(data1.success).toBe(true);
+    expect(data1.data?.name).toBe("matryoshka_multi_512");
+    expect(data1.data?.fields[1]?.num_dim).toBe(512);
+
+    const res2 = await fetchMultiNode(1, "/collections", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "matryoshka_multi_1024",
+        fields: [
+          {
+            name: "text",
+            type: "string",
+          },
+          {
+            name: "embedding",
+            type: "float[]",
+            num_dim: 1024,
+            embed: {
+              from: ["text"],
+              model_config: {
+                model_name: modelName,
+                api_key: apiKey,
+              },
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(res2.ok).toBe(true);
+    const res2Json = await res2.json();
+    const data2 = CreateCollectionResponse.safeParse(res2Json);
+    expect(data2.success).toBe(true);
+    expect(data2.data?.name).toBe("matryoshka_multi_1024");
+    expect(data2.data?.fields[1]?.num_dim).toBe(1024);
+  });
+
+  it(`${Filters.SECRETS} should add documents with matryoshka embeddings in multi-node`, async () => {
+    const collections = (["matryoshka_multi_512", "matryoshka_multi_1024"] as const).reduce((acc, name) => {
+      acc[name] = COLLECTION_DIMENSIONS[name];
+      return acc;
+    }, {} as Record<string, number>);
+
+    for (const [collectionName, expectedDim] of Object.entries(collections)) {
+      const addRes = await fetchMultiNode(1, `/collections/${collectionName}/documents`, {
+        method: "POST",
+        body: JSON.stringify({
+          id: "1",
+          text: "Test document for multi-node dimension verification",
+        }),
+      });
+
+      expect(addRes.ok).toBe(true);
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      const getDocRes = await fetchMultiNode(1, `/collections/${collectionName}/documents/1`);
+      expect(getDocRes.ok).toBe(true);
+      const docData = DocumentWithEmbedding.safeParse(await getDocRes.json());
+      expect(docData.success).toBe(true);
+      if (docData.success && docData.data.embedding) {
+        expect(Array.isArray(docData.data.embedding)).toBe(true);
+        expect(docData.data.embedding.length).toBe(expectedDim);
+      }
+    }
+  });
+
+  it(`${Filters.SECRETS} should perform vector search with matryoshka embeddings in multi-node`, async () => {
+    const res = await fetchMultiNode(1, "/multi_search", {
+      method: "POST",
+      body: JSON.stringify({
+        searches: [
+          {
+            collection: "matryoshka_multi_512",
+            q: "*",
+            query_by: "embedding",
+            exclude_fields: "embedding",
+            prefix: "false",
+            vector_query: "embedding:([], k: 1)",
+          },
+        ],
+      }),
+    });
+
+    expect(res.ok).toBe(true);
+    const searchResult = MultiSearchResponse.safeParse(await res.json());
+    expect(searchResult.success).toBe(true);
+    if (searchResult.success) {
+      expect(searchResult.data.results).toBeDefined();
+      expect(searchResult.data.results[0]?.hits).toBeDefined();
+      expect(searchResult.data.results[0]?.hits.length).toBeGreaterThan(0);
+      expect(searchResult.data.results[0]?.found).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe(Phases.MULTI_RESTARTED, () => {
+  it(`${Filters.SECRETS} should persist matryoshka collections with different dimensions after multi-node restart`, async () => {
+    const collections = (["matryoshka_multi_512", "matryoshka_multi_1024"] as const).reduce((acc, name) => {
+      acc[name] = COLLECTION_DIMENSIONS[name];
+      return acc;
+    }, {} as Record<string, number>);
+
+    for (const [collectionName, expectedDim] of Object.entries(collections)) {
+      const res = await fetchMultiNode(2, `/collections/${collectionName}`, {
+        method: "GET",
+      });
+
+      expect(res.ok).toBe(true);
+      const resJson = await res.json();
+      const data = CreateCollectionResponse.safeParse(resJson);
+      expect(data.success).toBe(true);
+      if (data.success) {
+        expect(data.data.name).toBe(collectionName);
+        const embeddingField = data.data.fields[1];
+        expect(embeddingField).toBeDefined();
+        if (embeddingField && embeddingField.num_dim !== undefined) {
+          expect(embeddingField.num_dim).toBe(expectedDim);
+        }
+      }
+    }
+  });
+
+  it(`${Filters.SECRETS} should perform vector search with matryoshka embeddings after multi-node restart`, async () => {
+    const res = await fetchMultiNode(1, "/multi_search", {
+      method: "POST",
+      body: JSON.stringify({
+        searches: [
+          {
+            collection: "matryoshka_multi_512",
+            q: "*",
+            query_by: "embedding",
+            exclude_fields: "embedding",
+            prefix: "false",
+            vector_query: "embedding:([], k: 1)",
+          },
+        ],
+      }),
+    });
+
+    expect(res.ok).toBe(true);
+    const searchResult = MultiSearchResponse.safeParse(await res.json());
+    expect(searchResult.success).toBe(true);
+    if (searchResult.success) {
+      expect(searchResult.data.results).toBeDefined();
+      expect(searchResult.data.results[0]?.hits).toBeDefined();
+      expect(searchResult.data.results[0]?.hits.length).toBeGreaterThan(0);
+      expect(searchResult.data.results[0]?.found).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe(Phases.MULTI_SNAPSHOT, () => {
+  it(`${Filters.SECRETS} should persist matryoshka collections with different dimensions after multi-node snapshot`, async () => {
+    const collections = (["matryoshka_multi_512", "matryoshka_multi_1024"] as const).reduce((acc, name) => {
+      acc[name] = COLLECTION_DIMENSIONS[name];
+      return acc;
+    }, {} as Record<string, number>);
+
+    for (const [collectionName, expectedDim] of Object.entries(collections)) {
+      const res = await fetchMultiNode(3, `/collections/${collectionName}`, {
+        method: "GET",
+      });
+
+      expect(res.ok).toBe(true);
+      const resJson = await res.json();
+      const data = CreateCollectionResponse.safeParse(resJson);
+      expect(data.success).toBe(true);
+      if (data.success) {
+        expect(data.data.name).toBe(collectionName);
+        const embeddingField = data.data.fields[1];
+        expect(embeddingField).toBeDefined();
+        if (embeddingField && embeddingField.num_dim !== undefined) {
+          expect(embeddingField.num_dim).toBe(expectedDim);
+        }
+      }
+    }
   });
 });

--- a/include/embedder_manager.h
+++ b/include/embedder_manager.h
@@ -42,7 +42,7 @@ public:
     EmbedderManager(const EmbedderManager&) = delete;
     EmbedderManager& operator=(const EmbedderManager&) = delete;
 
-    Option<TextEmbedder*> get_text_embedder(const nlohmann::json& model_config);
+    Option<TextEmbedder*> get_text_embedder(const nlohmann::json& model_config, size_t num_dims = 0);
     Option<ImageEmbedder*> get_image_embedder(const nlohmann::json& model_config);
 
     void delete_text_embedder(const std::string& model_path);

--- a/include/embedder_manager.h
+++ b/include/embedder_manager.h
@@ -85,7 +85,7 @@ public:
     Option<bool> validate_and_init_local_model(const nlohmann::json& model_config, size_t& num_dims);
     Option<bool> validate_and_init_model(const nlohmann::json& model_config, size_t& num_dims);
 
-    Option<bool> update_remote_model_apikey(const nlohmann::json& model_config, const std::string& new_apikey);
+    Option<bool> update_remote_model_apikey(const nlohmann::json& model_config, const std::string& new_apikey, size_t num_dims = 0);
 
     std::unordered_map<std::string, std::shared_ptr<TextEmbedder>> _get_text_embedders() {
         return text_embedders;

--- a/include/text_embedder_remote.h
+++ b/include/text_embedder_remote.h
@@ -59,7 +59,7 @@ class RemoteEmbedder {
         virtual embedding_res_t embed_query(const std::string& text, const size_t remote_embedder_timeout_ms = 30000, const size_t remote_embedding_num_tries = 2) = 0;
         virtual std::vector<embedding_res_t> embed_documents(const std::vector<std::string>& inputs, const size_t remote_embedding_batch_size = 200,
                                                          const size_t remote_embedding_timeout_ms = 60000, const size_t remote_embedding_num_tries = 2) = 0;
-        static const std::string get_model_key(const nlohmann::json& model_config);
+        static const std::string get_model_key(const nlohmann::json& model_config, size_t num_dims = 0);
         static void init(ReplicationState* rs) {
             raft_server = rs;
         }
@@ -83,7 +83,7 @@ class AzureEmbedder : public RemoteEmbedder {
         std::vector<embedding_res_t> embed_documents(const std::vector<std::string>& inputs, const size_t remote_embedding_batch_size = 200,
                                                  const size_t remote_embedding_timeout_ms = 60000, const size_t remote_embedding_num_tries = 2) override;
         nlohmann::json get_error_json(const nlohmann::json& req_body, long res_code, const std::string& res_body) override;
-        static std::string get_model_key(const nlohmann::json& model_config);
+        static std::string get_model_key(const nlohmann::json& model_config, size_t num_dims = 0);
         bool update_api_key(const std::string& api_key) override {
             std::lock_guard<std::shared_mutex> lock(mutex);
             this->api_key = api_key;
@@ -139,7 +139,7 @@ class OpenAIEmbedder : public RemoteEmbedder {
         std::vector<embedding_res_t> embed_documents(const std::vector<std::string>& inputs, const size_t remote_embedding_batch_size = 200,
                                                  const size_t remote_embedding_timeout_ms = 60000, const size_t remote_embedding_num_tries = 2) override;
         nlohmann::json get_error_json(const nlohmann::json& req_body, long res_code, const std::string& res_body) override;
-        static std::string get_model_key(const nlohmann::json& model_config);
+        static std::string get_model_key(const nlohmann::json& model_config, size_t num_dims = 0);
 
         bool update_api_key(const std::string& apikey) override {
             std::lock_guard<std::shared_mutex> lock(mutex);
@@ -163,7 +163,7 @@ class GoogleEmbedder : public RemoteEmbedder {
         std::vector<embedding_res_t> embed_documents(const std::vector<std::string>& inputs, const size_t remote_embedding_batch_size = 200,
                                                  const size_t remote_embedding_timeout_ms = 60000, const size_t remote_embedding_num_tries = 2) override;
         nlohmann::json get_error_json(const nlohmann::json& req_body, long res_code, const std::string& res_body) override;
-        static std::string get_model_key(const nlohmann::json& model_config);
+        static std::string get_model_key(const nlohmann::json& model_config, size_t num_dims = 0);
         bool update_api_key(const std::string& apikey) override {
             std::lock_guard<std::shared_mutex> lock(mutex);
             google_api_key = apikey;
@@ -220,7 +220,7 @@ class GCPEmbedder : public RemoteEmbedder {
         std::vector<embedding_res_t> embed_documents(const std::vector<std::string>& inputs, const size_t remote_embedding_batch_size = 200,
                                                  const size_t remote_embedding_timeout_ms = 60000, const size_t remote_embedding_num_tries = 2) override;
         nlohmann::json get_error_json(const nlohmann::json& req_body, long res_code, const std::string& res_body) override;
-        static std::string get_model_key(const nlohmann::json& model_config);
+        static std::string get_model_key(const nlohmann::json& model_config, size_t num_dims = 0);
         bool update_api_key(const std::string& api_key) override {
             return true;
         }

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -6271,7 +6271,7 @@ Option<bool> Collection::update_apikey(const nlohmann::json& model_config, const
             }
 
             //update in remote embedder first the in collection
-            auto update_op = EmbedderManager::get_instance().update_remote_model_apikey(coll_model_config, api_key);
+            auto update_op = EmbedderManager::get_instance().update_remote_model_apikey(coll_model_config, api_key, coll_field.num_dim);
 
             if (!update_op.ok()) {
                 return update_op;

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -1378,7 +1378,7 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
                     std::vector<std::vector<float>> embeddings;
                     for(const auto& q: sort_field_std.vector_query.query.queries) {
                         EmbedderManager& embedder_manager = EmbedderManager::get_instance();
-                        auto embedder_op = embedder_manager.get_text_embedder(vector_field_it.value().embed[fields::model_config]);
+                        auto embedder_op = embedder_manager.get_text_embedder(vector_field_it.value().embed[fields::model_config], vector_field_it.value().num_dim);
                         if(!embedder_op.ok()) {
                             return Option<bool>(400, embedder_op.error());
                         }
@@ -1442,7 +1442,7 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
                     // generate embeddings for the query
 
                     EmbedderManager& embedder_manager = EmbedderManager::get_instance();
-                    auto embedder_op = embedder_manager.get_text_embedder(vector_field_it.value().embed[fields::model_config]);
+                    auto embedder_op = embedder_manager.get_text_embedder(vector_field_it.value().embed[fields::model_config], vector_field_it.value().num_dim);
                     if(!embedder_op.ok()) {
                         return Option<bool>(embedder_op.code(), embedder_op.error());
                     }
@@ -2253,7 +2253,7 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
                 }
 
                 EmbedderManager& embedder_manager = EmbedderManager::get_instance();
-                auto embedder_op = embedder_manager.get_text_embedder(search_field.embed[fields::model_config]);
+                auto embedder_op = embedder_manager.get_text_embedder(search_field.embed[fields::model_config], search_field.num_dim);
                 if(!embedder_op.ok()) {
                     return Option<bool>(400, embedder_op.error());
                 }
@@ -8366,7 +8366,7 @@ Option<bool> Collection::parse_and_validate_vector_query(const std::string& vect
         std::vector<std::vector<float>> embeddings;
         for(const auto& q: vector_query.queries) {
             EmbedderManager& embedder_manager = EmbedderManager::get_instance();
-            auto embedder_op = embedder_manager.get_text_embedder(vector_field_it.value().embed[fields::model_config]);
+            auto embedder_op = embedder_manager.get_text_embedder(vector_field_it.value().embed[fields::model_config], vector_field_it.value().num_dim);
             if(!embedder_op.ok()) {
                 return Option<bool>(400, embedder_op.error());
             }

--- a/src/embedder_manager.cpp
+++ b/src/embedder_manager.cpp
@@ -60,7 +60,7 @@ Option<bool> EmbedderManager::validate_and_init_remote_model(const nlohmann::jso
     }
 
     std::unique_lock<std::mutex> lock(text_embedders_mutex);
-    std::string model_key = is_remote_model(model_name) ? RemoteEmbedder::get_model_key(model_config) : model_name;
+    std::string model_key = is_remote_model(model_name) ? RemoteEmbedder::get_model_key(model_config, num_dims) : model_name;
     auto text_embedder_it = text_embedders.find(model_key);
     if(text_embedder_it == text_embedders.end()) {
         text_embedders.emplace(model_key, std::make_shared<TextEmbedder>(model_config, num_dims, has_custom_dims));
@@ -181,10 +181,10 @@ Option<bool> EmbedderManager::validate_and_init_local_model(const nlohmann::json
     return Option<bool>(true);
 }
 
-Option<TextEmbedder*> EmbedderManager::get_text_embedder(const nlohmann::json& model_config) {
+Option<TextEmbedder*> EmbedderManager::get_text_embedder(const nlohmann::json& model_config, size_t num_dims) {
     std::unique_lock<std::mutex> lock(text_embedders_mutex);
     const std::string& model_name = model_config.at("model_name");
-    std::string model_key = is_remote_model(model_name) ? RemoteEmbedder::get_model_key(model_config) : model_name;
+    std::string model_key = is_remote_model(model_name) ? RemoteEmbedder::get_model_key(model_config, num_dims) : model_name;
     auto text_embedder_it = text_embedders.find(model_key);
 
     if(text_embedder_it == text_embedders.end()) {

--- a/src/embedder_manager.cpp
+++ b/src/embedder_manager.cpp
@@ -69,9 +69,9 @@ Option<bool> EmbedderManager::validate_and_init_remote_model(const nlohmann::jso
     return Option<bool>(true);
 }
 
-Option<bool> EmbedderManager::update_remote_model_apikey(const nlohmann::json &model_config, const std::string& new_apikey) {
+Option<bool> EmbedderManager::update_remote_model_apikey(const nlohmann::json &model_config, const std::string& new_apikey, size_t num_dims) {
     std::unique_lock<std::mutex> lock(text_embedders_mutex);
-    const auto& model_key = RemoteEmbedder::get_model_key(model_config);
+    const auto& model_key = RemoteEmbedder::get_model_key(model_config, num_dims);
 
     if(text_embedders.find(model_key) == text_embedders.end()) {
         return Option<bool>(404, "Text embedder was not found.");
@@ -88,7 +88,7 @@ Option<bool> EmbedderManager::update_remote_model_apikey(const nlohmann::json &m
     //update text embedder with new api_key and remove old entry
     auto updated_model_config = model_config;
     updated_model_config["api_key"] = new_apikey;
-    const auto& updated_model_key = RemoteEmbedder::get_model_key(updated_model_config);
+    const auto& updated_model_key = RemoteEmbedder::get_model_key(updated_model_config, num_dims);
     text_embedders[updated_model_key] = text_embedders[model_key];
     text_embedders.erase(model_key);
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -8293,7 +8293,7 @@ void Index::batch_embed_fields(std::vector<index_record*>& records,
         }
 
         if(!values_text.empty()) {
-            auto embedder_op = embedder_manager.get_text_embedder(field.embed[fields::model_config]);
+            auto embedder_op = embedder_manager.get_text_embedder(field.embed[fields::model_config], field.num_dim);
             if(!embedder_op.ok()) {
                 LOG(ERROR) << "Error while getting embedder for model: " << field.embed[fields::model_config];
                 LOG(ERROR) << "Error: " << embedder_op.error();


### PR DESCRIPTION
## Change Summary
- port changes of #2721 with added tests and a fix for the embedder's key when updating a collection
- drop https://github.com/typesense/typesense/pull/2586

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
