### PR TITLE
batch import per doc action type

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -25,6 +25,8 @@
 struct doc_seq_id_t {
     uint32_t seq_id;
     bool is_new;
+    index_operation_t operation;
+    bool is_same_batch = false;
 };
 
 struct highlight_field_t {
@@ -859,6 +861,7 @@ public:
     Option<doc_seq_id_t> to_doc(const std::string& json_str, nlohmann::json& document,
                                 const index_operation_t& operation,
                                 const DIRTY_VALUES dirty_values,
+                                const spp::sparse_hash_map<std::string, uint32_t>& batch_docs,
                                 const std::string& id="");
 
 

--- a/include/field.h
+++ b/include/field.h
@@ -464,8 +464,25 @@ enum index_operation_t {
     UPSERT,
     UPDATE,
     EMPLACE,
-    DELETE
+    DELETE,
+    ALL
 };
+
+static index_operation_t get_index_operation(const std::string& action) {
+    if(action == "create") {
+        return CREATE;
+    } else if(action == "update") {
+        return UPDATE;
+    } else if(action == "upsert") {
+        return UPSERT;
+    } else if(action == "emplace") {
+        return EMPLACE;
+    } else if(action == "delete") {
+        return DELETE;
+    }
+
+    return CREATE;
+}
 
 enum class DIRTY_VALUES {
     REJECT = 1,

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -296,6 +296,7 @@ Option<bool> Collection::update_async_references_with_lock(const std::string& re
 Option<doc_seq_id_t> Collection::to_doc(const std::string & json_str, nlohmann::json& document,
                                         const index_operation_t& operation,
                                         const DIRTY_VALUES dirty_values,
+                                        const spp::sparse_hash_map<std::string, uint32_t>& batch_docs,
                                         const std::string& id) {
     try {
         document = nlohmann::json::parse(json_str);
@@ -321,15 +322,26 @@ Option<doc_seq_id_t> Collection::to_doc(const std::string & json_str, nlohmann::
         return Option<doc_seq_id_t>(400, "The `id` should not be empty.");
     }
 
+    index_operation_t action = operation;
+
+    if(action == ALL) {
+        //we have to fetch individual doc action
+        if(document.count("action") == 0) {
+            return Option<doc_seq_id_t>(400, "The `action` should not be empty at doc level when using `all`");
+        }
+
+        action = get_index_operation(document["action"]);
+    }
+
     if(document.count("id") == 0) {
-        if(operation == UPDATE) {
-            return Option<doc_seq_id_t>(400, "For update, the `id` key must be provided.");
+        if(action == UPDATE || action == DELETE) {
+            return Option<doc_seq_id_t>(400, "For update/delete, the `id` key must be provided.");
         }
         // for UPSERT, EMPLACE or CREATE, if a document does not have an ID, we will treat it as a new doc
         uint32_t seq_id = get_next_seq_id();
         document["id"] = std::to_string(seq_id);
 
-        return Option<doc_seq_id_t>(doc_seq_id_t{seq_id, true});
+        return Option<doc_seq_id_t>(doc_seq_id_t{seq_id, true, action});
     } else {
         if(!document["id"].is_string()) {
             return Option<doc_seq_id_t>(400, "Document's `id` field should be a string.");
@@ -346,26 +358,28 @@ Option<doc_seq_id_t> Collection::to_doc(const std::string & json_str, nlohmann::
         }
 
         if(seq_id_status == StoreStatus::FOUND) {
-            if(operation == CREATE) {
+            if(action == CREATE) {
                 return Option<doc_seq_id_t>(409, std::string("A document with id ") + doc_id + " already exists.");
             }
-            
 
-
-            // UPSERT, EMPLACE or UPDATE
+            // UPSERT, EMPLACE, UPDATE or DELETE
             uint32_t seq_id = (uint32_t) std::stoul(seq_id_str);
-
-            return Option<doc_seq_id_t>(doc_seq_id_t{seq_id, false});
-
+            return Option<doc_seq_id_t>(doc_seq_id_t{seq_id, false, action});
         } else {
-            if(operation == UPDATE) {
-                // for UPDATE, a document with given ID must be found
+            if(action == UPDATE || action == DELETE) {
+                //check if seq_id is already in current batch which is yet to be indexed
+                if(batch_docs.find(doc_id) != batch_docs.end()) {
+                    uint32_t seq_id = (uint32_t) std::stoul(doc_id);
+                    return Option<doc_seq_id_t>(doc_seq_id_t{seq_id, false, action, true});
+                }
+
+                // else for UPDATE/DELETE, a document with given ID must be found
                 return Option<doc_seq_id_t>(404, "Could not find a document with id: " + doc_id);
             } else {
                 // for UPSERT, EMPLACE or CREATE, if a document with given ID is not found, we will treat it as a new doc
                 uint32_t seq_id = get_next_seq_id();
 
-                return Option<doc_seq_id_t>(doc_seq_id_t{seq_id, true});
+                return Option<doc_seq_id_t>(doc_seq_id_t{seq_id, true, action});
             }
         }
     }
@@ -575,108 +589,159 @@ nlohmann::json Collection::add_many(std::vector<std::string>& json_lines, nlohma
 
     const size_t index_batch_size = 1000;
     size_t num_indexed = 0;
+    size_t num_removed = 0;
+    size_t num_updated = 0;
     //bool exceeds_memory_limit = false;
 
     // ensures that document IDs are not repeated within the same batch
-    std::set<std::string> batch_doc_ids;
+    spp::sparse_hash_map<std::string, uint32_t> batch_docs_map;
     bool found_batch_new_field = false;
+    bool repeated_doc = false;
 
     for(size_t i=0; i < json_lines.size(); i++) {
-        const std::string & json_line = json_lines[i];
-        Option<doc_seq_id_t> doc_seq_id_op = to_doc(json_line, document, operation, dirty_values, id);
+        const std::string& json_line = json_lines[i];
+        Option<doc_seq_id_t> doc_seq_id_op = to_doc(json_line, document, operation, dirty_values, batch_docs_map, id);
 
         const uint32_t seq_id = doc_seq_id_op.ok() ? doc_seq_id_op.get().seq_id : 0;
-        index_record record(i, seq_id, document, operation, dirty_values);
+        const auto& updated_operation = doc_seq_id_op.ok() ? doc_seq_id_op.get().operation : operation;
 
-        // NOTE: we overwrite the input json_lines with result to avoid memory pressure
+        if(updated_operation == DELETE) {
+            if(!doc_seq_id_op.get().is_same_batch) {
+                //doc is already indexed, so we have to remove from memory and disk
+                Option<std::string> deleted_id_op = remove(document["id"]);
+                if(deleted_id_op.ok()) {
+                    num_removed++;
+                } else {
+                    nlohmann::json res;
+                    res["code"] = deleted_id_op.code();
+                    res["error"] = deleted_id_op.error();
+                    res["success"] = false;
 
-        record.is_update = false;
-        bool repeated_doc = false;
-
-        std::vector<field> new_fields;
-        if(!doc_seq_id_op.ok()) {
-            record.index_failure(doc_seq_id_op.code(), doc_seq_id_op.error());
-        } else {
-            const std::string& doc_id = record.doc["id"].get<std::string>();
-            repeated_doc = (batch_doc_ids.find(doc_id) != batch_doc_ids.end());
-
-            if(repeated_doc) {
-                // when a document repeats, we send the batch until this document so that we can deal with conflicts
-                i--;
-                goto do_batched_index;
-            }
-
-            record.is_update = !doc_seq_id_op.get().is_new;
-
-            if(record.is_update) {
-                get_document_from_store(get_seq_id_key(seq_id), record.old_doc);
-            }
-
-            batch_doc_ids.insert(doc_id);
-
-            std::string fallback_field_type_copy;
-            std::unordered_map<std::string, field> dynamic_fields_copy;
-            tsl::htrie_map<char, field> nested_fields_copy;
-            spp::sparse_hash_map<std::string, reference_info_t> reference_fields_copy;
-            spp::sparse_hash_map<std::string, std::set<reference_pair_t>> async_referenced_ins_copy;
-            tsl::htrie_map<char, field> search_schema_copy;
-            tsl::htrie_set<char> object_reference_fields_copy;
-            {
-                std::shared_lock lock(mutex);
-                fallback_field_type_copy = fallback_field_type;
-                dynamic_fields_copy = dynamic_fields;
-                nested_fields_copy = nested_fields;
-                reference_fields_copy = reference_fields;
-                async_referenced_ins_copy = async_referenced_ins;
-                search_schema_copy = search_schema;
-                object_reference_fields_copy = object_reference_fields;
-            }
-
-            // if `fallback_field_type` or `dynamic_fields` is enabled, update schema first before indexing
-            if(!fallback_field_type_copy.empty() || !dynamic_fields_copy.empty() || !nested_fields_copy.empty() ||
-                !reference_fields_copy.empty() || !async_referenced_ins_copy.empty()) {
-
-                Option<bool> new_fields_op = detect_new_fields(record.doc, dirty_values,
-                                                               search_schema_copy, dynamic_fields_copy,
-                                                               nested_fields_copy,
-                                                               fallback_field_type_copy,
-                                                               record.is_update,
-                                                               new_fields,
-                                                               enable_nested_fields,
-                                                               reference_fields_copy, object_reference_fields_copy);
-                if(!new_fields_op.ok()) {
-                    record.index_failure(new_fields_op.code(), new_fields_op.error());
+                    json_lines[i] = res.dump();
                 }
+            } else {
+                //doc is in same batch and not indexed yet, remove from index record batch
+                auto ind = batch_docs_map[document["id"]];
+                //swap with last element
+                std::swap(index_records.back(), index_records.at(ind));
+
+                //update the moved record index in map
+                const auto& swapped_rec = index_records.at(ind);
+                batch_docs_map[swapped_rec.doc["id"]] = ind;
+
+                //erase key from map and index batch
+                index_records.pop_back();
+                batch_docs_map.erase(document["id"]);
+                num_removed++;
             }
-        }
+        } else if (updated_operation == UPDATE && doc_seq_id_op.get().is_same_batch) {
+            //we've to handle only same batch case as indexed doc case is already taken care
+            auto ind = batch_docs_map[document["id"]];
+            auto& current_doc = index_records.at(ind).doc;
 
-        if(!new_fields.empty()) {
-            std::unique_lock lock(mutex);
+            for(const auto& kv : document.items()) {
+                current_doc[kv.key()] = kv.value();
+            }
+            num_updated++;
+        } else if (updated_operation == ALL) {
+            //it is top level action type and has not been updated while parsing, mostly due to some error
+            nlohmann::json res;
+            res["code"] = doc_seq_id_op.code();
+            res["error"] = doc_seq_id_op.error();
+            res["success"] = false;
 
-            bool found_new_field = false;
-            for(auto& new_field: new_fields) {
-                if(search_schema.find(new_field.name) == search_schema.end()) {
-                    found_new_field = true;
-                    found_batch_new_field = true;
-                    search_schema.emplace(new_field.name, new_field);
-                    fields.emplace_back(new_field);
-                    if(new_field.nested) {
-                        check_and_add_nested_field(nested_fields, new_field);
+            json_lines[i] = res.dump();
+        } else {
+            index_record record(i, seq_id, document, updated_operation, dirty_values);
+
+            // NOTE: we overwrite the input json_lines with result to avoid memory pressure
+            record.is_update = false;
+
+            std::vector<field> new_fields;
+            if(!doc_seq_id_op.ok()) {
+                record.index_failure(doc_seq_id_op.code(), doc_seq_id_op.error());
+            } else {
+                const std::string& doc_id = record.doc["id"].get<std::string>();
+                repeated_doc = (batch_docs_map.find(doc_id) != batch_docs_map.end());
+
+                if(repeated_doc) {
+                    // when a document repeats, we send the batch until this document so that we can deal with conflicts
+                    i--;
+                    goto do_batched_index;
+                }
+
+                batch_docs_map[doc_id] = index_records.size();
+
+                record.is_update = !doc_seq_id_op.get().is_new;
+
+                if(record.is_update) {
+                    get_document_from_store(get_seq_id_key(seq_id), record.old_doc);
+                }
+
+                std::string fallback_field_type_copy;
+                std::unordered_map<std::string, field> dynamic_fields_copy;
+                tsl::htrie_map<char, field> nested_fields_copy;
+                spp::sparse_hash_map<std::string, reference_info_t> reference_fields_copy;
+                spp::sparse_hash_map<std::string, std::set<reference_pair_t>> async_referenced_ins_copy;
+                tsl::htrie_map<char, field> search_schema_copy;
+                tsl::htrie_set<char> object_reference_fields_copy;
+                {
+                    std::shared_lock lock(mutex);
+                    fallback_field_type_copy = fallback_field_type;
+                    dynamic_fields_copy = dynamic_fields;
+                    nested_fields_copy = nested_fields;
+                    reference_fields_copy = reference_fields;
+                    async_referenced_ins_copy = async_referenced_ins;
+                    search_schema_copy = search_schema;
+                    object_reference_fields_copy = object_reference_fields;
+                }
+
+                // if `fallback_field_type` or `dynamic_fields` is enabled, update schema first before indexing
+                if(!fallback_field_type_copy.empty() || !dynamic_fields_copy.empty() || !nested_fields_copy.empty() ||
+                   !reference_fields_copy.empty() || !async_referenced_ins_copy.empty()) {
+
+                    Option<bool> new_fields_op = detect_new_fields(record.doc, dirty_values,
+                                                                   search_schema_copy, dynamic_fields_copy,
+                                                                   nested_fields_copy,
+                                                                   fallback_field_type_copy,
+                                                                   record.is_update,
+                                                                   new_fields,
+                                                                   enable_nested_fields,
+                                                                   reference_fields_copy, object_reference_fields_copy);
+                    if(!new_fields_op.ok()) {
+                        record.index_failure(new_fields_op.code(), new_fields_op.error());
                     }
                 }
             }
 
-            if(found_new_field) {
-                index->refresh_schemas(new_fields, {});
+            if(!new_fields.empty()) {
+                std::unique_lock lock(mutex);
+
+                bool found_new_field = false;
+                for(auto& new_field: new_fields) {
+                    if(search_schema.find(new_field.name) == search_schema.end()) {
+                        found_new_field = true;
+                        found_batch_new_field = true;
+                        search_schema.emplace(new_field.name, new_field);
+                        fields.emplace_back(new_field);
+                        if(new_field.nested) {
+                            check_and_add_nested_field(nested_fields, new_field);
+                        }
+                    }
+                }
+
+                if(found_new_field) {
+                    index->refresh_schemas(new_fields, {});
+                }
             }
+
+            index_records.emplace_back(std::move(record));
         }
 
-        index_records.emplace_back(std::move(record));
-
         do_batched_index:
-
-        if((i+1) % index_batch_size == 0 || i == json_lines.size()-1 || repeated_doc) {
-            batch_index(index_records, json_lines, num_indexed, return_doc, return_id, remote_embedding_batch_size, remote_embedding_timeout_ms, remote_embedding_num_tries);
+        if((i+1) % index_batch_size == 0 || i == json_lines.size() - 1 || repeated_doc) {
+            batch_index(index_records, json_lines, num_indexed, return_doc, return_id, remote_embedding_batch_size,
+                        remote_embedding_timeout_ms, remote_embedding_num_tries);
 
             if(found_batch_new_field) {
                 persist_collection_meta();
@@ -691,13 +756,18 @@ nlohmann::json Collection::add_many(std::vector<std::string>& json_lines, nlohma
             }
 
             index_records.clear();
-            batch_doc_ids.clear();
+            batch_docs_map.clear();
         }
+
     }
+
+    auto lines_processed = num_indexed + num_updated + (num_removed * 2);
 
     nlohmann::json resp_summary;
     resp_summary["num_imported"] = num_indexed;
-    resp_summary["success"] = (num_indexed == json_lines.size());
+    resp_summary["num_removed"] = num_removed;
+    resp_summary["num_updated"] = num_updated;
+    resp_summary["success"] = (lines_processed == json_lines.size());
 
     return resp_summary;
 }

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -326,14 +326,14 @@ Option<doc_seq_id_t> Collection::to_doc(const std::string & json_str, nlohmann::
 
     if(action == ALL) {
         //we have to fetch individual doc action
-        if(document.count("_action") != 1) {
-            return Option<doc_seq_id_t>(400, "The `_action` should not be empty at doc level when using `all`");
+        if(document.count("$action") != 1) {
+            return Option<doc_seq_id_t>(400, "The `$action` should not be empty at doc level when using `all`");
         }
 
-        action = get_index_operation(document["_action"]);
+        action = get_index_operation(document["$action"]);
 
         //remove _action field from doc which will be later indexed
-        document.erase("_action");
+        document.erase("$action");
     }
 
     if(document.count("id") == 0) {

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -326,11 +326,14 @@ Option<doc_seq_id_t> Collection::to_doc(const std::string & json_str, nlohmann::
 
     if(action == ALL) {
         //we have to fetch individual doc action
-        if(document.count("action") == 0) {
-            return Option<doc_seq_id_t>(400, "The `action` should not be empty at doc level when using `all`");
+        if(document.count("_action") != 1) {
+            return Option<doc_seq_id_t>(400, "The `_action` should not be empty at doc level when using `all`");
         }
 
-        action = get_index_operation(document["action"]);
+        action = get_index_operation(document["_action"]);
+
+        //remove _action field from doc which will be later indexed
+        document.erase("_action");
     }
 
     if(document.count("id") == 0) {

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -209,20 +209,6 @@ void get_collections_for_auth(std::map<std::string, std::string>& req_params,
     }
 }
 
-index_operation_t get_index_operation(const std::string& action) {
-    if(action == "create") {
-        return CREATE;
-    } else if(action == "update") {
-        return UPDATE;
-    } else if(action == "upsert") {
-        return UPSERT;
-    } else if(action == "emplace") {
-        return EMPLACE;
-    }
-
-    return CREATE;
-}
-
 bool get_collections(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     CollectionManager & collectionManager = CollectionManager::get_instance();
 
@@ -1563,9 +1549,9 @@ bool post_import_documents(const std::shared_ptr<http_req>& req, const std::shar
     }
 
     if(req->params[ACTION] != "create" && req->params[ACTION] != "update" && req->params[ACTION] != "upsert" &&
-       req->params[ACTION] != "emplace") {
+       req->params[ACTION] != "emplace" && req->params[ACTION] != "all") {
         res->final = true;
-        res->set_400("Parameter `" + std::string(ACTION) + "` must be a create|update|upsert.");
+        res->set_400("Parameter `" + std::string(ACTION) + "` must be a create|update|upsert|all.");
         stream_response(req, res);
         return false;
     }

--- a/test/collection_specific_test.cpp
+++ b/test/collection_specific_test.cpp
@@ -3436,10 +3436,10 @@ TEST_F(CollectionSpecificTest, DeleteUpdateDocsInSameBatch) {
     ASSERT_TRUE(coll1->add(doc1.dump()).ok());
 
     std::vector<std::string> docs = {
-            R"({"id": "1", "title": "title1", "points": 100, "action": "create"})",
-            R"({"id": "2", "title": "title2", "points": 200, "action": "create"})",
-            R"({"id": "3", "title": "title3", "points": 200, "action": "create"})",
-            R"({"id": "2", "action": "delete"})",
+            R"({"id": "1", "title": "title1", "points": 100, "_action": "create"})",
+            R"({"id": "2", "title": "title2", "points": 200, "_action": "create"})",
+            R"({"id": "3", "title": "title3", "points": 200, "_action": "create"})",
+            R"({"id": "2", "_action": "delete"})",
     };
 
     nlohmann::json doc;
@@ -3450,9 +3450,9 @@ TEST_F(CollectionSpecificTest, DeleteUpdateDocsInSameBatch) {
     ASSERT_EQ(0, import_response["num_updated"].get<int>());
 
     docs = {
-            R"({"id": "2", "title": "title2", "points": 100, "action": "create"})",
-            R"({"id": "4", "title": "title4", "points": 200, "action": "create"})",
-            R"({"id": "4", "points": 500, "action": "update"})",
+            R"({"id": "2", "title": "title2", "points": 100, "_action": "create"})",
+            R"({"id": "4", "title": "title4", "points": 200, "_action": "create"})",
+            R"({"id": "4", "points": 500, "_action": "update"})",
     };
 
     doc.clear();
@@ -3477,9 +3477,9 @@ TEST_F(CollectionSpecificTest, DeleteUpdateDocsInSameBatch) {
 
     //invalid request
     docs = {
-            R"({"id": "5", "title": "title5", "points": 100, "action": "create"})",
-            R"({"id": "6", "title": "title6", "points": 200, "action": "create"})",
-            R"({"id": "10", "points": 500, "action": "delete"})",
+            R"({"id": "5", "title": "title5", "points": 100, "_action": "create"})",
+            R"({"id": "6", "title": "title6", "points": 200, "_action": "create"})",
+            R"({"id": "10", "points": 500, "_action": "delete"})",
     };
 
     doc.clear();

--- a/test/collection_specific_test.cpp
+++ b/test/collection_specific_test.cpp
@@ -3436,10 +3436,10 @@ TEST_F(CollectionSpecificTest, DeleteUpdateDocsInSameBatch) {
     ASSERT_TRUE(coll1->add(doc1.dump()).ok());
 
     std::vector<std::string> docs = {
-            R"({"id": "1", "title": "title1", "points": 100, "_action": "create"})",
-            R"({"id": "2", "title": "title2", "points": 200, "_action": "create"})",
-            R"({"id": "3", "title": "title3", "points": 200, "_action": "create"})",
-            R"({"id": "2", "_action": "delete"})",
+            R"({"id": "1", "title": "title1", "points": 100, "$action": "create"})",
+            R"({"id": "2", "title": "title2", "points": 200, "$action": "create"})",
+            R"({"id": "3", "title": "title3", "points": 200, "$action": "create"})",
+            R"({"id": "2", "$action": "delete"})",
     };
 
     nlohmann::json doc;
@@ -3450,9 +3450,9 @@ TEST_F(CollectionSpecificTest, DeleteUpdateDocsInSameBatch) {
     ASSERT_EQ(0, import_response["num_updated"].get<int>());
 
     docs = {
-            R"({"id": "2", "title": "title2", "points": 100, "_action": "create"})",
-            R"({"id": "4", "title": "title4", "points": 200, "_action": "create"})",
-            R"({"id": "4", "points": 500, "_action": "update"})",
+            R"({"id": "2", "title": "title2", "points": 100, "$action": "create"})",
+            R"({"id": "4", "title": "title4", "points": 200, "$action": "create"})",
+            R"({"id": "4", "points": 500, "$action": "update"})",
     };
 
     doc.clear();
@@ -3477,9 +3477,9 @@ TEST_F(CollectionSpecificTest, DeleteUpdateDocsInSameBatch) {
 
     //invalid request
     docs = {
-            R"({"id": "5", "title": "title5", "points": 100, "_action": "create"})",
-            R"({"id": "6", "title": "title6", "points": 200, "_action": "create"})",
-            R"({"id": "10", "points": 500, "_action": "delete"})",
+            R"({"id": "5", "title": "title5", "points": 100, "$action": "create"})",
+            R"({"id": "6", "title": "title6", "points": 200, "$action": "create"})",
+            R"({"id": "10", "points": 500, "$action": "delete"})",
     };
 
     doc.clear();

--- a/test/collection_specific_test.cpp
+++ b/test/collection_specific_test.cpp
@@ -3421,3 +3421,71 @@ TEST_F(CollectionSpecificTest, TruncationEdgeCasesTest) {
     ASSERT_EQ(1, result["hits"].size());
     ASSERT_EQ("3", result["hits"][0]["document"]["id"]);
 }
+
+TEST_F(CollectionSpecificTest, DeleteUpdateDocsInSameBatch) {
+    std::vector<field> fields = {field("title", field_types::STRING, false),
+                                 field("points", field_types::INT32, false),};
+
+    Collection* coll1 = collectionManager.create_collection("coll1", 1, fields, "points").get();
+
+    nlohmann::json doc1;
+    doc1["id"] = "0";
+    doc1["title"] = "title0";
+    doc1["points"] = 100;
+
+    ASSERT_TRUE(coll1->add(doc1.dump()).ok());
+
+    std::vector<std::string> docs = {
+            R"({"id": "1", "title": "title1", "points": 100, "action": "create"})",
+            R"({"id": "2", "title": "title2", "points": 200, "action": "create"})",
+            R"({"id": "3", "title": "title3", "points": 200, "action": "create"})",
+            R"({"id": "2", "action": "delete"})",
+    };
+
+    nlohmann::json doc;
+    auto import_response = coll1->add_many(docs, doc, ALL);
+    ASSERT_TRUE(import_response["success"].get<bool>());
+    ASSERT_EQ(2, import_response["num_imported"].get<int>());
+    ASSERT_EQ(1, import_response["num_removed"].get<int>());
+    ASSERT_EQ(0, import_response["num_updated"].get<int>());
+
+    docs = {
+            R"({"id": "2", "title": "title2", "points": 100, "action": "create"})",
+            R"({"id": "4", "title": "title4", "points": 200, "action": "create"})",
+            R"({"id": "4", "points": 500, "action": "update"})",
+    };
+
+    doc.clear();
+    import_response = coll1->add_many(docs, doc, ALL);
+    ASSERT_TRUE(import_response["success"].get<bool>());
+    ASSERT_EQ(2, import_response["num_imported"].get<int>());
+    ASSERT_EQ(0, import_response["num_removed"].get<int>());
+    ASSERT_EQ(1, import_response["num_updated"].get<int>());
+
+    //verify the docs
+    ASSERT_EQ(5, coll1->get_num_documents());
+    ASSERT_EQ("title0", coll1->get("0").get()["title"]);
+    ASSERT_EQ(100, coll1->get("0").get()["points"].get<size_t>());
+    ASSERT_EQ("title1", coll1->get("1").get()["title"]);
+    ASSERT_EQ(100, coll1->get("1").get()["points"].get<size_t>());
+    ASSERT_EQ("title2", coll1->get("2").get()["title"]);
+    ASSERT_EQ(100, coll1->get("2").get()["points"].get<size_t>());
+    ASSERT_EQ("title3", coll1->get("3").get()["title"]);
+    ASSERT_EQ(200, coll1->get("3").get()["points"].get<size_t>());
+    ASSERT_EQ("title4", coll1->get("4").get()["title"]);
+    ASSERT_EQ(500, coll1->get("4").get()["points"].get<size_t>());
+
+    //invalid request
+    docs = {
+            R"({"id": "5", "title": "title5", "points": 100, "action": "create"})",
+            R"({"id": "6", "title": "title6", "points": 200, "action": "create"})",
+            R"({"id": "10", "points": 500, "action": "delete"})",
+    };
+
+    doc.clear();
+    import_response = coll1->add_many(docs, doc, ALL);
+    ASSERT_FALSE(import_response["success"].get<bool>());
+    ASSERT_EQ(2, import_response["num_imported"].get<int>());
+    ASSERT_EQ(0, import_response["num_removed"].get<int>());
+    ASSERT_EQ(0, import_response["num_updated"].get<int>());
+}

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -2464,7 +2464,7 @@ TEST_F(CollectionTest, UpdateDocument) {
     doc2["tags"] = {"SENTENCE"};
     add_op = coll1->add(doc2.dump(), UPDATE);
     ASSERT_FALSE(add_op.ok());
-    ASSERT_STREQ("For update, the `id` key must be provided.", add_op.error().c_str());
+    ASSERT_STREQ("For update/delete, the `id` key must be provided.", add_op.error().c_str());
 
     // now change tags with id
     doc2["id"] = "100";


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
### `all` action type
Typesense currently supports create, upsert, update actions type for importing docs.
These actions are defined at root level which applies to all docs in the batch.

#### Issues
In some pipelined jobs for adding, updating, deleting docs in the same batch one needs to filter and segregate all such docs and call their respective APIs for operation.

#### Proposed Approach
- Introduced a new per doc level approach to process doc on the go in same batch.
- new root level action type `all` is introduced to denote that import batch contain doc level actions which can be called like below,
```curl
curl -H "X-TYPESENSE-API-KEY: ${TYPESENSE_API_KEY}" \
      -X POST \
      -T documents.jsonl \
      "http://localhost:8108/collections/companies/documents/import?action=all"
```
and at doc level, one need to specify action like below
```json
{"id": "1", "company_name": "Stark Industries", "num_employees": 5215, "country": "USA", "$action": "create"}
{"id": "2", "company_name": "Orbit Inc.", "num_employees": 256, "country": "UK", "$action": "create"}
{"id": "1", "$action": "delete"}
```
`$action` value can be any of `create`, `update`, `delete`, `upsert`

In above sample import payload, in the end only doc with `id:2` will be indexed.

Similar way,
```json
{"id": "3", "company_name": "Avengers Inc", "num_employees": 5215, "country": "USA", "$action": "create"}
{"id": "4", "company_name": "Inifnity Inc.", "num_employees": 256, "country": "UK", "$action": "create"}
{"id": "4", "company_name": "Hulk Smashers", "$action": "update"}
```
for above import payload, doc with `id:3` will be indexed as usual but doc with `id:4` will be indexed with updated `company_name: Hulk Smashers`.

#### Notes
- when using `all` action type at rootlevel, at doc level  `$action` type is mandatory. Not doing so will  fail indexing  the doc.
- Normal uniform action types `create`, `update`, and `upsert` are still functional as before and can be used.


## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
