### PR TITLE
feat: add support for SigLIP tokenizer and image processor

### DIFF
--- a/include/image_embedder.h
+++ b/include/image_embedder.h
@@ -29,7 +29,7 @@ class CLIPImageEmbedder : public ImageEmbedder {
         std::mutex mutex_;
         CLIPImageProcessor image_processor_;     
     public:
-        CLIPImageEmbedder(const std::shared_ptr<Ort::Session>& session, const std::shared_ptr<Ort::Env>& env, const std::string& model_path);
+        CLIPImageEmbedder(const std::shared_ptr<Ort::Session>& session, const std::shared_ptr<Ort::Env>& env, const std::string& model_path, const std::string& processor_filename = "clip_image_processor.onnx");
         embedding_res_t embed(const std::string& image_encoded) override;
         std::vector<embedding_res_t> embed_documents(const std::vector<std::string>& inputs) override;
         virtual ImageEmbedderType get_image_embedder_type() override {

--- a/include/image_processor.h
+++ b/include/image_processor.h
@@ -23,6 +23,6 @@ class CLIPImageProcessor : public ImageProcessor {
         std::mutex mutex_;
 
     public:
-        CLIPImageProcessor(const std::string& model_path);
-        Option<processed_image_t> process_image(const std::string& image) override;  
+        CLIPImageProcessor(const std::string& model_path, const std::string& processor_filename = "clip_image_processor.onnx");
+        Option<processed_image_t> process_image(const std::string& image) override;
 };

--- a/include/text_embedder.h
+++ b/include/text_embedder.h
@@ -57,5 +57,6 @@ class TextEmbedder {
         std::string output_tensor_name;
         size_t num_dim;
         bool is_image_embedding_model = false;
+        bool has_attention_mask_input = true;
         std::mutex mutex_;
 };

--- a/include/text_embedder_tokenizer.h
+++ b/include/text_embedder_tokenizer.h
@@ -13,7 +13,8 @@ enum class TokenizerType {
     bert,
     distilbert,
     xlm_roberta,
-    clip
+    clip,
+    siglip
 };
 
 struct encoded_input_t {
@@ -75,6 +76,19 @@ class XLMRobertaTokenizer : public TextEmbeddingTokenizer {
         encoded_input_t Encode(const std::string& text) override;
         virtual TokenizerType get_tokenizer_type() override {
             return TokenizerType::xlm_roberta;
+        }
+};
+
+class SigLIPTokenizer : public TextEmbeddingTokenizer {
+    private:
+        std::unique_ptr<sentencepiece::SentencePieceProcessor> sentencepiece_tokenizer_;
+        static constexpr size_t max_length_ = 64;
+        static constexpr int64_t eos_token_id_ = 1;
+    public:
+        SigLIPTokenizer(const std::string& model_path);
+        encoded_input_t Encode(const std::string& text) override;
+        virtual TokenizerType get_tokenizer_type() override {
+            return TokenizerType::siglip;
         }
 };
 

--- a/src/embedder_manager.cpp
+++ b/src/embedder_manager.cpp
@@ -135,7 +135,7 @@ Option<bool> EmbedderManager::validate_and_init_local_model(const nlohmann::json
             return Option<bool>(400, "Vocab file not found");
         }
 
-        if(config["model_type"].get<std::string>() != "bert" && config["model_type"].get<std::string>() != "xlm_roberta" && config["model_type"].get<std::string>() != "distilbert" && config["model_type"].get<std::string>() != "clip") {
+        if(config["model_type"].get<std::string>() != "bert" && config["model_type"].get<std::string>() != "xlm_roberta" && config["model_type"].get<std::string>() != "distilbert" && config["model_type"].get<std::string>() != "clip" && config["model_type"].get<std::string>() != "siglip") {
             LOG(ERROR) << "Invalid model type: " << config["model_type"].get<std::string>();
             return Option<bool>(400, "Invalid model type");
         }
@@ -173,9 +173,21 @@ Option<bool> EmbedderManager::validate_and_init_local_model(const nlohmann::json
     num_dims = embedder->get_num_dim();
     text_embedders.emplace(model_name, embedder);
 
-    // if model is clip, generate image embedder
+    // if model has image embedding capability, generate image embedder
     if(embedder->is_image_embedding()) {
-        auto image_embedder = std::make_shared<CLIPImageEmbedder>(embedder->get_session(), embedder->get_env(), get_model_subdir(model_name_without_namespace, is_public_model));
+        LOG(INFO) << "IMAGE";
+        std::string processor_filename = "clip_image_processor.onnx";
+        auto config_path = get_absolute_config_path(model_name_without_namespace, is_public_model);
+        if(std::filesystem::exists(config_path)) {
+            std::ifstream cfg_file(config_path);
+            nlohmann::json cfg;
+            cfg_file >> cfg;
+            if(cfg.count("image_processor_file_name") > 0) {
+                processor_filename = cfg["image_processor_file_name"].get<std::string>();
+            }
+        }
+        auto image_embedder = std::make_shared<CLIPImageEmbedder>(embedder->get_session(), embedder->get_env(), get_model_subdir(model_name_without_namespace, is_public_model), processor_filename);
+        LOG(INFO) << "Image embedder: " << model_name;
         image_embedders.emplace(model_name, image_embedder);
     }
     return Option<bool>(true);
@@ -240,6 +252,8 @@ const TokenizerType EmbedderManager::get_tokenizer_type(const nlohmann::json& mo
             return TokenizerType::xlm_roberta;
         } else if(tokenizer_type == "clip") {
             return TokenizerType::clip;
+        } else if(tokenizer_type == "siglip") {
+            return TokenizerType::siglip;
         } else {
             return TokenizerType::bert;
         }

--- a/src/image_embedder.cpp
+++ b/src/image_embedder.cpp
@@ -1,7 +1,7 @@
 #include "image_embedder.h"
 #include "text_embedder_remote.h"
 
-CLIPImageEmbedder::CLIPImageEmbedder(const std::shared_ptr<Ort::Session>& session, const std::shared_ptr<Ort::Env>& env, const std::string& model_path) : image_processor_(model_path), session_(session), env_(env) {
+CLIPImageEmbedder::CLIPImageEmbedder(const std::shared_ptr<Ort::Session>& session, const std::shared_ptr<Ort::Env>& env, const std::string& model_path, const std::string& processor_filename) : image_processor_(model_path, processor_filename), session_(session), env_(env) {
 }
 
 embedding_res_t CLIPImageEmbedder::embed(const std::string& encoded_image) {
@@ -17,22 +17,40 @@ embedding_res_t CLIPImageEmbedder::embed(const std::string& encoded_image) {
 
     auto processed_image = processed_image_op.get();
 
-    // create input tensor
+    // create input tensors
     std::vector<int64_t> input_shape = {1, 3, 224, 224};
-    std::vector<const char*> input_names = {"pixel_values"};
     Ort::MemoryInfo memory_info = Ort::MemoryInfo::CreateCpu(OrtArenaAllocator, OrtMemTypeDefault);
 
+    std::vector<const char*> input_names;
+    std::vector<Ort::Value> input_tensors;
 
+    // Check if model requires input_ids (e.g. SigLIP has input_ids + pixel_values, no attention_mask)
+    std::vector<int64_t> dummy_input_ids = {0};
+    std::vector<int64_t> dummy_input_ids_shape = {1, 1};
+    bool has_input_ids = false;
+    auto input_count = session_->GetInputCount();
+    for(size_t i = 0; i < input_count; i++) {
+        auto name = session_->GetInputNameAllocated(i, Ort::AllocatorWithDefaultOptions());
+        if(std::strcmp(name.get(), "input_ids") == 0) {
+            has_input_ids = true;
+            break;
+        }
+    }
 
-    Ort::Value input_tensor = Ort::Value::CreateTensor<float>(memory_info, (float*) processed_image.data(), processed_image.size(), input_shape.data(), input_shape.size());
+    if(has_input_ids) {
+        input_names.push_back("input_ids");
+        input_tensors.push_back(Ort::Value::CreateTensor<int64_t>(memory_info, dummy_input_ids.data(), dummy_input_ids.size(), dummy_input_ids_shape.data(), dummy_input_ids_shape.size()));
+    }
+
+    input_names.push_back("pixel_values");
+    input_tensors.push_back(Ort::Value::CreateTensor<float>(memory_info, (float*) processed_image.data(), processed_image.size(), input_shape.data(), input_shape.size()));
 
     // create output tensor
     std::vector<const char*> output_names = {"image_embeds"};
 
     // run inference
-    // LOG(INFO) << "Running image embedder";
     lock.lock();
-    auto output_tensors = session_->Run(Ort::RunOptions{nullptr}, input_names.data(), &input_tensor, 1, output_names.data(), output_names.size());
+    auto output_tensors = session_->Run(Ort::RunOptions{nullptr}, input_names.data(), input_tensors.data(), input_tensors.size(), output_names.data(), output_names.size());
     lock.unlock();
 
     // get output tensor
@@ -88,7 +106,7 @@ std::vector<embedding_res_t> CLIPImageEmbedder::embed_documents(const std::vecto
 
     // create input tensor
     std::vector<int64_t> input_shape = {static_cast<int64_t>(processed_images.size()), 3, 224, 224};
-    std::vector<const char*> input_names = {"input_ids", "pixel_values", "attention_mask"};
+    std::vector<const char*> input_names;
     std::vector<int64_t> dummy_input_ids_shape = {1,1};
     std::vector<int64_t> dummy_input_ids = {0};
     std::vector<int64_t> dummy_attention_mask_shape = {1,1};
@@ -102,10 +120,27 @@ std::vector<embedding_res_t> CLIPImageEmbedder::embed_documents(const std::vecto
         std::move(image.begin(), image.end(), std::back_inserter(input_vector));
         image.clear();
     }
+
+    // Build inputs dynamically based on what the model expects
+    bool has_attention_mask = false;
+    auto input_count = session_->GetInputCount();
+    for(size_t idx = 0; idx < input_count; idx++) {
+        auto name = session_->GetInputNameAllocated(idx, Ort::AllocatorWithDefaultOptions());
+        if(std::strcmp(name.get(), "attention_mask") == 0) {
+            has_attention_mask = true;
+            break;
+        }
+    }
+
     std::vector<Ort::Value> input_tensors;
+    input_names.push_back("input_ids");
     input_tensors.push_back(Ort::Value::CreateTensor<int64_t>(memory_info, (int64_t*) dummy_input_ids.data(), dummy_input_ids.size(), dummy_input_ids_shape.data(), dummy_input_ids_shape.size()));
+    input_names.push_back("pixel_values");
     input_tensors.push_back(Ort::Value::CreateTensor<float>(memory_info, (float*) input_vector.data(), input_vector.size(), input_shape.data(), input_shape.size()));
-    input_tensors.push_back(Ort::Value::CreateTensor<int64_t>(memory_info, (int64_t*) dummy_attention_mask.data(), dummy_attention_mask.size(), dummy_attention_mask_shape.data(), dummy_attention_mask_shape.size()));
+    if(has_attention_mask) {
+        input_names.push_back("attention_mask");
+        input_tensors.push_back(Ort::Value::CreateTensor<int64_t>(memory_info, (int64_t*) dummy_attention_mask.data(), dummy_attention_mask.size(), dummy_attention_mask_shape.data(), dummy_attention_mask_shape.size()));
+    }
 
 
     std::vector<const char*> output_names = {"image_embeds"};

--- a/src/image_processor.cpp
+++ b/src/image_processor.cpp
@@ -1,10 +1,10 @@
 #include "image_processor.h"
 #include "logger.h"
 
-CLIPImageProcessor::CLIPImageProcessor(const std::string& model_path) {
+CLIPImageProcessor::CLIPImageProcessor(const std::string& model_path, const std::string& processor_filename) {
     Ort::SessionOptions session_options;
     session_options.EnableOrtCustomOps();
-    auto processor_path = model_path + "/clip_image_processor.onnx";
+    auto processor_path = model_path + "/" + processor_filename;
     LOG(INFO) << "Loading image processor from " << processor_path;
     session_ = std::make_unique<Ort::Session>(env_, processor_path.c_str(), session_options);
 }

--- a/src/text_embedder.cpp
+++ b/src/text_embedder.cpp
@@ -45,6 +45,8 @@ TextEmbedder::TextEmbedder(const std::string& model_name, const bool is_public_m
     }
     else if(tokenizer_type == TokenizerType::xlm_roberta) {
         tokenizer_ = std::make_unique<XLMRobertaTokenizer>(vocab_path);
+    } else if(tokenizer_type == TokenizerType::siglip) {
+        tokenizer_ = std::make_unique<SigLIPTokenizer>(vocab_path);
     } else if(tokenizer_type == TokenizerType::clip) {
         tokenizer_ = std::make_unique<CLIPTokenizerWrapper>(vocab_path);
     }
@@ -65,13 +67,17 @@ TextEmbedder::TextEmbedder(const std::string& model_name, const bool is_public_m
     }
 
     auto input_count = session_->GetInputCount();
+    bool found_attention_mask = false;
     for(size_t i = 0; i < input_count; i++) {
         auto input_name = session_->GetInputNameAllocated(i, Ort::AllocatorWithDefaultOptions());
         if(std::strcmp(input_name.get(), "pixel_values") == 0) {
             is_image_embedding_model = true;
-            break;
+        }
+        if(std::strcmp(input_name.get(), "attention_mask") == 0) {
+            found_attention_mask = true;
         }
     }
+    has_attention_mask_input = found_attention_mask;
 }
 
 TextEmbedder::TextEmbedder(const nlohmann::json& model_config, size_t num_dims, const bool has_custom_dims) {
@@ -164,36 +170,36 @@ embedding_res_t TextEmbedder::embed_query(const std::string& text, const size_t 
         Ort::MemoryInfo memory_info = Ort::MemoryInfo::CreateCpu(OrtAllocatorType::OrtArenaAllocator, OrtMemType::OrtMemTypeDefault);
         std::vector<Ort::Value> input_tensors;
         std::vector<std::vector<int64_t>> input_shapes;
-        std::vector<const char*> input_node_names = {"input_ids", "attention_mask"};
+        std::vector<const char*> input_node_names;
+        std::vector<float> pixel_values;
 
+        // Build inputs based on what the model expects
+        input_node_names.push_back("input_ids");
         input_shapes.push_back({1, static_cast<int64_t>(encoded_input.input_ids.size())});
-        input_shapes.push_back({1, static_cast<int64_t>(encoded_input.attention_mask.size())});
-
         input_tensors.push_back(Ort::Value::CreateTensor<int64_t>(memory_info, encoded_input.input_ids.data(), encoded_input.input_ids.size(), input_shapes[0].data(), input_shapes[0].size()));
-        input_tensors.push_back(Ort::Value::CreateTensor<int64_t>(memory_info, encoded_input.attention_mask.data(), encoded_input.attention_mask.size(), input_shapes[1].data(), input_shapes[1].size()));
 
-        // If model is DistilBERT or sentencepiece, it has 2 inputs, else it has 3 inputs
-        if(session_->GetInputCount() == 3) {
-            if(is_image_embedding_model) {
-                input_node_names.push_back("pixel_values");
+        if(has_attention_mask_input) {
+            input_node_names.push_back("attention_mask");
+            input_shapes.push_back({1, static_cast<int64_t>(encoded_input.attention_mask.size())});
+            input_tensors.push_back(Ort::Value::CreateTensor<int64_t>(memory_info, encoded_input.attention_mask.data(), encoded_input.attention_mask.size(), input_shapes.back().data(), input_shapes.back().size()));
+        }
 
-                // dummy input for clip
-                input_shapes.push_back({1, 3, 224, 224});
+        if(is_image_embedding_model) {
+            input_node_names.push_back("pixel_values");
+            // dummy pixel_values for text-only query
+            input_shapes.push_back({1, 3, 224, 224});
+            pixel_values.resize(3 * 224 * 224, 0.5);
+            input_tensors.push_back(Ort::Value::CreateTensor<float>(memory_info, pixel_values.data(), pixel_values.size(), input_shapes.back().data(), input_shapes.back().size()));
+        } else if(session_->GetInputCount() == 3) {
+            input_node_names.push_back("token_type_ids");
 
-                std::vector<float> pixel_values(3 * 224 * 224, 0.5);
-                input_tensors.push_back(Ort::Value::CreateTensor<float>(memory_info, pixel_values.data(), pixel_values.size(), input_shapes[2].data(), input_shapes[2].size()));
-            } else {
-                input_node_names.push_back("token_type_ids");
-
-                // edge case: xlm_roberta does not have token_type_ids, but if the model has it as input, we need to fill it with 0s
-                if(encoded_input.token_type_ids.size() == 0) {
-                    encoded_input.token_type_ids.resize(encoded_input.input_ids.size(), 0);
-                }
-
-                input_shapes.push_back({1, static_cast<int64_t>(encoded_input.token_type_ids.size())});
-
-                input_tensors.push_back(Ort::Value::CreateTensor<int64_t>(memory_info, encoded_input.token_type_ids.data(), encoded_input.token_type_ids.size(), input_shapes[2].data(), input_shapes[2].size()));
+            // edge case: xlm_roberta does not have token_type_ids, but if the model has it as input, we need to fill it with 0s
+            if(encoded_input.token_type_ids.size() == 0) {
+                encoded_input.token_type_ids.resize(encoded_input.input_ids.size(), 0);
             }
+
+            input_shapes.push_back({1, static_cast<int64_t>(encoded_input.token_type_ids.size())});
+            input_tensors.push_back(Ort::Value::CreateTensor<int64_t>(memory_info, encoded_input.token_type_ids.data(), encoded_input.token_type_ids.size(), input_shapes.back().data(), input_shapes.back().size()));
         }
         
         //LOG(INFO) << "Running model";
@@ -242,14 +248,12 @@ std::vector<embedding_res_t> TextEmbedder::embed_documents(const std::vector<std
             Ort::MemoryInfo memory_info = Ort::MemoryInfo::CreateCpu(OrtAllocatorType::OrtArenaAllocator, OrtMemType::OrtMemTypeDefault);
             std::vector<Ort::Value> input_tensors;
             std::vector<std::vector<int64_t>> input_shapes;
-            std::vector<const char*> input_node_names = {"input_ids", "attention_mask"};
-
-            input_shapes.push_back({static_cast<int64_t>(encoded_inputs.input_ids.size()), static_cast<int64_t>(encoded_inputs.input_ids[0].size())});
-            input_shapes.push_back({static_cast<int64_t>(encoded_inputs.attention_mask.size()), static_cast<int64_t>(encoded_inputs.attention_mask[0].size())});
+            std::vector<const char*> input_node_names;
 
             std::vector<int64_t> input_ids_flatten;
             std::vector<int64_t> attention_mask_flatten;
             std::vector<int64_t> token_type_ids_flatten;
+            std::vector<float> pixel_values;
 
             for (int i = 0; i < encoded_inputs.input_ids.size(); i++) {
                 for (int j = 0; j < encoded_inputs.input_ids[i].size(); j++) {
@@ -257,38 +261,40 @@ std::vector<embedding_res_t> TextEmbedder::embed_documents(const std::vector<std
                 }
             }
 
-            for (int i = 0; i < encoded_inputs.attention_mask.size(); i++) {
-                for (int j = 0; j < encoded_inputs.attention_mask[i].size(); j++) {
-                    attention_mask_flatten.push_back(encoded_inputs.attention_mask[i][j]);
+            // Build inputs based on what the model expects
+            input_node_names.push_back("input_ids");
+            input_shapes.push_back({static_cast<int64_t>(encoded_inputs.input_ids.size()), static_cast<int64_t>(encoded_inputs.input_ids[0].size())});
+            input_tensors.push_back(Ort::Value::CreateTensor<int64_t>(memory_info, input_ids_flatten.data(), input_ids_flatten.size(), input_shapes.back().data(), input_shapes.back().size()));
+
+            if(has_attention_mask_input) {
+                for (int i = 0; i < encoded_inputs.attention_mask.size(); i++) {
+                    for (int j = 0; j < encoded_inputs.attention_mask[i].size(); j++) {
+                        attention_mask_flatten.push_back(encoded_inputs.attention_mask[i][j]);
+                    }
                 }
+
+                input_node_names.push_back("attention_mask");
+                input_shapes.push_back({static_cast<int64_t>(encoded_inputs.attention_mask.size()), static_cast<int64_t>(encoded_inputs.attention_mask[0].size())});
+                input_tensors.push_back(Ort::Value::CreateTensor<int64_t>(memory_info, attention_mask_flatten.data(), attention_mask_flatten.size(), input_shapes.back().data(), input_shapes.back().size()));
             }
 
-            input_tensors.push_back(Ort::Value::CreateTensor<int64_t>(memory_info, input_ids_flatten.data(), input_ids_flatten.size(), input_shapes[0].data(), input_shapes[0].size()));
-            input_tensors.push_back(Ort::Value::CreateTensor<int64_t>(memory_info, attention_mask_flatten.data(), attention_mask_flatten.size(), input_shapes[1].data(), input_shapes[1].size()));
-            
-            if(session_->GetInputCount() == 3) {
-                if(is_image_embedding_model) {
-                    input_node_names.push_back("pixel_values");
+            if(is_image_embedding_model) {
+                input_node_names.push_back("pixel_values");
+                // dummy pixel_values for text-only batch
+                input_shapes.push_back({1, 3, 224, 224});
+                pixel_values.resize(3 * 224 * 224, 0.5);
+                input_tensors.push_back(Ort::Value::CreateTensor<float>(memory_info, pixel_values.data(), pixel_values.size(), input_shapes.back().data(), input_shapes.back().size()));
+            } else if(session_->GetInputCount() == 3) {
+                input_node_names.push_back("token_type_ids");
 
-                    // dummy input for clip
-                    input_shapes.push_back({1, 3, 224, 224});
-
-                    std::vector<float> pixel_values(3 * 224 * 224, 0.5);
-                    input_tensors.push_back(Ort::Value::CreateTensor<float>(memory_info, pixel_values.data(), pixel_values.size(), input_shapes[2].data(), input_shapes[2].size()));
-                } else {
-                    input_node_names.push_back("token_type_ids");
-
-
-                    
-                    for (int i = 0; i < encoded_inputs.token_type_ids.size(); i++) {
-                        for (int j = 0; j < encoded_inputs.token_type_ids[i].size(); j++) {
-                            token_type_ids_flatten.push_back(encoded_inputs.token_type_ids[i][j]);
-                        }
+                for (int i = 0; i < encoded_inputs.token_type_ids.size(); i++) {
+                    for (int j = 0; j < encoded_inputs.token_type_ids[i].size(); j++) {
+                        token_type_ids_flatten.push_back(encoded_inputs.token_type_ids[i][j]);
                     }
-
-                    input_shapes.push_back({static_cast<int64_t>(encoded_inputs.token_type_ids.size()), static_cast<int64_t>(encoded_inputs.token_type_ids[0].size())});
-                    input_tensors.push_back(Ort::Value::CreateTensor<int64_t>(memory_info, token_type_ids_flatten.data(), token_type_ids_flatten.size(), input_shapes[2].data(), input_shapes[2].size()));
                 }
+
+                input_shapes.push_back({static_cast<int64_t>(encoded_inputs.token_type_ids.size()), static_cast<int64_t>(encoded_inputs.token_type_ids[0].size())});
+                input_tensors.push_back(Ort::Value::CreateTensor<int64_t>(memory_info, token_type_ids_flatten.data(), token_type_ids_flatten.size(), input_shapes.back().data(), input_shapes.back().size()));
             }
 
             //LOG(INFO) << "Running model";
@@ -388,11 +394,13 @@ Option<bool> TextEmbedder::validate() {
     }
 
 
-    auto attention_mask_index = tokenizer_->get_tokenizer_type() == TokenizerType::clip ? 2 : 1;
-    auto attention_mask_name = session_->GetInputNameAllocated(attention_mask_index, allocator);
-    if (std::strcmp(attention_mask_name.get(), "attention_mask") != 0) {
-        LOG(ERROR) << "Invalid model: attention_mask tensor not found";
-        return Option<bool>(400, "Invalid model: attention_mask tensor not found");
+    if(has_attention_mask_input) {
+        auto attention_mask_index = tokenizer_->get_tokenizer_type() == TokenizerType::clip ? 2 : 1;
+        auto attention_mask_name = session_->GetInputNameAllocated(attention_mask_index, allocator);
+        if (std::strcmp(attention_mask_name.get(), "attention_mask") != 0) {
+            LOG(ERROR) << "Invalid model: attention_mask tensor not found";
+            return Option<bool>(400, "Invalid model: attention_mask tensor not found");
+        }
     }
 
     if(session_->GetInputCount() == 3) {

--- a/src/text_embedder_tokenizer.cpp
+++ b/src/text_embedder_tokenizer.cpp
@@ -1,5 +1,6 @@
 #include <fstream>
 #include <sstream>
+#include <algorithm>
 #include "text_embedder_tokenizer.h"
 #include "logger.h"
 #include <unicode/normalizer2.h>
@@ -85,6 +86,43 @@ encoded_input_t XLMRobertaTokenizer::Encode(const std::string& text) {
         attention_mask.resize(128);
         input_ids[input_ids.size() - 1] = fairseq_tokens_to_ids_["<eos>"];
     }
+
+    return {input_ids, {}, attention_mask};
+}
+
+
+SigLIPTokenizer::SigLIPTokenizer(const std::string& model_path) {
+    sentencepiece_tokenizer_ = std::make_unique<sentencepiece::SentencePieceProcessor>();
+    sentencepiece_tokenizer_->Load(model_path);
+}
+
+encoded_input_t SigLIPTokenizer::Encode(const std::string& text) {
+    // Lowercase the input text
+    std::string lower_text = text;
+    std::transform(lower_text.begin(), lower_text.end(), lower_text.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+
+    // Tokenize with SentencePiece (raw IDs, no fairseq offset)
+    std::vector<int> piece_ids;
+    sentencepiece_tokenizer_->Encode(lower_text, &piece_ids);
+
+    std::vector<int64_t> input_ids(piece_ids.begin(), piece_ids.end());
+
+    // Append EOS token
+    input_ids.push_back(eos_token_id_);
+
+    // Truncate to max_length, ensuring last token is EOS
+    if (input_ids.size() > max_length_) {
+        input_ids.resize(max_length_);
+        input_ids[max_length_ - 1] = eos_token_id_;
+    }
+
+    // Build attention mask: 1 for real tokens, 0 for padding
+    std::vector<int64_t> attention_mask(input_ids.size(), 1);
+
+    // Pad with EOS token to max_length
+    input_ids.resize(max_length_, eos_token_id_);
+    attention_mask.resize(max_length_, 0);
 
     return {input_ids, {}, attention_mask};
 }


### PR DESCRIPTION
## Change Summary
Add support for using SigLIP tokenizer and image processor with the new SigLIP image embedding model.

### Usage
```json
{
    "name": "images",
    "fields": [
        {
            "name": "title",
            "type": "string"
        },
        {
            "name": "image",
            "type": "image",
            "store": false
        },
        {
            "name": "embedding",
            "type": "float[]",
            "embed": {
                "from": [
                    "title",
                    "image"
                ],
                "model_config": {
                    "model_name": "ts/siglip-base-patch16-224"
                }
            }
        }
    ]
}
```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
