### PR TITLE
fix: route /health endpoint to meta_thread_pool to prevent timeouts during bulk inserts

### DIFF
--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -496,7 +496,7 @@ int HttpServer::catch_all_handler(h2o_handler_t *_h2o_handler, h2o_req_t *req) {
              root_resource == "config" || root_resource == "status" || root_resource == "proxy_sse"
          );
 
-    bool use_meta_thread_pool = (root_resource == "status");
+    bool use_meta_thread_pool = (root_resource == "status" || root_resource == "health");
 
     if(needs_readiness_check) {
         bool write_op = is_write_request(root_resource, http_method, rpath->handler);


### PR DESCRIPTION
## Summary
- Route `/health` requests to the dedicated `meta_thread_pool` (4 threads) instead of the main `thread_pool`
- Ensures `/health` stays responsive even when the main pool is saturated by bulk imports

## Fixes
Closes #2638

## Change
One-line change in `src/http_server.cpp`:
```cpp
// Before
bool use_meta_thread_pool = (root_resource == "status");

// After
bool use_meta_thread_pool = (root_resource == "status" || root_resource == "health");
```

## Why this works
- `meta_thread_pool` is a separate `ThreadPool(4)` never used for writes, searches, or imports
- `/health` is already a lightweight liveness probe (bypasses replication readiness checks)
- `/status` already uses this pool for the same isolation reason