### PR TITLE
Add curl to Docker image for container healthchecks

### DIFF
--- a/docker/deployment.Dockerfile
+++ b/docker/deployment.Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-RUN apt-get -y update && apt-get -y install ca-certificates
+RUN apt-get -y update && apt-get -y install ca-certificates curl && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /opt
 COPY typesense-server /opt


### PR DESCRIPTION
Currently there's no easy way to use Docker healthchecks because the images don't include curl. 

## Change Summary
This PR adds curl, along with the recommended `rm -rf /var/lib/apt/lists/*` post apt install cleanup, to the Dockerfile. This enables users to configure container healthchecks in container orchestration tools (Docker Compose, Kubernetes, etc.) using curl to hit the health endpoint.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
