### PR TITLE
fix(analytics): use meta fields in query id generation

### DIFF
--- a/src/search_analytics.cpp
+++ b/src/search_analytics.cpp
@@ -24,9 +24,19 @@ void search_event_t::to_json(nlohmann::json& obj, const std::string& coll, const
 void search_counter_event_t::serialize_as_docs(std::string& docs) {
   for(const auto& kv : query_counts) {
     nlohmann::json doc;
-    doc["id"] = std::to_string(StringUtils::hash_wy(kv.first.query.c_str(), kv.first.query.size()));
+    std::string id_source = kv.first.query;
+
+    if (meta_fields.find("filter_by") != meta_fields.end() && !kv.first.filter_str.empty()) {
+      id_source += "|filter:" + kv.first.filter_str;
+    }
+
+    if (meta_fields.find("analytics_tag") != meta_fields.end() && !kv.first.tag_str.empty()) {
+      id_source += "|tag:" + kv.first.tag_str;
+    }
+
+    doc["id"] = std::to_string(StringUtils::hash_wy(id_source.c_str(), id_source.size()));
     doc["q"] = kv.first.query;
-    if (meta_fields.find("filter_by") != meta_fields.end() && kv.first.filter_str.empty()) {
+    if (meta_fields.find("filter_by") != meta_fields.end() && !kv.first.filter_str.empty()) {
       doc["filter_by"] = kv.first.filter_str;
     }
 
@@ -539,5 +549,4 @@ void SearchAnalytics::remove_all_rules() {
 void SearchAnalytics::dispose() {
   remove_all_rules();
 }
-
 

--- a/test/analytics_manager_test.cpp
+++ b/test/analytics_manager_test.cpp
@@ -724,6 +724,184 @@ TEST_F(AnalyticsManagerTest, PopularQueries) {
   }
 }
 
+TEST_F(AnalyticsManagerTest, MetaFieldsGenerateUniqueIDs) {
+  nlohmann::json products_schema = R"({
+      "name": "products_meta_id",
+      "fields": [
+        {"name": "company_name", "type": "string" },
+        {"name": "num_employees", "type": "int32" }
+      ],
+      "default_sorting_field": "num_employees"
+  })"_json;
+
+  nlohmann::json queries_schema = R"({
+      "name": "queries_meta_id",
+      "fields": [
+          {"name": "q", "type": "string"},
+          {"name": "analytics_tag", "type": "string"},
+          {"name": "count", "type": "int32"}
+      ]
+  })"_json;
+
+  auto coll_create_op = collectionManager.create_collection(products_schema);
+  ASSERT_TRUE(coll_create_op.ok());
+  auto queries_coll_create_op = collectionManager.create_collection(queries_schema);
+  ASSERT_TRUE(queries_coll_create_op.ok());
+
+  nlohmann::json rule = R"({
+    "name": "unique_id_meta_tag_rule",
+    "type": "popular_queries",
+    "collection": "products_meta_id",
+    "event_type": "search",
+    "params": {
+      "destination_collection": "queries_meta_id",
+      "capture_search_requests": false,
+      "meta_fields": ["analytics_tag"],
+      "limit": 100
+    }
+  })"_json;
+
+  auto create_op = analyticsManager.create_rule(rule, false, true, true);
+  ASSERT_TRUE(create_op.ok());
+
+  auto add_event_op = analyticsManager.add_external_event("127.0.0.1", R"({
+    "name": "unique_id_meta_tag_rule",
+    "data": {
+      "q": "black",
+      "user_id": "user1",
+      "analytics_tag": "tag1"
+    }
+  })"_json);
+  ASSERT_TRUE(add_event_op.ok());
+
+  add_event_op = analyticsManager.add_external_event("127.0.0.1", R"({
+    "name": "unique_id_meta_tag_rule",
+    "data": {
+      "q": "black",
+      "user_id": "user2",
+      "analytics_tag": "tag2"
+    }
+  })"_json);
+  ASSERT_TRUE(add_event_op.ok());
+
+  auto get_counter_op = search_analytics.get_search_counter_events();
+  ASSERT_EQ(get_counter_op.size(), 1);
+  ASSERT_EQ(get_counter_op["unique_id_meta_tag_rule"].query_counts.size(), 2);
+
+  std::string docs;
+  get_counter_op["unique_id_meta_tag_rule"].serialize_as_docs(docs);
+  std::stringstream docs_stream(docs);
+  std::string line;
+  std::unordered_set<std::string> ids;
+  while (std::getline(docs_stream, line)) {
+    if (line.empty()) {
+      continue;
+    }
+    auto doc = nlohmann::json::parse(line);
+    ids.insert(doc["id"].get<std::string>());
+    ASSERT_EQ(doc["q"].get<std::string>(), "black");
+    ASSERT_TRUE(doc.contains("analytics_tag"));
+    ASSERT_FALSE(doc.contains("filter_by"));
+  }
+  ASSERT_EQ(ids.size(), 2);
+}
+
+TEST_F(AnalyticsManagerTest, MetaFieldsGenerateUniqueIDsWithFilterAndTag) {
+  nlohmann::json products_schema = R"({
+      "name": "products_meta_id_filter",
+      "fields": [
+        {"name": "company_name", "type": "string" },
+        {"name": "num_employees", "type": "int32" }
+      ],
+      "default_sorting_field": "num_employees"
+  })"_json;
+
+  nlohmann::json queries_schema = R"({
+      "name": "queries_meta_id_filter",
+      "fields": [
+          {"name": "q", "type": "string"},
+          {"name": "filter_by", "type": "string"},
+          {"name": "analytics_tag", "type": "string"},
+          {"name": "count", "type": "int32"}
+      ]
+  })"_json;
+
+  auto coll_create_op = collectionManager.create_collection(products_schema);
+  ASSERT_TRUE(coll_create_op.ok());
+  auto queries_coll_create_op = collectionManager.create_collection(queries_schema);
+  ASSERT_TRUE(queries_coll_create_op.ok());
+
+  nlohmann::json rule = R"({
+    "name": "unique_id_filter_tag_rule",
+    "type": "popular_queries",
+    "collection": "products_meta_id_filter",
+    "event_type": "search",
+    "params": {
+      "destination_collection": "queries_meta_id_filter",
+      "capture_search_requests": false,
+      "meta_fields": ["filter_by", "analytics_tag"],
+      "limit": 100
+    }
+  })"_json;
+
+  auto create_op = analyticsManager.create_rule(rule, false, true, true);
+  ASSERT_TRUE(create_op.ok());
+
+  auto add_event_op = analyticsManager.add_external_event("127.0.0.1", R"({
+    "name": "unique_id_filter_tag_rule",
+    "data": {
+      "q": "black",
+      "user_id": "user1",
+      "filter_by": "size:>30",
+      "analytics_tag": "tag1"
+    }
+  })"_json);
+  ASSERT_TRUE(add_event_op.ok());
+
+  add_event_op = analyticsManager.add_external_event("127.0.0.1", R"({
+    "name": "unique_id_filter_tag_rule",
+    "data": {
+      "q": "black",
+      "user_id": "user2",
+      "filter_by": "size:>30",
+      "analytics_tag": "tag2"
+    }
+  })"_json);
+  ASSERT_TRUE(add_event_op.ok());
+
+  add_event_op = analyticsManager.add_external_event("127.0.0.1", R"({
+    "name": "unique_id_filter_tag_rule",
+    "data": {
+      "q": "black",
+      "user_id": "user3",
+      "filter_by": "size:>40",
+      "analytics_tag": "tag1"
+    }
+  })"_json);
+  ASSERT_TRUE(add_event_op.ok());
+
+  auto get_counter_op = search_analytics.get_search_counter_events();
+  ASSERT_EQ(get_counter_op.size(), 1);
+  ASSERT_EQ(get_counter_op["unique_id_filter_tag_rule"].query_counts.size(), 3);
+
+  std::string docs;
+  get_counter_op["unique_id_filter_tag_rule"].serialize_as_docs(docs);
+  std::stringstream docs_stream(docs);
+  std::string line;
+  std::unordered_set<std::string> ids;
+  while (std::getline(docs_stream, line)) {
+    if (line.empty()) {
+      continue;
+    }
+    auto doc = nlohmann::json::parse(line);
+    ids.insert(doc["id"].get<std::string>());
+    ASSERT_EQ(doc["q"].get<std::string>(), "black");
+    ASSERT_TRUE(doc.contains("filter_by"));
+    ASSERT_TRUE(doc.contains("analytics_tag"));
+  }
+  ASSERT_EQ(ids.size(), 3);
+}
+
 TEST_F(AnalyticsManagerTest, NoHitsQueries) {
   nlohmann::json products_schema = R"({
       "name": "products",


### PR DESCRIPTION
## Change Summary
Fix analytics ID generation so search counter documents are uniquely keyed by query plus configured meta fields (`filter_by` and  `analytics_tag`). This prevents different meta variants of the same query from collapsing into a single record and producing incorrect counts. 

Also fixes `filter_by` serialization to only include non-empty values

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
