### PR TITLE
fix: ensure forward-only iterator reads lower seq_id first in diversity similarity

### DIFF
--- a/src/diversity.cpp
+++ b/src/diversity.cpp
@@ -104,8 +104,16 @@ Option<double> similarity_t::calculate(uint32_t seq_id_i, uint32_t seq_id_j, con
                 if (!facet_it.valid()) {
                     continue;
                 }
-                facet_it.skip_to(seq_id_i);
-                if (!facet_it.valid() || facet_it.id() != seq_id_i) {
+
+                // The posting list iterator is forward-only: skip_to() can only
+                // advance, never reverse. Read the lower seq_id first to ensure
+                // the second skip_to always moves forward. Jaccard/equality are
+                // symmetric so the order doesn't affect the result.
+                uint32_t first_id = std::min(seq_id_i, seq_id_j);
+                uint32_t second_id = std::max(seq_id_i, seq_id_j);
+
+                facet_it.skip_to(first_id);
+                if (!facet_it.valid() || facet_it.id() != first_id) {
                     continue;
                 }
 
@@ -118,8 +126,8 @@ Option<double> similarity_t::calculate(uint32_t seq_id_i, uint32_t seq_id_j, con
                     i_facet_hashes.insert(facet_it.offset());
                 }
 
-                facet_it.skip_to(seq_id_j);
-                if (!facet_it.valid() || facet_it.id() != seq_id_j) {
+                facet_it.skip_to(second_id);
+                if (!facet_it.valid() || facet_it.id() != second_id) {
                     continue;
                 }
 

--- a/test/collection_curation_test.cpp
+++ b/test/collection_curation_test.cpp
@@ -5714,10 +5714,10 @@ TEST_F(CollectionCurationTest, DiversityOverride) {
     ASSERT_EQ(6, res_obj["hits"].size());
     ASSERT_EQ("5", res_obj["hits"][0]["document"]["id"]);
     ASSERT_EQ("2", res_obj["hits"][1]["document"]["id"]);
-    ASSERT_EQ("4", res_obj["hits"][2]["document"]["id"]);
+    ASSERT_EQ("0", res_obj["hits"][2]["document"]["id"]);
     ASSERT_EQ("3", res_obj["hits"][3]["document"]["id"]);
     ASSERT_EQ("1", res_obj["hits"][4]["document"]["id"]);
-    ASSERT_EQ("0", res_obj["hits"][5]["document"]["id"]);
+    ASSERT_EQ("4", res_obj["hits"][5]["document"]["id"]);
 
     req_params = {
             {"collection", "tags"},
@@ -5761,7 +5761,7 @@ TEST_F(CollectionCurationTest, DiversityOverride) {
     res_obj = nlohmann::json::parse(json_res);
     ASSERT_EQ(6, res_obj["found"].get<size_t>());
     ASSERT_EQ(2, res_obj["hits"].size());
-    ASSERT_EQ("4", res_obj["hits"][0]["document"]["id"]);
+    ASSERT_EQ("0", res_obj["hits"][0]["document"]["id"]);
     ASSERT_EQ("3", res_obj["hits"][1]["document"]["id"]);
 
     req_params = {
@@ -5777,7 +5777,7 @@ TEST_F(CollectionCurationTest, DiversityOverride) {
     ASSERT_EQ(6, res_obj["found"].get<size_t>());
     ASSERT_EQ(2, res_obj["hits"].size());
     ASSERT_EQ("1", res_obj["hits"][0]["document"]["id"]);
-    ASSERT_EQ("0", res_obj["hits"][1]["document"]["id"]);
+    ASSERT_EQ("4", res_obj["hits"][1]["document"]["id"]);
 
     req_params = {
             {"collection", "tags"},
@@ -5818,8 +5818,8 @@ TEST_F(CollectionCurationTest, DiversityOverride) {
     res_obj = nlohmann::json::parse(json_res);
     ASSERT_EQ("5", res_obj["hits"][0]["document"]["id"]);
     ASSERT_EQ("2", res_obj["hits"][1]["document"]["id"]);
-    ASSERT_EQ("4", res_obj["hits"][2]["document"]["id"]);
-    ASSERT_EQ("3", res_obj["hits"][3]["document"]["id"]);
+    ASSERT_EQ("3", res_obj["hits"][2]["document"]["id"]);
+    ASSERT_EQ("4", res_obj["hits"][3]["document"]["id"]);
     ASSERT_EQ("1", res_obj["hits"][4]["document"]["id"]);
     ASSERT_EQ("0", res_obj["hits"][5]["document"]["id"]);
 

--- a/test/collection_curation_test.cpp
+++ b/test/collection_curation_test.cpp
@@ -5882,6 +5882,115 @@ TEST_F(CollectionCurationTest, DiversityOverride) {
     ASSERT_EQ("3", res_obj["hits"][4]["document"]["id"]);
 }
 
+// Bug: forward-only facet iterator in similarity_t::calculate() silently returns 0
+// when seq_id_j < seq_id_i, defeating MMR diversity reranking.
+// With sort_by=sort_order:asc, position 0 has the lowest seq_id, so all candidates
+// have higher seq_ids and the iterator always advances forward for the first doc --
+// but when comparing against the selected doc (lower seq_id), it can't reverse.
+TEST_F(CollectionCurationTest, DiversityForwardOnlyIteratorBug) {
+    Collection* coll = nullptr;
+    auto schema_json =
+            R"({
+                "name": "diversity_iter",
+                "fields": [
+                    {"name": "sort_order", "type": "int32", "sort": true},
+                    {"name": "tag_groups", "type": "string[]", "facet": true}
+                ]
+            })"_json;
+
+    // Doc 0 & 1 share tags "a","b" => Jaccard(0,1) = |{a,b}|/|{a,b,c,d}| = 0.5
+    // Docs 2,3,4 share nothing with Doc 0 => Jaccard(0,N) = 0
+    std::vector<nlohmann::json> documents = {
+            R"({"sort_order": 1, "tag_groups": ["a", "b", "c"]})"_json,
+            R"({"sort_order": 2, "tag_groups": ["a", "b", "d"]})"_json,
+            R"({"sort_order": 3, "tag_groups": ["e", "f"]})"_json,
+            R"({"sort_order": 4, "tag_groups": ["g", "h"]})"_json,
+            R"({"sort_order": 5, "tag_groups": ["i", "j"]})"_json
+    };
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto& ov_manager = CurationIndexManager::get_instance();
+
+    coll = collection_create_op.get();
+    coll->set_curation_sets({"index"});
+    for (auto const &json: documents) {
+        auto add_op = coll->add(json.dump());
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    // Create curation rule with Jaccard diversity on tag_groups
+    auto curation_json =
+            R"({
+                "id": "diversity_iter_rule",
+                "rule": {
+                    "tags": ["diverse"]
+                },
+                "diversity": {
+                    "similarity_metric": [
+                        {
+                            "field": "tag_groups",
+                            "method": "jaccard"
+                        }
+                    ]
+                }
+            })"_json;
+    curation_t curation;
+    auto op = curation_t::parse(curation_json, "", curation, "", {}, {});
+    ASSERT_TRUE(op.ok());
+    ov_manager.upsert_curation_item("index", curation_json);
+
+    nlohmann::json embedded_params;
+    std::string json_res;
+    long now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    // Baseline: sort_by ascending, NO diversity (lambda=1)
+    std::map<std::string, std::string> req_params = {
+            {"collection", "diversity_iter"},
+            {"q", "*"},
+            {"query_by", "tag_groups"},
+            {"sort_by", "sort_order:asc"},
+            {"curation_tags", "diverse"},
+            {"diversity_lambda", "1"},
+            {"diversity_limit", "10"}
+    };
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    auto res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(5, res_obj["found"].get<size_t>());
+    ASSERT_EQ(5, res_obj["hits"].size());
+    // With no diversity, order follows sort_order:asc => 0, 1, 2, 3, 4
+    ASSERT_EQ("0", res_obj["hits"][0]["document"]["id"]);
+    ASSERT_EQ("1", res_obj["hits"][1]["document"]["id"]);
+
+    // MAX diversity (lambda=0): position 1 should NOT be doc "1" (Jaccard=0.5 with doc "0")
+    // It should be doc "2", "3", or "4" (Jaccard=0 with doc "0", maximally different)
+    req_params = {
+            {"collection", "diversity_iter"},
+            {"q", "*"},
+            {"query_by", "tag_groups"},
+            {"sort_by", "sort_order:asc"},
+            {"curation_tags", "diverse"},
+            {"diversity_lambda", "0"},
+            {"diversity_limit", "10"}
+    };
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(5, res_obj["found"].get<size_t>());
+    ASSERT_EQ(5, res_obj["hits"].size());
+    // Position 0 is still doc "0" (first in sort order, highest relevance with lambda=0)
+    ASSERT_EQ("0", res_obj["hits"][0]["document"]["id"]);
+    // Position 1 must NOT be doc "1" -- it has Jaccard=0.5 with doc "0" (most similar)
+    // With max diversity, any of docs "2","3","4" (Jaccard=0) should come first
+    ASSERT_NE("1", res_obj["hits"][1]["document"]["id"].get<std::string>());
+
+    collectionManager.drop_collection("diversity_iter");
+}
+
 TEST_F(CollectionCurationTest, TextSortBucketDiversification) {
     Collection* coll = nullptr;
     auto schema_json =


### PR DESCRIPTION
## Summary

MMR diversity reranking via curation sets silently fails when the selected document has a lower internal `seq_id` than the candidate document.

**Root cause:** `posting_list_t::iterator_t::skip_to()` is forward-only — it can only advance, never reverse. In `similarity_t::calculate()`, when `seq_id_j < seq_id_i`, the second `skip_to(seq_id_j)` stays at `seq_id_i`'s position because it cannot go backward. The subsequent ID check (`facet_it.id() != seq_id_j`) fails, and the function silently returns similarity = 0 for that facet field.

This defeats diversity reranking in any scenario where a previously selected document has a lower `seq_id` than the current candidate — most notably with `sort_by=...:asc`, where the first selected document (position 0) has the lowest `seq_id` and all subsequent candidates have higher IDs.

**Fix:** Use `std::min(seq_id_i, seq_id_j)` / `std::max(seq_id_i, seq_id_j)` to always read the lower `seq_id` first, ensuring the forward-only iterator always advances correctly. Jaccard and equality similarity are symmetric (`sim(A,B) == sim(B,A)`), so reading order does not affect correctness.

## Changes

- **`src/diversity.cpp`** — Read `min(seq_id_i, seq_id_j)` first and `max(...)` second in `similarity_t::calculate()`, guaranteeing the iterator always moves forward.
- **`test/collection_curation_test.cpp`** — Added `DiversityForwardOnlyIteratorBug` regression test that reproduces the bug using `sort_by=sort_order:asc` with `diversity_lambda=0`. Also updated expected assertions in the existing `DiversityOverride` test to reflect the correct diversity ordering now that similarity is computed correctly in both iterator directions.

## Test plan

- [ ] New `DiversityForwardOnlyIteratorBug` test passes (fails without the fix, passes with it)
- [ ] Existing `DiversityOverride` test passes with updated assertions
- [ ] Full `collection_curation_test` suite passes
- [ ] Verify no regressions in other diversity/curation tests