### PR TITLE
fix(filter): correct deep nested field validation in delete operations

### DIFF
--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -3301,7 +3301,8 @@ bool filter_result_iterator_t::validate_object_filter() {
         return false;
     }
 
-    for (const auto& nested_object: document[filter_node->object_field_name]) {
+    const auto& doc = get_nested_field_doc(filter_node->object_field_name, document);
+    for (const auto& nested_object: doc) {
         if (validate_object_filter_helper(index, nested_object, filter_node)) {
             return true;
         }

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -3120,3 +3120,173 @@ TEST_F(CoreAPIUtilsTest, UnionRemoveDuplicates) {
     ASSERT_EQ("1", response["hits"][3]["document"]["id"]);
     ASSERT_EQ("1", response["hits"][4]["document"]["id"]);
 }
+
+TEST_F(CoreAPIUtilsTest, DeleteDocumentsWithNestedFieldFilter) {
+    // Test delete with nested object filter to ensure only intended documents are deleted
+    nlohmann::json schema_json = R"({
+        "name": "nested_delete_test",
+        "fields": [
+            {"name": "name", "type": "string"},
+            {"name": "items", "type": "object[]"},
+            {"name": "items.status", "type": "string", "facet": true},
+            {"name": "items.price", "type": "int32", "facet": true}
+        ],
+        "enable_nested_fields": true
+    })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto coll = collection_create_op.get();
+
+    // Doc 0: Should NOT be deleted - has active item but price >= 100
+    nlohmann::json doc0 = R"({
+        "id": "0",
+        "name": "Product A",
+        "items": [{"status": "active", "price": 150}, {"status": "inactive", "price": 50}]
+    })"_json;
+
+    // Doc 1: Should be deleted - has active item with price < 100
+    nlohmann::json doc1 = R"({
+        "id": "1",
+        "name": "Product B",
+        "items": [{"status": "active", "price": 50}, {"status": "inactive", "price": 200}]
+    })"_json;
+
+    // Doc 2: Should NOT be deleted - no active item with price < 100 (active has price 100, not < 100)
+    nlohmann::json doc2 = R"({
+        "id": "2",
+        "name": "Product C",
+        "items": [{"status": "active", "price": 100}, {"status": "pending", "price": 30}]
+    })"_json;
+
+    // Doc 3: Should be deleted - has active item with price < 100
+    nlohmann::json doc3 = R"({
+        "id": "3",
+        "name": "Product D",
+        "items": [{"status": "active", "price": 80}]
+    })"_json;
+
+    // Doc 4: Should NOT be deleted - no active status
+    nlohmann::json doc4 = R"({
+        "id": "4",
+        "name": "Product E",
+        "items": [{"status": "inactive", "price": 40}, {"status": "pending", "price": 20}]
+    })"_json;
+
+    ASSERT_TRUE(coll->add(doc0.dump()).ok());
+    ASSERT_TRUE(coll->add(doc1.dump()).ok());
+    ASSERT_TRUE(coll->add(doc2.dump()).ok());
+    ASSERT_TRUE(coll->add(doc3.dump()).ok());
+    ASSERT_TRUE(coll->add(doc4.dump()).ok());
+
+    // Verify all 5 documents exist
+    nlohmann::json result;
+    coll->get_document_from_store("0", result);
+    ASSERT_EQ("Product A", result["name"]);
+
+    // Delete documents where items has status=active AND price < 100 (in the same nested object)
+    std::shared_ptr<http_req> req = std::make_shared<http_req>();
+    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
+
+    req->params["collection"] = "nested_delete_test";
+    req->params["filter_by"] = "items.{status: active && price: <100}";
+    req->params["return_id"] = "true";
+
+    del_remove_documents(req, res);
+
+    nlohmann::json res_json = nlohmann::json::parse(res->body);
+    ASSERT_EQ(2, res_json["num_deleted"].get<size_t>());
+
+    // Verify deleted IDs are 1 and 3
+    std::set<std::string> deleted_ids;
+    for (const auto& id : res_json["ids"]) {
+        deleted_ids.insert(id.get<std::string>());
+    }
+    ASSERT_TRUE(deleted_ids.count("1") > 0);
+    ASSERT_TRUE(deleted_ids.count("3") > 0);
+
+    // Verify remaining documents (0, 2, 4) still exist
+    ASSERT_TRUE(coll->get_document_from_store("0", result).ok());
+    ASSERT_TRUE(coll->get_document_from_store("2", result).ok());
+    ASSERT_TRUE(coll->get_document_from_store("4", result).ok());
+
+    // Verify deleted documents (1, 3) no longer exist
+    ASSERT_FALSE(coll->get_document_from_store("1", result).ok());
+    ASSERT_FALSE(coll->get_document_from_store("3", result).ok());
+
+    collectionManager.drop_collection("nested_delete_test");
+}
+
+TEST_F(CoreAPIUtilsTest, DeleteDocumentsWithDeepNestedFieldFilter) {
+    // Test delete with deep nested object filter (e.g., main.items.{...})
+    nlohmann::json schema_json = R"({
+        "name": "deep_nested_delete_test",
+        "fields": [
+            {"name": "name", "type": "string"},
+            {"name": "main", "type": "object"},
+            {"name": "main.items", "type": "object[]"},
+            {"name": "main.items.status", "type": "string", "facet": true},
+            {"name": "main.items.price", "type": "int32", "facet": true}
+        ],
+        "enable_nested_fields": true
+    })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto coll = collection_create_op.get();
+
+    // Doc 0: Should NOT be deleted - active item has price >= 100
+    nlohmann::json doc0 = R"({
+        "id": "0",
+        "name": "Product A",
+        "main": {
+            "items": [{"status": "active", "price": 150}]
+        }
+    })"_json;
+
+    // Doc 1: Should be deleted - has active item with price < 100
+    nlohmann::json doc1 = R"({
+        "id": "1",
+        "name": "Product B",
+        "main": {
+            "items": [{"status": "active", "price": 50}]
+        }
+    })"_json;
+
+    // Doc 2: Should NOT be deleted - no active status
+    nlohmann::json doc2 = R"({
+        "id": "2",
+        "name": "Product C",
+        "main": {
+            "items": [{"status": "inactive", "price": 30}]
+        }
+    })"_json;
+
+    ASSERT_TRUE(coll->add(doc0.dump()).ok());
+    ASSERT_TRUE(coll->add(doc1.dump()).ok());
+    ASSERT_TRUE(coll->add(doc2.dump()).ok());
+
+    // Delete documents where main.items has status=active AND price < 100
+    std::shared_ptr<http_req> req = std::make_shared<http_req>();
+    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
+
+    req->params["collection"] = "deep_nested_delete_test";
+    req->params["filter_by"] = "main.items.{status: active && price: <100}";
+    req->params["return_id"] = "true";
+
+    del_remove_documents(req, res);
+
+    nlohmann::json res_json = nlohmann::json::parse(res->body);
+    ASSERT_EQ(1, res_json["num_deleted"].get<size_t>());
+    ASSERT_EQ("1", res_json["ids"][0].get<std::string>());
+
+    // Verify remaining documents (0, 2) still exist
+    nlohmann::json result;
+    ASSERT_TRUE(coll->get_document_from_store("0", result).ok());
+    ASSERT_TRUE(coll->get_document_from_store("2", result).ok());
+
+    // Verify deleted document (1) no longer exists
+    ASSERT_FALSE(coll->get_document_from_store("1", result).ok());
+
+    collectionManager.drop_collection("deep_nested_delete_test");
+}


