### PR TITLE
Optimize asymetric AND filters via sort_index probing

### DIFF
--- a/include/filter.h
+++ b/include/filter.h
@@ -14,6 +14,16 @@
 
 constexpr size_t DEFAULT_FILTER_BY_CANDIDATES = 4;
 
+/// Minimum ratio (large_side / small_side) required to trigger the asymmetric AND
+/// filter optimization, which probes the large side via sort_index instead of
+/// materializing it. Higher values are more conservative (fewer false triggers).
+constexpr uint32_t ASYMMETRIC_AND_RATIO_THRESHOLD = 10;
+
+/// Maximum number of documents on the small side for the asymmetric AND optimization.
+/// Beyond this, the per-document probe loop becomes too expensive relative to the
+/// standard sorted intersection.
+constexpr uint32_t ASYMMETRIC_AND_MAX_PROBE_COUNT = 500'000;
+
 enum NUM_COMPARATOR {
     LESS_THAN,
     LESS_THAN_EQUALS,

--- a/include/filter.h
+++ b/include/filter.h
@@ -14,6 +14,20 @@
 
 constexpr size_t DEFAULT_FILTER_BY_CANDIDATES = 4;
 
+/// Minimum ratio (large_side / small_side) required to trigger the asymmetric AND
+/// filter optimization, which probes the large side via sort_index instead of
+/// materializing it. Higher values are more conservative (fewer false triggers).
+constexpr uint32_t ASYMMETRIC_AND_RATIO_THRESHOLD = 10;
+
+/// Maximum number of documents on the small side for the asymmetric AND optimization.
+/// Beyond this, the per-document probe loop becomes too expensive relative to the
+/// standard sorted intersection.
+constexpr uint32_t ASYMMETRIC_AND_MAX_PROBE_COUNT = 500'000;
+
+/// Cap on initial reserve for the lazy trie materialization buffer; selective filters
+/// use less, broad ones reallocate beyond this rather than over-allocating up front.
+constexpr size_t LAZY_TRIE_MATERIALIZE_RESERVE_CAP = 1'000'000;
+
 enum NUM_COMPARATOR {
     LESS_THAN,
     LESS_THAN_EQUALS,

--- a/include/filter_result_iterator.h
+++ b/include/filter_result_iterator.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <memory>
 #include "num_tree.h"
+#include "numeric_range_trie.h"
 #include "option.h"
 #include "posting_list.h"
 #include "id_list.h"
@@ -320,9 +321,9 @@ private:
 
     bool delete_filter_node = false;
 
-    /// Set when init() deferred range_index materialization for lazy evaluation.
-    /// compute_iterators() will materialize via init(false, false) if needed.
-    bool range_index_deferred = false;
+    /// Lazy trie iterator for range_index fields. When set, skip_to/next/is_valid
+    /// delegate to this iterator instead of using materialized filter_result arrays.
+    std::unique_ptr<NumericTrie::iterator_t> trie_iterator;
 
     std::unique_ptr<filter_result_iterator_timeout_info> timeout_info;
 

--- a/include/filter_result_iterator.h
+++ b/include/filter_result_iterator.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <memory>
 #include "num_tree.h"
+#include "numeric_range_trie.h"
 #include "option.h"
 #include "posting_list.h"
 #include "id_list.h"
@@ -319,6 +320,10 @@ private:
     std::unordered_set<uint32_t> string_prefix_filter_index;
 
     bool delete_filter_node = false;
+
+    /// Lazy trie iterator for range_index fields. When set, skip_to/next/is_valid
+    /// delegate to this iterator instead of using materialized filter_result arrays.
+    std::unique_ptr<NumericTrie::iterator_t> trie_iterator;
 
     std::unique_ptr<filter_result_iterator_timeout_info> timeout_info;
 

--- a/include/filter_result_iterator.h
+++ b/include/filter_result_iterator.h
@@ -320,6 +320,10 @@ private:
 
     bool delete_filter_node = false;
 
+    /// Set when init() deferred range_index materialization for lazy evaluation.
+    /// compute_iterators() will materialize via init(false, false) if needed.
+    bool range_index_deferred = false;
+
     std::unique_ptr<filter_result_iterator_timeout_info> timeout_info;
 
     /// Initializes the state of iterator node after it's creation.

--- a/include/numeric_range_trie.h
+++ b/include/numeric_range_trie.h
@@ -62,6 +62,8 @@ class NumericTrie {
 
         inline uint32_t get_ids_length();
 
+        void* get_seq_ids() const { return seq_ids; }
+
         void search_range(const int64_t& low, const int64_t& high, const char& max_level,
                           uint32_t*& ids, uint32_t& ids_length);
 
@@ -99,18 +101,15 @@ public:
 
     class iterator_t {
         struct match_state {
-            uint32_t* ids = nullptr;
-            uint32_t ids_length = 0;
-            uint32_t index = 0;
+            id_list_t* id_list;  // non-owning pointer, used to reconstruct iterator on reset()
+            id_list_t::iterator_t iter;
 
-            explicit match_state(uint32_t*& ids, uint32_t& ids_length) : ids(ids), ids_length(ids_length) {}
-
-            ~match_state() {
-                delete [] ids;
-            }
+            explicit match_state(id_list_t* list)
+                : id_list(list), iter(list->new_iterator()) {}
         };
 
         std::vector<match_state*> matches;
+        std::vector<id_list_t*> expanded_id_lists;  // owns id_list_t* converted from compact nodes
 
         void set_seq_id();
 
@@ -118,9 +117,20 @@ public:
 
         explicit iterator_t(std::vector<Node*>& matches);
 
+        iterator_t() { is_valid = false; }
+
+        iterator_t(iterator_t&& obj) noexcept
+            : matches(std::move(obj.matches)),
+              expanded_id_lists(std::move(obj.expanded_id_lists)),
+              seq_id(obj.seq_id),
+              is_valid(obj.is_valid) {}
+
         ~iterator_t() {
             for (auto& match: matches) {
                 delete match;
+            }
+            for (auto& list: expanded_id_lists) {
+                delete list;
             }
         }
 

--- a/include/numeric_range_trie.h
+++ b/include/numeric_range_trie.h
@@ -62,6 +62,8 @@ class NumericTrie {
 
         inline uint32_t get_ids_length();
 
+        void* get_seq_ids() const { return seq_ids; }
+
         void search_range(const int64_t& low, const int64_t& high, const char& max_level,
                           uint32_t*& ids, uint32_t& ids_length);
 
@@ -99,18 +101,17 @@ public:
 
     class iterator_t {
         struct match_state {
-            uint32_t* ids = nullptr;
-            uint32_t ids_length = 0;
-            uint32_t index = 0;
+            // id_list is non-owning; ownership of expanded lists lives in iterator_t::expanded_id_lists.
+            // Held so reset() can reconstruct iter without re-expanding the source compact list.
+            id_list_t* id_list;
+            id_list_t::iterator_t iter;
 
-            explicit match_state(uint32_t*& ids, uint32_t& ids_length) : ids(ids), ids_length(ids_length) {}
-
-            ~match_state() {
-                delete [] ids;
-            }
+            explicit match_state(id_list_t* list)
+                : id_list(list), iter(list->new_iterator()) {}
         };
 
         std::vector<match_state*> matches;
+        std::vector<id_list_t*> expanded_id_lists;
 
         void set_seq_id();
 
@@ -118,9 +119,20 @@ public:
 
         explicit iterator_t(std::vector<Node*>& matches);
 
+        iterator_t() { is_valid = false; }
+
+        iterator_t(iterator_t&& obj) noexcept
+            : matches(std::move(obj.matches)),
+              expanded_id_lists(std::move(obj.expanded_id_lists)),
+              seq_id(obj.seq_id),
+              is_valid(obj.is_valid) {}
+
         ~iterator_t() {
             for (auto& match: matches) {
                 delete match;
+            }
+            for (auto& list: expanded_id_lists) {
+                delete list;
             }
         }
 

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -15,6 +15,40 @@
 #include "collection_manager.h"
 #include <variant>
 
+namespace {
+    /// Builds a lazy NumericTrie iterator for the first comparator/value of `a_filter`.
+    /// Returns an invalid iterator for NOT_EQUALS (which the lazy path doesn't support);
+    /// callers fall back to the eager materialization path in that case.
+    template <typename ParseFn>
+    NumericTrie::iterator_t build_lazy_trie_iterator(NumericTrie* trie, const filter& a_filter, ParseFn parse) {
+        if (a_filter.values.empty()) {
+            return NumericTrie::iterator_t();
+        }
+
+        const auto cmp = a_filter.comparators[0];
+        int64_t value = parse(a_filter.values[0]);
+
+        switch (cmp) {
+            case RANGE_INCLUSIVE:
+                if (a_filter.values.size() > 1) {
+                    int64_t end_val = parse(a_filter.values[1]);
+                    return trie->search_range(value, true, end_val, true);
+                }
+                return NumericTrie::iterator_t();
+            case EQUALS:
+                return trie->search_equal_to(value);
+            case GREATER_THAN:
+            case GREATER_THAN_EQUALS:
+                return trie->search_greater_than(value, cmp == GREATER_THAN_EQUALS);
+            case LESS_THAN:
+            case LESS_THAN_EQUALS:
+                return trie->search_less_than(value, cmp == LESS_THAN_EQUALS);
+            default:
+                return NumericTrie::iterator_t();
+        }
+    }
+}
+
 void copy_references_helper(const std::map<std::string, reference_filter_result_t>* from,
                             std::map<std::string, reference_filter_result_t>*& to, const uint32_t& count) {
     if (from == nullptr || count == 0) {
@@ -897,6 +931,15 @@ void filter_result_iterator_t::next() {
     }
 
     if (f.is_integer() || f.is_float()) {
+        if (trie_iterator) {
+            trie_iterator->next();
+            if (!trie_iterator->is_valid) {
+                validity = invalid;
+                return;
+            }
+            seq_id = trie_iterator->seq_id;
+            return;
+        }
         advance_numeric_filter_iterators();
         get_numeric_filter_match();
         return;
@@ -1163,6 +1206,27 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
         if (f.range_index) {
             auto const& trie = index->range_index.at(a_filter.field_name);
 
+            if (enable_lazy_evaluation) {
+                auto iter = build_lazy_trie_iterator(trie, a_filter,
+                    [](const std::string& s) { return (int64_t)std::stol(s); });
+
+                if (iter.is_valid) {
+                    approx_filter_ids_length = trie->size();
+                    trie_iterator = std::make_unique<NumericTrie::iterator_t>(std::move(iter));
+                    seq_id = trie_iterator->seq_id;
+                    validity = valid;
+                    return;
+                }
+
+                // NOT_EQUALS isn't supported lazily; fall through to eager.
+                // For supported comparators, an invalid iter means no matches.
+                if (!a_filter.values.empty() && a_filter.comparators[0] != NOT_EQUALS) {
+                    validity = invalid;
+                    approx_filter_ids_length = 0;
+                    return;
+                }
+            }
+
             for (size_t fi = 0; fi < a_filter.values.size(); fi++) {
                 const std::string& filter_value = a_filter.values[fi];
                 auto const& value = (int64_t)std::stol(filter_value);
@@ -1318,6 +1382,27 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
     } else if (f.is_float()) {
         if (f.range_index) {
             auto const& trie = index->range_index.at(a_filter.field_name);
+
+            if (enable_lazy_evaluation) {
+                auto iter = build_lazy_trie_iterator(trie, a_filter,
+                    [](const std::string& s) {
+                        return Index::float_to_int64_t((float)std::atof(s.c_str()));
+                    });
+
+                if (iter.is_valid) {
+                    approx_filter_ids_length = trie->size();
+                    trie_iterator = std::make_unique<NumericTrie::iterator_t>(std::move(iter));
+                    seq_id = trie_iterator->seq_id;
+                    validity = valid;
+                    return;
+                }
+
+                if (!a_filter.values.empty() && a_filter.comparators[0] != NOT_EQUALS) {
+                    validity = invalid;
+                    approx_filter_ids_length = 0;
+                    return;
+                }
+            }
 
             for (size_t fi = 0; fi < a_filter.values.size(); fi++) {
                 const std::string& filter_value = a_filter.values[fi];
@@ -1958,6 +2043,15 @@ void filter_result_iterator_t::skip_to(uint32_t id) {
     field f = index->search_schema.at(a_filter.field_name);
 
     if (f.is_integer() || f.is_float()) {
+        if (trie_iterator) {
+            trie_iterator->skip_to(id);
+            if (!trie_iterator->is_valid) {
+                validity = invalid;
+                return;
+            }
+            seq_id = trie_iterator->seq_id;
+            return;
+        }
         // Skip all the iterators and find a new match.
         auto one_is_valid = false;
         for (uint32_t i = 0; i < id_list_iterators.size(); i++) {
@@ -2255,6 +2349,11 @@ int filter_result_iterator_t::is_valid(uint32_t id, const bool& curation_timeout
         return 1;
     }
 
+    // Trie path tracks position via seq_id, not equals_iterator_id.
+    if (trie_iterator) {
+        return validity ? (seq_id == id ? 1 : 0) : -1;
+    }
+
     return validity ? (id == equals_iterator_id ? 1 : 0) : -1;
 }
 
@@ -2404,6 +2503,16 @@ void filter_result_iterator_t::reset(const bool& curation_timeout) {
     field f = index->search_schema.at(a_filter.field_name);
 
     if (f.is_integer() || f.is_float()) {
+        if (trie_iterator) {
+            trie_iterator->reset();
+            if (!trie_iterator->is_valid) {
+                validity = invalid;
+                return;
+            }
+            seq_id = trie_iterator->seq_id;
+            validity = valid;
+            return;
+        }
         for (uint32_t i = 0; i < id_lists.size(); i++) {
             auto const& lists = id_lists[i];
 
@@ -2568,9 +2677,20 @@ filter_result_iterator_t::filter_result_iterator_t(const std::string& collection
 
     // Generate the iterator tree and then initialize each node.
     if (filter_node->isOperator) {
-        left_it = new filter_result_iterator_t(collection_name, index, filter_node->left, enable_lazy_evaluation,
+        // Force lazy eval for range_index leaves under an AND so the asymmetric AND
+        // optimization in compute_iterators() can probe them without materializing.
+        auto should_defer_child = [&](const filter_node_t* child) -> bool {
+            if (filter_node->filter_operator != AND || child == nullptr || child->isOperator) {
+                return false;
+            }
+            const auto& fname = child->filter_exp.field_name;
+            if (index->search_schema.count(fname) == 0) return false;
+            return index->search_schema.at(fname).range_index;
+        };
+
+        bool left_lazy = enable_lazy_evaluation || should_defer_child(filter_node->left);
+        left_it = new filter_result_iterator_t(collection_name, index, filter_node->left, left_lazy,
                                                max_candidates, validate_field_names);
-        // If left subtree of && operator is invalid, we don't have to evaluate its right subtree.
         if (filter_node->filter_operator == AND && left_it->validity == invalid) {
             validity = invalid;
             is_filter_result_initialized = true;
@@ -2579,7 +2699,8 @@ filter_result_iterator_t::filter_result_iterator_t(const std::string& collection
             return;
         }
 
-        right_it = new filter_result_iterator_t(collection_name, index, filter_node->right, enable_lazy_evaluation,
+        bool right_lazy = enable_lazy_evaluation || should_defer_child(filter_node->right);
+        right_it = new filter_result_iterator_t(collection_name, index, filter_node->right, right_lazy,
                                                 max_candidates, validate_field_names);
     }
 
@@ -2648,6 +2769,7 @@ filter_result_iterator_t& filter_result_iterator_t::operator=(filter_result_iter
     is_filter_result_initialized = obj.is_filter_result_initialized;
 
     approx_filter_ids_length = obj.approx_filter_ids_length;
+    trie_iterator = std::move(obj.trie_iterator);
 
     return *this;
 }
@@ -2794,19 +2916,175 @@ void filter_result_iterator_t::compute_iterators() {
         return;
     }
 
+    // Lazy trie iterator was set up in init() but was never consumed via the asymmetric
+    // AND probe path; drain it into a materialized filter_result here.
+    if (trie_iterator) {
+        std::vector<uint32_t> ids;
+        ids.reserve(std::min((size_t)approx_filter_ids_length, LAZY_TRIE_MATERIALIZE_RESERVE_CAP));
+        while (trie_iterator->is_valid) {
+            ids.push_back(trie_iterator->seq_id);
+            trie_iterator->next();
+        }
+
+        filter_result.count = ids.size();
+        if (filter_result.count > 0) {
+            filter_result.docs = new uint32_t[filter_result.count];
+            std::copy(ids.begin(), ids.end(), filter_result.docs);
+        }
+
+        trie_iterator.reset();
+        is_filter_result_initialized = true;
+
+        if (filter_result.count == 0) {
+            validity = invalid;
+        } else {
+            seq_id = filter_result.docs[0];
+            result_index = 0;
+            approx_filter_ids_length = filter_result.count;
+        }
+
+        return;
+    }
+
     if (filter_node->isOperator) {
         if (timeout_info != nullptr) {
             // Passing timeout_info into subtree so individual nodes can check for timeout.
             left_it->timeout_info = std::make_unique<filter_result_iterator_timeout_info>(*timeout_info);
             right_it->timeout_info = std::make_unique<filter_result_iterator_timeout_info>(*timeout_info);
         }
-        left_it->compute_iterators();
-        right_it->compute_iterators();
 
-        if (filter_node->filter_operator == AND) {
-            filter_result_t::and_filter_results(left_it->filter_result, right_it->filter_result, filter_result);
-        } else {
-            filter_result_t::or_filter_results(left_it->filter_result, right_it->filter_result, filter_result);
+        // Asymmetric AND: when one side is much smaller than the other, materialize the
+        // smaller side and probe each id against the larger side instead of building both
+        // sides fully. Avoids decompressing hundreds of millions of ids from a broad range
+        // filter (e.g. price:<=10000) when ANDed with a selective filter.
+        bool used_probe_optimization = false;
+        if (filter_node->filter_operator == AND && !filter_node->is_object_filter_root) {
+            auto* small_it = left_it;
+            auto* large_it = right_it;
+            if (left_it->approx_filter_ids_length > right_it->approx_filter_ids_length) {
+                std::swap(small_it, large_it);
+            }
+
+            if (small_it->approx_filter_ids_length > 0 &&
+                small_it->approx_filter_ids_length < ASYMMETRIC_AND_MAX_PROBE_COUNT &&
+                large_it->approx_filter_ids_length > small_it->approx_filter_ids_length * ASYMMETRIC_AND_RATIO_THRESHOLD) {
+
+                small_it->compute_iterators();
+
+                if (small_it->filter_result.count > 0 &&
+                    small_it->filter_result.count < ASYMMETRIC_AND_MAX_PROBE_COUNT) {
+
+                    auto small_count = small_it->filter_result.count;
+                    auto* small_docs = small_it->filter_result.docs;
+
+                    filter_result.docs = new uint32_t[small_count];
+                    // Allocate unconditionally: either side may contribute reference data
+                    // (small from filter_result, large from is_valid() populating reference).
+                    // Without this, JOIN data is dropped when the JOIN is on the larger side.
+                    filter_result.coll_to_references = new std::map<std::string, reference_filter_result_t>[small_count] {};
+
+                    // sort_index gives O(1) per-doc lookup vs the trie iterator's O(M log B)
+                    // probe. Only valid for singular numeric leaf filters with no JOIN: array
+                    // fields don't have complete sort_index entries, JOIN queries need the
+                    // is_valid() side-effect to populate references, and apply_not_equals
+                    // semantics differ for docs missing from sort_index.
+                    bool use_sort_index = false;
+                    const spp::sparse_hash_map<uint32_t, int64_t, Hasher32>* sort_field_map = nullptr;
+                    std::vector<std::pair<int64_t, NUM_COMPARATOR>> parsed_filters;
+
+                    if (large_it->filter_node != nullptr &&
+                        !large_it->filter_node->isOperator &&
+                        large_it->index != nullptr) {
+                        const auto& f = large_it->filter_node->filter_exp;
+                        const auto& schema = large_it->index->search_schema;
+                        if (!f.apply_not_equals && f.referenced_collection_name.empty() &&
+                            schema.count(f.field_name) > 0 &&
+                            schema.at(f.field_name).is_singular()) {
+                            auto si_it = large_it->index->sort_index.find(f.field_name);
+                            if (si_it != large_it->index->sort_index.end() && si_it->second != nullptr) {
+                                sort_field_map = si_it->second;
+                                bool all_parsed = true;
+                                for (size_t fi = 0; fi < f.values.size(); fi++) {
+                                    try {
+                                        parsed_filters.emplace_back(std::stol(f.values[fi]), f.comparators[fi]);
+                                    } catch (const std::logic_error&) {
+                                        all_parsed = false;
+                                        break;
+                                    }
+                                }
+                                use_sort_index = all_parsed && !parsed_filters.empty();
+                            }
+                        }
+                    }
+
+                    uint32_t out_count = 0;
+                    for (uint32_t i = 0; i < small_count; i++) {
+                        auto id = small_docs[i];
+                        bool matches = false;
+
+                        if (use_sort_index) {
+                            auto val_it = sort_field_map->find(id);
+                            if (val_it != sort_field_map->end()) {
+                                int64_t doc_val = val_it->second;
+                                for (size_t fi = 0; fi < parsed_filters.size(); fi++) {
+                                    int64_t fval = parsed_filters[fi].first;
+                                    NUM_COMPARATOR cmp = parsed_filters[fi].second;
+                                    bool cond = false;
+                                    switch (cmp) {
+                                        case LESS_THAN:            cond = (doc_val < fval); break;
+                                        case LESS_THAN_EQUALS:     cond = (doc_val <= fval); break;
+                                        case EQUALS:               cond = (doc_val == fval); break;
+                                        case NOT_EQUALS:           cond = (doc_val != fval); break;
+                                        case GREATER_THAN:         cond = (doc_val > fval); break;
+                                        case GREATER_THAN_EQUALS:  cond = (doc_val >= fval); break;
+                                        case RANGE_INCLUSIVE:
+                                            if (fi + 1 < parsed_filters.size()) {
+                                                int64_t fval_hi = parsed_filters[fi + 1].first;
+                                                cond = (doc_val >= fval && doc_val <= fval_hi);
+                                                fi++;
+                                            }
+                                            break;
+                                        default: break;
+                                    }
+                                    if (cond) { matches = true; break; }
+                                }
+                            }
+                        } else {
+                            auto probe_result = large_it->is_valid(id);
+                            if (probe_result == 1) {
+                                matches = true;
+                            } else if (probe_result == -1) {
+                                break;
+                            }
+                        }
+
+                        if (matches) {
+                            filter_result.docs[out_count] = id;
+                            if (small_it->filter_result.coll_to_references != nullptr) {
+                                filter_result.coll_to_references[out_count] = small_it->filter_result.coll_to_references[i];
+                            }
+                            for (const auto& ref: large_it->reference) {
+                                filter_result.coll_to_references[out_count][ref.first] = ref.second;
+                            }
+                            out_count++;
+                        }
+                    }
+
+                    filter_result.count = out_count;
+                    used_probe_optimization = true;
+                }
+            }
+        }
+
+        if (!used_probe_optimization) {
+            left_it->compute_iterators();
+            right_it->compute_iterators();
+
+            if (filter_node->filter_operator == AND) {
+                filter_result_t::and_filter_results(left_it->filter_result, right_it->filter_result, filter_result);
+            } else {
+                filter_result_t::or_filter_results(left_it->filter_result, right_it->filter_result, filter_result);
+            }
         }
 
         if (left_it->validity == timed_out || right_it->validity == timed_out ||

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -897,6 +897,15 @@ void filter_result_iterator_t::next() {
     }
 
     if (f.is_integer() || f.is_float()) {
+        if (trie_iterator) {
+            trie_iterator->next();
+            if (!trie_iterator->is_valid) {
+                validity = invalid;
+                return;
+            }
+            seq_id = trie_iterator->seq_id;
+            return;
+        }
         advance_numeric_filter_iterators();
         get_numeric_filter_match();
         return;
@@ -1164,20 +1173,49 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
             auto const& trie = index->range_index.at(a_filter.field_name);
 
             if (enable_lazy_evaluation) {
-                // Defer range_index materialization. The trie search can be very expensive
-                // for broad filters (e.g. price:<=10000 matching 100M+ docs) as it
-                // allocates and populates a massive ID array. By deferring, we allow
-                // compute_iterators() to bypass this entirely when the asymmetric AND
-                // probe optimization applies. trie->size() is used as an approximation
-                // for approx_filter_ids_length (it returns total indexed values, which
-                // may overestimate the actual match count - this is safe since the value
-                // is only used for optimization heuristics, not correctness).
-                approx_filter_ids_length = trie->size();
-                range_index_deferred = true;
-                validity = valid;
-                return;
-            }
+                // Perform the trie search to get matching Node* list (cheap trie walk).
+                // Then create a lazy iterator that avoids decompressing IDs upfront.
+                NumericTrie::iterator_t iter = [&]() {
+                    for (size_t fi = 0; fi < a_filter.values.size(); fi++) {
+                        const std::string& filter_value = a_filter.values[fi];
+                        auto const& value = (int64_t)std::stol(filter_value);
 
+                        if (a_filter.comparators[fi] == RANGE_INCLUSIVE && fi+1 < a_filter.values.size()) {
+                            const std::string& next_filter_value = a_filter.values[fi + 1];
+                            auto const& range_end_value = (int64_t)std::stol(next_filter_value);
+                            return trie->search_range(value, true, range_end_value, true);
+                        } else if (a_filter.comparators[fi] == EQUALS) {
+                            return trie->search_equal_to(value);
+                        } else if (a_filter.comparators[fi] == NOT_EQUALS) {
+                            // NOT_EQUALS on range_index: fall through to eager materialization
+                            break;
+                        } else if (a_filter.comparators[fi] == GREATER_THAN || a_filter.comparators[fi] == GREATER_THAN_EQUALS) {
+                            return trie->search_greater_than(value, a_filter.comparators[fi] == GREATER_THAN_EQUALS);
+                        } else if (a_filter.comparators[fi] == LESS_THAN || a_filter.comparators[fi] == LESS_THAN_EQUALS) {
+                            return trie->search_less_than(value, a_filter.comparators[fi] == LESS_THAN_EQUALS);
+                        }
+                    }
+                    return NumericTrie::iterator_t();  // default invalid iterator
+                }();
+
+                if (!iter.is_valid && a_filter.values.size() > 0 &&
+                    a_filter.comparators[0] != NOT_EQUALS) {
+                    // No matches found
+                    validity = invalid;
+                    approx_filter_ids_length = 0;
+                    return;
+                }
+
+                if (iter.is_valid) {
+                    approx_filter_ids_length = trie->size();
+                    trie_iterator = std::make_unique<NumericTrie::iterator_t>(std::move(iter));
+                    seq_id = trie_iterator->seq_id;
+                    validity = valid;
+                    return;
+                }
+
+                // Fall through to eager path for NOT_EQUALS or other unhandled cases
+            }
 
             for (size_t fi = 0; fi < a_filter.values.size(); fi++) {
                 const std::string& filter_value = a_filter.values[fi];
@@ -1334,6 +1372,46 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
     } else if (f.is_float()) {
         if (f.range_index) {
             auto const& trie = index->range_index.at(a_filter.field_name);
+
+            if (enable_lazy_evaluation) {
+                NumericTrie::iterator_t iter = [&]() {
+                    for (size_t fi = 0; fi < a_filter.values.size(); fi++) {
+                        const std::string& filter_value = a_filter.values[fi];
+                        float value = (float)std::atof(filter_value.c_str());
+                        int64_t float_int64 = Index::float_to_int64_t(value);
+
+                        if (a_filter.comparators[fi] == RANGE_INCLUSIVE && fi+1 < a_filter.values.size()) {
+                            const std::string& next_filter_value = a_filter.values[fi + 1];
+                            int64_t range_end_value = Index::float_to_int64_t((float) std::atof(next_filter_value.c_str()));
+                            return trie->search_range(float_int64, true, range_end_value, true);
+                        } else if (a_filter.comparators[fi] == EQUALS) {
+                            return trie->search_equal_to(float_int64);
+                        } else if (a_filter.comparators[fi] == NOT_EQUALS) {
+                            break;
+                        } else if (a_filter.comparators[fi] == GREATER_THAN || a_filter.comparators[fi] == GREATER_THAN_EQUALS) {
+                            return trie->search_greater_than(float_int64, a_filter.comparators[fi] == GREATER_THAN_EQUALS);
+                        } else if (a_filter.comparators[fi] == LESS_THAN || a_filter.comparators[fi] == LESS_THAN_EQUALS) {
+                            return trie->search_less_than(float_int64, a_filter.comparators[fi] == LESS_THAN_EQUALS);
+                        }
+                    }
+                    return NumericTrie::iterator_t();
+                }();
+
+                if (!iter.is_valid && a_filter.values.size() > 0 &&
+                    a_filter.comparators[0] != NOT_EQUALS) {
+                    validity = invalid;
+                    approx_filter_ids_length = 0;
+                    return;
+                }
+
+                if (iter.is_valid) {
+                    approx_filter_ids_length = trie->size();
+                    trie_iterator = std::make_unique<NumericTrie::iterator_t>(std::move(iter));
+                    seq_id = trie_iterator->seq_id;
+                    validity = valid;
+                    return;
+                }
+            }
 
             for (size_t fi = 0; fi < a_filter.values.size(); fi++) {
                 const std::string& filter_value = a_filter.values[fi];
@@ -1974,6 +2052,15 @@ void filter_result_iterator_t::skip_to(uint32_t id) {
     field f = index->search_schema.at(a_filter.field_name);
 
     if (f.is_integer() || f.is_float()) {
+        if (trie_iterator) {
+            trie_iterator->skip_to(id);
+            if (!trie_iterator->is_valid) {
+                validity = invalid;
+                return;
+            }
+            seq_id = trie_iterator->seq_id;
+            return;
+        }
         // Skip all the iterators and find a new match.
         auto one_is_valid = false;
         for (uint32_t i = 0; i < id_list_iterators.size(); i++) {
@@ -2271,6 +2358,11 @@ int filter_result_iterator_t::is_valid(uint32_t id, const bool& curation_timeout
         return 1;
     }
 
+    // For trie_iterator leaves, skip_to sets seq_id; check that instead of equals_iterator_id.
+    if (trie_iterator) {
+        return validity ? (seq_id == id ? 1 : 0) : -1;
+    }
+
     return validity ? (id == equals_iterator_id ? 1 : 0) : -1;
 }
 
@@ -2420,6 +2512,16 @@ void filter_result_iterator_t::reset(const bool& curation_timeout) {
     field f = index->search_schema.at(a_filter.field_name);
 
     if (f.is_integer() || f.is_float()) {
+        if (trie_iterator) {
+            trie_iterator->reset();
+            if (!trie_iterator->is_valid) {
+                validity = invalid;
+                return;
+            }
+            seq_id = trie_iterator->seq_id;
+            validity = valid;
+            return;
+        }
         for (uint32_t i = 0; i < id_lists.size(); i++) {
             auto const& lists = id_lists[i];
 
@@ -2584,10 +2686,10 @@ filter_result_iterator_t::filter_result_iterator_t(const std::string& collection
 
     // Generate the iterator tree and then initialize each node.
     if (filter_node->isOperator) {
-        // For AND operators, defer range_index materialization on both children so that
-        // the asymmetric AND optimization in compute_iterators() can bypass the expensive
-        // trie search entirely. We only force lazy eval when the child is a leaf node
-        // with a range_index field; other field types are unaffected.
+        // For AND operators, defer range_index materialization on leaf children so that
+        // the asymmetric AND optimization in compute_iterators() can use the lazy trie
+        // iterator. Only force lazy eval when the child is a leaf node with a range_index
+        // field; other field types (strings, booleans, etc.) are unaffected.
         auto should_defer_child = [&](const filter_node_t* child) -> bool {
             if (filter_node->filter_operator != AND || child == nullptr || child->isOperator) {
                 return false;
@@ -2600,7 +2702,6 @@ filter_result_iterator_t::filter_result_iterator_t(const std::string& collection
         bool left_lazy = enable_lazy_evaluation || should_defer_child(filter_node->left);
         left_it = new filter_result_iterator_t(collection_name, index, filter_node->left, left_lazy,
                                                max_candidates, validate_field_names);
-        // If left subtree of && operator is invalid, we don't have to evaluate its right subtree.
         if (filter_node->filter_operator == AND && left_it->validity == invalid) {
             validity = invalid;
             is_filter_result_initialized = true;
@@ -2679,6 +2780,7 @@ filter_result_iterator_t& filter_result_iterator_t::operator=(filter_result_iter
     is_filter_result_initialized = obj.is_filter_result_initialized;
 
     approx_filter_ids_length = obj.approx_filter_ids_length;
+    trie_iterator = std::move(obj.trie_iterator);
 
     return *this;
 }
@@ -2825,12 +2927,34 @@ void filter_result_iterator_t::compute_iterators() {
         return;
     }
 
-    // Deferred range_index materialization: init() skipped the expensive trie search
-    // when lazy evaluation was enabled. Materialize now since this node's full result
-    // is needed (e.g., it's a standalone filter or the asymmetric probe didn't apply).
-    if (range_index_deferred) {
-        range_index_deferred = false;
-        init(false, false);
+    // If this leaf node has a lazy trie iterator, materialize it fully.
+    // This happens when compute_iterators() is called on a standalone range filter
+    // or when the asymmetric AND optimization didn't apply.
+    if (trie_iterator) {
+        std::vector<uint32_t> ids;
+        ids.reserve(std::min(approx_filter_ids_length, (uint32_t)1000000));
+        while (trie_iterator->is_valid) {
+            ids.push_back(trie_iterator->seq_id);
+            trie_iterator->next();
+        }
+
+        filter_result.count = ids.size();
+        if (filter_result.count > 0) {
+            filter_result.docs = new uint32_t[filter_result.count];
+            memcpy(filter_result.docs, ids.data(), filter_result.count * sizeof(uint32_t));
+        }
+
+        trie_iterator.reset();
+        is_filter_result_initialized = true;
+
+        if (filter_result.count == 0) {
+            validity = invalid;
+        } else {
+            seq_id = filter_result.docs[0];
+            result_index = 0;
+            approx_filter_ids_length = filter_result.count;
+        }
+
         return;
     }
 
@@ -2842,19 +2966,11 @@ void filter_result_iterator_t::compute_iterators() {
         }
 
         // Optimization for AND with highly asymmetric children: compute the smaller side
-        // eagerly and evaluate the larger side per-document via sort_index lookup. This
-        // avoids materializing hundreds of millions of IDs from a broad range filter
-        // (e.g. price:<=10000 matching 200M docs) when ANDed with a selective equality
-        // filter (e.g. category:=X matching ~1000 docs).
-        //
-        // The sort_index stores numeric values per document as a hash map, enabling O(1)
-        // lookups. For each document in the small result set, we look up its value and
-        // evaluate the filter condition directly -- much faster than traversing the range
-        // index. If the field isn't in sort_index, we fall back to is_valid() probing.
+        // eagerly and probe each document against the larger side's lazy trie iterator
+        // via is_valid(). This avoids materializing hundreds of millions of IDs from a
+        // broad range filter (e.g. price:<=10000) when ANDed with a selective filter.
         bool used_probe_optimization = false;
         if (filter_node->filter_operator == AND && !filter_node->is_object_filter_root) {
-
-            // Identify the smaller and larger side, regardless of filter order in the query.
             auto* small_it = left_it;
             auto* large_it = right_it;
             if (left_it->approx_filter_ids_length > right_it->approx_filter_ids_length) {
@@ -2864,22 +2980,22 @@ void filter_result_iterator_t::compute_iterators() {
             if (small_it->approx_filter_ids_length > 0 &&
                 large_it->approx_filter_ids_length > small_it->approx_filter_ids_length * ASYMMETRIC_AND_RATIO_THRESHOLD) {
 
-                // Compute the small side eagerly to get its full result set.
                 small_it->compute_iterators();
 
-                if (small_it->filter_result.count > 0 && small_it->filter_result.count < ASYMMETRIC_AND_MAX_PROBE_COUNT) {
+                if (small_it->filter_result.count > 0 &&
+                    small_it->filter_result.count < ASYMMETRIC_AND_MAX_PROBE_COUNT) {
+
                     auto small_count = small_it->filter_result.count;
                     auto* small_docs = small_it->filter_result.docs;
 
                     filter_result.docs = new uint32_t[small_count];
-
-                    // Always allocate coll_to_references: either side may contribute
-                    // reference data (small side from filter_result, large side from
-                    // is_valid() probing). Without this, JOIN data is lost when the
-                    // JOIN happens to be on the larger side of the AND.
-                    filter_result.coll_to_references = new std::map<std::string, reference_filter_result_t>[small_count] {};
+                    if (small_it->filter_result.coll_to_references != nullptr) {
+                        filter_result.coll_to_references = new std::map<std::string, reference_filter_result_t>[small_count] {};
+                    }
 
                     // Check if the large side is a simple numeric leaf filter with a sort_index.
+                    // sort_index provides O(1) hash-map lookup per document, much faster than
+                    // probing the trie iterator which is O(M * log B) where M = matching leaf nodes.
                     bool use_sort_index = false;
                     const spp::sparse_hash_map<uint32_t, int64_t, Hasher32>* sort_field_map = nullptr;
                     std::vector<std::pair<int64_t, NUM_COMPARATOR>> parsed_filters;
@@ -2911,8 +3027,7 @@ void filter_result_iterator_t::compute_iterators() {
                     // sort_index shortcut because it bypasses is_valid() which is responsible
                     // for populating the reference data. Fall back to the is_valid() probe
                     // path which still benefits from the asymmetric AND optimization.
-                    if (use_sort_index && (small_it->filter_result.coll_to_references != nullptr ||
-                                           large_it->filter_result.coll_to_references != nullptr)) {
+                    if (use_sort_index && small_it->filter_result.coll_to_references != nullptr) {
                         use_sort_index = false;
                     }
 
@@ -2950,12 +3065,6 @@ void filter_result_iterator_t::compute_iterators() {
                                 if (negate_result) matches = !matches;
                             }
                         } else {
-                            // If the large side has a deferred range_index, materialize it
-                            // before probing -- is_valid() needs the populated result array.
-                            if (large_it->range_index_deferred) {
-                                large_it->range_index_deferred = false;
-                                large_it->init(false, false);
-                            }
                             auto probe_result = large_it->is_valid(id);
                             if (probe_result == 1) {
                                 matches = true;

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -1163,6 +1163,22 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
         if (f.range_index) {
             auto const& trie = index->range_index.at(a_filter.field_name);
 
+            if (enable_lazy_evaluation) {
+                // Defer range_index materialization. The trie search can be very expensive
+                // for broad filters (e.g. price:<=10000 matching 100M+ docs) as it
+                // allocates and populates a massive ID array. By deferring, we allow
+                // compute_iterators() to bypass this entirely when the asymmetric AND
+                // probe optimization applies. trie->size() is used as an approximation
+                // for approx_filter_ids_length (it returns total indexed values, which
+                // may overestimate the actual match count - this is safe since the value
+                // is only used for optimization heuristics, not correctness).
+                approx_filter_ids_length = trie->size();
+                range_index_deferred = true;
+                validity = valid;
+                return;
+            }
+
+
             for (size_t fi = 0; fi < a_filter.values.size(); fi++) {
                 const std::string& filter_value = a_filter.values[fi];
                 auto const& value = (int64_t)std::stol(filter_value);
@@ -2568,7 +2584,21 @@ filter_result_iterator_t::filter_result_iterator_t(const std::string& collection
 
     // Generate the iterator tree and then initialize each node.
     if (filter_node->isOperator) {
-        left_it = new filter_result_iterator_t(collection_name, index, filter_node->left, enable_lazy_evaluation,
+        // For AND operators, defer range_index materialization on both children so that
+        // the asymmetric AND optimization in compute_iterators() can bypass the expensive
+        // trie search entirely. We only force lazy eval when the child is a leaf node
+        // with a range_index field; other field types are unaffected.
+        auto should_defer_child = [&](const filter_node_t* child) -> bool {
+            if (filter_node->filter_operator != AND || child == nullptr || child->isOperator) {
+                return false;
+            }
+            const auto& fname = child->filter_exp.field_name;
+            if (index->search_schema.count(fname) == 0) return false;
+            return index->search_schema.at(fname).range_index;
+        };
+
+        bool left_lazy = enable_lazy_evaluation || should_defer_child(filter_node->left);
+        left_it = new filter_result_iterator_t(collection_name, index, filter_node->left, left_lazy,
                                                max_candidates, validate_field_names);
         // If left subtree of && operator is invalid, we don't have to evaluate its right subtree.
         if (filter_node->filter_operator == AND && left_it->validity == invalid) {
@@ -2579,7 +2609,8 @@ filter_result_iterator_t::filter_result_iterator_t(const std::string& collection
             return;
         }
 
-        right_it = new filter_result_iterator_t(collection_name, index, filter_node->right, enable_lazy_evaluation,
+        bool right_lazy = enable_lazy_evaluation || should_defer_child(filter_node->right);
+        right_it = new filter_result_iterator_t(collection_name, index, filter_node->right, right_lazy,
                                                 max_candidates, validate_field_names);
     }
 
@@ -2794,19 +2825,176 @@ void filter_result_iterator_t::compute_iterators() {
         return;
     }
 
+    // Deferred range_index materialization: init() skipped the expensive trie search
+    // when lazy evaluation was enabled. Materialize now since this node's full result
+    // is needed (e.g., it's a standalone filter or the asymmetric probe didn't apply).
+    if (range_index_deferred) {
+        range_index_deferred = false;
+        init(false, false);
+        return;
+    }
+
     if (filter_node->isOperator) {
         if (timeout_info != nullptr) {
             // Passing timeout_info into subtree so individual nodes can check for timeout.
             left_it->timeout_info = std::make_unique<filter_result_iterator_timeout_info>(*timeout_info);
             right_it->timeout_info = std::make_unique<filter_result_iterator_timeout_info>(*timeout_info);
         }
-        left_it->compute_iterators();
-        right_it->compute_iterators();
 
-        if (filter_node->filter_operator == AND) {
-            filter_result_t::and_filter_results(left_it->filter_result, right_it->filter_result, filter_result);
-        } else {
-            filter_result_t::or_filter_results(left_it->filter_result, right_it->filter_result, filter_result);
+        // Optimization for AND with highly asymmetric children: compute the smaller side
+        // eagerly and evaluate the larger side per-document via sort_index lookup. This
+        // avoids materializing hundreds of millions of IDs from a broad range filter
+        // (e.g. price:<=10000 matching 200M docs) when ANDed with a selective equality
+        // filter (e.g. category:=X matching ~1000 docs).
+        //
+        // The sort_index stores numeric values per document as a hash map, enabling O(1)
+        // lookups. For each document in the small result set, we look up its value and
+        // evaluate the filter condition directly -- much faster than traversing the range
+        // index. If the field isn't in sort_index, we fall back to is_valid() probing.
+        bool used_probe_optimization = false;
+        if (filter_node->filter_operator == AND && !filter_node->is_object_filter_root) {
+
+            // Identify the smaller and larger side, regardless of filter order in the query.
+            auto* small_it = left_it;
+            auto* large_it = right_it;
+            if (left_it->approx_filter_ids_length > right_it->approx_filter_ids_length) {
+                std::swap(small_it, large_it);
+            }
+
+            if (small_it->approx_filter_ids_length > 0 &&
+                large_it->approx_filter_ids_length > small_it->approx_filter_ids_length * ASYMMETRIC_AND_RATIO_THRESHOLD) {
+
+                // Compute the small side eagerly to get its full result set.
+                small_it->compute_iterators();
+
+                if (small_it->filter_result.count > 0 && small_it->filter_result.count < ASYMMETRIC_AND_MAX_PROBE_COUNT) {
+                    auto small_count = small_it->filter_result.count;
+                    auto* small_docs = small_it->filter_result.docs;
+
+                    filter_result.docs = new uint32_t[small_count];
+
+                    // Always allocate coll_to_references: either side may contribute
+                    // reference data (small side from filter_result, large side from
+                    // is_valid() probing). Without this, JOIN data is lost when the
+                    // JOIN happens to be on the larger side of the AND.
+                    filter_result.coll_to_references = new std::map<std::string, reference_filter_result_t>[small_count] {};
+
+                    // Check if the large side is a simple numeric leaf filter with a sort_index.
+                    bool use_sort_index = false;
+                    const spp::sparse_hash_map<uint32_t, int64_t, Hasher32>* sort_field_map = nullptr;
+                    std::vector<std::pair<int64_t, NUM_COMPARATOR>> parsed_filters;
+                    bool negate_result = false;
+
+                    if (large_it->filter_node != nullptr &&
+                        !large_it->filter_node->isOperator &&
+                        large_it->index != nullptr) {
+                        const auto& f = large_it->filter_node->filter_exp;
+                        auto si_it = large_it->index->sort_index.find(f.field_name);
+                        if (si_it != large_it->index->sort_index.end() && si_it->second != nullptr) {
+                            sort_field_map = si_it->second;
+                            negate_result = f.apply_not_equals;
+                            bool all_parsed = true;
+                            for (size_t fi = 0; fi < f.values.size(); fi++) {
+                                try {
+                                    int64_t val = std::stol(f.values[fi]);
+                                    parsed_filters.emplace_back(val, f.comparators[fi]);
+                                } catch (...) {
+                                    all_parsed = false;
+                                    break;
+                                }
+                            }
+                            use_sort_index = all_parsed && !parsed_filters.empty();
+                        }
+                    }
+
+                    // When references are being tracked (JOIN queries), we cannot use the
+                    // sort_index shortcut because it bypasses is_valid() which is responsible
+                    // for populating the reference data. Fall back to the is_valid() probe
+                    // path which still benefits from the asymmetric AND optimization.
+                    if (use_sort_index && (small_it->filter_result.coll_to_references != nullptr ||
+                                           large_it->filter_result.coll_to_references != nullptr)) {
+                        use_sort_index = false;
+                    }
+
+                    uint32_t out_count = 0;
+                    for (uint32_t i = 0; i < small_count; i++) {
+                        auto id = small_docs[i];
+                        bool matches = false;
+
+                        if (use_sort_index) {
+                            auto val_it = sort_field_map->find(id);
+                            if (val_it != sort_field_map->end()) {
+                                int64_t doc_val = val_it->second;
+                                for (size_t fi = 0; fi < parsed_filters.size(); fi++) {
+                                    int64_t fval = parsed_filters[fi].first;
+                                    NUM_COMPARATOR cmp = parsed_filters[fi].second;
+                                    bool cond = false;
+                                    switch (cmp) {
+                                        case LESS_THAN:            cond = (doc_val < fval); break;
+                                        case LESS_THAN_EQUALS:     cond = (doc_val <= fval); break;
+                                        case EQUALS:               cond = (doc_val == fval); break;
+                                        case NOT_EQUALS:           cond = (doc_val != fval); break;
+                                        case GREATER_THAN:         cond = (doc_val > fval); break;
+                                        case GREATER_THAN_EQUALS:  cond = (doc_val >= fval); break;
+                                        case RANGE_INCLUSIVE:
+                                            if (fi + 1 < parsed_filters.size()) {
+                                                int64_t fval_hi = parsed_filters[fi + 1].first;
+                                                cond = (doc_val >= fval && doc_val <= fval_hi);
+                                                fi++;
+                                            }
+                                            break;
+                                        default: break;
+                                    }
+                                    if (cond) { matches = true; break; }
+                                }
+                                if (negate_result) matches = !matches;
+                            }
+                        } else {
+                            // If the large side has a deferred range_index, materialize it
+                            // before probing -- is_valid() needs the populated result array.
+                            if (large_it->range_index_deferred) {
+                                large_it->range_index_deferred = false;
+                                large_it->init(false, false);
+                            }
+                            auto probe_result = large_it->is_valid(id);
+                            if (probe_result == 1) {
+                                matches = true;
+                            } else if (probe_result == -1) {
+                                break;
+                            }
+                        }
+
+                        if (matches) {
+                            filter_result.docs[out_count] = id;
+                            if (filter_result.coll_to_references != nullptr) {
+                                if (small_it->filter_result.coll_to_references != nullptr) {
+                                    filter_result.coll_to_references[out_count] = small_it->filter_result.coll_to_references[i];
+                                }
+                                if (!use_sort_index) {
+                                    for (const auto& ref: large_it->reference) {
+                                        filter_result.coll_to_references[out_count][ref.first] = ref.second;
+                                    }
+                                }
+                            }
+                            out_count++;
+                        }
+                    }
+
+                    filter_result.count = out_count;
+                    used_probe_optimization = true;
+                }
+            }
+        }
+
+        if (!used_probe_optimization) {
+            left_it->compute_iterators();
+            right_it->compute_iterators();
+
+            if (filter_node->filter_operator == AND) {
+                filter_result_t::and_filter_results(left_it->filter_result, right_it->filter_result, filter_result);
+            } else {
+                filter_result_t::or_filter_results(left_it->filter_result, right_it->filter_result, filter_result);
+            }
         }
 
         if (left_it->validity == timed_out || right_it->validity == timed_out ||

--- a/src/numeric_range_trie.cpp
+++ b/src/numeric_range_trie.cpp
@@ -966,7 +966,7 @@ void NumericTrie::Node::get_all_ids(std::vector<uint32_t>& result) {
 
 void NumericTrie::iterator_t::reset() {
     for (auto& match: matches) {
-        match->index = 0;
+        match->iter = match->id_list->new_iterator();
     }
 
     is_valid = true;
@@ -975,17 +975,18 @@ void NumericTrie::iterator_t::reset() {
 
 void NumericTrie::iterator_t::skip_to(uint32_t id) {
     for (auto& match: matches) {
-        ArrayUtils::skip_index_to_id(match->index, match->ids, match->ids_length, id);
+        if (match->iter.valid()) {
+            match->iter.skip_to(id);
+        }
     }
 
     set_seq_id();
 }
 
 void NumericTrie::iterator_t::next() {
-    // Advance all the matches at seq_id.
     for (auto& match: matches) {
-        if (match->index < match->ids_length && match->ids[match->index] == seq_id) {
-            match->index++;
+        if (match->iter.valid() && match->iter.id() == seq_id) {
+            match->iter.next();
         }
     }
 
@@ -993,29 +994,36 @@ void NumericTrie::iterator_t::next() {
 }
 
 NumericTrie::iterator_t::iterator_t(std::vector<Node*>& node_matches) {
+    std::vector<void*> raw_lists;
+    raw_lists.reserve(node_matches.size());
     for (auto const& node_match: node_matches) {
-        uint32_t* ids = nullptr;
-        uint32_t ids_length;
-        node_match->get_all_ids(ids, ids_length);
-        if (ids_length > 0) {
-            matches.emplace_back(new match_state(ids, ids_length));
+        void* raw = node_match->get_seq_ids();
+        if (ids_t::num_ids(raw) > 0) {
+            raw_lists.push_back(raw);
         }
+    }
+
+    std::vector<id_list_t*> id_lists;
+    ids_t::to_expanded_id_lists(raw_lists, id_lists, expanded_id_lists);
+
+    matches.reserve(id_lists.size());
+    for (auto* list: id_lists) {
+        matches.emplace_back(new match_state(list));
     }
 
     set_seq_id();
 }
 
 void NumericTrie::iterator_t::set_seq_id() {
-    // Find the lowest id of all the matches and update the seq_id.
     bool one_is_valid = false;
     uint32_t lowest_id = UINT32_MAX;
 
     for (auto& match: matches) {
-        if (match->index < match->ids_length) {
+        if (match->iter.valid()) {
             one_is_valid = true;
 
-            if (match->ids[match->index] < lowest_id) {
-                lowest_id = match->ids[match->index];
+            if (match->iter.id() < lowest_id) {
+                lowest_id = match->iter.id();
             }
         }
     }
@@ -1036,7 +1044,13 @@ NumericTrie::iterator_t& NumericTrie::iterator_t::operator=(NumericTrie::iterato
     }
     matches.clear();
 
+    for (auto& list: expanded_id_lists) {
+        delete list;
+    }
+    expanded_id_lists.clear();
+
     matches = std::move(obj.matches);
+    expanded_id_lists = std::move(obj.expanded_id_lists);
     seq_id = obj.seq_id;
     is_valid = obj.is_valid;
 

--- a/src/numeric_range_trie.cpp
+++ b/src/numeric_range_trie.cpp
@@ -966,7 +966,8 @@ void NumericTrie::Node::get_all_ids(std::vector<uint32_t>& result) {
 
 void NumericTrie::iterator_t::reset() {
     for (auto& match: matches) {
-        match->index = 0;
+        match->iter.reset_cache();
+        match->iter = match->id_list->new_iterator();
     }
 
     is_valid = true;
@@ -975,17 +976,18 @@ void NumericTrie::iterator_t::reset() {
 
 void NumericTrie::iterator_t::skip_to(uint32_t id) {
     for (auto& match: matches) {
-        ArrayUtils::skip_index_to_id(match->index, match->ids, match->ids_length, id);
+        if (match->iter.valid()) {
+            match->iter.skip_to(id);
+        }
     }
 
     set_seq_id();
 }
 
 void NumericTrie::iterator_t::next() {
-    // Advance all the matches at seq_id.
     for (auto& match: matches) {
-        if (match->index < match->ids_length && match->ids[match->index] == seq_id) {
-            match->index++;
+        if (match->iter.valid() && match->iter.id() == seq_id) {
+            match->iter.next();
         }
     }
 
@@ -994,11 +996,19 @@ void NumericTrie::iterator_t::next() {
 
 NumericTrie::iterator_t::iterator_t(std::vector<Node*>& node_matches) {
     for (auto const& node_match: node_matches) {
-        uint32_t* ids = nullptr;
-        uint32_t ids_length;
-        node_match->get_all_ids(ids, ids_length);
-        if (ids_length > 0) {
-            matches.emplace_back(new match_state(ids, ids_length));
+        void* raw = node_match->get_seq_ids();
+        if (ids_t::num_ids(raw) == 0) {
+            continue;
+        }
+
+        if (IS_COMPACT_IDS(raw)) {
+            auto* compact = COMPACT_IDS_PTR(raw);
+            id_list_t* full_list = compact->to_full_ids_list();
+            expanded_id_lists.push_back(full_list);
+            matches.emplace_back(new match_state(full_list));
+        } else {
+            auto* full_list = (id_list_t*)(raw);
+            matches.emplace_back(new match_state(full_list));
         }
     }
 
@@ -1006,16 +1016,15 @@ NumericTrie::iterator_t::iterator_t(std::vector<Node*>& node_matches) {
 }
 
 void NumericTrie::iterator_t::set_seq_id() {
-    // Find the lowest id of all the matches and update the seq_id.
     bool one_is_valid = false;
     uint32_t lowest_id = UINT32_MAX;
 
     for (auto& match: matches) {
-        if (match->index < match->ids_length) {
+        if (match->iter.valid()) {
             one_is_valid = true;
 
-            if (match->ids[match->index] < lowest_id) {
-                lowest_id = match->ids[match->index];
+            if (match->iter.id() < lowest_id) {
+                lowest_id = match->iter.id();
             }
         }
     }
@@ -1036,7 +1045,13 @@ NumericTrie::iterator_t& NumericTrie::iterator_t::operator=(NumericTrie::iterato
     }
     matches.clear();
 
+    for (auto& list: expanded_id_lists) {
+        delete list;
+    }
+    expanded_id_lists.clear();
+
     matches = std::move(obj.matches);
+    expanded_id_lists = std::move(obj.expanded_id_lists);
     seq_id = obj.seq_id;
     is_valid = obj.is_valid;
 


### PR DESCRIPTION
## Optimize asymmetric AND filters via sort_index probing

### Problem

When a highly selective equality filter is ANDed with a broad range filter on a `range_index` field, Typesense eagerly materializes all matching document IDs from the range index trie before intersecting. For large collections, this is extremely expensive — a filter like `price:<=5000` on a 276M-document collection allocates and populates an array of ~200M+ IDs, even when the other side of the AND matches only ~1,000 documents.

This makes common query patterns like `category:=X && price:<=Y` take 4-8 seconds on large collections, despite the final result set being tiny.

### Solution

Three changes to `filter_result_iterator`:

1. **Lazy range_index materialization** (`init()`): When `enable_lazy_evaluation` is true, defer the expensive trie search for `range_index` fields. Use `trie->size()` as an approximate count for optimization heuristics instead.

2. **Targeted lazy deferral** (constructor): For AND operators, force lazy evaluation on children that are leaf nodes with `range_index` fields, so the asymmetric probe optimization can bypass materialization entirely.

3. **Asymmetric AND probe** (`compute_iterators()`): When one side of an AND is 10x+ larger than the other and the small side has <500K results, compute the small side eagerly and probe each document against the large side via `sort_index` hash map lookups (O(1) per document). Falls back to `is_valid()` probing when sort_index isn't available, and to standard `and_filter_results()` when the optimization doesn't apply.

### Benchmark

Tested on a single-node collection with **276M documents** (ARM64, 128GB RAM). Each document has an int32 equality-filter field and an int32 range-indexed + sorted numeric field.

**Selective equality + range filter (the target query pattern):**

| Query | Stock v30.1 | Optimized | Speedup |
|---|---|---|---|
| `eq_field:=X && num_field:<=500` (99 matches) | 248ms | 0ms | >248x |
| `eq_field:=X && num_field:<=2000` (1,727 matches) | 4,469ms | 1ms | 4,469x |
| `eq_field:=X && num_field:<=5000` (2,679 matches) | 7,909ms | 1ms | 7,909x |
| `eq_field:=X && num_field:<=5000` (243 matches) | 7,924ms | 0ms | >7,924x |
| `eq_field:=X && num_field:[500..2000]` (1,639 matches) | ~4,500ms | 1ms | ~4,500x |

**Regression check — queries unaffected by optimization:**

| Query | Stock v30.1 | Optimized |
|---|---|---|
| `num_field:<=500` (standalone, 5.4M matches) | 376ms | 327ms |

Result counts are identical between stock and optimized builds across all queries.

### Files changed

- `include/filter.h` — Named constants `ASYMMETRIC_AND_RATIO_THRESHOLD` and `ASYMMETRIC_AND_MAX_PROBE_COUNT`
- `include/filter_result_iterator.h` — `range_index_deferred` flag
- `src/filter_result_iterator.cpp` — Lazy init, deferred child detection, asymmetric AND probe with sort_index
