### PR TITLE
Fix latency metrics overflow issue #2732

### DIFF
--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1630,8 +1630,9 @@ Option<bool> CollectionManager::do_union(std::map<std::string, std::string>& req
 
     auto union_op = Collection::do_union(collection_ids, coll_searches, searchTimeMillis, union_params, response, remove_duplicates);
 
-    auto reqTimeMillis = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::high_resolution_clock::now().time_since_epoch()).count() - start_ts;
+    auto end_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+    auto reqTimeMillis = (end_ts - start_ts) / 1000;
     update_app_metrics(reqTimeMillis);
 
     if (!union_op.ok()) {

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1451,8 +1451,9 @@ Option<bool> CollectionManager::do_search(std::map<std::string, std::string>& re
 
     Option<nlohmann::json> result_op = collection->search(args);
 
-    auto reqTimeMillis = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::high_resolution_clock::now().time_since_epoch()).count() - start_ts;
+    auto end_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+    auto reqTimeMillis = (end_ts - start_ts) / 1000;
     update_app_metrics(reqTimeMillis);
 
     if(!result_op.ok()) {

--- a/test/app_metrics_test.cpp
+++ b/test/app_metrics_test.cpp
@@ -1,16 +1,35 @@
 #include <gtest/gtest.h>
+#include <string>
+#include <vector>
+#include <collection_manager.h>
 #include "app_metrics.h"
+#include "collection.h"
 
 class AppMetricsTest : public ::testing::Test {
 protected:
     AppMetrics& metrics = AppMetrics::get_instance();
+    Store *store;
+    CollectionManager & collectionManager = CollectionManager::get_instance();
+    std::atomic<bool> quit = false;
 
     virtual void SetUp() {
-      metrics.window_reset();
+        std::string state_dir_path = "/tmp/typesense_test/app_metrics_test_db";
+        system(("rm -rf "+state_dir_path+" && mkdir -p "+state_dir_path).c_str());
+
+        store = new Store(state_dir_path);
+        collectionManager.init(store, 1.0, "auth_key", quit);
+        collectionManager.load(8, 1000);
+        
+        metrics.window_reset();
     }
 
     virtual void TearDown() {
-      metrics.window_reset();
+        metrics.window_reset();
+        
+        if(store != nullptr) {
+            collectionManager.dispose();
+            delete store;
+        }
     }
 };
 
@@ -82,4 +101,133 @@ TEST_F(AppMetricsTest, EstimateQuantileDuration) {
     ASSERT_EQ(computeNthPercentile(70), 701);
     ASSERT_EQ(computeNthPercentile(95), 950);
     ASSERT_EQ(computeNthPercentile(99), 990);
+}
+
+TEST_F(AppMetricsTest, SearchLatencyStats) {
+    metrics.window_reset();
+
+    std::vector<field> fields = {field("title", field_types::STRING, false, false, true, "", -1, 1),
+                                 field("points", field_types::INT32, false)};
+    Collection* coll1 = collectionManager.create_collection("latency_test", 1, fields, "points").get();
+
+    nlohmann::json doc1;
+    doc1["title"] = "Test Doc";
+    doc1["points"] = 100;
+    coll1->add(doc1.dump());
+
+    std::map<std::string, std::string> req_params;
+    req_params["collection"] = "latency_test";
+    req_params["q"] = "*";
+    nlohmann::json embedded_params;
+    std::string json_res;
+
+    // Simulate request start time using system_clock (as done in http_server)
+    auto start_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    // Sleep briefly to ensure non-zero latency
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, start_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    nlohmann::json metrics_result;
+    metrics.get("rps", "latency", metrics_result);
+
+    // Verify search latency is reasonable
+    ASSERT_TRUE(metrics_result.contains("search_latency"));
+    double latency = metrics_result["search_latency"];
+    
+    // Check for overflow (huge values) or negative values (cast to double might preserve sign or look huge unsigned)
+    // The bug produced values like 1.84e19
+    ASSERT_GE(latency, 0.0);
+    ASSERT_LT(latency, 100000.0); // 100s is plenty margin, well below 1.84e19
+
+    collectionManager.drop_collection("latency_test");
+}
+
+TEST_F(AppMetricsTest, MultiSearchLatencyStats) {
+    // Test both multi-search scenarios: without union and with union
+    
+    // Create two collections for multi search
+    std::vector<field> fields = {field("title", field_types::STRING, false, false, true, "", -1, 1),
+                                 field("points", field_types::INT32, false)};
+    
+    Collection* products_coll = collectionManager.create_collection("products_collection", 1, fields, "points").get();
+    Collection* reviews_coll = collectionManager.create_collection("reviews_collection", 1, fields, "points").get();
+
+    // Add test documents
+    nlohmann::json product_doc;
+    product_doc["title"] = "Test Product";
+    product_doc["points"] = 100;
+    products_coll->add(product_doc.dump());
+
+    nlohmann::json review_doc;
+    review_doc["title"] = "Test Review";
+    review_doc["points"] = 200;
+    reviews_coll->add(review_doc.dump());
+
+    // Prepare multi search request
+    std::map<std::string, std::string> req_params;
+    nlohmann::json searches = nlohmann::json::array();
+    
+    nlohmann::json products_search;
+    products_search["collection"] = "products_collection";
+    products_search["q"] = "*";
+    searches.push_back(products_search);
+
+    nlohmann::json reviews_search;
+    reviews_search["collection"] = "reviews_collection";
+    reviews_search["q"] = "*";
+    searches.push_back(reviews_search);
+
+    std::vector<nlohmann::json> embedded_params_vec = {nlohmann::json::object(), nlohmann::json::object()};
+    nlohmann::json response;
+
+    // Test 1: Multi-search WITHOUT union
+    {
+        metrics.window_reset();
+
+        auto start_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+        auto multi_op = collectionManager.do_union(req_params, embedded_params_vec, searches, response, start_ts, false);
+        ASSERT_TRUE(multi_op.ok());
+
+        nlohmann::json metrics_result;
+        metrics.get("rps", "latency", metrics_result);
+
+        ASSERT_TRUE(metrics_result.contains("search_latency"));
+        double latency = metrics_result["search_latency"];
+        
+        ASSERT_GE(latency, 0.0);
+        ASSERT_LT(latency, 100000.0); // 100s is plenty margin, well below 1.84e19
+    }
+
+    // Test 2: Multi-search WITH union
+    {
+        metrics.window_reset();
+
+        auto start_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+        auto union_op = collectionManager.do_union(req_params, embedded_params_vec, searches, response, start_ts, true);
+        ASSERT_TRUE(union_op.ok());
+
+        nlohmann::json metrics_result;
+        metrics.get("rps", "latency", metrics_result);
+
+        ASSERT_TRUE(metrics_result.contains("search_latency"));
+        double latency = metrics_result["search_latency"];
+        
+        ASSERT_GE(latency, 0.0);
+        ASSERT_LT(latency, 100000.0); // 100s is plenty margin, well below 1.84e19
+    }
+
+    collectionManager.drop_collection("products_collection");
+    collectionManager.drop_collection("reviews_collection");
 }

--- a/test/app_metrics_test.cpp
+++ b/test/app_metrics_test.cpp
@@ -193,8 +193,15 @@ TEST_F(AppMetricsTest, MultiSearchLatencyStats) {
 
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
-        auto multi_op = collectionManager.do_union(req_params, embedded_params_vec, searches, response, start_ts, false);
-        ASSERT_TRUE(multi_op.ok());
+        for(size_t i = 0; i < searches.size(); i++) {
+            std::map<std::string, std::string> search_params;
+            search_params["collection"] = searches[i]["collection"];
+            search_params["q"] = searches[i]["q"];
+            std::string json_res;
+            
+            auto search_op = collectionManager.do_search(search_params, embedded_params_vec[i], json_res, start_ts);
+            ASSERT_TRUE(search_op.ok());
+        }
 
         nlohmann::json metrics_result;
         metrics.get("rps", "latency", metrics_result);

--- a/test/app_metrics_test.cpp
+++ b/test/app_metrics_test.cpp
@@ -139,9 +139,10 @@ TEST_F(AppMetricsTest, SearchLatencyStats) {
     double latency = metrics_result["search_latency"];
     
     // Check for overflow (huge values) or negative values (cast to double might preserve sign or look huge unsigned)
-    // The bug produced values like 1.84e19
-    ASSERT_GE(latency, 0.0);
-    ASSERT_LT(latency, 100000.0); // 100s is plenty margin, well below 1.84e19
+    // The bug produced values like 1.84e19 due to mixing system_clock and high_resolution_clock
+    // We slept for 10ms, so latency should be at least 10ms
+    ASSERT_GE(latency, 10.0); // At least 10ms since we slept for 10ms
+    ASSERT_LT(latency, 1000.0);
 
     collectionManager.drop_collection("latency_test");
 }
@@ -208,9 +209,9 @@ TEST_F(AppMetricsTest, MultiSearchLatencyStats) {
 
         ASSERT_TRUE(metrics_result.contains("search_latency"));
         double latency = metrics_result["search_latency"];
-        
-        ASSERT_GE(latency, 0.0);
-        ASSERT_LT(latency, 100000.0); // 100s is plenty margin, well below 1.84e19
+
+        ASSERT_GE(latency, 10.0); 
+        ASSERT_LT(latency, 1000.0); 
     }
 
     // Test 2: Multi-search WITH union
@@ -231,8 +232,8 @@ TEST_F(AppMetricsTest, MultiSearchLatencyStats) {
         ASSERT_TRUE(metrics_result.contains("search_latency"));
         double latency = metrics_result["search_latency"];
         
-        ASSERT_GE(latency, 0.0);
-        ASSERT_LT(latency, 100000.0); // 100s is plenty margin, well below 1.84e19
+        ASSERT_GE(latency, 10.0); 
+        ASSERT_LT(latency, 1000.0);
     }
 
     collectionManager.drop_collection("products_collection");

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <fstream>
 #include <collection_manager.h>
+#include "app_metrics.h"
 #include "analytics_manager.h"
 #include "string_utils.h"
 #include "collection.h"
@@ -2104,4 +2105,47 @@ TEST_F(CollectionManagerTest, CloneCollectionWithDocuments) {
     collectionManager.drop_collection("source_collection");
     collectionManager.drop_collection("cloned_collection_no_docs");
     collectionManager.drop_collection("cloned_collection_with_docs");
+}
+
+TEST_F(CollectionManagerTest, VerifySearchLatencyMetric) {
+    AppMetrics::get_instance().window_reset();
+
+    std::vector<field> fields = {field("title", field_types::STRING, false, false, true, "", -1, 1),
+                                 field("points", field_types::INT32, false)};
+    Collection* coll1 = collectionManager.create_collection("latency_test", 1, fields, "points").get();
+
+    nlohmann::json doc1;
+    doc1["title"] = "Test Doc";
+    doc1["points"] = 100;
+    coll1->add(doc1.dump());
+
+    std::map<std::string, std::string> req_params;
+    req_params["collection"] = "latency_test";
+    req_params["q"] = "*";
+    nlohmann::json embedded_params;
+    std::string json_res;
+
+    // Simulate request start time using system_clock (as done in http_server)
+    auto start_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    // Sleep briefly to ensure non-zero latency
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, start_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    nlohmann::json metrics_result;
+    AppMetrics::get_instance().get("rps", "latency", metrics_result);
+
+    // Verify search latency is reasonable
+    ASSERT_TRUE(metrics_result.contains("search_latency"));
+    double latency = metrics_result["search_latency"];
+    
+    // Check for overflow (huge values) or negative values (cast to double might preserve sign or look huge unsigned)
+    // The bug produced values like 1.84e19
+    ASSERT_GE(latency, 0.0);
+    ASSERT_LT(latency, 100000.0); // 100s is plenty margin, well below 1.84e19
+
+    collectionManager.drop_collection("latency_test");
 }

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -3,7 +3,6 @@
 #include <vector>
 #include <fstream>
 #include <collection_manager.h>
-#include "app_metrics.h"
 #include "analytics_manager.h"
 #include "string_utils.h"
 #include "collection.h"
@@ -2105,111 +2104,4 @@ TEST_F(CollectionManagerTest, CloneCollectionWithDocuments) {
     collectionManager.drop_collection("source_collection");
     collectionManager.drop_collection("cloned_collection_no_docs");
     collectionManager.drop_collection("cloned_collection_with_docs");
-}
-
-TEST_F(CollectionManagerTest, VerifySearchLatencyMetric) {
-    AppMetrics::get_instance().window_reset();
-
-    std::vector<field> fields = {field("title", field_types::STRING, false, false, true, "", -1, 1),
-                                 field("points", field_types::INT32, false)};
-    Collection* coll1 = collectionManager.create_collection("latency_test", 1, fields, "points").get();
-
-    nlohmann::json doc1;
-    doc1["title"] = "Test Doc";
-    doc1["points"] = 100;
-    coll1->add(doc1.dump());
-
-    std::map<std::string, std::string> req_params;
-    req_params["collection"] = "latency_test";
-    req_params["q"] = "*";
-    nlohmann::json embedded_params;
-    std::string json_res;
-
-    // Simulate request start time using system_clock (as done in http_server)
-    auto start_ts = std::chrono::duration_cast<std::chrono::microseconds>(
-            std::chrono::system_clock::now().time_since_epoch()).count();
-
-    // Sleep briefly to ensure non-zero latency
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
-    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, start_ts);
-    ASSERT_TRUE(search_op.ok());
-
-    nlohmann::json metrics_result;
-    AppMetrics::get_instance().get("rps", "latency", metrics_result);
-
-    // Verify search latency is reasonable
-    ASSERT_TRUE(metrics_result.contains("search_latency"));
-    double latency = metrics_result["search_latency"];
-    
-    // Check for overflow (huge values) or negative values (cast to double might preserve sign or look huge unsigned)
-    // The bug produced values like 1.84e19
-    ASSERT_GE(latency, 0.0);
-    ASSERT_LT(latency, 100000.0); // 100s is plenty margin, well below 1.84e19
-
-    collectionManager.drop_collection("latency_test");
-}
-
-TEST_F(CollectionManagerTest, VerifyUnionSearchLatencyMetric) {
-    AppMetrics::get_instance().window_reset();
-
-    // Create two collections for union search
-    std::vector<field> fields = {field("title", field_types::STRING, false, false, true, "", -1, 1),
-                                 field("points", field_types::INT32, false)};
-    
-    Collection* coll1 = collectionManager.create_collection("union_latency_test1", 1, fields, "points").get();
-    Collection* coll2 = collectionManager.create_collection("union_latency_test2", 1, fields, "points").get();
-
-    // Add test documents
-    nlohmann::json doc1;
-    doc1["title"] = "Test Doc 1";
-    doc1["points"] = 100;
-    coll1->add(doc1.dump());
-
-    nlohmann::json doc2;
-    doc2["title"] = "Test Doc 2";
-    doc2["points"] = 200;
-    coll2->add(doc2.dump());
-
-    // Prepare union search request
-    std::map<std::string, std::string> req_params;
-    nlohmann::json searches = nlohmann::json::array();
-    
-    nlohmann::json search1;
-    search1["collection"] = "union_latency_test1";
-    search1["q"] = "*";
-    searches.push_back(search1);
-
-    nlohmann::json search2;
-    search2["collection"] = "union_latency_test2";
-    search2["q"] = "*";
-    searches.push_back(search2);
-
-    std::vector<nlohmann::json> embedded_params_vec = {nlohmann::json::object(), nlohmann::json::object()};
-    nlohmann::json response;
-
-    // Simulate request start time using system_clock (as done in http_server)
-    auto start_ts = std::chrono::duration_cast<std::chrono::microseconds>(
-            std::chrono::system_clock::now().time_since_epoch()).count();
-
-    // Sleep briefly to ensure non-zero latency
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-
-    auto union_op = collectionManager.do_union(req_params, embedded_params_vec, searches, response, start_ts, true);
-    ASSERT_TRUE(union_op.ok());
-
-    nlohmann::json metrics_result;
-    AppMetrics::get_instance().get("rps", "latency", metrics_result);
-
-    // Verify union search latency is reasonable
-    ASSERT_TRUE(metrics_result.contains("search_latency"));
-    double latency = metrics_result["search_latency"];
-    
-    // Check for overflow (huge values) or negative values
-    // The bug produced values like 1.84e19
-    ASSERT_GE(latency, 0.0);
-    ASSERT_LT(latency, 100000.0); // 100s is plenty margin, well below 1.84e19
-
-    collectionManager.drop_collection("union_latency_test1");
-    collectionManager.drop_collection("union_latency_test2");
 }

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -2149,3 +2149,67 @@ TEST_F(CollectionManagerTest, VerifySearchLatencyMetric) {
 
     collectionManager.drop_collection("latency_test");
 }
+
+TEST_F(CollectionManagerTest, VerifyUnionSearchLatencyMetric) {
+    AppMetrics::get_instance().window_reset();
+
+    // Create two collections for union search
+    std::vector<field> fields = {field("title", field_types::STRING, false, false, true, "", -1, 1),
+                                 field("points", field_types::INT32, false)};
+    
+    Collection* coll1 = collectionManager.create_collection("union_latency_test1", 1, fields, "points").get();
+    Collection* coll2 = collectionManager.create_collection("union_latency_test2", 1, fields, "points").get();
+
+    // Add test documents
+    nlohmann::json doc1;
+    doc1["title"] = "Test Doc 1";
+    doc1["points"] = 100;
+    coll1->add(doc1.dump());
+
+    nlohmann::json doc2;
+    doc2["title"] = "Test Doc 2";
+    doc2["points"] = 200;
+    coll2->add(doc2.dump());
+
+    // Prepare union search request
+    std::map<std::string, std::string> req_params;
+    nlohmann::json searches = nlohmann::json::array();
+    
+    nlohmann::json search1;
+    search1["collection"] = "union_latency_test1";
+    search1["q"] = "*";
+    searches.push_back(search1);
+
+    nlohmann::json search2;
+    search2["collection"] = "union_latency_test2";
+    search2["q"] = "*";
+    searches.push_back(search2);
+
+    std::vector<nlohmann::json> embedded_params_vec = {nlohmann::json::object(), nlohmann::json::object()};
+    nlohmann::json response;
+
+    // Simulate request start time using system_clock (as done in http_server)
+    auto start_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    // Sleep briefly to ensure non-zero latency
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    auto union_op = collectionManager.do_union(req_params, embedded_params_vec, searches, response, start_ts, true);
+    ASSERT_TRUE(union_op.ok());
+
+    nlohmann::json metrics_result;
+    AppMetrics::get_instance().get("rps", "latency", metrics_result);
+
+    // Verify union search latency is reasonable
+    ASSERT_TRUE(metrics_result.contains("search_latency"));
+    double latency = metrics_result["search_latency"];
+    
+    // Check for overflow (huge values) or negative values
+    // The bug produced values like 1.84e19
+    ASSERT_GE(latency, 0.0);
+    ASSERT_LT(latency, 100000.0); // 100s is plenty margin, well below 1.84e19
+
+    collectionManager.drop_collection("union_latency_test1");
+    collectionManager.drop_collection("union_latency_test2");
+}


### PR DESCRIPTION
## Change Summary
Issue
The /stats.json endpoint was reporting invalid, extremely large values (e.g., 1.84e19) for latency metrics. This was caused by a mismatch in clock sources and units in CollectionManager::do_search.

>Start Time: Calculated using std::chrono::system_clock (in http_req constructor).
>End Time: Calculated using std::chrono::high_resolution_clock (in do_search).
>Unit Mismatch: The subtraction was checking different units without proper conversion.

Fix:
Updated src/collection_manager.cpp to use std::chrono::system_clock for the end time, ensuring it matches the start time source. Both are now converted to microseconds before subtraction, then converted to milliseconds.
 
 Verification
Added a regression test VerifySearchLatencyMetric in 
test/collection_manager_test.cpp

>Simulates a search request with a known start time.
>Verifies that search_latency_ms in AppMetrics is non-negative and within reasonable bounds (< 100s).

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