### PR DESCRIPTION
## Summary

Fixes incorrect document deletion when using deep nested field filters
(e.g. `main.items.{status: active && price: <100}`).

---

## Root Cause

`validate_object_filter()` in `src/filter_result_iterator.cpp` has two code paths:

- Batched path (when `is_filter_result_initialized` is true)
- Non-batched path (used during iterative AND/OR evaluation)

The batched path correctly used `get_nested_field_doc()` to traverse deep
nested JSON structures.

However, the non-batched path accessed:

document[filter_node->object_field_name]

This fails for multi-level paths such as `main.items`, because it attempts
to look up the literal key instead of navigating:

main → items

As a result, nested filters could match incorrectly, leading to unintended
document deletions.

---

## Solution

Updated the non-batched path to use `get_nested_field_doc()`, making it
consistent with the batched implementation.

### Before

for (const auto& nested_object: document[filter_node->object_field_name])

### After

const auto& doc = get_nested_field_doc(filter_node->object_field_name, document);
for (const auto& nested_object: doc)

---

## Files Changed

- src/filter_result_iterator.cpp  
  → Use get_nested_field_doc() in non-batched validation path (1-line fix)

- test/core_api_utils_test.cpp  
  → Added two test cases covering nested and deep-nested delete filters

---

## Test Plan

Added:

- DeleteDocumentsWithNestedFieldFilter
- DeleteDocumentsWithDeepNestedFieldFilter

Both tests verify:

- Only matching documents are deleted
- Non-matching documents remain
- AND conditions within the same nested object are respected

Run tests:

bazel test //:typesense-test --test_filter="CoreAPIUtilsTest.DeleteDocumentsWithNestedFieldFilter"

bazel test //:typesense-test --test_filter="CoreAPIUtilsTest.DeleteDocumentsWithDeepNestedFieldFilter"

Or full suite:

bazel test //:typesense-test

---

## Checklist

- [x] Minimal fix (single logic change)
- [x] Tests added
- [x] No unrelated refactors

Closes #2765
