### PR TITLE
Multi search concurrency

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -709,11 +709,13 @@ private:
                                         const bool& is_union_search,
                                         const uint32_t& union_search_index) const;
 
-    Option<bool> run_search_with_lock(search_args* search_params) const;
+    Option<bool> search_index_with_lock(search_args* search_params) const;
 
     void reset_alter_status_counters();
 
     std::string get_facet_str_val(const std::string& field_name, uint32_t facet_id);
+
+    Option<nlohmann::json> run_search_with_lock(collection_search_args_t& coll_args);
 
 public:
 
@@ -997,8 +999,12 @@ public:
                                                           bool& is_wildcard_query) const;
 
     static Option<bool> do_union(const std::vector<uint32_t>& collection_ids,
+                                 std::vector<collection_search_args_t>& searches, const union_global_params_t& union_params,
+                                 nlohmann::json& result, bool remove_duplicates, bool is_concurrent);
+
+    static Option<bool> do_multi_search(const std::vector<uint32_t>& collection_ids,
                                  std::vector<collection_search_args_t>& searches, std::vector<long>& searchTimeMillis,
-                                 const union_global_params_t& union_params, nlohmann::json& result, bool remove_duplicates);
+                                 nlohmann::json& result, const std::string& user_id, bool is_concurrent);
 
     Option<bool> get_filter_ids(const std::string & filter_query, filter_result_t& filter_result,
                                 const bool& should_timeout = true, const bool& validate_field_names = true) const;

--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -163,7 +163,18 @@ public:
 
     static Option<bool> do_union(std::map<std::string, std::string>& req_params,
                                  std::vector<nlohmann::json>& embedded_params_vec, nlohmann::json searches,
-                                 nlohmann::json& response, uint64_t start_ts, bool remove_duplicates = true);
+                                 nlohmann::json& response, uint64_t start_ts, bool remove_duplicates = true,
+                                 bool concurrency = false);
+
+    static Option<bool> populate_collection_args(std::map<std::string, std::string>& req_params,
+                                          std::vector<nlohmann::json>& embedded_params_vec, nlohmann::json searches,
+                                          std::vector<collection_search_args_t>& coll_searches, std::vector<uint32_t>& collection_ids,
+                                          int& group_by_args_count, uint64_t start_ts,
+                                          std::optional<union_global_params_t> union_params = std::nullopt);
+
+    static Option<bool> do_multi_search(std::map<std::string, std::string>& req_params,
+                                        std::vector<nlohmann::json>& embedded_params_vec, nlohmann::json searches,
+                                        nlohmann::json& results, uint64_t start_ts, bool concurrency = false);
 
     static bool parse_sort_by_str(std::string sort_by_str, std::vector<sort_by>& sort_fields);
 

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -3590,6 +3590,12 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) c
     return Option<nlohmann::json>(result);
 }
 
