### PR TITLE
Use `nlohmann::json::dump()` to handle JSON escaping

### DIFF
--- a/include/http_data.h
+++ b/include/http_data.h
@@ -86,6 +86,12 @@ struct http_res {
         cv.notify_all();
     }
 
+    static std::string serialize_response_message(const std::string& message) {
+        nlohmann::json j;
+        j["message"] = message;
+        return j.dump();
+    }
+
     static const char* get_status_reason(uint32_t status_code) {
         switch(status_code) {
             case 200: return "OK";
@@ -115,12 +121,12 @@ struct http_res {
 
     void set_400(const std::string & message) {
         status_code = 400;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
     void set_401(const std::string & message) {
         status_code = 400;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
     void set_403() {
@@ -130,38 +136,38 @@ struct http_res {
 
     void set_404(const std::string & message = "Not Found") {
         status_code = 404;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
 
     void set_405(const std::string & message) {
         status_code = 405;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
     void set_409(const std::string & message) {
         status_code = 409;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
     void set_422(const std::string & message) {
         status_code = 422;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
     void set_500(const std::string & message) {
         status_code = 500;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
     void set_503(const std::string & message) {
         status_code = 503;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
     void set(uint32_t code, const std::string & message) {
         status_code = code;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
     void set_body(uint32_t code, const std::string & message) {

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -284,7 +284,7 @@ TEST_F(CoreAPIUtilsTest, MultiSearchEmbeddedKeys) {
     // try setting max search limit
     req->embedded_params_vec[0]["limit_multi_searches"] = 0;
     ASSERT_FALSE(post_multi_search(req, res));
-    ASSERT_EQ("{\"message\": \"Number of multi searches exceeds `limit_multi_searches` parameter.\"}", res->body);
+    ASSERT_EQ("{\"message\":\"Number of multi searches exceeds `limit_multi_searches` parameter.\"}", res->body);
 
     req->embedded_params_vec[0]["limit_multi_searches"] = 1;
     ASSERT_TRUE(post_multi_search(req, res));
@@ -293,7 +293,7 @@ TEST_F(CoreAPIUtilsTest, MultiSearchEmbeddedKeys) {
     req->embedded_params_vec[0]["limit_multi_searches"] = 0;
     req->params["limit_multi_searches"] = "100";
     ASSERT_FALSE(post_multi_search(req, res));
-    ASSERT_EQ("{\"message\": \"Number of multi searches exceeds `limit_multi_searches` parameter.\"}", res->body);
+    ASSERT_EQ("{\"message\":\"Number of multi searches exceeds `limit_multi_searches` parameter.\"}", res->body);
 
     // use req params if embedded param not present
     req->embedded_params_vec[0].erase("limit_multi_searches");
@@ -2021,14 +2021,14 @@ TEST_F(CoreAPIUtilsTest, CollectionsPagination) {
     get_collections(req, resp);
 
     ASSERT_EQ(400, resp->status_code);
-    ASSERT_EQ("{\"message\": \"Offset param should be unsigned integer.\"}", resp->body);
+    ASSERT_EQ("{\"message\":\"Offset param should be unsigned integer.\"}", resp->body);
 
     //invalid limit string
     req->params["offset"] = "0";
     req->params["limit"] = "-1";
     get_collections(req, resp);
     ASSERT_EQ(400, resp->status_code);
-    ASSERT_EQ("{\"message\": \"Limit param should be unsigned integer.\"}", resp->body);
+    ASSERT_EQ("{\"message\":\"Limit param should be unsigned integer.\"}", resp->body);
 }
 
 TEST_F(CoreAPIUtilsTest, OverridesPagination) {
@@ -2096,14 +2096,14 @@ TEST_F(CoreAPIUtilsTest, OverridesPagination) {
     get_collections(req, resp);
 
     ASSERT_EQ(400, resp->status_code);
-    ASSERT_EQ("{\"message\": \"Offset param should be unsigned integer.\"}", resp->body);
+    ASSERT_EQ("{\"message\":\"Offset param should be unsigned integer.\"}", resp->body);
 
     //invalid limit string
     req->params["offset"] = "0";
     req->params["limit"] = "-1";
     get_collections(req, resp);
     ASSERT_EQ(400, resp->status_code);
-    ASSERT_EQ("{\"message\": \"Limit param should be unsigned integer.\"}", resp->body);
+    ASSERT_EQ("{\"message\":\"Limit param should be unsigned integer.\"}", resp->body);
 }
 
 TEST_F(CoreAPIUtilsTest, SynonymsPagination) {
@@ -2147,14 +2147,14 @@ TEST_F(CoreAPIUtilsTest, SynonymsPagination) {
     get_collections(req, resp);
 
     ASSERT_EQ(400, resp->status_code);
-    ASSERT_EQ("{\"message\": \"Offset param should be unsigned integer.\"}", resp->body);
+    ASSERT_EQ("{\"message\":\"Offset param should be unsigned integer.\"}", resp->body);
 
     //invalid limit string
     req->params["offset"] = "0";
     req->params["limit"] = "-1";
     get_collections(req, resp);
     ASSERT_EQ(400, resp->status_code);
-    ASSERT_EQ("{\"message\": \"Limit param should be unsigned integer.\"}", resp->body);
+    ASSERT_EQ("{\"message\":\"Limit param should be unsigned integer.\"}", resp->body);
 }
 
 
@@ -2430,7 +2430,7 @@ TEST_F(CoreAPIUtilsTest, CollectionUpdateValidation) {
 
     req->body = alter_schema.dump();
     ASSERT_FALSE(patch_update_collection(req, res));
-    ASSERT_EQ("{\"message\": \"Only `fields`, `metadata` and `synonym_sets` can be updated at the moment.\"}", res->body);
+    ASSERT_EQ("{\"message\":\"Only `fields`, `metadata` and `synonym_sets` can be updated at the moment.\"}", res->body);
 
     alter_schema = R"({
         "symbols_to_index":[]
@@ -2438,7 +2438,7 @@ TEST_F(CoreAPIUtilsTest, CollectionUpdateValidation) {
 
     req->body = alter_schema.dump();
     ASSERT_FALSE(patch_update_collection(req, res));
-    ASSERT_EQ("{\"message\": \"Only `fields`, `metadata` and `synonym_sets` can be updated at the moment.\"}", res->body);
+    ASSERT_EQ("{\"message\":\"Only `fields`, `metadata` and `synonym_sets` can be updated at the moment.\"}", res->body);
 
     alter_schema = R"({
         "name": "collection_meta2",
@@ -2450,14 +2450,14 @@ TEST_F(CoreAPIUtilsTest, CollectionUpdateValidation) {
 
     req->body = alter_schema.dump();
     ASSERT_FALSE(patch_update_collection(req, res));
-    ASSERT_EQ("{\"message\": \"Only `fields`, `metadata` and `synonym_sets` can be updated at the moment.\"}", res->body);
+    ASSERT_EQ("{\"message\":\"Only `fields`, `metadata` and `synonym_sets` can be updated at the moment.\"}", res->body);
 
     alter_schema = R"({
     })"_json;
 
     req->body = alter_schema.dump();
     ASSERT_FALSE(patch_update_collection(req, res));
-    ASSERT_EQ("{\"message\": \"Alter payload is empty.\"}", res->body);
+    ASSERT_EQ("{\"message\":\"Alter payload is empty.\"}", res->body);
 }
 
 TEST_F(CoreAPIUtilsTest, DocumentGetIncludeExcludeFields) {

--- a/test/ratelimit_test.cpp
+++ b/test/ratelimit_test.cpp
@@ -579,7 +579,7 @@ TEST_F(RateLimitManagerTest, TestMultiSearchRateLimiting) {
 
     EXPECT_FALSE(post_multi_search(req, res));
     EXPECT_EQ(res->status_code, 429);
-    EXPECT_EQ(res->body, "{\"message\": \"Rate limit exceeded or blocked\"}");
+    EXPECT_EQ(res->body, "{\"message\":\"Rate limit exceeded or blocked\"}");
 
     body.erase("searches");
     body["searches"] = nlohmann::json::array();

--- a/test/stopwords_manager_test.cpp
+++ b/test/stopwords_manager_test.cpp
@@ -293,7 +293,7 @@ TEST_F(StopwordsManagerTest, StopwordsBasics) {
 
     result = del_stopword(req, res);
     ASSERT_EQ(404, res->status_code);
-    ASSERT_STREQ("{\"message\": \"Stopword `state` not found.\"}", res->body.c_str());
+    ASSERT_STREQ("{\"message\":\"Stopword `state` not found.\"}", res->body.c_str());
 
     req->params.clear();
     json_results.clear();
@@ -360,7 +360,7 @@ TEST_F(StopwordsManagerTest, StopwordsValidation) {
 
     auto result = put_upsert_stopword(req, res);
     ASSERT_EQ(400, res->status_code);
-    ASSERT_STREQ("{\"message\": \"Parameter `stopwords` is required\"}", res->body.c_str());
+    ASSERT_STREQ("{\"message\":\"Parameter `stopwords` is required\"}", res->body.c_str());
 
     //check for value types
     stopword_value = R"(
@@ -373,7 +373,7 @@ TEST_F(StopwordsManagerTest, StopwordsValidation) {
 
     result = put_upsert_stopword(req, res);
     ASSERT_EQ(400, res->status_code);
-    ASSERT_STREQ("{\"message\": \"Parameter `locale` is required as string value\"}", res->body.c_str());
+    ASSERT_STREQ("{\"message\":\"Parameter `locale` is required as string value\"}", res->body.c_str());
 
     stopword_value = R"(
             {"stopwords": [1, 5, 2], "locale": "ko"}
@@ -385,7 +385,7 @@ TEST_F(StopwordsManagerTest, StopwordsValidation) {
 
     result = put_upsert_stopword(req, res);
     ASSERT_EQ(400, res->status_code);
-    ASSERT_STREQ("{\"message\": \"Parameter `stopwords` is required as string array value\"}", res->body.c_str());
+    ASSERT_STREQ("{\"message\":\"Parameter `stopwords` is required as string array value\"}", res->body.c_str());
 
     collectionManager.drop_collection("coll1");
 }


### PR DESCRIPTION
Fixes #2709