### PR TITLE
fix(highlight): correctly mark single token phrase query matches

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -5382,22 +5382,45 @@ bool Collection::handle_highlight_text(std::string& text, const bool& normalise,
 
     size_t text_len = Tokenizer::is_ascii_char(text[0]) ? text.size() : StringUtils::get_num_chars(text);
 
-    std::unordered_set<size_t> phrase_matched_token_indices;
-    std::unordered_set<std::string> single_token_phrase_tokens;
+    std::vector<std::pair<size_t, size_t>> valid_phrase_ranges;
     if(is_phrase_query) {
-        for(const auto& offset : match.offsets) {
-            phrase_matched_token_indices.insert(offset.offset);
+        size_t min_phrase_len = 0;
+        for(const auto& phrase : q_phrases) {
+            if(!phrase.empty()) {
+                min_phrase_len = (min_phrase_len == 0) ? phrase.size() : std::min(min_phrase_len, phrase.size());
+            }
         }
 
-        for(const auto& phrase : q_phrases) {
-            if(phrase.size() == 1) {
-                std::string phrase_token = phrase[0];
-                StringUtils::tolowercase(phrase_token);
-                single_token_phrase_tokens.insert(std::move(phrase_token));
+        if(min_phrase_len > 0) {
+            std::vector<size_t> matched_offsets;
+            matched_offsets.reserve(match.offsets.size());
+            for(const auto& offset : match.offsets) {
+                matched_offsets.push_back(offset.offset);
+            }
+
+            std::sort(matched_offsets.begin(), matched_offsets.end());
+            matched_offsets.erase(std::unique(matched_offsets.begin(), matched_offsets.end()), matched_offsets.end());
+
+            size_t run_start = 0;
+            for(size_t i = 1; i <= matched_offsets.size(); i++) {
+                const bool is_run_break = (i == matched_offsets.size()) ||
+                                          (matched_offsets[i] != matched_offsets[i - 1] + 1);
+                if(!is_run_break) {
+                    continue;
+                }
+
+                const size_t run_end = i - 1;
+                const size_t run_len = run_end - run_start + 1;
+                if(run_len >= min_phrase_len) {
+                    valid_phrase_ranges.emplace_back(matched_offsets[run_start], matched_offsets[run_end]);
+                }
+
+                run_start = i;
             }
         }
     }
 
+    size_t valid_phrase_range_idx = 0;
     while(tokenizer.next(raw_token, raw_token_index, tok_start, tok_end)) {
         if(use_word_tokenizer) {
             bool found_token = word_tokenizer.tokenize(raw_token);
@@ -5432,28 +5455,15 @@ bool Collection::handle_highlight_text(std::string& text, const bool& normalise,
         if (is_phrase_query && match_offset_found) {
             bool is_consecutive_phrase_match = false;
 
-            if (phrase_matched_token_indices.count(raw_token_index) > 0) {
-                if(!single_token_phrase_tokens.empty()) {
-                    std::string raw_token_lower = raw_token;
-                    StringUtils::tolowercase(raw_token_lower);
-                    if(single_token_phrase_tokens.count(raw_token_lower) > 0) {
-                        is_consecutive_phrase_match = true;
-                    }
-                }
+            while(valid_phrase_range_idx < valid_phrase_ranges.size() &&
+                  raw_token_index > valid_phrase_ranges[valid_phrase_range_idx].second) {
+                valid_phrase_range_idx++;
+            }
 
-                // check if the next token in the phrase is also in the match offsets
-                size_t next_token_index = raw_token_index + 1;
-                if (phrase_matched_token_indices.count(next_token_index) > 0) {
-                    is_consecutive_phrase_match = true;
-                }
-
-                if (!is_consecutive_phrase_match && raw_token_index > 0) {
-                    // the next token is not in the match offsets, check if the previous token is in the phrase
-                    size_t prev_token_index = raw_token_index - 1;
-                    if (phrase_matched_token_indices.count(prev_token_index) > 0) {
-                        is_consecutive_phrase_match = true;
-                    }
-                }
+            if(valid_phrase_range_idx < valid_phrase_ranges.size()) {
+                const auto& current_range = valid_phrase_ranges[valid_phrase_range_idx];
+                is_consecutive_phrase_match = (raw_token_index >= current_range.first &&
+                                               raw_token_index <= current_range.second);
             }
 
             // this is not part of a consecutive phrase match, don't highlight it

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -5383,6 +5383,20 @@ bool Collection::handle_highlight_text(std::string& text, const bool& normalise,
     size_t text_len = Tokenizer::is_ascii_char(text[0]) ? text.size() : StringUtils::get_num_chars(text);
 
     std::unordered_set<size_t> phrase_matched_token_indices;
+    std::unordered_set<std::string> single_token_phrase_tokens;
+    if(is_phrase_query) {
+        for(const auto& offset : match.offsets) {
+            phrase_matched_token_indices.insert(offset.offset);
+        }
+
+        for(const auto& phrase : q_phrases) {
+            if(phrase.size() == 1) {
+                std::string phrase_token = phrase[0];
+                StringUtils::tolowercase(phrase_token);
+                single_token_phrase_tokens.insert(std::move(phrase_token));
+            }
+        }
+    }
 
     while(tokenizer.next(raw_token, raw_token_index, tok_start, tok_end)) {
         if(use_word_tokenizer) {
@@ -5418,21 +5432,25 @@ bool Collection::handle_highlight_text(std::string& text, const bool& normalise,
         if (is_phrase_query && match_offset_found) {
             bool is_consecutive_phrase_match = false;
 
-            std::unordered_set<size_t> offset_indices;
-            for (const auto& offset : match.offsets) {
-                offset_indices.insert(offset.offset);
-            }
-            if (offset_indices.count(raw_token_index) > 0) {
+            if (phrase_matched_token_indices.count(raw_token_index) > 0) {
+                if(!single_token_phrase_tokens.empty()) {
+                    std::string raw_token_lower = raw_token;
+                    StringUtils::tolowercase(raw_token_lower);
+                    if(single_token_phrase_tokens.count(raw_token_lower) > 0) {
+                        is_consecutive_phrase_match = true;
+                    }
+                }
+
                 // check if the next token in the phrase is also in the match offsets
                 size_t next_token_index = raw_token_index + 1;
-                if (offset_indices.count(next_token_index) > 0) {
+                if (phrase_matched_token_indices.count(next_token_index) > 0) {
                     is_consecutive_phrase_match = true;
                 }
 
                 if (!is_consecutive_phrase_match && raw_token_index > 0) {
                     // the next token is not in the match offsets, check if the previous token is in the phrase
                     size_t prev_token_index = raw_token_index - 1;
-                    if (offset_indices.count(prev_token_index) > 0) {
+                    if (phrase_matched_token_indices.count(prev_token_index) > 0) {
                         is_consecutive_phrase_match = true;
                     }
                 }

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -3817,6 +3817,30 @@ TEST_F(CollectionSpecificMoreTest, PhraseQueryHighlightingShouldNotHighlightPart
     collectionManager.drop_collection("coll1");
 }
 
+TEST_F(CollectionSpecificMoreTest, SingleTokenPhraseQueryShouldHighlightExactMatch) {
+    std::vector<field> fields = {field("speechText", field_types::STRING, false)};
+    Collection* coll1 = collectionManager.create_collection("single_token_phrase_highlight", 1, fields).get();
+
+    nlohmann::json doc1;
+    doc1["id"] = "1";
+    doc1["speechText"] = "AddLife";
+    ASSERT_TRUE(coll1->add(doc1.dump()).ok());
+
+    auto results = coll1->search("\"addlife\"", {"speechText"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, 0,
+                                 spp::sparse_hash_set<std::string>(),
+                                 spp::sparse_hash_set<std::string>(), 10, "", 30, 4, "speechText", 20, {}, {}, {}, 0,
+                                 "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7,
+                                 fallback, 1000).get();
+
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_EQ(1, results["hits"][0]["highlights"].size());
+    ASSERT_EQ("speechText", results["hits"][0]["highlights"][0]["field"].get<std::string>());
+    ASSERT_EQ("<mark>AddLife</mark>", results["hits"][0]["highlights"][0]["snippet"].get<std::string>());
+
+    collectionManager.drop_collection("single_token_phrase_highlight");
+}
+
 TEST_F(CollectionSpecificMoreTest, PhraseQueryHighlightingInNestedFields) {
     nlohmann::json schema = R"({
         "name": "coll1",


### PR DESCRIPTION


## Change Summary
<!--- Described your changes here -->
- reuse phrase offset indices and treat exact single-token phrases as valid phrase matches during highlighting
- add a regression test for `"addlife"` to ensure `AddLife` is fully highlighted
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