+Option<nlohmann::json> Collection::run_search_with_lock(collection_search_args_t& coll_args) {
+    std::shared_lock lock(mutex);
+
+    return search(coll_args);
+}
+
 void Collection::do_highlighting(const tsl::htrie_map<char, field>& search_schema, const bool& enable_nested_fields,
                                  const std::vector<char>& symbols_to_index, const std::vector<char>& token_separators,
                                  const string& query, const std::vector<std::string>& raw_search_fields,
@@ -3722,13 +3728,14 @@ void Collection::do_highlighting(const tsl::htrie_map<char, field>& search_schem
 
 }
 
-Option<bool> Collection::run_search_with_lock(search_args* search_params) const {
+Option<bool> Collection::search_index_with_lock(search_args* search_params) const {
     std::shared_lock lock(mutex);
     return index->run_search(search_params);
 }
+
 Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
-                                  std::vector<collection_search_args_t>& searches, std::vector<long>& searchTimeMillis,
-                                  const union_global_params_t& union_params, nlohmann::json& result, bool remove_duplicates) {
+                                  std::vector<collection_search_args_t>& searches, const union_global_params_t& union_params,
+                                  nlohmann::json& result, bool remove_duplicates, bool is_concurrent) {
     if (searches.size() != collection_ids.size()) {
         return Option<bool>(400, "Expected `collection_ids` and `searches` size to be equal.");
     }
@@ -3759,159 +3766,244 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
     auto group_limit = searches[0].group_limit;
     auto found_docs = 0;
 
-    for (size_t search_index = 0; search_index < searches.size(); search_index++) {
-        auto begin = std::chrono::high_resolution_clock::now();
-        auto& coll_args = searches[search_index];
-        const auto& coll_id = collection_ids[search_index];
+    std::mutex mut;
 
-        auto& cm = CollectionManager::get_instance();
-        auto coll = cm.get_collection_with_id(coll_id);
-        if (coll == nullptr) {
-            return Option<bool>(400, "Collection having `coll_id: " + std::to_string(coll_id) + "` not found.");
-        }
-
-        auto& search_params_guard = search_params_guards[search_index];
-        auto& query = queries[search_index];
-        auto& included_ids = included_ids_list[search_index];
-        auto& include_fields_full = include_fields_full_list[search_index];
-        auto& exclude_fields_full = exclude_fields_full_list[search_index];
-        auto& q_tokens = q_tokens_list[search_index];
-        auto& conversation_standalone_query = conversation_standalone_queries[search_index];
-        auto& vector_query = vector_queries[search_index];
-        auto& facets = facets_list[search_index];
-        auto& per_page = per_pages[search_index] = union_params.per_page;;
-        auto& transcribed_query = transcribed_queries[search_index];
-        auto& curation_metadata = curation_metadata_list[search_index];
-        const auto default_sorting_field_used = coll_args.sort_fields.empty() &&
-                                                !coll->default_sorting_field.empty();
-
-        const auto init_index_search_args_op = coll->init_index_search_args_with_lock(coll_args, search_params_guard, query, included_ids,
-                                                                                      include_fields_full, exclude_fields_full,
-                                                                                      q_tokens, conversation_standalone_query,
-                                                                                      vector_query, facets, per_page,
-                                                                                      transcribed_query, curation_metadata,
-                                                                                      true, search_index);
-        if (!init_index_search_args_op.ok()) {
-            return init_index_search_args_op;
-        }
-
-        const auto search_op = coll->run_search_with_lock(search_params_guard.get());
-
-        searchTimeMillis.emplace_back(std::chrono::duration_cast<std::chrono::milliseconds>(
-                                            std::chrono::high_resolution_clock::now() - begin).count());
-        totalSearchTime += searchTimeMillis.back();
-
-        if (!search_op.ok()) {
-            return search_op;
-        }
-
-        const auto& search_params = search_params_guard;
-        const auto& found = search_params->found_count;
-        total += found;
-        found_docs += found;
-        if (unique_collection_ids.count(coll_id) == 0) {
-            out_of += coll->get_num_documents();
-            unique_collection_ids.insert(coll_id);
-        }
-
-        auto& index_symbols = index_symbols_list[search_index];
-        for(char c: coll->get_symbols_to_index()) {
-            index_symbols[uint8_t(c)] = 1;
-        }
-
-        const auto& highlight_fields = coll_args.highlight_fields;
-        const auto& highlight_full_fields = coll_args.highlight_full_fields;
-        const auto& weighted_search_fields = search_params->search_fields;
-        const auto& raw_search_fields = coll_args.search_fields;
-        const auto& infixes = search_params->infixes;
-
-        auto& highlight_field_names = highlight_field_names_list[search_index];
-        StringUtils::split(highlight_fields, highlight_field_names, ",");
-
-        auto& highlight_full_field_names = highlight_full_field_names_list[search_index];
-        StringUtils::split(highlight_full_fields, highlight_full_field_names, ",");
-        if (query != "*") {
-            coll->process_highlight_fields_with_lock(weighted_search_fields, raw_search_fields, include_fields_full, exclude_fields_full,
-                                     highlight_field_names, highlight_full_field_names, infixes, q_tokens,
-                                     search_params->qtoken_set, highlight_items_list[search_index]);
-        }
-
-        nlohmann::json params;
-        params["collection_name"] = coll->get_name();
-        params["per_page"] = union_params.per_page;
-        params["q"] = coll_args.raw_query;
-        params["found"] = found;
-        request_json_list[search_index] = params;
-
-        // All the searches should sort_by on the same type of field and in the same order.
-        if (search_index > 0) {
-            const auto& first_search_sort_fields = search_params_guards[0]->sort_fields_std;
-            const auto& this_search_sort_fields = search_params->sort_fields_std;
-            if (this_search_sort_fields.size() != first_search_sort_fields.size()) {
-                std::string message = "Expected size of `sort_by` parameter of all searches to be equal. "
-                                      "The first union search sorts on {";
-                for (const auto& item: first_search_sort_fields) {
-                    message += ("`" + item.name + ": " + std::string(magic_enum::enum_name(item.type)) + "`, ");
-                }
-                if (message.back() != '{') {
-                    message[message.size() - 2] = '}';
-                } else {
-                    message += "} ";
-                }
-                message += ( "but the search at index `" + std::to_string(search_index) + "` sorts on {");
-                for (const auto& item: this_search_sort_fields) {
-                    message += ("`" + item.name + ": " + std::string(magic_enum::enum_name(item.type)) + "`, ");
-                }
-                if (message.back() != '{') {
-                    message[message.size() - 2] = '}';
-                    message[message.size() - 1] = '.';
-                } else {
-                    message += "}.";
-                }
-                return Option<bool>(400, message);
+    auto process_and_search = [&](size_t start_index, size_t batch_len)->Option<bool> {
+        for (int i = 0; i < batch_len; ++i) {
+            auto search_index = start_index + i;
+            auto begin = std::chrono::high_resolution_clock::now();
+            auto& coll_args = searches[search_index];
+            const auto& coll_id = collection_ids[search_index];
+            auto& cm = CollectionManager::get_instance();
+            auto coll = cm.get_collection_with_id(coll_id);
+            if (coll == nullptr) {
+                return Option<bool>(400, "Collection having `coll_id: " + std::to_string(coll_id) + "` not found.");
             }
 
-            for (size_t i = 0; i < first_search_sort_fields.size(); i++) {
-                if (this_search_sort_fields[i].type != first_search_sort_fields[i].type) {
-                    std::string append_hint;
-                    const auto& first_search_collection_name = request_json_list[0]["collection_name"].get<std::string>();
-                    if (default_sorting_field_used && first_request_default_sorting_field_used) {
-                        // Both the current and first search request have declared a default sorting field.
-                        append_hint = " Both `" + coll->get_name() + "` and `" + first_search_collection_name +
-                                        "` collections have declared a default sorting field of different type. Since"
-                                        " union expects the searches to sort_by on the same type of fields, default"
-                                        " sorting fields of the collections should be removed.";
-                    } else if (default_sorting_field_used) {
-                        append_hint = " `" + coll->get_name() + "` collection has declared a default sorting field of "
-                                        "different type. Since union expects the searches to sort_by on the same type "
-                                        "of fields, default sorting field of the collection should be removed.";
-                    } else if (first_request_default_sorting_field_used) {
-                        append_hint = " `" + first_search_collection_name + "` collection has declared a default sorting"
-                                        " field of different type. Since union expects the searches to sort_by on the"
-                                        " same type of fields, default sorting field of the collection should be removed.";
+            auto& search_params_guard = search_params_guards[search_index];
+            auto& query = queries[search_index];
+            auto& included_ids = included_ids_list[search_index];
+            auto& include_fields_full = include_fields_full_list[search_index];
+            auto& exclude_fields_full = exclude_fields_full_list[search_index];
+            auto& q_tokens = q_tokens_list[search_index];
+            auto& conversation_standalone_query = conversation_standalone_queries[search_index];
+            auto& vector_query = vector_queries[search_index];
+            auto& facets = facets_list[search_index];
+            auto& per_page = per_pages[search_index] = union_params.per_page;;
+            auto& transcribed_query = transcribed_queries[search_index];
+            auto& curation_metadata = curation_metadata_list[search_index];
+            const auto default_sorting_field_used = coll_args.sort_fields.empty() &&
+                                                    !coll->default_sorting_field.empty();
+
+            const auto init_index_search_args_op = coll->init_index_search_args_with_lock(coll_args,
+                                                                                          search_params_guard, query,
+                                                                                          included_ids,
+                                                                                          include_fields_full,
+                                                                                          exclude_fields_full,
+                                                                                          q_tokens,
+                                                                                          conversation_standalone_query,
+                                                                                          vector_query, facets,
+                                                                                          per_page,
+                                                                                          transcribed_query,
+                                                                                          curation_metadata,
+                                                                                          true, search_index);
+            if (!init_index_search_args_op.ok()) {
+                return init_index_search_args_op;
+            }
+
+            const auto search_op = coll->search_index_with_lock(search_params_guard.get());
+
+            auto searchTimeMillis = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::high_resolution_clock::now() - begin).count();
+
+            //update common data structures
+            std::unique_lock<std::mutex> lock(mut);
+
+            totalSearchTime += searchTimeMillis;
+
+            if (!search_op.ok()) {
+                return search_op;
+            }
+
+            const auto& search_params = search_params_guard;
+            const auto& found = search_params->found_count;
+            total += found;
+            found_docs += found;
+            if (unique_collection_ids.count(coll_id) == 0) {
+                out_of += coll->get_num_documents();
+                unique_collection_ids.insert(coll_id);
+            }
+
+            auto& index_symbols = index_symbols_list[search_index];
+            for (char c: coll->get_symbols_to_index()) {
+                index_symbols[uint8_t(c)] = 1;
+            }
+
+            lock.unlock();
+
+            const auto& highlight_fields = coll_args.highlight_fields;
+            const auto& highlight_full_fields = coll_args.highlight_full_fields;
+            const auto& weighted_search_fields = search_params->search_fields;
+            const auto& raw_search_fields = coll_args.search_fields;
+            const auto& infixes = search_params->infixes;
+
+            auto& highlight_field_names = highlight_field_names_list[search_index];
+            StringUtils::split(highlight_fields, highlight_field_names, ",");
+
+            auto& highlight_full_field_names = highlight_full_field_names_list[search_index];
+            StringUtils::split(highlight_full_fields, highlight_full_field_names, ",");
+            if (query != "*") {
+                coll->process_highlight_fields_with_lock(weighted_search_fields, raw_search_fields, include_fields_full,
+                                                         exclude_fields_full,
+                                                         highlight_field_names, highlight_full_field_names, infixes,
+                                                         q_tokens,
+                                                         search_params->qtoken_set, highlight_items_list[search_index]);
+            }
+
+            nlohmann::json params;
+            params["collection_name"] = coll->get_name();
+            params["per_page"] = union_params.per_page;
+            params["q"] = coll_args.raw_query;
+            params["found"] = found;
+            request_json_list[search_index] = params;
+
+            // All the searches should sort_by on the same type of field and in the same order.
+            if (search_index > 0) {
+                const auto& first_search_sort_fields = search_params_guards[0]->sort_fields_std;
+                const auto& this_search_sort_fields = search_params->sort_fields_std;
+                if (this_search_sort_fields.size() != first_search_sort_fields.size()) {
+                    std::string message = "Expected size of `sort_by` parameter of all searches to be equal. "
+                                          "The first union search sorts on {";
+                    for (const auto& item: first_search_sort_fields) {
+                        message += ("`" + item.name + ": " + std::string(magic_enum::enum_name(item.type)) + "`, ");
+                    }
+                    if (message.back() != '{') {
+                        message[message.size() - 2] = '}';
+                    } else {
+                        message += "} ";
+                    }
+                    message += ("but the search at index `" + std::to_string(search_index) + "` sorts on {");
+                    for (const auto& item: this_search_sort_fields) {
+                        message += ("`" + item.name + ": " + std::string(magic_enum::enum_name(item.type)) + "`, ");
+                    }
+                    if (message.back() != '{') {
+                        message[message.size() - 2] = '}';
+                        message[message.size() - 1] = '.';
+                    } else {
+                        message += "}.";
+                    }
+                    return Option<bool>(400, message);
+                }
+
+                for (size_t i = 0; i < first_search_sort_fields.size(); i++) {
+                    if (this_search_sort_fields[i].type != first_search_sort_fields[i].type) {
+                        std::string append_hint;
+                        const auto& first_search_collection_name = request_json_list[0]["collection_name"].get<std::string>();
+                        if (default_sorting_field_used && first_request_default_sorting_field_used) {
+                            // Both the current and first search request have declared a default sorting field.
+                            append_hint = " Both `" + coll->get_name() + "` and `" + first_search_collection_name +
+                                          "` collections have declared a default sorting field of different type. Since"
+                                          " union expects the searches to sort_by on the same type of fields, default"
+                                          " sorting fields of the collections should be removed.";
+                        } else if (default_sorting_field_used) {
+                            append_hint =
+                                    " `" + coll->get_name() + "` collection has declared a default sorting field of "
+                                                              "different type. Since union expects the searches to sort_by on the same type "
+                                                              "of fields, default sorting field of the collection should be removed.";
+                        } else if (first_request_default_sorting_field_used) {
+                            append_hint =
+                                    " `" + first_search_collection_name + "` collection has declared a default sorting"
+                                                                          " field of different type. Since union expects the searches to sort_by on the"
+                                                                          " same type of fields, default sorting field of the collection should be removed.";
+                        }
+
+                        return Option<bool>(400, "Expected type of `" + this_search_sort_fields[i].name + "` sort_by ("
+                                                 + std::string(magic_enum::enum_name(this_search_sort_fields[i].type)) +
+                                                 ") at search index `" += std::to_string(search_index) + "` to be "
+                                                                                                         "the same as the type of `" +
+                                                                          first_search_sort_fields[i].name +
+                                                                          "` sort_by (" += std::string(
+                                magic_enum::enum_name(first_search_sort_fields[i].type)) +
+                                                                                           ") at search index `" +=
+                                                                          std::to_string(0) + "`." += append_hint);
                     }
 
-                    return Option<bool>(400, "Expected type of `" + this_search_sort_fields[i].name + "` sort_by ("
-                                                + std::string(magic_enum::enum_name(this_search_sort_fields[i].type)) +
-                                                ") at search index `" += std::to_string(search_index) + "` to be "
-                                                "the same as the type of `" + first_search_sort_fields[i].name +
-                                                "` sort_by (" += std::string(magic_enum::enum_name(first_search_sort_fields[i].type)) +
-                                                ") at search index `" += std::to_string(0) + "`." += append_hint);
+                    if (this_search_sort_fields[i].order != first_search_sort_fields[i].order) {
+                        return Option<bool>(400, "Expected order of `" + this_search_sort_fields[i].name + "` sort_by ("
+                                += this_search_sort_fields[i].order + ") at search index `" +=
+                                   std::to_string(search_index) + "` to be the same as the order of `" +
+                                   first_search_sort_fields[i].name + "` sort_by ("
+                                           += first_search_sort_fields[i].order + ") at search index `" +=
+                                           std::to_string(0) + "`.");
+                    }
                 }
-
-                if (this_search_sort_fields[i].order != first_search_sort_fields[i].order) {
-                    return Option<bool>(400, "Expected order of `" + this_search_sort_fields[i].name + "` sort_by ("
-                                             += this_search_sort_fields[i].order + ") at search index `" +=
-                                             std::to_string(search_index) + "` to be the same as the order of `" +
-                                             first_search_sort_fields[i].name + "` sort_by ("
-                                             += first_search_sort_fields[i].order + ") at search index `" +=
-                                             std::to_string(0) + "`.");
-                }
+            } else {
+                first_request_default_sorting_field_used = default_sorting_field_used;
             }
-        } else {
-            first_request_default_sorting_field_used = default_sorting_field_used;
+        }
+
+        return Option<bool>(true);
+    };
+
+
+    if (is_concurrent) {
+        auto thread_pool = CollectionManager::get_instance().get_thread_pool();
+
+        const size_t concurrency = 4;
+        const size_t num_threads = std::min(concurrency, searches.size());
+        const size_t window_size = (num_threads == 0) ? 0 :
+                                   (searches.size() + num_threads - 1) / num_threads;
+
+        std::mutex m_process;
+        std::condition_variable cv_process;
+        size_t num_queued = 0;
+        size_t num_processed = 0;
+        size_t search_index = 0;
+        Option<bool> error_state = Option<bool>(true);
+
+        for (size_t thread_id = 0; thread_id < num_threads && search_index < searches.size(); thread_id++) {
+            size_t batch_len = window_size;
+
+            if (search_index + window_size > searches.size()) {
+                batch_len = searches.size() - search_index;
+            }
+
+            num_queued++;
+
+            thread_pool->enqueue([&, search_index, batch_len]() {
+                error_state = process_and_search(search_index, batch_len);
+
+                std::unique_lock<std::mutex> lock(m_process);
+                num_processed++;
+
+                cv_process.notify_one();
+            });
+
+            if(!error_state.ok()) {
+                break;
+            }
+
+            search_index += batch_len;
+        }
+
+        {
+            std::unique_lock<std::mutex> lock_process(m_process);
+            cv_process.wait(lock_process, [&]() { return num_processed == num_queued; });
+        }
+
+        if(!error_state.ok()) {
+            return error_state;
+        }
+
+    } else {
+        for (size_t search_index = 0; search_index < searches.size(); ++search_index) {
+            auto op = process_and_search(search_index, 1);
+            if(!op.ok()) {
+                return op;
+            }
         }
     }
+
 
     if (search_cutoff && total == 0) {
         // this can happen if other requests stopped this request from being processed
@@ -4189,6 +4281,140 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
     }
 
     result["search_cutoff"] = search_cutoff;
+
+    return Option<bool>(true);
+}
+
+Option<bool> Collection::do_multi_search(const std::vector<uint32_t>& collection_ids,
+                                         std::vector<collection_search_args_t>& searches,
+                                         std::vector<long>& searchTimeMillis, nlohmann::json& results,
+                                         const std::string& user_id, bool is_concurrent) {
+    std::mutex mut;
+
+    auto process_and_search = [&](size_t start_index, size_t batch_len)->Option<bool> {
+        for (int i = 0; i < batch_len; ++i) {
+            auto search_index = start_index + i;
+            auto begin = std::chrono::high_resolution_clock::now();
+            auto& coll_args = searches[search_index];
+            const auto& coll_id = collection_ids[search_index];
+            auto& cm = CollectionManager::get_instance();
+            auto coll = cm.get_collection_with_id(coll_id);
+            if (coll == nullptr) {
+                return Option<bool>(400, "Collection having `coll_id: " + std::to_string(coll_id) + "` not found.");
+            }
+
+            auto search_op = coll->run_search_with_lock(coll_args);
+
+            if(!search_op.ok()) {
+                return Option<bool>(search_op.code(), search_op.error());
+            }
+
+            auto result = search_op.get();
+
+            if(Config::get_instance().get_enable_search_analytics()) {
+                if(coll_args.enable_analytics && result.contains("found")) {
+                    std::string analytics_query = Tokenizer::normalize_ascii_no_spaces(coll_args.raw_query);
+                    search_internal_event_t internal_event = {
+                            SearchAnalytics::LOG_TYPE,
+                            coll->name,
+                            analytics_query,
+                            "",
+                            user_id,
+                            coll_args.filter_query,
+                            coll_args.analytics_tag
+                    };
+
+                    if(result["found"].get<size_t>() != 0) {
+                        const std::string& expanded_query = Tokenizer::normalize_ascii_no_spaces(
+                                result["request_params"]["first_q"].get<std::string>());
+                        internal_event.expanded_q = expanded_query;
+                        AnalyticsManager::get_instance().add_internal_event(internal_event);
+                        internal_event.type = SearchAnalytics::POPULAR_QUERIES_TYPE;
+                        AnalyticsManager::get_instance().add_internal_event(internal_event);
+                    } else {
+                        AnalyticsManager::get_instance().add_internal_event(internal_event);
+                        internal_event.type = SearchAnalytics::NO_HIT_QUERIES_TYPE;
+                        AnalyticsManager::get_instance().add_internal_event(internal_event);
+                    }
+                }
+            }
+
+            if(coll_args.exclude_fields.count("search_time_ms") == 0) {
+                auto searchTimeMillis = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        std::chrono::high_resolution_clock::now() - begin).count();
+                result["search_time_ms"] = searchTimeMillis;
+            }
+
+            if(coll_args.page == 0 && coll_args.offset != 0) {
+                result["offset"] = coll_args.offset;
+            } else {
+                result["page"] = (coll_args.page == 0) ? 1 : coll_args.page;
+            }
+
+            std::unique_lock<std::mutex> lock(mut); //fencing to avoid race
+            results.push_back(result);
+        }
+
+        return Option<bool>(true);
+    };
+
+    if (is_concurrent) {
+        auto thread_pool = CollectionManager::get_instance().get_thread_pool();
+
+        const size_t concurrency = 4;
+        const size_t num_threads = std::min(concurrency, searches.size());
+        const size_t window_size = (num_threads == 0) ? 0 :
+                                   (searches.size() + num_threads - 1) / num_threads;
+
+        std::mutex m_process;
+        std::condition_variable cv_process;
+        size_t num_queued = 0;
+        size_t num_processed = 0;
+        size_t search_index = 0;
+        Option<bool> error_state = Option<bool>(true);
+
+        for (size_t thread_id = 0; thread_id < num_threads && search_index < searches.size(); thread_id++) {
+            size_t batch_len = window_size;
+
+            if (search_index + window_size > searches.size()) {
+                batch_len = searches.size() - search_index;
+            }
+
+            num_queued++;
+
+            thread_pool->enqueue([&, search_index, batch_len]() {
+                error_state = process_and_search(search_index, batch_len);
+
+                std::unique_lock<std::mutex> lock(m_process);
+                num_processed++;
+
+                cv_process.notify_one();
+            });
+
+            if(!error_state.ok()) {
+                break;
+            }
+
+            search_index += batch_len;
+        }
+
+        {
+            std::unique_lock<std::mutex> lock_process(m_process);
+            cv_process.wait(lock_process, [&]() { return num_processed == num_queued; });
+        }
+
+        if(!error_state.ok()) {
+            return error_state;
+        }
+
+    } else {
+        for (size_t search_index = 0; search_index < searches.size(); ++search_index) {
+            auto op = process_and_search(search_index, 1);
+            if(!op.ok()) {
+                return op;
+            }
+        }
+    }
 
     return Option<bool>(true);
 }

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -2594,8 +2594,10 @@ Option<bool> CollectionManager::populate_collection_args(std::map<std::string, s
         auto& search_params = searches[i];
         req_params = orig_req_params;
 
-        // Only global pagination params are considered during union.
-        remove_global_params(search_params);
+        if(union_params) {
+            // Only global pagination params are considered during union.
+            remove_global_params(search_params);
+        }
 
         auto validate_op = multi_search_validate_and_add_params(req_params, search_params, false);
         if (!validate_op.ok()) {
@@ -2641,12 +2643,12 @@ Option<bool> CollectionManager::populate_collection_args(std::map<std::string, s
             group_by_args_count++;
         }
 
-        coll_searches.emplace_back(std::move(args));
-        collection_ids.emplace_back(collection->get_collection_id());
-
         if(union_params) {
             args.curation_union_global_params(union_params.value());
         }
+
+        coll_searches.emplace_back(std::move(args));
+        collection_ids.emplace_back(collection->get_collection_id());
     }
 
     return Option<bool>(true);

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1537,7 +1537,7 @@ void remove_global_params(std::map<std::string, std::string>& req_params) {
 
 Option<bool> CollectionManager::do_union(std::map<std::string, std::string>& req_params,
                                          std::vector<nlohmann::json>& embedded_params_vec, nlohmann::json searches,
-                                         nlohmann::json& response, uint64_t start_ts, bool remove_duplicates) {
+                                         nlohmann::json& response, uint64_t start_ts, bool remove_duplicates, bool concurrency) {
     union_global_params_t union_params(req_params);
     if (!union_params.init_op.ok()) {
         const auto& op = union_params.init_op;
@@ -1547,73 +1547,12 @@ Option<bool> CollectionManager::do_union(std::map<std::string, std::string>& req
     }
     remove_global_params(req_params);
 
-    auto const orig_req_params = req_params;
     std::vector<collection_search_args_t> coll_searches;
     std::vector<uint32_t> collection_ids;
-    auto result_op = Option<bool>(true);
     auto group_by_args_count = 0;
 
-    for(size_t i = 0; i < searches.size(); i++) {
-        auto& search_params = searches[i];
-        req_params = orig_req_params;
-
-        // Only global pagination params are considered during union.
-        remove_global_params(search_params);
-
-        auto validate_op = multi_search_validate_and_add_params(req_params, search_params, false);
-        if (!validate_op.ok()) {
-            result_op = std::move(validate_op);
-            break;
-        }
-
-        auto begin = std::chrono::high_resolution_clock::now();
-
-        auto &embedded_params = embedded_params_vec[i];
-        // enrich params with values from embedded params
-        auto apply_embedded_params_op = apply_embedded_params(embedded_params, req_params);
-        if (!apply_embedded_params_op.ok()) {
-            result_op = std::move(apply_embedded_params_op);
-            break;
-        }
-
-        auto apply_preset_op = apply_preset(req_params);
-        if (!apply_preset_op.ok()) {
-            result_op = std::move(apply_preset_op);
-            break;
-        }
-
-        std::string stopwords_set;
-        auto get_stopwords_op = get_stopword_set(req_params, stopwords_set);
-        if (!get_stopwords_op.ok()) {
-            result_op = std::move(get_stopwords_op);
-            break;
-        }
-
-        CollectionManager& collectionManager = CollectionManager::get_instance();
-        const std::string& orig_coll_name = req_params["collection"];
-        auto collection = collectionManager.get_collection(orig_coll_name);
-
-        if (collection == nullptr) {
-            result_op = Option<bool>(404, "`" + orig_coll_name + "` collection not found.");
-            break;
-        }
-
-        collection_search_args_t args;
-        auto init_op = collection_search_args_t::init(req_params, collection->get_num_documents(), stopwords_set,
-                                                      start_ts, args);
-        if (!init_op.ok()) {
-            result_op = std::move(init_op);
-            break;
-        }
-
-        if(args.group_limit) {
-            group_by_args_count++;
-        }
-
-        args.curation_union_global_params(union_params);
-        coll_searches.emplace_back(std::move(args));
-        collection_ids.emplace_back(collection->get_collection_id());
-    }
+    auto result_op = populate_collection_args(req_params, embedded_params_vec, searches, coll_searches, collection_ids,
+                                              group_by_args_count, start_ts, union_params);
 
     if(result_op.ok() && group_by_args_count > 0 && group_by_args_count != searches.size()) {
         result_op = Option<bool>(400, "Invalid group_by searches count. All searches with union search should be uniform.");
@@ -1625,9 +1564,7 @@ Option<bool> CollectionManager::do_union(std::map<std::string, std::string>& req
         return Option<bool>(true);
     }
 
-    std::vector<long> searchTimeMillis;
-
-    auto union_op = Collection::do_union(collection_ids, coll_searches, searchTimeMillis, union_params, response, remove_duplicates);
+    auto union_op = Collection::do_union(collection_ids, coll_searches, union_params, response, remove_duplicates, concurrency);
 
     auto reqTimeMillis = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::high_resolution_clock::now().time_since_epoch()).count() - start_ts;
@@ -1641,6 +1578,32 @@ Option<bool> CollectionManager::do_union(std::map<std::string, std::string>& req
         response["error"] = union_op.error();
         response["code"] = union_op.code();
         return Option<bool>(true);
+    }
+
+    return Option<bool>(true);
+}
+
+Option<bool> CollectionManager::do_multi_search(std::map<std::string, std::string>& req_params,
+                             std::vector<nlohmann::json>& embedded_params_vec, nlohmann::json searches,
+                             nlohmann::json& results, uint64_t start_ts, bool concurrency) {
+
+    std::vector<collection_search_args_t> coll_searches;
+    std::vector<uint32_t> collection_ids;
+    int group_by_args_count = 0;
+
+    auto populate_args_op = CollectionManager::populate_collection_args(req_params, embedded_params_vec, searches,
+                                                                        coll_searches, collection_ids, group_by_args_count,
+                                                                        start_ts);
+    if(!populate_args_op.ok()) {
+        return Option<bool>(populate_args_op.code(), populate_args_op.error());
+    }
+
+    std::vector<long> searchTimeMillis;
+    auto search_op = Collection::do_multi_search(collection_ids, coll_searches, searchTimeMillis, results,
+                                                 req_params["x-typesense-user-id"], concurrency);
+
+    if(!search_op.ok()) {
+        return Option<bool>(search_op.code(), search_op.error());
     }
 
     return Option<bool>(true);
@@ -2618,4 +2581,73 @@ Option<bool> CollectionManager::process_ref_include_fields_sort(const std::strin
     }
 
     return collection->process_ref_include_fields_sort(sort_by_str, limit, doc_ids);
+}
+
+Option<bool> CollectionManager::populate_collection_args(std::map<std::string, std::string>& req_params,
+                                                         std::vector<nlohmann::json>& embedded_params_vec,
+                                                         nlohmann::json searches, std::vector<collection_search_args_t>& coll_searches,
+                                                         std::vector<uint32_t>& collection_ids, int& group_by_args_count,
+                                                         uint64_t start_ts, std::optional<union_global_params_t> union_params) {
+    auto const orig_req_params = req_params;
+
+    for(size_t i = 0; i < searches.size(); i++) {
+        auto& search_params = searches[i];
+        req_params = orig_req_params;
+
+        // Only global pagination params are considered during union.
+        remove_global_params(search_params);
+
+        auto validate_op = multi_search_validate_and_add_params(req_params, search_params, false);
+        if (!validate_op.ok()) {
+            return validate_op;
+        }
+
+        auto begin = std::chrono::high_resolution_clock::now();
+
+        auto &embedded_params = embedded_params_vec[i];
+        // enrich params with values from embedded params
+        auto apply_embedded_params_op = apply_embedded_params(embedded_params, req_params);
+        if (!apply_embedded_params_op.ok()) {
+            return apply_embedded_params_op;
+        }
+
+        auto apply_preset_op = apply_preset(req_params);
+        if (!apply_preset_op.ok()) {
+            return apply_preset_op;
+        }
+
+        std::string stopwords_set;
+        auto get_stopwords_op = get_stopword_set(req_params, stopwords_set);
+        if (!get_stopwords_op.ok()) {
+            return get_stopwords_op;
+        }
+
+        CollectionManager& collectionManager = CollectionManager::get_instance();
+        const std::string& orig_coll_name = req_params["collection"];
+        auto collection = collectionManager.get_collection(orig_coll_name);
+
+        if (collection == nullptr) {
+            return Option<bool>(404, "`" + orig_coll_name + "` collection not found.");
+        }
+
+        collection_search_args_t args;
+        auto init_op = collection_search_args_t::init(req_params, collection->get_num_documents(), stopwords_set,
+                                                      start_ts, args);
+        if (!init_op.ok()) {
+            return init_op;
+        }
+
+        if(args.group_limit) {
+            group_by_args_count++;
+        }
+
+        coll_searches.emplace_back(std::move(args));
+        collection_ids.emplace_back(collection->get_collection_id());
+
+        if(union_params) {
+            args.curation_union_global_params(union_params.value());
+        }
+    }
+
+    return Option<bool>(true);
 }

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -986,6 +986,7 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
 
     const char* UNION_RESULT = "union";
     const char* UNION_REMOVE_DUPLICATES = "remove_duplicates";
+    const char* CONCURRENCY = "concurrency";
     auto is_union = false;
     auto union_remove_duplicates = true;
     auto it = req_json.find(UNION_RESULT);
@@ -1066,9 +1067,15 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
         }
     }
 
+    bool is_concurrent = false;
+    it = req_json.find(CONCURRENCY);
+    if(it != req_json.end() && it.value().is_boolean()) {
+        is_concurrent = it.value();
+    }
+
     if (is_union) {
         Option<bool> union_op = CollectionManager::do_union(req->params, req->embedded_params_vec, searches,
-                                                            response, req->conn_ts, union_remove_duplicates);
+                                                            response, req->conn_ts, union_remove_duplicates, is_concurrent);
         if(!union_op.ok() && union_op.code() == 408) {
             res->set(union_op.code(), union_op.error());
             req->overloaded = true;
@@ -1077,57 +1084,39 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
     } else {
         response["results"] = nlohmann::json::array();
 
-        for(size_t i = 0; i < searches.size(); i++) {
-            auto& search_params = searches[i];
-            req->params = orig_req_params;
+        uint64_t prompt_cache_ttl = NaturalLanguageSearchModelManager::DEFAULT_SCHEMA_PROMPT_TTL_SEC;
+        if(req->params.count("nl_query_prompt_cache_ttl") && StringUtils::is_uint64_t(req->params["nl_query_prompt_cache_ttl"])) {
+            prompt_cache_ttl = std::stoull(req->params["nl_query_prompt_cache_ttl"]);
+        }
 
-            auto validate_op = multi_search_validate_and_add_params(req->params, search_params, conversation);
-            if (!validate_op.ok()) {
-                LOG(ERROR) << "multi_search parameter validation failed: " << validate_op.error()
-                          << " with code: " << validate_op.code();
-                // Log the problematic search parameters
-                LOG(ERROR) << "Problematic search parameters: " << search_params.dump();
-                res->set_400(validate_op.error());
-                res->final = true;
-                stream_response(req, res);
-                return false;
-            }
+        auto nl_search_op = NaturalLanguageSearchModelManager::process_nl_query_and_augment_params(req->params, prompt_cache_ttl);
 
-            uint64_t prompt_cache_ttl = NaturalLanguageSearchModelManager::DEFAULT_SCHEMA_PROMPT_TTL_SEC;
-            if(req->params.count("nl_query_prompt_cache_ttl") && StringUtils::is_uint64_t(req->params["nl_query_prompt_cache_ttl"])) {
-                prompt_cache_ttl = std::stoull(req->params["nl_query_prompt_cache_ttl"]);
-            }
+        auto multi_search_op = CollectionManager::do_multi_search(req->params, req->embedded_params_vec, searches, response["results"],
+                                                                  req->conn_ts, is_concurrent);
 
-            auto nl_search_op = NaturalLanguageSearchModelManager::process_nl_query_and_augment_params(req->params, prompt_cache_ttl);
+        auto nl_processing_time_ms = nl_search_op.ok() ? nl_search_op.get() : 0;
 
-            std::string results_json_str;
-            Option<bool> search_op = CollectionManager::do_search(req->params, req->embedded_params_vec[i],
-                                                                  results_json_str, req->conn_ts);
-
-            auto nl_processing_time_ms = nl_search_op.ok() ? nl_search_op.get() : 0;
-            if(search_op.ok()) {
-                auto results_json = nlohmann::json::parse(results_json_str);
-                if(conversation) {
-                    results_json["request_params"]["q"] = common_query;
+        if(multi_search_op.ok()) {
+            for(auto& json_res : response["results"]) {
+                if (conversation) {
+                    json_res["request_params"]["q"] = common_query;
                 }
 
-                NaturalLanguageSearchModelManager::add_nl_query_data_to_results(results_json, &(req->params), nl_processing_time_ms);
-
-                response["results"].push_back(results_json);
-            } else {
-                if(search_op.code() == 408) {
-                    res->set(search_op.code(), search_op.error());
+                NaturalLanguageSearchModelManager::add_nl_query_data_to_results(json_res, &(req->params), nl_processing_time_ms);
+            }
+        } else {
+                if(multi_search_op.code() == 408) {
+                    res->set(multi_search_op.code(), multi_search_op.error());
                     req->overloaded = true;
                     res->final = true;
                     stream_response(req, res);
                     return false;
                 }
                 nlohmann::json err_res;
-                err_res["error"] = search_op.error();
-                err_res["code"] = search_op.code();
+                err_res["error"] = multi_search_op.error();
+                err_res["code"] = multi_search_op.code();
                 NaturalLanguageSearchModelManager::add_nl_query_data_to_results(err_res, &(req->params), nl_processing_time_ms, true);
                 response["results"].push_back(err_res);
-            }
         }
     }
 

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -3120,3 +3120,209 @@ TEST_F(CoreAPIUtilsTest, UnionRemoveDuplicates) {
     ASSERT_EQ("1", response["hits"][3]["document"]["id"]);
     ASSERT_EQ("1", response["hits"][4]["document"]["id"]);
 }
+
+TEST_F(CoreAPIUtilsTest, ConcurencyMultiSearch) {
+    nlohmann::json schema = R"({
+        "name": "coll1",
+        "fields": [
+            {"name": "name", "type": "string"}
+        ]
+    })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto coll1 = collection_create_op.get();
+
+    nlohmann::json doc;
+    for(auto i = 0; i < 100; ++i) {
+        doc["name"] = "Shampoo_" + std::to_string(i+1);
+        ASSERT_TRUE(coll1->add(doc.dump()).ok());
+    }
+
+    for(auto i = 100; i < 200; ++i) {
+        doc["name"] = "Soap_" + std::to_string(i+1);
+        ASSERT_TRUE(coll1->add(doc.dump()).ok());
+    }
+
+    for(auto i = 200; i < 300; ++i) {
+        doc["name"] = "Perfume_" + std::to_string(i+1);
+        ASSERT_TRUE(coll1->add(doc.dump()).ok());
+    }
+
+
+    nlohmann::json searches = R"([
+                    {
+                        "collection": "coll1",
+                        "q": "shampoo",
+                        "query_by": "name"
+                    },
+                    {
+                        "collection": "coll1",
+                        "q": "soap",
+                        "query_by": "name"
+                    },
+                    {
+                        "collection": "coll1",
+                        "q": "perfume",
+                        "query_by": "name"
+                    }
+                ])"_json;
+
+    std::shared_ptr<http_req> req = std::make_shared<http_req>();
+    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
+
+    //try union search first
+    //without concurrency
+    nlohmann::json body;
+    body["searches"] = searches;
+    body["union"] = true;
+
+    req->body = body.dump();
+    nlohmann::json embedded_params;
+    req->embedded_params_vec = std::vector<nlohmann::json>(3, embedded_params);
+    req->params["concurrency"] = false;
+
+    post_multi_search(req, res);
+    auto response = nlohmann::json::parse(res->body);
+    ASSERT_EQ(30, response["found"].get<size_t>());
+    ASSERT_EQ(10, response["hits"].size());
+    ASSERT_EQ("83", response["hits"][0]["document"]["id"]);
+    ASSERT_EQ("68", response["hits"][1]["document"]["id"]);
+    ASSERT_EQ("67", response["hits"][2]["document"]["id"]);
+    ASSERT_EQ("66", response["hits"][3]["document"]["id"]);
+    ASSERT_EQ("65", response["hits"][4]["document"]["id"]);
+    ASSERT_EQ("63", response["hits"][5]["document"]["id"]);
+    ASSERT_EQ("61", response["hits"][6]["document"]["id"]);
+    ASSERT_EQ("60", response["hits"][7]["document"]["id"]);
+    ASSERT_EQ("59", response["hits"][8]["document"]["id"]);
+    ASSERT_EQ("5", response["hits"][9]["document"]["id"]);
+
+    //try with concurrency, results should be same
+    req->params.clear();
+    req->body.clear();
+    body["searches"] = searches;
+    body["union"] = true;
+
+    req->body = body.dump();
+    embedded_params.clear();
+    req->embedded_params_vec = std::vector<nlohmann::json>(3, embedded_params);
+    req->params["concurrency"] = true;
+
+    post_multi_search(req, res);
+    response = nlohmann::json::parse(res->body);
+    ASSERT_EQ(30, response["found"].get<size_t>());
+    ASSERT_EQ(10, response["hits"].size());
+    ASSERT_EQ("83", response["hits"][0]["document"]["id"]);
+    ASSERT_EQ("68", response["hits"][1]["document"]["id"]);
+    ASSERT_EQ("67", response["hits"][2]["document"]["id"]);
+    ASSERT_EQ("66", response["hits"][3]["document"]["id"]);
+    ASSERT_EQ("65", response["hits"][4]["document"]["id"]);
+    ASSERT_EQ("63", response["hits"][5]["document"]["id"]);
+    ASSERT_EQ("61", response["hits"][6]["document"]["id"]);
+    ASSERT_EQ("60", response["hits"][7]["document"]["id"]);
+    ASSERT_EQ("59", response["hits"][8]["document"]["id"]);
+    ASSERT_EQ("5", response["hits"][9]["document"]["id"]);
+
+    //try normal searches now
+    res->body.clear();
+    req->params.clear();
+    req->body.clear();
+    body["union"] = false;
+    body["searches"] = searches;
+
+    req->body = body.dump();
+    embedded_params.clear();
+    req->embedded_params_vec = std::vector<nlohmann::json>(3, embedded_params);
+    req->params["concurrency"] = false;
+    post_multi_search(req, res);
+
+    response = nlohmann::json::parse(res->body);
+    ASSERT_EQ(3, response["results"].size());
+    ASSERT_EQ(10, response["results"][0]["found"].get<size_t>());
+    ASSERT_EQ(10, response["results"][0]["hits"].size());
+    ASSERT_EQ("83", response["results"][0]["hits"][0]["document"]["id"]);
+    ASSERT_EQ("68", response["results"][0]["hits"][1]["document"]["id"]);
+    ASSERT_EQ("67", response["results"][0]["hits"][2]["document"]["id"]);
+    ASSERT_EQ("66", response["results"][0]["hits"][3]["document"]["id"]);
+    ASSERT_EQ("65", response["results"][0]["hits"][4]["document"]["id"]);
+    ASSERT_EQ("63", response["results"][0]["hits"][5]["document"]["id"]);
+    ASSERT_EQ("61", response["results"][0]["hits"][6]["document"]["id"]);
+    ASSERT_EQ("60", response["results"][0]["hits"][7]["document"]["id"]);
+    ASSERT_EQ("59", response["results"][0]["hits"][8]["document"]["id"]);
+    ASSERT_EQ("5", response["results"][0]["hits"][9]["document"]["id"]);
+
+    ASSERT_EQ(10, response["results"][1]["hits"].size());
+    ASSERT_EQ("148", response["results"][1]["hits"][0]["document"]["id"]);
+    ASSERT_EQ("147", response["results"][1]["hits"][1]["document"]["id"]);
+    ASSERT_EQ("146", response["results"][1]["hits"][2]["document"]["id"]);
+    ASSERT_EQ("145", response["results"][1]["hits"][3]["document"]["id"]);
+    ASSERT_EQ("144", response["results"][1]["hits"][4]["document"]["id"]);
+    ASSERT_EQ("143", response["results"][1]["hits"][5]["document"]["id"]);
+    ASSERT_EQ("142", response["results"][1]["hits"][6]["document"]["id"]);
+    ASSERT_EQ("141", response["results"][1]["hits"][7]["document"]["id"]);
+    ASSERT_EQ("140", response["results"][1]["hits"][8]["document"]["id"]);
+    ASSERT_EQ("139", response["results"][1]["hits"][9]["document"]["id"]);
+
+    ASSERT_EQ(10, response["results"][2]["hits"].size());
+    ASSERT_EQ("248", response["results"][2]["hits"][0]["document"]["id"]);
+    ASSERT_EQ("247", response["results"][2]["hits"][1]["document"]["id"]);
+    ASSERT_EQ("246", response["results"][2]["hits"][2]["document"]["id"]);
+    ASSERT_EQ("245", response["results"][2]["hits"][3]["document"]["id"]);
+    ASSERT_EQ("244", response["results"][2]["hits"][4]["document"]["id"]);
+    ASSERT_EQ("243", response["results"][2]["hits"][5]["document"]["id"]);
+    ASSERT_EQ("242", response["results"][2]["hits"][6]["document"]["id"]);
+    ASSERT_EQ("241", response["results"][2]["hits"][7]["document"]["id"]);
+    ASSERT_EQ("240", response["results"][2]["hits"][8]["document"]["id"]);
+    ASSERT_EQ("239", response["results"][2]["hits"][9]["document"]["id"]);
+
+    //with concurrency, result should be same
+    res->body.clear();
+    req->params.clear();
+    req->body.clear();
+    body["searches"] = searches;
+
+    req->body = body.dump();
+    embedded_params.clear();
+    req->embedded_params_vec = std::vector<nlohmann::json>(3, embedded_params);
+    req->params["concurrency"] = true;
+    post_multi_search(req, res);
+
+    response = nlohmann::json::parse(res->body);
+    ASSERT_EQ(3, response["results"].size());
+    ASSERT_EQ(10, response["results"][0]["found"].get<size_t>());
+    ASSERT_EQ(10, response["results"][0]["hits"].size());
+    ASSERT_EQ("83", response["results"][0]["hits"][0]["document"]["id"]);
+    ASSERT_EQ("68", response["results"][0]["hits"][1]["document"]["id"]);
+    ASSERT_EQ("67", response["results"][0]["hits"][2]["document"]["id"]);
+    ASSERT_EQ("66", response["results"][0]["hits"][3]["document"]["id"]);
+    ASSERT_EQ("65", response["results"][0]["hits"][4]["document"]["id"]);
+    ASSERT_EQ("63", response["results"][0]["hits"][5]["document"]["id"]);
+    ASSERT_EQ("61", response["results"][0]["hits"][6]["document"]["id"]);
+    ASSERT_EQ("60", response["results"][0]["hits"][7]["document"]["id"]);
+    ASSERT_EQ("59", response["results"][0]["hits"][8]["document"]["id"]);
+    ASSERT_EQ("5", response["results"][0]["hits"][9]["document"]["id"]);
+
+    ASSERT_EQ(10, response["results"][1]["hits"].size());
+    ASSERT_EQ("148", response["results"][1]["hits"][0]["document"]["id"]);
+    ASSERT_EQ("147", response["results"][1]["hits"][1]["document"]["id"]);
+    ASSERT_EQ("146", response["results"][1]["hits"][2]["document"]["id"]);
+    ASSERT_EQ("145", response["results"][1]["hits"][3]["document"]["id"]);
+    ASSERT_EQ("144", response["results"][1]["hits"][4]["document"]["id"]);
+    ASSERT_EQ("143", response["results"][1]["hits"][5]["document"]["id"]);
+    ASSERT_EQ("142", response["results"][1]["hits"][6]["document"]["id"]);
+    ASSERT_EQ("141", response["results"][1]["hits"][7]["document"]["id"]);
+    ASSERT_EQ("140", response["results"][1]["hits"][8]["document"]["id"]);
+    ASSERT_EQ("139", response["results"][1]["hits"][9]["document"]["id"]);
+
+    ASSERT_EQ(10, response["results"][2]["hits"].size());
+    ASSERT_EQ("248", response["results"][2]["hits"][0]["document"]["id"]);
+    ASSERT_EQ("247", response["results"][2]["hits"][1]["document"]["id"]);
+    ASSERT_EQ("246", response["results"][2]["hits"][2]["document"]["id"]);
+    ASSERT_EQ("245", response["results"][2]["hits"][3]["document"]["id"]);
+    ASSERT_EQ("244", response["results"][2]["hits"][4]["document"]["id"]);
+    ASSERT_EQ("243", response["results"][2]["hits"][5]["document"]["id"]);
+    ASSERT_EQ("242", response["results"][2]["hits"][6]["document"]["id"]);
+    ASSERT_EQ("241", response["results"][2]["hits"][7]["document"]["id"]);
+    ASSERT_EQ("240", response["results"][2]["hits"][8]["document"]["id"]);
+    ASSERT_EQ("239", response["results"][2]["hits"][9]["document"]["id"]);
+}


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
### Concurrency with Multi-Search

To enable concurrency with multi-search, one need to pass `concurrency` param in the search request like below,
```curl
curl "http://localhost:8108/multi_search" -X POST -H "Content-Type: application/json" -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" 
-d '{
        "concurrency" : true,
        "searches": [
            {
              "collection": "hnstories",
              "q": "more",
              "query_by": "title"
            },
            {
              "collection": "hnstories",
              "q": "little",
              "query_by": "title"
            },
            {
              "collection": "hnstories",
              "q": "the",
              "query_by": "title"
            },
	        {
              "collection": "hnstories",
              "q": "more",
              "query_by": "title"
            }
          ]
    }'
```
It can help to speed up multiple searches using concurrency. 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
