### PR TITLE
ci: update pipeline to support new integration tests & bazel cache cleaning

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -214,6 +214,8 @@ jobs:
           TYPESENSE_V29_BINARY_PATH: ${{ github.workspace }}/api_tests/artifacts/v29/typesense-server
           TYPESENSE_DATA_DIR: ${{ github.workspace }}/tmp/test
           OPEN_AI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_URL: ${{ secrets.AZURE_OPENAI_URL }}
         run: typesense-api-tests
 
       - name: Run API tests without secrets

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
         uses: bazel-contrib/setup-bazel@0.14.0
         with:
           bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}
+          disk-cache: ${{ vars.BAZEL_CACHE_KEY != '' && vars.BAZEL_CACHE_KEY || github.workflow }}
           repository-cache: true
           external-cache: true
 


### PR DESCRIPTION
## Change Summary
* API integration tests rely on `AZURE_OPENAI_URL` and `AZURE_OPENAI_API_KEY`. Add them to the environment variables list in order for the tests to access them.
* Bazel cache has grown in size. Give an alternative way to update the cache key in order to clean it through repo variables.
     -  Settings → Actions → Variables, set BAZEL_CACHE_KEY to tests_v2, tests_v3, etc.
  - Next run uses that new key and builds a fresh cache. All subsequent runs use it too.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
