### PR TITLE
Fix missing synonyms, stem, and stemming_dictionary fields in curation GET responses

### DIFF
--- a/src/curation.cpp
+++ b/src/curation.cpp
@@ -299,6 +299,13 @@ nlohmann::json curation_t::to_json() const {
         curation["rule"]["tags"] = rule.tags;
     }
 
+    curation["rule"]["synonyms"] = rule.synonyms;
+    curation["rule"]["stem"] = rule.stem;
+
+    if(!rule.stemming_dictionary.empty()) {
+        curation["rule"]["stemming_dictionary"] = rule.stemming_dictionary;
+    }
+
     curation["includes"] = nlohmann::json::array();
 
     for(const auto & add_hit: add_hits) {

--- a/test/collection_curation_test.cpp
+++ b/test/collection_curation_test.cpp
@@ -6174,6 +6174,93 @@ TEST_F(CollectionCurationTest, SynonymsMatchWithCuration) {
     ASSERT_EQ("6", results["hits"][1]["document"]["id"].get<std::string>());
 }
 
+TEST_F(CollectionCurationTest, ToJsonSerializesSynonymsStemFields) {
+    // curation with synonyms + stem + stemming_dictionary
+    std::vector<std::string> json_lines;
+    json_lines.push_back(R"({"word": "shoes", "root": "shoe"})");
+    ASSERT_TRUE(stemmerManager.upsert_stemming_dictionary("test-dict", json_lines).ok());
+
+    nlohmann::json curation_json = R"({
+        "id": "test-all-fields",
+        "rule": {
+            "query": "running shoes",
+            "match": "exact",
+            "synonyms": true,
+            "stem": true,
+            "stemming_dictionary": "test-dict"
+        },
+        "includes": [{"id": "0", "position": 1}]
+    })"_json;
+
+    curation_t curation;
+    auto parse_op = curation_t::parse(curation_json, "test-all-fields", curation);
+    ASSERT_TRUE(parse_op.ok());
+
+    nlohmann::json serialized = curation.to_json();
+    ASSERT_TRUE(serialized["rule"]["synonyms"].get<bool>());
+    ASSERT_TRUE(serialized["rule"]["stem"].get<bool>());
+    ASSERT_EQ("test-dict", serialized["rule"]["stemming_dictionary"].get<std::string>());
+
+    // curation with only synonyms (no stem)
+    curation_json = R"({
+        "id": "test-synonyms-only",
+        "rule": {
+            "query": "sneakers",
+            "match": "exact",
+            "synonyms": true
+        },
+        "includes": [{"id": "0", "position": 1}]
+    })"_json;
+
+    curation_t curation2;
+    parse_op = curation_t::parse(curation_json, "test-synonyms-only", curation2);
+    ASSERT_TRUE(parse_op.ok());
+
+    serialized = curation2.to_json();
+    ASSERT_TRUE(serialized["rule"]["synonyms"].get<bool>());
+    ASSERT_FALSE(serialized["rule"]["stem"].get<bool>());
+    ASSERT_EQ(0, serialized["rule"].count("stemming_dictionary"));
+
+    // curation with only stem (no synonyms, no dictionary)
+    curation_json = R"({
+        "id": "test-stem-only",
+        "rule": {
+            "query": "walking",
+            "match": "exact",
+            "stem": true
+        },
+        "includes": [{"id": "0", "position": 1}]
+    })"_json;
+
+    curation_t curation3;
+    parse_op = curation_t::parse(curation_json, "test-stem-only", curation3);
+    ASSERT_TRUE(parse_op.ok());
+
+    serialized = curation3.to_json();
+    ASSERT_FALSE(serialized["rule"]["synonyms"].get<bool>());
+    ASSERT_TRUE(serialized["rule"]["stem"].get<bool>());
+    ASSERT_EQ(0, serialized["rule"].count("stemming_dictionary"));
+
+    // curation with neither synonyms nor stem (defaults)
+    curation_json = R"({
+        "id": "test-defaults",
+        "rule": {
+            "query": "boots",
+            "match": "exact"
+        },
+        "includes": [{"id": "0", "position": 1}]
+    })"_json;
+
+    curation_t curation4;
+    parse_op = curation_t::parse(curation_json, "test-defaults", curation4);
+    ASSERT_TRUE(parse_op.ok());
+
+    serialized = curation4.to_json();
+    ASSERT_FALSE(serialized["rule"]["synonyms"].get<bool>());
+    ASSERT_FALSE(serialized["rule"]["stem"].get<bool>());
+    ASSERT_EQ(0, serialized["rule"].count("stemming_dictionary"));
+}
+
 TEST_F(CollectionCurationTest, OverridesWithRerankHybridSearches) {
     auto& ov_manager = CurationIndexManager::get_instance();
     nlohmann::json schema = R"({

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -2082,7 +2082,9 @@ TEST_F(CoreAPIUtilsTest, OverridesPagination) {
                         "remove_matched_tokens":false,
                         "rule":{
                                 "match":"exact",
-                                "query":"not-found"
+                                "query":"not-found",
+                                "stem":false,
+                                "synonyms":false
                         },
                         "stop_processing":true
                     }])"_json;


### PR DESCRIPTION
When creating a curation item with `rule.synonyms`, `rule.stem`, and `rule.stemming_dictionary`, the PUT response correctly echoes these fields back, but subsequent GET requests don't return these fields.

**Create a curation set:**

```bash
curl -s "http://localhost:8108/curation_sets/test-set/items/test-item" -X PUT \
  -H "Content-Type: application/json" \
  -H "X-TYPESENSE-API-KEY: xyz" \
  -d '{
    "rule": {
      "query": "running shoes",
      "match": "exact",
      "synonyms": true,
      "stem": true,
      "stemming_dictionary": "test-plurals"
    },
    "stop_processing": true
  }'
```

**Create response (correct):**
```json
{
  "rule": {
    "match": "exact",
    "query": "running shoes",
    "stem": true,
    "stemming_dictionary": "test-plurals",
    "synonyms": true
  }
}
```

**GET curation set:**
```bash
curl -s "http://localhost:8108/curation_sets/test-set/items/test-item" \
  -H "X-TYPESENSE-API-KEY: xyz"
```

**GET response (before fix - missing synonyms, stem and stemming dictionary):**
```json
{
  "rule": {
    "match": "exact",
    "query": "running shoes"
  }
}
```

**GET response (after fix):**
```json
{
  "rule": {
    "match": "exact",
    "query": "running shoes",
    "stem": true,
    "stemming_dictionary": "test-plurals",
    "synonyms": true
  }
}
```