### PR TITLE
fix: validate int32 range on document write

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <unordered_map>
 #include <thread>
+#include <memory>
 #include <mutex>
 #include <condition_variable>
 #include <shared_mutex>
@@ -27,17 +28,34 @@ struct doc_seq_id_t {
     bool is_new;
 };
 
+struct highlight_query_token_t {
+    bool is_prefix = false;
+    uint32_t root_len = 0;
+    uint32_t num_typos = 0;
+
+    highlight_query_token_t() = default;
+
+    highlight_query_token_t(uint32_t root_len, uint32_t num_typos, bool is_prefix):
+            is_prefix(is_prefix), root_len(root_len), num_typos(num_typos) {
+    }
+};
+
 struct highlight_field_t {
     std::string name;
     bool fully_highlighted;
     bool infix;
     bool is_string;
-    tsl::htrie_map<char, token_leaf> qtoken_leaves;
+    tsl::htrie_map<char, highlight_query_token_t> qtoken_leaves;
 
     highlight_field_t(const std::string& name, bool fully_highlighted, bool infix, bool is_string):
             name(name), fully_highlighted(fully_highlighted), infix(infix), is_string(is_string) {
 
     }
+};
+
+struct highlight_field_snapshot_t {
+    tsl::htrie_map<char, highlight_query_token_t> qtoken_leaves;
+    std::vector<std::unique_ptr<posting_list_t>> posting_lists;
 };
 
 struct union_global_params_t {
@@ -477,7 +495,7 @@ private:
                                       const std::vector<char>& symbols_to_index, const std::vector<char>& token_separators,
                                       highlight_t& highlight, StringUtils& string_utils, const bool& use_word_tokenizer,
                                       const size_t& highlight_affix_num_tokens,
-                                      const tsl::htrie_map<char, token_leaf>& qtoken_leaves, const int& last_valid_offset_index,
+                                      const tsl::htrie_map<char, highlight_query_token_t>& qtoken_leaves, const int& last_valid_offset_index,
                                       const size_t& prefix_token_num_chars, const bool& highlight_fully,
                                       const size_t& snippet_threshold, const bool& is_infix_search,
                                       const std::vector<std::string>& raw_query_tokens, const size_t& last_valid_offset,
@@ -488,7 +506,7 @@ private:
     static void highlight_result(const bool& enable_nested_fields, const std::vector<char>& symbols_to_index,const std::vector<char>& token_separators,
                                  const std::string& raw_query, const field& search_field,
                                  const size_t& search_field_index,
-                                 const tsl::htrie_map<char, token_leaf>& qtoken_leaves,
+                                 const highlight_field_snapshot_t& highlight_snapshot,
                                  const KV* field_order_kv, const nlohmann::json& document,
                                  nlohmann::json& highlight_doc,
                                  StringUtils& string_utils,
@@ -511,7 +529,9 @@ private:
                                 const size_t& highlight_affix_num_tokens, const string& highlight_start_tag,
                                 const string& highlight_end_tag, const std::vector<std::string>& highlight_field_names,
                                 const std::vector<std::string>& highlight_full_field_names,
-                                const std::vector<highlight_field_t>& highlight_items, const uint8_t* index_symbols,
+                                const std::vector<highlight_field_t>& highlight_items,
+                                const std::vector<highlight_field_snapshot_t>& highlight_snapshots,
+                                const uint8_t* index_symbols,
                                 const KV* field_order_kv, const nlohmann::json& document, nlohmann::json& highlight_res,
                                 nlohmann::json& wrapper_doc,
                                 const std::vector<std::vector<std::string>>& q_phrases = {});
@@ -1113,6 +1133,12 @@ public:
                                   std::vector<std::string>& q_tokens,
                                   const tsl::htrie_map<char, token_leaf>& qtoken_set,
                                   std::vector<highlight_field_t>& highlight_items) const;
+
+    void build_highlight_snapshots_with_lock(const std::vector<highlight_field_t>& highlight_items,
+                                             std::vector<highlight_field_snapshot_t>& highlight_snapshots) const;
+
+    void build_highlight_snapshots(const std::vector<highlight_field_t>& highlight_items,
+                                   std::vector<highlight_field_snapshot_t>& highlight_snapshots) const;
 
     static void copy_highlight_doc(const std::vector<highlight_field_t>& hightlight_items,
                                    const bool nested_fields_enabled,

--- a/include/collection.h
+++ b/include/collection.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 #include <thread>
 #include <memory>
+#include <atomic>
 #include <mutex>
 #include <condition_variable>
 #include <shared_mutex>
@@ -459,6 +460,17 @@ private:
     /// "field name" -> reference_info(referenced_collection_name, referenced_field_name, is_async)
     spp::sparse_hash_map<std::string, reference_info_t> reference_fields;
 
+    struct read_state_t {
+        tsl::htrie_map<char, field> search_schema;
+        std::vector<char> symbols_to_index;
+        std::vector<char> token_separators;
+        bool enable_nested_fields = false;
+        spp::sparse_hash_map<std::string, reference_info_t> reference_fields;
+        std::string collection_name;
+    };
+
+    std::shared_ptr<const read_state_t> read_state_snapshot;
+
     /// Contains the info where the current collection is referenced.
     /// Useful to perform operations such as cascading delete.
     /// collection_name -> field_name
@@ -728,6 +740,10 @@ private:
                                         nlohmann::json& curation_metadata,
                                         const bool& is_union_search,
                                         const uint32_t& union_search_index) const;
+
+    std::shared_ptr<const read_state_t> get_read_state_snapshot() const;
+
+    void rebuild_read_state_snapshot_unlocked();
 
     Option<bool> run_search_with_lock(search_args* search_params) const;
 

--- a/include/collection.h
+++ b/include/collection.h
@@ -1061,6 +1061,10 @@ public:
 
     Option<bool> remove_if_found(uint32_t seq_id, bool remove_from_store = true);
 
+    Option<size_t> remove_if_found_many(const std::vector<uint32_t>& seq_ids,
+                                        bool remove_from_store = true,
+                                        std::vector<nlohmann::json>* removed_docs = nullptr);
+
     size_t get_num_documents() const;
 
     DIRTY_VALUES parse_dirty_values_option(std::string& dirty_values) const;

--- a/include/collection.h
+++ b/include/collection.h
@@ -56,7 +56,6 @@ struct highlight_field_t {
 
 struct highlight_field_snapshot_t {
     tsl::htrie_map<char, highlight_query_token_t> qtoken_leaves;
-    std::vector<std::unique_ptr<posting_list_t>> posting_lists;
 };
 
 struct union_global_params_t {
@@ -515,38 +514,38 @@ private:
                                       const uint8_t* index_symbols, const match_index_t& match_index, const std::string& raw_query,
                                       const std::vector<std::vector<std::string>>& q_phrases = {});
 
-    static void highlight_result(const bool& enable_nested_fields, const std::vector<char>& symbols_to_index,const std::vector<char>& token_separators,
-                                 const std::string& raw_query, const field& search_field,
-                                 const size_t& search_field_index,
-                                 const highlight_field_snapshot_t& highlight_snapshot,
-                                 const KV* field_order_kv, const nlohmann::json& document,
-                                 nlohmann::json& highlight_doc,
-                                 StringUtils& string_utils,
-                                 const size_t& snippet_threshold,
-                                 const size_t& highlight_affix_num_tokens,
-                                 const bool& highlight_fully,
-                                 const bool& is_infix_search,
-                                 const std::string& highlight_start_tag,
-                                 const std::string& highlight_end_tag,
-                                 const uint8_t* index_symbols,
-                                 highlight_t& highlight,
-                                 bool& found_highlight,
-                                 bool& found_full_highlight,
-                                 const std::vector<std::vector<std::string>>& q_phrases = {});
+    void highlight_result(const bool& enable_nested_fields, const std::vector<char>& symbols_to_index,const std::vector<char>& token_separators,
+                          const std::string& raw_query, const field& search_field,
+                          const size_t& search_field_index,
+                          const highlight_field_snapshot_t& highlight_snapshot,
+                          const KV* field_order_kv, const nlohmann::json& document,
+                          nlohmann::json& highlight_doc,
+                          StringUtils& string_utils,
+                          const size_t& snippet_threshold,
+                          const size_t& highlight_affix_num_tokens,
+                          const bool& highlight_fully,
+                          const bool& is_infix_search,
+                          const std::string& highlight_start_tag,
+                          const std::string& highlight_end_tag,
+                          const uint8_t* index_symbols,
+                          highlight_t& highlight,
+                          bool& found_highlight,
+                          bool& found_full_highlight,
+                          const std::vector<std::vector<std::string>>& q_phrases = {}) const;
 
-    static void do_highlighting(const tsl::htrie_map<char, field>& search_schema, const bool& enable_nested_fields,
-                                const std::vector<char>& symbols_to_index, const std::vector<char>& token_separators,
-                                const string& query, const std::vector<std::string>& raw_search_fields,
-                                const string& raw_query, const bool& enable_highlight_v1, const size_t& snippet_threshold,
-                                const size_t& highlight_affix_num_tokens, const string& highlight_start_tag,
-                                const string& highlight_end_tag, const std::vector<std::string>& highlight_field_names,
-                                const std::vector<std::string>& highlight_full_field_names,
-                                const std::vector<highlight_field_t>& highlight_items,
-                                const std::vector<highlight_field_snapshot_t>& highlight_snapshots,
-                                const uint8_t* index_symbols,
-                                const KV* field_order_kv, const nlohmann::json& document, nlohmann::json& highlight_res,
-                                nlohmann::json& wrapper_doc,
-                                const std::vector<std::vector<std::string>>& q_phrases = {});
+    void do_highlighting(const tsl::htrie_map<char, field>& search_schema, const bool& enable_nested_fields,
+                         const std::vector<char>& symbols_to_index, const std::vector<char>& token_separators,
+                         const string& query, const std::vector<std::string>& raw_search_fields,
+                         const string& raw_query, const bool& enable_highlight_v1, const size_t& snippet_threshold,
+                         const size_t& highlight_affix_num_tokens, const string& highlight_start_tag,
+                         const string& highlight_end_tag, const std::vector<std::string>& highlight_field_names,
+                         const std::vector<std::string>& highlight_full_field_names,
+                         const std::vector<highlight_field_t>& highlight_items,
+                         const std::vector<highlight_field_snapshot_t>& highlight_snapshots,
+                         const uint8_t* index_symbols,
+                         const KV* field_order_kv, const nlohmann::json& document, nlohmann::json& highlight_res,
+                         nlohmann::json& wrapper_doc,
+                         const std::vector<std::vector<std::string>>& q_phrases = {}) const;
 
     void remove_document(nlohmann::json & document, const uint32_t seq_id, bool remove_from_store);
 

--- a/include/filter_result_iterator.h
+++ b/include/filter_result_iterator.h
@@ -172,7 +172,9 @@ struct filter_result_t {
 
     filter_result_t() = default;
 
-    filter_result_t(uint32_t count, uint32_t* docs) : count(count), docs(docs) {}
+    filter_result_t(uint32_t count, uint32_t* docs,
+                    std::map<std::string, reference_filter_result_t>* coll_to_references = nullptr) :
+                    count(count), docs(docs), coll_to_references(coll_to_references) {}
 
     filter_result_t(const filter_result_t& obj) {
         if (&obj == this) {
@@ -382,7 +384,8 @@ public:
 
     explicit filter_result_iterator_t(uint32_t* ids, const uint32_t& ids_count,
                                       const size_t& max_candidates = DEFAULT_FILTER_BY_CANDIDATES,
-                                      uint64_t search_begin_us = 0, uint64_t search_stop_us = UINT64_MAX);
+                                      uint64_t search_begin_us = 0, uint64_t search_stop_us = UINT64_MAX,
+                                      std::map<std::string, reference_filter_result_t>* coll_to_references = nullptr);
 
     explicit filter_result_iterator_t(const std::string& collection_name,
                                       Index const* const index, filter_node_t const* const filter_node,

--- a/include/housekeeper.h
+++ b/include/housekeeper.h
@@ -13,6 +13,7 @@ private:
     std::atomic<uint32_t> remove_expired_keys_interval_s = 3600;
     std::atomic<uint32_t> memory_req_min_age_s = 6;
     std::atomic<uint32_t> memory_usage_interval_s = 3;
+    std::atomic<uint32_t> long_req_log_s = 60;
 
     // used to track in-flight queries so they can be logged during a crash / rapid memory growth
     std::mutex ifq_mutex;
@@ -59,6 +60,8 @@ public:
     void log_bad_queries();
 
     void log_running_queries();
+
+    size_t get_num_inflight_queries();
 
     void run();
 

--- a/include/http_data.h
+++ b/include/http_data.h
@@ -86,6 +86,12 @@ struct http_res {
         cv.notify_all();
     }
 
+    static std::string serialize_response_message(const std::string& message) {
+        nlohmann::json j;
+        j["message"] = message;
+        return j.dump();
+    }
+
     static const char* get_status_reason(uint32_t status_code) {
         switch(status_code) {
             case 200: return "OK";
@@ -115,12 +121,12 @@ struct http_res {
 
     void set_400(const std::string & message) {
         status_code = 400;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
     void set_401(const std::string & message) {
         status_code = 400;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
     void set_403() {
@@ -130,38 +136,38 @@ struct http_res {
 
     void set_404(const std::string & message = "Not Found") {
         status_code = 404;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
 
     void set_405(const std::string & message) {
         status_code = 405;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
     void set_409(const std::string & message) {
         status_code = 409;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
     void set_422(const std::string & message) {
         status_code = 422;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
     void set_500(const std::string & message) {
         status_code = 500;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
     void set_503(const std::string & message) {
         status_code = 503;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
     void set(uint32_t code, const std::string & message) {
         status_code = code;
-        body = "{\"message\": \"" + message + "\"}";
+        body = serialize_response_message(message);
     }
 
     void set_body(uint32_t code, const std::string & message) {

--- a/include/posting.h
+++ b/include/posting.h
@@ -115,6 +115,8 @@ public:
 
     static void get_or_iterator(void*& raw_posting_lists, std::vector<or_iterator_t>& or_iterators,
                                 std::vector<posting_list_t*>& expanded_plists);
+
+    static posting_list_t* to_owned_posting_list(const void* raw_posting_list);
 };
 
 template<class T>

--- a/src/cached_resource_stat.cpp
+++ b/src/cached_resource_stat.cpp
@@ -1,7 +1,8 @@
 #include "cached_resource_stat.h"
-#include <fstream>
-#include <system_metrics.h>
 #include "logger.h"
+#include <fstream>
+#include <housekeeper.h>
+#include <system_metrics.h>
 
 cached_resource_stat_t::resource_check_t
 cached_resource_stat_t::has_enough_resources(const std::string& data_dir_path,
@@ -70,6 +71,7 @@ cached_resource_stat_t::get_resource_status(const std::string& data_dir_path, co
         LOG(INFO) << "memory_total: " << memory_total_bytes << ", memory_available: " << memory_available_bytes
                   << ", all_memory_used: " << memory_used_bytes << ", free_mem: " << free_mem
                   << ", memory_free_min: " << memory_free_min_bytes;
+        HouseKeeper::get_instance().log_running_queries();
         return cached_resource_stat_t::OUT_OF_MEMORY;
     }
 

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -86,6 +86,7 @@ Collection::Collection(const std::string& name, const uint32_t collection_id, co
     this->alter_in_progress = false;
     this->altered_docs= 0;
     this->validated_docs= 0;
+    rebuild_read_state_snapshot_unlocked();
 }
 
 Collection::~Collection() {
@@ -99,6 +100,24 @@ Collection::~Collection() {
             VQModelManager::get_instance().delete_model(vq_model->get_model_name());
         }
     }
+}
+
+std::shared_ptr<const Collection::read_state_t> Collection::get_read_state_snapshot() const {
+    return std::atomic_load_explicit(&read_state_snapshot, std::memory_order_acquire);
+}
+
+void Collection::rebuild_read_state_snapshot_unlocked() {
+    auto snapshot = std::make_shared<read_state_t>();
+    snapshot->search_schema = search_schema;
+    snapshot->symbols_to_index = symbols_to_index;
+    snapshot->token_separators = token_separators;
+    snapshot->enable_nested_fields = enable_nested_fields;
+    snapshot->reference_fields = reference_fields;
+    snapshot->collection_name = name;
+
+    std::atomic_store_explicit(&read_state_snapshot,
+                               std::shared_ptr<const read_state_t>(std::move(snapshot)),
+                               std::memory_order_release);
 }
 
 uint32_t Collection::get_next_seq_id() {
@@ -593,6 +612,7 @@ nlohmann::json Collection::add_many(std::vector<std::string>& json_lines, nlohma
 
             if(found_new_field) {
                 index->refresh_schemas(new_fields, {});
+                rebuild_read_state_snapshot_unlocked();
             }
         }
 
@@ -2820,8 +2840,6 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
                                           float diversity_lamda,
                                           size_t group_max_candidates,
                                           size_t diversity_limit) {
-    std::shared_lock lock(mutex);
-
     auto args = collection_search_args_t(query, search_fields, filter_query,
                                          facet_fields, sort_fields,
                                          num_typos, per_page, page, token_order,
@@ -2856,8 +2874,6 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
 }
 
 Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
-    std::shared_lock lock(mutex);
-
     std::unique_ptr<search_args> search_params_guard;
     std::string query;
     std::vector<std::pair<uint32_t, uint32_t>> included_ids; // ID -> position
@@ -2871,19 +2887,30 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
     std::string transcribed_query;
     nlohmann::json curation_metadata;
 
-    const auto init_index_search_args_op = init_index_search_args(coll_args, search_params_guard, query, included_ids,
-                                                                  include_fields_full, exclude_fields_full, q_tokens,
-                                                                  conversation_standalone_query, vector_query,
-                                                                  facets, per_page, transcribed_query, curation_metadata,
-                                                                  false, 0);
+    const auto init_index_search_args_op = init_index_search_args_with_lock(coll_args, search_params_guard, query, included_ids,
+                                                                             include_fields_full, exclude_fields_full, q_tokens,
+                                                                             conversation_standalone_query, vector_query,
+                                                                             facets, per_page, transcribed_query, curation_metadata,
+                                                                             false, 0);
     if (!init_index_search_args_op.ok()) {
         return Option<nlohmann::json>(init_index_search_args_op.code(), init_index_search_args_op.error());
     }
 
-    const auto search_op = index->run_search(search_params_guard.get());
+    const auto search_op = run_search_with_lock(search_params_guard.get());
     if (!search_op.ok()) {
         return Option<nlohmann::json>(search_op.code(), search_op.error());
     }
+
+    const auto read_state_snapshot = get_read_state_snapshot();
+    if(read_state_snapshot == nullptr) {
+        return Option<nlohmann::json>(500, "Collection read state unavailable.");
+    }
+    const auto& search_schema_snapshot = read_state_snapshot->search_schema;
+    const auto& symbols_to_index_snapshot = read_state_snapshot->symbols_to_index;
+    const auto& token_separators_snapshot = read_state_snapshot->token_separators;
+    const auto enable_nested_fields_snapshot = read_state_snapshot->enable_nested_fields;
+    const auto& reference_fields_snapshot = read_state_snapshot->reference_fields;
+    const auto& collection_name_snapshot = read_state_snapshot->collection_name;
 
     const auto& search_params = search_params_guard.get();
     const auto& group_limit = search_params->group_limit;
@@ -3096,13 +3123,13 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
     if(!facet_query.query.empty()) {
         // identify facet hash tokens
 
-        auto fq_field = search_schema.at(facet_query.field_name);
+        auto fq_field = search_schema_snapshot.at(facet_query.field_name);
         bool is_cyrillic = Tokenizer::is_cyrillic(fq_field.locale);
         bool normalise = is_cyrillic ? false : true;
 
         // Use field-level symbols/separators if available, otherwise fall back to collection-level
-        const auto& symbols = fq_field.symbols_to_index.empty() ? symbols_to_index : fq_field.symbols_to_index;
-        const auto& separators = fq_field.token_separators.empty() ? token_separators : fq_field.token_separators;
+        const auto& symbols = fq_field.symbols_to_index.empty() ? symbols_to_index_snapshot : fq_field.symbols_to_index;
+        const auto& separators = fq_field.token_separators.empty() ? token_separators_snapshot : fq_field.token_separators;
 
         std::vector<std::string> facet_query_tokens;
         Tokenizer(facet_query.query, normalise, !fq_field.is_string(), fq_field.locale,
@@ -3126,12 +3153,12 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
 
     std::vector<highlight_field_t> highlight_items;
     if(query != "*") {
-        process_highlight_fields(weighted_search_fields, raw_search_fields, include_fields_full, exclude_fields_full,
-                                 highlight_field_names, highlight_full_field_names, infixes, q_tokens,
-                                 search_params->qtoken_set, highlight_items);
+        process_highlight_fields_with_lock(weighted_search_fields, raw_search_fields, include_fields_full, exclude_fields_full,
+                                           highlight_field_names, highlight_full_field_names, infixes, q_tokens,
+                                           search_params->qtoken_set, highlight_items);
     }
     std::vector<highlight_field_snapshot_t> highlight_snapshots;
-    build_highlight_snapshots(highlight_items, highlight_snapshots);
+    build_highlight_snapshots_with_lock(highlight_items, highlight_snapshots);
 
     nlohmann::json result = nlohmann::json::object();
     result["found"] = total;
@@ -3147,7 +3174,7 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
     result[hits_key] = nlohmann::json::array();
 
     uint8_t index_symbols[256] = {};
-    for(char c: symbols_to_index) {
+    for(char c: symbols_to_index_snapshot) {
         index_symbols[uint8_t(c)] = 1;
     }
 
@@ -3176,17 +3203,17 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
                 continue;
             }
             nlohmann::json broken_ref_doc{};
-            for (auto it = document.begin(); !reference_fields.empty() && it != document.end(); it++) {
+            for (auto it = document.begin(); !reference_fields_snapshot.empty() && it != document.end(); it++) {
                 const auto& key = it.key();
                 if (key == "id" || key == ".flat" || key == fields::reference_helper_fields ||
-                        reference_fields.count(key) != 0) {
+                        reference_fields_snapshot.count(key) != 0) {
                     broken_ref_doc[key] = it.value();
                 }
             }
 
             nlohmann::json highlight_res;
             nlohmann::json wrapper_doc;
-            do_highlighting(search_schema, enable_nested_fields, symbols_to_index, token_separators, query,
+            do_highlighting(search_schema_snapshot, enable_nested_fields_snapshot, symbols_to_index_snapshot, token_separators_snapshot, query,
                             raw_search_fields, raw_query, enable_highlight_v1, snippet_threshold,
                             highlight_affix_num_tokens, highlight_start_tag, highlight_end_tag, highlight_field_names,
                             highlight_full_field_names, highlight_items, highlight_snapshots, index_symbols, field_order_kv, document,
@@ -3210,14 +3237,13 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
                                       "",
                                       0,
                                       field_order_kv->reference_filter_results,
-                                      get_name(), seq_id,
+                                      collection_name_snapshot, seq_id,
                                       ref_include_exclude_fields_vec);
             if (!prune_op.ok()) {
                 // Error code 1 returned from `Join::include_references` means reference value is invalid.
                 if (prune_op.code() != 1) {
                     return Option<nlohmann::json>(prune_op.code(), prune_op.error());
                 }
-                lock.unlock();
                 document = broken_ref_doc;
                 auto fix_op = fix_broken_reference(seq_id_key, seq_id,
                                                    include_fields_full, exclude_fields_full,
@@ -3228,7 +3254,6 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
                     }
                     return Option<nlohmann::json>(fix_op.code(), fix_op.error());
                 }
-                lock.lock();
             }
 
             wrapper_doc["document"] = document;
@@ -3258,12 +3283,12 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
                     const bool is_asc = sort_field.order == sort_field_const::asc;
 
                     auto get_geo_distance_op = !sort_field.reference_collection_name.empty() ?
-                                                index->get_referenced_geo_distance(sort_field, is_asc, field_order_kv->key,
-                                                                                   field_order_kv->reference_filter_results,
-                                                                                   reference_lat_lng, true) :
-                                                   index->get_geo_distance_with_lock(sort_field.name, is_asc,
-                                                                                     {(uint32_t) field_order_kv->key},
-                                                                                     reference_lat_lng, true);
+                                                get_referenced_geo_distance_with_lock(sort_field, is_asc, field_order_kv->key,
+                                                                                      field_order_kv->reference_filter_results,
+                                                                                      reference_lat_lng, true) :
+                                                get_geo_distance_with_lock(sort_field.name, is_asc,
+                                                                           {(uint32_t) field_order_kv->key},
+                                                                           reference_lat_lng, true);
                     if (!get_geo_distance_op.ok()) {
                         return Option<nlohmann::json>(get_geo_distance_op.code(), get_geo_distance_op.error());
                     }
@@ -3351,7 +3376,7 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
         field the_field;
         std::shared_ptr<Collection> ref_collection;
         if (a_facet.reference_collection_name.empty()) {
-            the_field = search_schema.at(a_facet.field_name);
+            the_field = search_schema_snapshot.at(a_facet.field_name);
         } else {
             auto& cm = CollectionManager::get_instance();
             ref_collection = cm.get_collection(a_facet.reference_collection_name);
@@ -3429,7 +3454,7 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
                 } else if(ref_collection != nullptr) {
                     value = ref_collection->get_facet_str_val_with_lock(the_field.name, facet_count.fhash);
                 } else {
-                    value = index->get_facet_str_val(the_field.name, facet_count.fhash);
+                    value = get_facet_str_val_with_lock(the_field.name, facet_count.fhash);
                 }
 
                 highlight_t highlight;
@@ -3439,8 +3464,8 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
                     bool normalise = !use_word_tokenizer;
 
                     // Use field-level symbols/separators if available, otherwise fall back to collection-level
-                    const auto& symbols = the_field.symbols_to_index.empty() ? symbols_to_index : the_field.symbols_to_index;
-                    const auto& separators = the_field.token_separators.empty() ? token_separators : the_field.token_separators;
+                    const auto& symbols = the_field.symbols_to_index.empty() ? symbols_to_index_snapshot : the_field.symbols_to_index;
+                    const auto& separators = the_field.token_separators.empty() ? token_separators_snapshot : the_field.token_separators;
 
                     std::vector<std::string> fquery_tokens;
                     Tokenizer(facet_query.query, true, false, the_field.locale, symbols,
@@ -3600,13 +3625,13 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
     result["search_cutoff"] = search_cutoff;
 
     result["request_params"] = nlohmann::json::object();
-    result["request_params"]["collection_name"] = name;
+    result["request_params"]["collection_name"] = collection_name_snapshot;
     result["request_params"]["per_page"] = per_page;
     result["request_params"]["q"] = raw_query;
 
     // handle analytics query expansion
     std::string first_q = raw_query;
-    expand_search_query(search_schema, symbols_to_index, token_separators,
+    expand_search_query(search_schema_snapshot, symbols_to_index_snapshot, token_separators_snapshot,
                         raw_query, offset, total, search_params, result_group_kvs, raw_search_fields, first_q);
     result["request_params"]["first_q"] = first_q;
 
@@ -4074,6 +4099,10 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
             if (coll == nullptr) {
                 return Option<bool>(400, "Collection having `coll_id: " + std::to_string(coll_id) + "` not found.");
             }
+            const auto read_state_snapshot = coll->get_read_state_snapshot();
+            if(read_state_snapshot == nullptr) {
+                return Option<bool>(500, "Collection read state unavailable.");
+            }
             const std::string& seq_id_key = coll->get_seq_id_key((uint32_t) kv->key);
 
             nlohmann::json document;
@@ -4084,20 +4113,21 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
                 continue;
             }
             nlohmann::json broken_ref_doc{};
-            for (auto it = document.begin(); !coll->reference_fields.empty() && it != document.end(); it++) {
+            const auto& reference_fields = read_state_snapshot->reference_fields;
+            for (auto it = document.begin(); !reference_fields.empty() && it != document.end(); it++) {
                 const auto& key = it.key();
                 if (key == "id" || key == ".flat" || key == fields::reference_helper_fields ||
-                        coll->reference_fields.count(key) != 0) {
+                        reference_fields.count(key) != 0) {
                     broken_ref_doc[key] = it.value();
                 }
             }
 
             const auto& coll_args = searches[search_index];
             const auto& search_params = search_params_guards[search_index].get();
-            const auto& search_schema = coll->get_schema();
-            const auto& enable_nested_fields = coll->get_enable_nested_fields();
-            const auto& symbols_to_index = coll->get_symbols_to_index();
-            const auto& token_separators = coll->get_token_separators();
+            const auto& search_schema = read_state_snapshot->search_schema;
+            const auto& enable_nested_fields = read_state_snapshot->enable_nested_fields;
+            const auto& symbols_to_index = read_state_snapshot->symbols_to_index;
+            const auto& token_separators = read_state_snapshot->token_separators;
             const auto& query = queries[search_index];
             const auto& raw_search_fields = coll_args.search_fields;
             const auto& raw_query = coll_args.raw_query;
@@ -6664,6 +6694,8 @@ Option<bool> Collection::batch_alter_data(const std::vector<field>& alter_fields
         fields.push_back(f);
     }
 
+    rebuild_read_state_snapshot_unlocked();
+
     ulock.unlock();
     std::shared_lock shlock(mutex);
 
@@ -6816,6 +6848,8 @@ Option<bool> Collection::batch_alter_data(const std::vector<field>& alter_fields
 
         process_remove_field_for_embedding_fields(del_field, garbage_embedding_fields_vec);
     }
+
+    rebuild_read_state_snapshot_unlocked();
 
     ulock.unlock();
     shlock.lock();
@@ -7156,6 +7190,7 @@ Option<bool> Collection::validate_alter_payload(nlohmann::json& schema_changes,
                     if (field_it->nested) {
                         object_reference_fields.erase(field_name);
                     }
+                    rebuild_read_state_snapshot_unlocked();
 
                     //validated before only, so directly add to fields to delete
                     const auto ref_helper_field_name = field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX;
@@ -7254,6 +7289,7 @@ Option<bool> Collection::validate_alter_payload(nlohmann::json& schema_changes,
                     if (field.nested) {
                         object_reference_fields.insert(field.name);
                     }
+                    rebuild_read_state_snapshot_unlocked();
 
                     for (auto& update_ref_info: update_ref_infos) {
                         update_reference_field(update_ref_info.field, update_ref_info.referenced_field);
@@ -8463,6 +8499,7 @@ void Collection::update_reference_field(const std::string& field_name, const fie
     }
 
     it->second.referenced_field = ref_field;
+    rebuild_read_state_snapshot_unlocked();
 }
 
 Option<uint32_t> Collection::get_sort_index_value_with_lock(const std::string& field_name,

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -5576,9 +5576,45 @@ bool Collection::handle_highlight_text(std::string& text, const bool& normalise,
     size_t first_match_token_index = 0;  
 
     size_t text_len = Tokenizer::is_ascii_char(text[0]) ? text.size() : StringUtils::get_num_chars(text);
+    std::vector<std::pair<size_t, size_t>> valid_phrase_ranges;
+    if(is_phrase_query) {
+        size_t min_phrase_len = 0;
+        for(const auto& phrase : q_phrases) {
+            if(!phrase.empty()) {
+                min_phrase_len = (min_phrase_len == 0) ? phrase.size() : std::min(min_phrase_len, phrase.size());
+            }
+        }
 
-    std::unordered_set<size_t> phrase_matched_token_indices;
-    
+        if(min_phrase_len > 0) {
+            std::vector<size_t> matched_offsets;
+            matched_offsets.reserve(match.offsets.size());
+            for(const auto& offset : match.offsets) {
+                matched_offsets.push_back(offset.offset);
+            }
+
+            std::sort(matched_offsets.begin(), matched_offsets.end());
+            matched_offsets.erase(std::unique(matched_offsets.begin(), matched_offsets.end()), matched_offsets.end());
+
+            size_t run_start = 0;
+            for(size_t i = 1; i <= matched_offsets.size(); i++) {
+                const bool is_run_break = (i == matched_offsets.size()) ||
+                                          (matched_offsets[i] != matched_offsets[i - 1] + 1);
+                if(!is_run_break) {
+                    continue;
+                }
+
+                const size_t run_end = i - 1;
+                const size_t run_len = run_end - run_start + 1;
+                if(run_len >= min_phrase_len) {
+                    valid_phrase_ranges.emplace_back(matched_offsets[run_start], matched_offsets[run_end]);
+                }
+
+                run_start = i;
+            }
+        }
+    }
+
+    size_t valid_phrase_range_idx = 0;
     while(tokenizer.next(raw_token, raw_token_index, tok_start, tok_end)) {
         if(use_word_tokenizer) {
             bool found_token = word_tokenizer.tokenize(raw_token);
@@ -5612,25 +5648,15 @@ bool Collection::handle_highlight_text(std::string& text, const bool& normalise,
         // phrase query, only highlight tokens that are part of consecutive phrase matches
         if (is_phrase_query && match_offset_found) {
             bool is_consecutive_phrase_match = false;
-            
-            std::unordered_set<size_t> offset_indices;
-            for (const auto& offset : match.offsets) {
-                offset_indices.insert(offset.offset);
+            while(valid_phrase_range_idx < valid_phrase_ranges.size() &&
+                  raw_token_index > valid_phrase_ranges[valid_phrase_range_idx].second) {
+                valid_phrase_range_idx++;
             }
-            if (offset_indices.count(raw_token_index) > 0) {
-                // check if the next token in the phrase is also in the match offsets
-                size_t next_token_index = raw_token_index + 1;
-                if (offset_indices.count(next_token_index) > 0) {
-                    is_consecutive_phrase_match = true;
-                }
-                
-                if (!is_consecutive_phrase_match && raw_token_index > 0) {
-                    // the next token is not in the match offsets, check if the previous token is in the phrase
-                    size_t prev_token_index = raw_token_index - 1;
-                    if (offset_indices.count(prev_token_index) > 0) {
-                        is_consecutive_phrase_match = true;
-                    }
-                }
+
+            if(valid_phrase_range_idx < valid_phrase_ranges.size()) {
+                const auto& current_range = valid_phrase_ranges[valid_phrase_range_idx];
+                is_consecutive_phrase_match = (raw_token_index >= current_range.first &&
+                                               raw_token_index <= current_range.second);
             }
             
             // this is not part of a consecutive phrase match, don't highlight it

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -3661,7 +3661,7 @@ void Collection::do_highlighting(const tsl::htrie_map<char, field>& search_schem
                                  const uint8_t* index_symbols,
                                  const KV* field_order_kv, const nlohmann::json& document, nlohmann::json& highlight_res,
                                  nlohmann::json& wrapper_doc,
-                                 const std::vector<std::vector<std::string>>& q_phrases) {
+                                 const std::vector<std::vector<std::string>>& q_phrases) const {
     highlight_res= nlohmann::json::object();
     if(!highlight_items.empty()) {
         copy_highlight_doc(highlight_items, enable_nested_fields, document, highlight_res);
@@ -4144,11 +4144,11 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
 
             nlohmann::json highlight_res;
             nlohmann::json wrapper_doc;
-            do_highlighting(search_schema, enable_nested_fields, symbols_to_index, token_separators, query,
-                            raw_search_fields, raw_query, enable_highlight_v1, snippet_threshold,
-                            highlight_affix_num_tokens, highlight_start_tag, highlight_end_tag, highlight_field_names,
-                            highlight_full_field_names, highlight_items, highlight_snapshots, index_symbols, kv, document,
-                            highlight_res, wrapper_doc, {});
+            coll->do_highlighting(search_schema, enable_nested_fields, symbols_to_index, token_separators, query,
+                                  raw_search_fields, raw_query, enable_highlight_v1, snippet_threshold,
+                                  highlight_affix_num_tokens, highlight_start_tag, highlight_end_tag, highlight_field_names,
+                                  highlight_full_field_names, highlight_items, highlight_snapshots, index_symbols, kv, document,
+                                  highlight_res, wrapper_doc, {});
 
             if(group_limit && group_key.empty()) {
                 const auto& group_by_fields = searches.at(search_index).group_by_fields;
@@ -4637,7 +4637,6 @@ void Collection::build_highlight_snapshots(
     highlight_snapshots.clear();
     highlight_snapshots.resize(highlight_items.size());
 
-    std::string qtoken;
     for(size_t i = 0; i < highlight_items.size(); i++) {
         const auto& highlight_item = highlight_items[i];
         auto& highlight_snapshot = highlight_snapshots[i];
@@ -4645,25 +4644,7 @@ void Collection::build_highlight_snapshots(
         if(!highlight_item.is_string || highlight_item.qtoken_leaves.empty()) {
             continue;
         }
-
-        for(auto it = highlight_item.qtoken_leaves.begin(); it != highlight_item.qtoken_leaves.end(); ++it) {
-            it.key(qtoken);
-
-            auto leaf = index->get_token_leaf(highlight_item.name,
-                                              (const unsigned char*) qtoken.c_str(),
-                                              qtoken.size() + 1);
-            if(leaf == nullptr) {
-                continue;
-            }
-
-            auto owned_posting_list = posting_t::to_owned_posting_list(leaf->values);
-            if(owned_posting_list == nullptr) {
-                continue;
-            }
-
-            highlight_snapshot.posting_lists.emplace_back(owned_posting_list);
-            highlight_snapshot.qtoken_leaves.insert(qtoken, it.value());
-        }
+        highlight_snapshot.qtoken_leaves = highlight_item.qtoken_leaves;
     }
 }
 
@@ -5150,7 +5131,7 @@ void Collection::highlight_result(const bool& enable_nested_fields, const std::v
                                   highlight_t& highlight,
                                   bool& found_highlight,
                                   bool& found_full_highlight,
-                                  const std::vector<std::vector<std::string>>& q_phrases) {
+                                  const std::vector<std::vector<std::string>>& q_phrases) const {
     const auto& qtoken_leaves = highlight_snapshot.qtoken_leaves;
 
     if(raw_query == "*") {
@@ -5216,14 +5197,27 @@ void Collection::highlight_result(const bool& enable_nested_fields, const std::v
         }*/
 
         if(!qtoken_leaves.empty()) {
-            std::vector<void*> posting_lists;
-            posting_lists.reserve(highlight_snapshot.posting_lists.size());
-            for(const auto& posting_list: highlight_snapshot.posting_lists) {
-                posting_lists.push_back(posting_list.get());
-            }
-
             std::map<size_t, std::vector<token_positions_t>> array_token_positions;
-            posting_t::get_array_token_positions(field_order_kv->key, posting_lists, array_token_positions);
+            std::vector<void*> posting_lists;
+            std::string qtoken;
+
+            {
+                // Protect ART leaf and posting-list lifetimes while collecting offsets.
+                std::shared_lock lock(mutex);
+                for(auto it = qtoken_leaves.begin(); it != qtoken_leaves.end(); ++it) {
+                    it.key(qtoken);
+                    auto leaf = index->get_token_leaf(search_field.name,
+                                                      (const unsigned char*) qtoken.c_str(),
+                                                      qtoken.size() + 1);
+                    if(leaf != nullptr) {
+                        posting_lists.push_back(leaf->values);
+                    }
+                }
+
+                if(!posting_lists.empty()) {
+                    posting_t::get_array_token_positions(field_order_kv->key, posting_lists, array_token_positions);
+                }
+            }
 
             for(const auto& kv: array_token_positions) {
                 const std::vector<token_positions_t>& token_positions = kv.second;

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -6283,6 +6283,101 @@ Option<bool> Collection::remove_if_found(uint32_t seq_id, const bool remove_from
     return Option<bool>(true);
 }
 
+Option<size_t> Collection::remove_if_found_many(const std::vector<uint32_t>& seq_ids,
+                                                const bool remove_from_store,
+                                                std::vector<nlohmann::json>* removed_docs) {
+    if(removed_docs != nullptr) {
+        removed_docs->clear();
+    }
+
+    if(seq_ids.empty()) {
+        return Option<size_t>(0);
+    }
+
+    bool has_referenced_in = false;
+    {
+        std::shared_lock lock(mutex);
+        has_referenced_in = !referenced_in.empty();
+    }
+
+    // If this collection is referenced by another collection, keep per-doc semantics
+    // so cascaded deletes can short-circuit subsequent IDs safely.
+    if(has_referenced_in) {
+        size_t removed_count = 0;
+
+        for(const auto seq_id: seq_ids) {
+            nlohmann::json document;
+            auto get_doc_op = get_document_from_store(get_seq_id_key(seq_id), document);
+            if(!get_doc_op.ok()) {
+                if(get_doc_op.code() == 404) {
+                    continue;
+                }
+                return Option<size_t>(500, "Error while fetching the document with seq id: " +
+                                           std::to_string(seq_id));
+            }
+
+            remove_document(document, seq_id, remove_from_store);
+            removed_count++;
+
+            if(removed_docs != nullptr) {
+                removed_docs->emplace_back(std::move(document));
+            }
+        }
+
+        return Option<size_t>(removed_count);
+    }
+
+    std::vector<uint32_t> found_seq_ids;
+    std::vector<nlohmann::json> found_documents;
+    found_seq_ids.reserve(seq_ids.size());
+    found_documents.reserve(seq_ids.size());
+
+    for(const auto seq_id: seq_ids) {
+        nlohmann::json document;
+        auto get_doc_op = get_document_from_store(get_seq_id_key(seq_id), document);
+        if(!get_doc_op.ok()) {
+            if(get_doc_op.code() == 404) {
+                continue;
+            }
+            return Option<size_t>(500, "Error while fetching the document with seq id: " +
+                                       std::to_string(seq_id));
+        }
+
+        found_seq_ids.emplace_back(seq_id);
+        found_documents.emplace_back(std::move(document));
+    }
+
+    if(found_seq_ids.empty()) {
+        return Option<size_t>(0);
+    }
+
+    {
+        std::unique_lock lock(mutex);
+        for(size_t i = 0; i < found_seq_ids.size(); i++) {
+            index->remove(found_seq_ids[i], found_documents[i], {}, false);
+            if (num_documents != 0) {
+                num_documents -= 1;
+            }
+        }
+    }
+
+    if(remove_from_store) {
+        for(size_t i = 0; i < found_seq_ids.size(); i++) {
+            const auto id = found_documents[i]["id"].get<std::string>();
+            store->remove(get_doc_id_key(id));
+            store->remove(get_seq_id_key(found_seq_ids[i]));
+        }
+    }
+
+    if(removed_docs != nullptr) {
+        for(auto& document: found_documents) {
+            removed_docs->emplace_back(std::move(document));
+        }
+    }
+
+    return Option<size_t>(found_seq_ids.size());
+}
+
 uint32_t Collection::get_seq_id_from_key(const std::string & key) {
     // last 4 bytes of the key would be the serialized version of the sequence id
     std::string serialized_seq_id = key.substr(key.length() - 4);

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -3130,6 +3130,8 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
                                  highlight_field_names, highlight_full_field_names, infixes, q_tokens,
                                  search_params->qtoken_set, highlight_items);
     }
+    std::vector<highlight_field_snapshot_t> highlight_snapshots;
+    build_highlight_snapshots(highlight_items, highlight_snapshots);
 
     nlohmann::json result = nlohmann::json::object();
     result["found"] = total;
@@ -3187,7 +3189,7 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
             do_highlighting(search_schema, enable_nested_fields, symbols_to_index, token_separators, query,
                             raw_search_fields, raw_query, enable_highlight_v1, snippet_threshold,
                             highlight_affix_num_tokens, highlight_start_tag, highlight_end_tag, highlight_field_names,
-                            highlight_full_field_names, highlight_items, index_symbols, field_order_kv, document,
+                            highlight_full_field_names, highlight_items, highlight_snapshots, index_symbols, field_order_kv, document,
                             highlight_res, wrapper_doc, field_query_tokens[0].q_phrases);
 
             if(group_limit && group_key.empty()) {
@@ -3451,7 +3453,7 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
                     std::vector<string>& ftokens = a_facet.is_intersected ? a_facet.fvalue_tokens[facet_count.fvalue] :
                                                    a_facet.hash_tokens[facet_count.fhash];
 
-                    tsl::htrie_map<char, token_leaf> qtoken_leaves;
+                    tsl::htrie_map<char, highlight_query_token_t> qtoken_leaves;
 
                     //LOG(INFO) << "working on hash_tokens for hash " << kv.first << " with size " << ftokens.size();
                     for(size_t ti = 0; ti < ftokens.size(); ti++) {
@@ -3471,7 +3473,7 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
                                           fquery_tokens[ti].size() :
                                           resolved_token.size();
 
-                        token_leaf leaf(nullptr, root_len, 0, (ti == ftokens.size()-1));
+                        highlight_query_token_t leaf(root_len, 0, (ti == ftokens.size()-1));
                         qtoken_leaves.emplace(resolved_token, leaf);
                     }
 
@@ -3629,7 +3631,9 @@ void Collection::do_highlighting(const tsl::htrie_map<char, field>& search_schem
                                  const size_t& highlight_affix_num_tokens, const string& highlight_start_tag,
                                  const string& highlight_end_tag, const std::vector<std::string>& highlight_field_names,
                                  const std::vector<std::string>& highlight_full_field_names,
-                                 const std::vector<highlight_field_t>& highlight_items, const uint8_t* index_symbols,
+                                 const std::vector<highlight_field_t>& highlight_items,
+                                 const std::vector<highlight_field_snapshot_t>& highlight_snapshots,
+                                 const uint8_t* index_symbols,
                                  const KV* field_order_kv, const nlohmann::json& document, nlohmann::json& highlight_res,
                                  nlohmann::json& wrapper_doc,
                                  const std::vector<std::vector<std::string>>& q_phrases) {
@@ -3653,6 +3657,8 @@ void Collection::do_highlighting(const tsl::htrie_map<char, field>& search_schem
 
     for(size_t i = 0; i < highlight_items.size(); i++) {
         auto& highlight_item = highlight_items[i];
+        const highlight_field_snapshot_t empty_highlight_snapshot;
+        const auto& highlight_snapshot = i < highlight_snapshots.size() ? highlight_snapshots[i] : empty_highlight_snapshot;
         const std::string& field_name = highlight_item.name;
         if(search_schema.count(field_name) == 0) {
             continue;
@@ -3668,7 +3674,7 @@ void Collection::do_highlighting(const tsl::htrie_map<char, field>& search_schem
             bool found_full_highlight = false;
 
             highlight_result(enable_nested_fields, symbols_to_index, token_separators,
-                             raw_query, search_field, i, highlight_item.qtoken_leaves, field_order_kv,
+                             raw_query, search_field, i, highlight_snapshot, field_order_kv,
                              document, highlight_res,
                              string_utils, snippet_threshold,
                              highlight_affix_num_tokens, highlight_item.fully_highlighted, highlight_item.infix,
@@ -3782,6 +3788,7 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
     auto highlight_field_names_list = std::vector<std::vector<std::string>>(size);
     auto highlight_full_field_names_list = std::vector<std::vector<std::string>>(size);
     auto highlight_items_list = std::vector<std::vector<highlight_field_t>>(size);
+    auto highlight_snapshots_list = std::vector<std::vector<highlight_field_snapshot_t>>(size);
     size_t total = 0;
     size_t out_of = 0;
     auto request_json_list = std::vector<nlohmann::json>(size);
@@ -3866,6 +3873,8 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
             coll->process_highlight_fields_with_lock(weighted_search_fields, raw_search_fields, include_fields_full, exclude_fields_full,
                                      highlight_field_names, highlight_full_field_names, infixes, q_tokens,
                                      search_params->qtoken_set, highlight_items_list[search_index]);
+            coll->build_highlight_snapshots_with_lock(highlight_items_list[search_index],
+                                                      highlight_snapshots_list[search_index]);
         }
 
         nlohmann::json params;
@@ -4100,6 +4109,7 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
             const auto& highlight_field_names = highlight_field_names_list[search_index];
             const auto& highlight_full_field_names = highlight_full_field_names_list[search_index];
             const auto& highlight_items = highlight_items_list[search_index];
+            const auto& highlight_snapshots = highlight_snapshots_list[search_index];
             const auto& index_symbols = index_symbols_list[search_index].data();
 
             nlohmann::json highlight_res;
@@ -4107,7 +4117,7 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
             do_highlighting(search_schema, enable_nested_fields, symbols_to_index, token_separators, query,
                             raw_search_fields, raw_query, enable_highlight_v1, snippet_threshold,
                             highlight_affix_num_tokens, highlight_start_tag, highlight_end_tag, highlight_field_names,
-                            highlight_full_field_names, highlight_items, index_symbols, kv, document,
+                            highlight_full_field_names, highlight_items, highlight_snapshots, index_symbols, kv, document,
                             highlight_res, wrapper_doc, {});
 
             if(group_limit && group_key.empty()) {
@@ -4560,7 +4570,7 @@ void Collection::process_highlight_fields(const std::vector<search_field_t>& sea
             art_leaf* leaf = index->get_token_leaf(field_name, (const unsigned char*) qtoken.c_str(), qtoken.size()+1);
             if(leaf) {
                 highlight_item.qtoken_leaves.insert(qtoken,
-                    token_leaf(leaf, it.value().root_len, it.value().num_typos, it.value().is_prefix)
+                    highlight_query_token_t(it.value().root_len, it.value().num_typos, it.value().is_prefix)
                 );
             }
         }
@@ -4577,12 +4587,56 @@ void Collection::process_highlight_fields(const std::vector<search_field_t>& sea
                 const auto& field_name = highlight_item.name;
                 art_leaf* leaf = index->get_token_leaf(field_name, (const unsigned char*) q_token.c_str(), q_token.size()+1);
                 if(leaf) {
-                    highlight_item.qtoken_leaves.insert(q_token, token_leaf(leaf, q_token.size(), 0, false));
+                    highlight_item.qtoken_leaves.insert(q_token, highlight_query_token_t(q_token.size(), 0, false));
                 }
             }
         }
     }
 }
+
+void Collection::build_highlight_snapshots_with_lock(
+    const std::vector<highlight_field_t>& highlight_items,
+    std::vector<highlight_field_snapshot_t>& highlight_snapshots) const {
+    std::shared_lock lock(mutex);
+    return build_highlight_snapshots(highlight_items, highlight_snapshots);
+}
+
+void Collection::build_highlight_snapshots(
+    const std::vector<highlight_field_t>& highlight_items,
+    std::vector<highlight_field_snapshot_t>& highlight_snapshots) const {
+    highlight_snapshots.clear();
+    highlight_snapshots.resize(highlight_items.size());
+
+    std::string qtoken;
+    for(size_t i = 0; i < highlight_items.size(); i++) {
+        const auto& highlight_item = highlight_items[i];
+        auto& highlight_snapshot = highlight_snapshots[i];
+
+        if(!highlight_item.is_string || highlight_item.qtoken_leaves.empty()) {
+            continue;
+        }
+
+        for(auto it = highlight_item.qtoken_leaves.begin(); it != highlight_item.qtoken_leaves.end(); ++it) {
+            it.key(qtoken);
+
+            auto leaf = index->get_token_leaf(highlight_item.name,
+                                              (const unsigned char*) qtoken.c_str(),
+                                              qtoken.size() + 1);
+            if(leaf == nullptr) {
+                continue;
+            }
+
+            auto owned_posting_list = posting_t::to_owned_posting_list(leaf->values);
+            if(owned_posting_list == nullptr) {
+                continue;
+            }
+
+            highlight_snapshot.posting_lists.emplace_back(owned_posting_list);
+            highlight_snapshot.qtoken_leaves.insert(qtoken, it.value());
+        }
+    }
+}
+
 void Collection::process_filter_sort_curations(std::vector<const curation_t*>& filter_sort_curations,
                                           std::vector<std::string>& q_include_tokens,
                                           token_ordering token_order,
@@ -5052,7 +5106,7 @@ bool Collection::is_nested_array(const nlohmann::json& obj, std::vector<std::str
 void Collection::highlight_result(const bool& enable_nested_fields, const std::vector<char>& symbols_to_index,const std::vector<char>& token_separators,
                                   const std::string& raw_query, const field& search_field,
                                   const size_t& search_field_index,
-                                  const tsl::htrie_map<char, token_leaf>& qtoken_leaves,
+                                  const highlight_field_snapshot_t& highlight_snapshot,
                                   const KV* field_order_kv, const nlohmann::json& document,
                                   nlohmann::json& highlight_doc,
                                   StringUtils& string_utils,
@@ -5067,6 +5121,7 @@ void Collection::highlight_result(const bool& enable_nested_fields, const std::v
                                   bool& found_highlight,
                                   bool& found_full_highlight,
                                   const std::vector<std::vector<std::string>>& q_phrases) {
+    const auto& qtoken_leaves = highlight_snapshot.qtoken_leaves;
 
     if(raw_query == "*") {
         return;
@@ -5132,8 +5187,9 @@ void Collection::highlight_result(const bool& enable_nested_fields, const std::v
 
         if(!qtoken_leaves.empty()) {
             std::vector<void*> posting_lists;
-            for(auto token_leaf: qtoken_leaves) {
-                posting_lists.push_back(token_leaf.leaf->values);
+            posting_lists.reserve(highlight_snapshot.posting_lists.size());
+            for(const auto& posting_list: highlight_snapshot.posting_lists) {
+                posting_lists.push_back(posting_list.get());
             }
 
             std::map<size_t, std::vector<token_positions_t>> array_token_positions;
@@ -5362,7 +5418,7 @@ bool Collection::handle_highlight_text(std::string& text, const bool& normalise,
                                        const std::vector<char>& symbols_to_index, const std::vector<char>& token_separators,
                                        highlight_t& highlight, StringUtils& string_utils, const bool& use_word_tokenizer,
                                        const size_t& highlight_affix_num_tokens,
-                                       const tsl::htrie_map<char, token_leaf>& qtoken_leaves, const int& last_valid_offset_index,
+                                       const tsl::htrie_map<char, highlight_query_token_t>& qtoken_leaves, const int& last_valid_offset_index,
                                        const size_t& prefix_token_num_chars, const bool& highlight_fully,
                                        const size_t& snippet_threshold, const bool& is_infix_search,
                                        const std::vector<std::string>& raw_query_tokens, const size_t& last_valid_offset,

--- a/src/core_api_utils.cpp
+++ b/src/core_api_utils.cpp
@@ -1,59 +1,61 @@
 #include "core_api_utils.h"
 #include "auth_manager.h"
+#include <algorithm>
 
 Option<bool> stateful_remove_docs(deletion_state_t* deletion_state, size_t batch_size, bool& done) {
-    bool removed = true;
-    size_t batch_count = 0;
+    static constexpr size_t INTERNAL_REMOVE_BATCH_MAX = 1000;
+    const size_t effective_batch_size = std::min(batch_size, INTERNAL_REMOVE_BATCH_MAX);
 
-    for(size_t i=0; i<deletion_state->index_ids.size(); i++) {
+    bool removed = false;
+    size_t batch_count = 0;
+    std::vector<uint32_t> batch_seq_ids;
+    batch_seq_ids.reserve(effective_batch_size);
+
+    for(size_t i = 0; i < deletion_state->index_ids.size(); i++) {
         std::pair<size_t, uint32_t*>& size_ids = deletion_state->index_ids[i];
         size_t ids_len = size_ids.first;
         uint32_t* ids = size_ids.second;
 
         size_t start_index = deletion_state->offsets[i];
-        size_t batched_len = std::min(ids_len, (start_index+batch_size));
-
-        for(size_t j=start_index; j<batched_len; j++) {
-            uint32_t seq_id = ids[j];
-
-            nlohmann::json doc;
-            bool doc_found = false;
-
-            if (deletion_state->return_doc || deletion_state->return_id) {
-                Option<bool> get_op = deletion_state->collection->get_document_from_store(seq_id, doc);
-                doc_found = get_op.ok();
-            }
-
-            Option<bool> remove_op = deletion_state->collection->remove_if_found(seq_id, true);
-            if (!remove_op.ok()) {
-                return remove_op;
-            }
-
-            removed = remove_op.get();
-            if (removed) {
-                deletion_state->num_removed++;
-                if (doc_found) {
-                    if (deletion_state->return_doc) {
-                        Collection::remove_flat_fields(doc);
-                        deletion_state->removed_docs.push_back(doc);
-                    }
-
-                    if (deletion_state->return_id) {
-                        deletion_state->removed_ids.push_back(doc["id"]);
-                    }
-                }
-            }
-
-            deletion_state->offsets[i]++;
+        while(start_index < ids_len && batch_count < effective_batch_size) {
+            batch_seq_ids.emplace_back(ids[start_index]);
+            start_index++;
             batch_count++;
+        }
 
-            if(batch_count == batch_size) {
-                goto END;
-            }
+        deletion_state->offsets[i] = start_index;
+        if(batch_count == effective_batch_size) {
+            break;
         }
     }
 
-    END:
+    std::vector<nlohmann::json> removed_docs_batch;
+    std::vector<nlohmann::json>* removed_docs_ptr = nullptr;
+    if(deletion_state->return_doc || deletion_state->return_id) {
+        removed_docs_ptr = &removed_docs_batch;
+    }
+
+    auto remove_op = deletion_state->collection->remove_if_found_many(batch_seq_ids, true, removed_docs_ptr);
+    if(!remove_op.ok()) {
+        return Option<bool>(remove_op.code(), remove_op.error());
+    }
+
+    auto removed_count = remove_op.get();
+    removed = removed_count > 0;
+    deletion_state->num_removed += removed_count;
+
+    if(removed_docs_ptr != nullptr) {
+        for(auto& doc: removed_docs_batch) {
+            if(deletion_state->return_doc) {
+                Collection::remove_flat_fields(doc);
+                deletion_state->removed_docs.push_back(doc);
+            }
+
+            if(deletion_state->return_id) {
+                deletion_state->removed_ids.push_back(doc["id"]);
+            }
+        }
+    }
 
     done = true;
     for(size_t i=0; i<deletion_state->index_ids.size(); i++) {

--- a/src/curation.cpp
+++ b/src/curation.cpp
@@ -299,6 +299,13 @@ nlohmann::json curation_t::to_json() const {
         curation["rule"]["tags"] = rule.tags;
     }
 
+    curation["rule"]["synonyms"] = rule.synonyms;
+    curation["rule"]["stem"] = rule.stem;
+
+    if(!rule.stemming_dictionary.empty()) {
+        curation["rule"]["stemming_dictionary"] = rule.stemming_dictionary;
+    }
+
     curation["includes"] = nlohmann::json::array();
 
     for(const auto & add_hit: add_hits) {

--- a/src/diversity.cpp
+++ b/src/diversity.cpp
@@ -66,8 +66,8 @@ Option<bool> diversity_t::parse(const nlohmann::json& json, diversity_t& diversi
         metric_it = metric.find("weight");
         if (metric_it == metric.end()) {
             weight = 1;
-        } else if (!metric_it.value().is_number_float()) {
-            return Option<bool>(400, "Invalid `weight` format: `" + metric_it.value().dump() + "`. Expected a float number.");
+        } else if (!metric_it.value().is_number()) {
+            return Option<bool>(400, "Invalid `weight` format: `" + metric_it.value().dump() + "`. Expected a number.");
         } else {
             weight = metric_it.value();
         }

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -927,7 +927,11 @@ void numeric_not_equals_filter(num_tree_t* const num_tree,
 
     num_tree->search(EQUALS, value, &to_exclude_ids, to_exclude_ids_len);
 
-    result_ids_len = ArrayUtils::exclude_scalar(all_ids, all_ids_length, to_exclude_ids, to_exclude_ids_len, &result_ids);
+    uint32_t* out_ids = nullptr;
+    result_ids_len = ArrayUtils::exclude_scalar(all_ids, all_ids_length, to_exclude_ids, to_exclude_ids_len, &out_ids);
+
+    delete[] result_ids;
+    result_ids = out_ids;
 
     delete[] all_ids;
     delete[] to_exclude_ids;
@@ -1179,6 +1183,8 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
                     uint32_t to_exclude_ids_len = 0;
                     trie->search_equal_to(value, to_exclude_ids, to_exclude_ids_len);
 
+                    delete[] filter_result.docs;
+                    filter_result.docs = nullptr;
                     auto all_ids = index->seq_ids->uncompress();
                     filter_result.count = ArrayUtils::exclude_scalar(all_ids, index->seq_ids->num_ids(),
                                                                      to_exclude_ids, to_exclude_ids_len, &filter_result.docs);
@@ -1336,6 +1342,8 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
                     uint32_t to_exclude_ids_len = 0;
                     trie->search_equal_to(float_int64, to_exclude_ids, to_exclude_ids_len);
 
+                    delete[] filter_result.docs;
+                    filter_result.docs = nullptr;
                     auto all_ids = index->seq_ids->uncompress();
                     filter_result.count = ArrayUtils::exclude_scalar(all_ids, index->seq_ids->num_ids(),
                                                                      to_exclude_ids, to_exclude_ids_len, &filter_result.docs);
@@ -1488,6 +1496,8 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
                     uint32_t to_exclude_ids_len = 0;
                     trie->search_equal_to(bool_int64, to_exclude_ids, to_exclude_ids_len);
 
+                    delete[] filter_result.docs;
+                    filter_result.docs = nullptr;
                     auto all_ids = index->seq_ids->uncompress();
                     filter_result.count = ArrayUtils::exclude_scalar(all_ids, index->seq_ids->num_ids(),
                                                                      to_exclude_ids, to_exclude_ids_len, &filter_result.docs);
@@ -2899,15 +2909,13 @@ void filter_result_iterator_t::compute_iterators() {
 
             for (const auto& list: lists) {
                 if (is_not_equals_comparator) {
-                    std::vector<uint32_t> equals_ids;
-                    list->uncompress(equals_ids);
-
-                    uint32_t* not_equals_ids = nullptr;
-                    auto const not_equals_ids_len = ArrayUtils::exclude_scalar(index->seq_ids->uncompress(), index->seq_ids->num_ids(),
-                                                                               &equals_ids[0], equals_ids.size(),
-                                                                               &not_equals_ids);
+                    auto* not_equals_ids = list->uncompress();
+                    auto not_equals_ids_len = static_cast<uint32_t>(list->num_ids());
+                    apply_not_equals(index->seq_ids->uncompress(), index->seq_ids->num_ids(),
+                                     not_equals_ids, not_equals_ids_len);
 
                     std::copy(not_equals_ids, not_equals_ids + not_equals_ids_len, std::back_inserter(f_id_buff));
+                    delete[] not_equals_ids;
                 } else {
                     list->uncompress(f_id_buff);
                 }

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -270,11 +270,11 @@ void filter_result_iterator_t::and_filter_iterators() {
                 seq_id = right_it->seq_id;
 
                 reference.clear();
-                for (const auto& item: left_it->reference) {
-                    reference[item.first] = item.second;
-                }
-                for (const auto& item: right_it->reference) {
-                    reference[item.first] = item.second;
+                if (!reference_filter_result_t::and_references(left_it->reference, right_it->reference, reference)) {
+                    // No common references found, move the right sub-nodes to the next seq_id.
+                    right_it->next();
+
+                    continue;
                 }
 
                 return;
@@ -293,11 +293,11 @@ void filter_result_iterator_t::and_filter_iterators() {
                 seq_id = left_it->seq_id;
 
                 reference.clear();
-                for (const auto& item: left_it->reference) {
-                    reference[item.first] = item.second;
-                }
-                for (const auto& item: right_it->reference) {
-                    reference[item.first] = item.second;
+                if (!reference_filter_result_t::and_references(left_it->reference, right_it->reference, reference)) {
+                    // No common references found, move the left sub-nodes to the next seq_id.
+                    left_it->next();
+
+                    continue;
                 }
 
                 return;
@@ -460,25 +460,7 @@ void filter_result_iterator_t::or_filter_iterators() {
 
         seq_id = left_it->seq_id;
         reference.clear();
-
-        for (const auto& item: left_it->reference) {
-            reference[item.first] = item.second;
-        }
-        for (const auto& item: right_it->reference) {
-            auto ref_it = reference.find(item.first);
-            if (ref_it == reference.end()) {
-                reference[item.first] = item.second;
-                continue;
-            }
-
-            // Both the docs of A and B have references to a particular collection.
-            uint32_t* or_result = nullptr;
-            auto& ref_result = ref_it->second;
-            ref_result.count = ArrayUtils::or_scalar(ref_result.docs, ref_result.count,
-                                                     item.second.docs, item.second.count, &or_result);
-            delete [] ref_result.docs;
-            ref_result.docs = or_result;
-        }
+        reference_filter_result_t::or_references(left_it->reference, right_it->reference, reference);
 
         return;
     }
@@ -2757,14 +2739,21 @@ filter_result_iterator_t::filter_result_iterator_t(uint32_t approx_filter_ids_le
 }
 
 filter_result_iterator_t::filter_result_iterator_t(uint32_t* ids, const uint32_t& ids_count, const size_t& max_candidates,
-                                                   uint64_t search_begin, uint64_t search_stop) {
-    filter_result.count = approx_filter_ids_length = ids_count;
-    filter_result.docs = ids;
+                                                   uint64_t search_begin, uint64_t search_stop,
+                                                   std::map<std::string, reference_filter_result_t>* coll_to_references) {
+    filter_result = filter_result_t(ids_count, ids, coll_to_references);
+    approx_filter_ids_length = ids_count;
     validity = ids_count > 0 ? valid : invalid;
 
     if (validity) {
         seq_id = filter_result.docs[result_index];
         is_filter_result_initialized = true;
+        reference.clear();
+        if (filter_result.coll_to_references != nullptr) {
+            auto& ref = filter_result.coll_to_references[result_index];
+            reference.insert(ref.begin(), ref.end());
+        }
+
         filter_node = new filter_node_t(filter{"dummy", {}, {}});
         delete_filter_node = true;
 

--- a/src/housekeeper.cpp
+++ b/src/housekeeper.cpp
@@ -107,13 +107,15 @@ void HouseKeeper::log_running_queries() {
 void HouseKeeper::log_bad_queries() {
     std::unique_lock ifq_lock(ifq_mutex);
 
-    auto now_ts_seconds = std::chrono::duration_cast<std::chrono::seconds>(
+    auto now_ts_us = std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::system_clock::now().time_since_epoch()).count();
+    const auto memory_req_min_age = memory_req_min_age_s.load();
+    const auto long_req_log = long_req_log_s.load();
 
     for(auto& kv: in_flight_queries) {
         auto req_ts = kv.first;
-
-        if(now_ts_seconds - req_ts < memory_req_min_age_s) {
+        uint64_t query_time_elapsed_s = now_ts_us >= req_ts ? (now_ts_us - req_ts) / 1000000 : 0;
+        if(query_time_elapsed_s < memory_req_min_age) {
             // since we use a map it's already ordered ascending on timestamp
             break;
         }
@@ -122,16 +124,23 @@ void HouseKeeper::log_bad_queries() {
             continue;
         }
 
-        // query that's atleast 10 seconds old: check if memory difference exceeds 1 GB
+        // either long running query or exceeding 1 GB of memory
         int64_t memory_req_start = kv.second.active_memory;
         int64_t curr_memory = active_memory_used;
         int64_t memory_diff = curr_memory - memory_req_start;
         const int64_t one_gb = 1073741824;
+        const bool high_memory = memory_diff > one_gb;
+        const bool long_running = query_time_elapsed_s > long_req_log;
 
-        if(memory_diff > one_gb) {
+        if(high_memory || long_running) {
             LOG(INFO) << "Detected bad query, start_ts: " << req_ts << ", memory_diff: " << memory_diff
                       << ", " << get_query_log(kv.second.req);
             kv.second.already_logged = true;
         }
     }
+}
+
+size_t HouseKeeper::get_num_inflight_queries() {
+  std::unique_lock ifq_lock(ifq_mutex);
+  return in_flight_queries.size();
 }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -8427,7 +8427,8 @@ Option<bool> Index::get_related_ids(const std::string& field_name, const std::ve
 
 Option<bool> Index::get_related_ids(const std::string& field_name, const uint32_t& seq_id,
                                     std::vector<uint32_t>& result) const {
-    return get_related_ids(field_name, {seq_id}, result);
+    const std::vector<uint32_t> seq_ids_vec{seq_id};
+    return get_related_ids(field_name, seq_ids_vec, result);
 }
 
 Option<bool> Index::get_object_array_related_id(const std::string& collection_name,

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2825,7 +2825,8 @@ void Index::collate_included_ids(const std::vector<token_t>& q_included_tokens,
             uint32_t inner_pos = index_seq_id.first;
             uint32_t seq_id = index_seq_id.second;
 
-            uint64_t distinct_id = 1;
+            // not grouped curated hits should deduped in a per-document basis in union mode
+            uint64_t distinct_id = (group_limit == 0) ? seq_id : 1;
             if (group_limit != 0) {
                 group_by_field_it_vec = get_group_by_field_iterators(group_by_fields, true);
             }

--- a/src/posting.cpp
+++ b/src/posting.cpp
@@ -440,6 +440,30 @@ void posting_t::to_expanded_plists(const std::vector<void*>& raw_posting_lists, 
     }
 }
 
+posting_list_t* posting_t::to_owned_posting_list(const void* raw_posting_list) {
+    if(raw_posting_list == nullptr) {
+        return nullptr;
+    }
+
+    if(IS_COMPACT_POSTING(raw_posting_list)) {
+        auto compact_posting_list = COMPACT_POSTING_PTR(raw_posting_list);
+        return compact_posting_list->to_full_posting_list();
+    }
+
+    auto source_posting_list = (posting_list_t*)(raw_posting_list);
+    auto owned_posting_list = new posting_list_t(posting_t::MAX_BLOCK_ELEMENTS);
+    auto source_iterator = source_posting_list->new_iterator();
+
+    while(source_iterator.valid()) {
+        std::vector<uint32_t> offsets;
+        posting_list_t::get_offsets(source_iterator, offsets);
+        owned_posting_list->upsert(source_iterator.id(), offsets);
+        source_iterator.next();
+    }
+
+    return owned_posting_list;
+}
+
 void posting_t::destroy_list(void*& obj) {
     if(obj == nullptr) {
         return;

--- a/src/raft_server.cpp
+++ b/src/raft_server.cpp
@@ -1,17 +1,18 @@
-#include "store.h"
 #include "raft_server.h"
-#include <butil/files/file_enumerator.h>
-#include <thread>
-#include <algorithm>
-#include <string_utils.h>
-#include <file_utils.h>
-#include <collection_manager.h>
-#include <http_client.h>
-#include <conversation_model_manager.h>
-#include "rocksdb/utilities/checkpoint.h"
-#include "thread_local_vars.h"
 #include "core_api.h"
 #include "personalization_model_manager.h"
+#include "rocksdb/utilities/checkpoint.h"
+#include "store.h"
+#include "thread_local_vars.h"
+#include <algorithm>
+#include <butil/files/file_enumerator.h>
+#include <collection_manager.h>
+#include <conversation_model_manager.h>
+#include <file_utils.h>
+#include <housekeeper.h>
+#include <http_client.h>
+#include <string_utils.h>
+#include <thread>
 
 namespace braft {
     DECLARE_int32(raft_do_snapshot_min_index_gap);
@@ -756,13 +757,13 @@ void ReplicationState::refresh_nodes(const std::string & nodes, const size_t raf
     node->get_status(&nodeStatus);
 
     LOG(INFO) << "Term: " << nodeStatus.term
-              << ", pending_queue: " << nodeStatus.pending_queue_size
               << ", last_index: " << nodeStatus.last_index
               << ", committed: " << nodeStatus.committed_index
               << ", known_applied: " << nodeStatus.known_applied_index
               << ", applying: " << nodeStatus.applying_index
               << ", pending_writes: " << pending_writes
               << ", queued_writes: " << batched_indexer->get_queued_writes()
+              << ", inflight_searches: " << HouseKeeper::get_instance().get_num_inflight_queries()
               << ", local_sequence: " << store->get_latest_seq_number();
 
     if(node->is_leader()) {

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -24,6 +24,16 @@ Option<uint32_t> validator_t::coerce_element(const field& a_field, nlohmann::jso
             if(!coerce_op.ok()) {
                 return coerce_op;
             }
+        } else {
+            // Bug #2798: JSON integers exceeding int32 range bypass coercion but must still be range-checked
+            int64_t val = doc_ele.get<int64_t>();
+            if(val > INT32_MAX || val < INT32_MIN) {
+                if(a_field.optional && (dirty_values == DIRTY_VALUES::DROP || dirty_values == DIRTY_VALUES::COERCE_OR_DROP)) {
+                    document.erase(field_name);
+                } else {
+                    return Option<>(400, "Field `" + field_name  + "` exceeds maximum value of int32.");
+                }
+            }
         }
     } else if(a_field.type == field_types::INT64) {
         if(!doc_ele.is_number_integer()) {
@@ -128,6 +138,17 @@ Option<uint32_t> validator_t::coerce_element(const field& a_field, nlohmann::jso
                 Option<uint32_t> coerce_op = coerce_int32_t(dirty_values, a_field, document, field_name, it, true, array_ele_erased);
                 if (!coerce_op.ok()) {
                     return coerce_op;
+                }
+            } else if (a_field.type == field_types::INT32_ARRAY && item.is_number_integer()) {
+                // Bug #2798: range-check integer array elements that bypass coercion
+                int64_t val = item.get<int64_t>();
+                if(val > INT32_MAX || val < INT32_MIN) {
+                    if(a_field.optional && (dirty_values == DIRTY_VALUES::DROP || dirty_values == DIRTY_VALUES::COERCE_OR_DROP)) {
+                        it = document[field_name].erase(it);
+                        array_ele_erased = true;
+                    } else {
+                        return Option<>(400, "Field `" + field_name  + "` exceeds maximum value of int32.");
+                    }
                 }
             } else if (a_field.type == field_types::INT64_ARRAY && !item.is_number_integer()) {
                 Option<uint32_t> coerce_op = coerce_int64_t(dirty_values, a_field, document, field_name, it, true, array_ele_erased);
@@ -320,7 +341,8 @@ Option<uint32_t> validator_t::coerce_int32_t(const DIRTY_VALUES& dirty_values, c
         }
     }
 
-    if(document.contains(field_name) && document[field_name].get<int64_t>() > INT32_MAX) {
+    if(document.contains(field_name) &&
+       (document[field_name].get<int64_t>() > INT32_MAX || document[field_name].get<int64_t>() < INT32_MIN)) {
         if(a_field.optional && (dirty_values == DIRTY_VALUES::DROP || dirty_values == DIRTY_VALUES::COERCE_OR_REJECT)) {
             document.erase(field_name);
         } else {

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -31,7 +31,7 @@ Option<uint32_t> validator_t::coerce_element(const field& a_field, nlohmann::jso
                 if(a_field.optional && (dirty_values == DIRTY_VALUES::DROP || dirty_values == DIRTY_VALUES::COERCE_OR_DROP)) {
                     document.erase(field_name);
                 } else {
-                    return Option<>(400, "Field `" + field_name  + "` exceeds maximum value of int32.");
+                    return Option<>(400, "Field `" + field_name  + "` is outside the range of int32.");
                 }
             }
         }
@@ -147,7 +147,7 @@ Option<uint32_t> validator_t::coerce_element(const field& a_field, nlohmann::jso
                         it = document[field_name].erase(it);
                         array_ele_erased = true;
                     } else {
-                        return Option<>(400, "Field `" + field_name  + "` exceeds maximum value of int32.");
+                        return Option<>(400, "Field `" + field_name  + "` is outside the range of int32.");
                     }
                 }
             } else if (a_field.type == field_types::INT64_ARRAY && !item.is_number_integer()) {
@@ -341,12 +341,13 @@ Option<uint32_t> validator_t::coerce_int32_t(const DIRTY_VALUES& dirty_values, c
         }
     }
 
-    if(document.contains(field_name) &&
-       (document[field_name].get<int64_t>() > INT32_MAX || document[field_name].get<int64_t>() < INT32_MIN)) {
-        if(a_field.optional && (dirty_values == DIRTY_VALUES::DROP || dirty_values == DIRTY_VALUES::COERCE_OR_REJECT)) {
-            document.erase(field_name);
+    auto it_field = document.find(field_name);
+    if(it_field != document.end() &&
+       (it_field.value().get<int64_t>() > INT32_MAX || it_field.value().get<int64_t>() < INT32_MIN)) {
+        if(a_field.optional && (dirty_values == DIRTY_VALUES::DROP || dirty_values == DIRTY_VALUES::COERCE_OR_DROP)) {
+            document.erase(it_field);
         } else {
-            return Option<>(400, "Field `" + field_name  + "` exceeds maximum value of int32.");
+            return Option<>(400, "Field `" + field_name  + "` is outside the range of int32.");
         }
     }
 

--- a/test/collection_curation_test.cpp
+++ b/test/collection_curation_test.cpp
@@ -5630,6 +5630,84 @@ TEST_F(CollectionCurationTest, DiversityOverrideParsing) {
     ASSERT_EQ(1, curation.rule.tags.size());
     ASSERT_EQ("screen_pattern_rule", *curation.rule.tags.begin());
     ASSERT_EQ(4, curation.diversity.similarity_equation.size());
+
+    //diversity weights should accept only numbers
+    json = R"({
+                  "diversity": {
+                    "similarity_metric": [
+                      {
+                        "field": "flow_id",
+                        "method": "equality",
+                        "weight": 6
+                      }
+                    ]
+                  }
+    })"_json;
+
+    diversity_t diversity2;
+    op = diversity_t::parse(json, diversity2);
+    ASSERT_TRUE(op.ok());
+
+    json = R"({
+                  "diversity": {
+                    "similarity_metric": [
+                      {
+                        "field": "flow_id",
+                        "method": "equality",
+                        "weight": "6"
+                      }
+                    ]
+                  }
+    })"_json;
+
+    op = diversity_t::parse(json, diversity2);
+    ASSERT_FALSE(op.ok());
+
+    diversity_t diversity3;
+    json = R"({
+                  "diversity": {
+                    "similarity_metric": [
+                      {
+                        "field": "flow_id",
+                        "method": "equality",
+                        "weight": "true"
+                      }
+                    ]
+                  }
+    })"_json;
+
+    op = diversity_t::parse(json, diversity3);
+    ASSERT_FALSE(op.ok());
+
+    json = R"({
+                  "diversity": {
+                    "similarity_metric": [
+                      {
+                        "field": "flow_id",
+                        "method": "equality",
+                        "weight": true
+                      }
+                    ]
+                  }
+    })"_json;
+
+    op = diversity_t::parse(json, diversity3);
+    ASSERT_FALSE(op.ok());
+
+    json = R"({
+                  "diversity": {
+                    "similarity_metric": [
+                      {
+                        "field": "flow_id",
+                        "method": "equality",
+                        "weight": "32.1244, 25.1242"
+                      }
+                    ]
+                  }
+    })"_json;
+
+    op = diversity_t::parse(json, diversity3);
+    ASSERT_FALSE(op.ok());
 }
 
 TEST_F(CollectionCurationTest, DiversityOverride) {

--- a/test/collection_curation_test.cpp
+++ b/test/collection_curation_test.cpp
@@ -6174,6 +6174,93 @@ TEST_F(CollectionCurationTest, SynonymsMatchWithCuration) {
     ASSERT_EQ("6", results["hits"][1]["document"]["id"].get<std::string>());
 }
 
+TEST_F(CollectionCurationTest, ToJsonSerializesSynonymsStemFields) {
+    // curation with synonyms + stem + stemming_dictionary
+    std::vector<std::string> json_lines;
+    json_lines.push_back(R"({"word": "shoes", "root": "shoe"})");
+    ASSERT_TRUE(stemmerManager.upsert_stemming_dictionary("test-dict", json_lines).ok());
+
+    nlohmann::json curation_json = R"({
+        "id": "test-all-fields",
+        "rule": {
+            "query": "running shoes",
+            "match": "exact",
+            "synonyms": true,
+            "stem": true,
+            "stemming_dictionary": "test-dict"
+        },
+        "includes": [{"id": "0", "position": 1}]
+    })"_json;
+
+    curation_t curation;
+    auto parse_op = curation_t::parse(curation_json, "test-all-fields", curation);
+    ASSERT_TRUE(parse_op.ok());
+
+    nlohmann::json serialized = curation.to_json();
+    ASSERT_TRUE(serialized["rule"]["synonyms"].get<bool>());
+    ASSERT_TRUE(serialized["rule"]["stem"].get<bool>());
+    ASSERT_EQ("test-dict", serialized["rule"]["stemming_dictionary"].get<std::string>());
+
+    // curation with only synonyms (no stem)
+    curation_json = R"({
+        "id": "test-synonyms-only",
+        "rule": {
+            "query": "sneakers",
+            "match": "exact",
+            "synonyms": true
+        },
+        "includes": [{"id": "0", "position": 1}]
+    })"_json;
+
+    curation_t curation2;
+    parse_op = curation_t::parse(curation_json, "test-synonyms-only", curation2);
+    ASSERT_TRUE(parse_op.ok());
+
+    serialized = curation2.to_json();
+    ASSERT_TRUE(serialized["rule"]["synonyms"].get<bool>());
+    ASSERT_FALSE(serialized["rule"]["stem"].get<bool>());
+    ASSERT_EQ(0, serialized["rule"].count("stemming_dictionary"));
+
+    // curation with only stem (no synonyms, no dictionary)
+    curation_json = R"({
+        "id": "test-stem-only",
+        "rule": {
+            "query": "walking",
+            "match": "exact",
+            "stem": true
+        },
+        "includes": [{"id": "0", "position": 1}]
+    })"_json;
+
+    curation_t curation3;
+    parse_op = curation_t::parse(curation_json, "test-stem-only", curation3);
+    ASSERT_TRUE(parse_op.ok());
+
+    serialized = curation3.to_json();
+    ASSERT_FALSE(serialized["rule"]["synonyms"].get<bool>());
+    ASSERT_TRUE(serialized["rule"]["stem"].get<bool>());
+    ASSERT_EQ(0, serialized["rule"].count("stemming_dictionary"));
+
+    // curation with neither synonyms nor stem (defaults)
+    curation_json = R"({
+        "id": "test-defaults",
+        "rule": {
+            "query": "boots",
+            "match": "exact"
+        },
+        "includes": [{"id": "0", "position": 1}]
+    })"_json;
+
+    curation_t curation4;
+    parse_op = curation_t::parse(curation_json, "test-defaults", curation4);
+    ASSERT_TRUE(parse_op.ok());
+
+    serialized = curation4.to_json();
+    ASSERT_FALSE(serialized["rule"]["synonyms"].get<bool>());
+    ASSERT_FALSE(serialized["rule"]["stem"].get<bool>());
+    ASSERT_EQ(0, serialized["rule"].count("stemming_dictionary"));
+}
+
 TEST_F(CollectionCurationTest, OverridesWithRerankHybridSearches) {
     auto& ov_manager = CurationIndexManager::get_instance();
     nlohmann::json schema = R"({

--- a/test/collection_faceting_test.cpp
+++ b/test/collection_faceting_test.cpp
@@ -4042,3 +4042,79 @@ TEST_F(CollectionFacetingTest, FacetSearchWithFieldLevelSymbolsToIndex) {
     collectionManager.drop_collection("test2");
 
 }
+
+TEST_F(CollectionFacetingTest, FacetByReferenceWithJoinFilter) {
+    auto clients_schema = R"({
+        "name": "clients",
+        "fields": [
+            {"name": "name", "type": "string", "facet": true}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(clients_schema);
+    ASSERT_TRUE(create_op.ok());
+    ASSERT_TRUE(create_op.get()->add(R"({
+        "id": "client_1",
+        "name": "Acme Corp"
+    })").ok());
+
+    auto reports_schema = R"({
+        "name": "reports",
+        "fields": [
+            {"name": "organization_uid", "type": "string", "facet": true},
+            {"name": "client_id", "type": "string", "reference": "clients.id"}
+        ]
+    })"_json;
+
+    create_op = collectionManager.create_collection(reports_schema);
+    ASSERT_TRUE(create_op.ok());
+    ASSERT_TRUE(create_op.get()->add(R"({
+        "id": "report_1",
+        "organization_uid": "org_1",
+        "client_id": "client_1"
+    })").ok());
+
+    auto versions_schema = R"({
+        "name": "versions",
+        "fields": [
+            {"name": "report_id", "type": "string", "reference": "reports.id"},
+            {"name": "is_latest", "type": "bool", "facet": true}
+        ]
+    })"_json;
+
+    create_op = collectionManager.create_collection(versions_schema);
+    ASSERT_TRUE(create_op.ok());
+    ASSERT_TRUE(create_op.get()->add(R"({
+        "id": "version_1",
+        "report_id": "report_1",
+        "is_latest": true
+    })").ok());
+
+    std::map<std::string, std::string> req_params = {
+        {"collection", "reports"},
+        {"q", "*"},
+        {"filter_by", "organization_uid:=org_1 && $versions(is_latest:=true)"},
+        {"facet_by", "$clients(name)"},
+        {"max_facet_values", "1000"},
+        {"per_page", "0"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    auto result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, result["found"]);
+    ASSERT_EQ(1, result["facet_counts"].size());
+    ASSERT_EQ("$clients(name)", result["facet_counts"][0]["field_name"].get<std::string>());
+    ASSERT_EQ(1, result["facet_counts"][0]["counts"].size());
+    ASSERT_EQ("Acme Corp", result["facet_counts"][0]["counts"][0]["value"].get<std::string>());
+    ASSERT_EQ(1, static_cast<int>(result["facet_counts"][0]["counts"][0]["count"]));
+
+    collectionManager.drop_collection("versions");
+    collectionManager.drop_collection("reports");
+    collectionManager.drop_collection("clients");
+}

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -12164,3 +12164,58 @@ TEST_F(CollectionJoinTest, FixReferencesAtQueryTime) {
     ASSERT_EQ("0", res_obj["hits"][4]["document"]["id"]);
     ASSERT_EQ("0", res_obj["hits"][4]["document"]["Products"]["id"]);
 }
+
+TEST_F(CollectionJoinTest, MultipleJoinsSameCollection) {
+    auto products_schema_json =
+            R"({
+                "name": "Products",
+                "fields": [
+                    {"name": "product_id", "type": "string"},
+                    {"name": "product_name", "type": "string"}
+                ]
+            })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(products_schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto products_collection = collection_create_op.get();
+
+    for (size_t i = 0; i < 5; i++) {
+        nlohmann::json product_doc;
+        product_doc["product_id"] = "product_" + std::to_string(i);
+        product_doc["product_name"] = "item " + std::to_string(i);
+        ASSERT_TRUE(products_collection->add(product_doc.dump()).ok());
+    }
+
+    auto customers_schema_json =
+            R"({
+                "name": "Customers",
+                "fields": [
+                    {"name": "customer_id", "type": "string"},
+                    {"name": "product_price", "type": "float"},
+                    {"name": "product_id", "type": "string", "reference": "Products.product_id"}
+                ]
+            })"_json;
+
+    collection_create_op = collectionManager.create_collection(customers_schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto customers_collection = collection_create_op.get();
+
+    for (size_t i = 0; i < 5; i++) {
+        nlohmann::json customer_doc;
+        customer_doc["customer_id"] = "customer_" + std::to_string(i);
+        customer_doc["product_id"] = "product_" + std::to_string(i);
+        customer_doc["product_price"] = (i >= 2) ? 50.0 + i : 150.0 + i;
+        ASSERT_TRUE(customers_collection->add(customer_doc.dump()).ok());
+    }
+
+    const std::string filter_query = "$Customers(id:*) && $Customers(product_price:<100)";
+
+    auto result = products_collection->search("item", {"product_name"}, filter_query, {}, {}, {0},
+                                              10, 1, FREQUENCY, {true}, Index::DROP_TOKENS_THRESHOLD).get();
+
+    ASSERT_EQ(3, result["found"].get<size_t>());
+    ASSERT_EQ(3, result["hits"].size());
+
+    collectionManager.drop_collection("Customers");
+    collectionManager.drop_collection("Products");
+}

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <fstream>
 #include <algorithm>
+#include <chrono>
 #include <collection_manager.h>
 #include "collection.h"
 #include "synonym_index.h"
@@ -4202,4 +4203,287 @@ TEST_F(CollectionSpecificMoreTest, NestedFieldSingleTokenSnippetTruncation) {
         << " chars. This indicates the bug where full text is included.";
     
     collectionManager.drop_collection("coll1");
+}
+
+TEST_F(CollectionSpecificMoreTest, WildcardAndKeywordLazyNumericNotEqualsShouldMatchFilteredResults) {
+    std::vector<field> fields = {
+        field("title", field_types::STRING, false),
+        field("product_site", field_types::INT32, false),
+        field("product_store", field_types::INT32, false),
+        field("product_publish_date_timestamp", field_types::INT64, false)
+    };
+    const std::string collection_name = "coll_lazy_numeric_not_equals_combined";
+    Collection* coll = collectionManager.create_collection(collection_name, 1, fields).get();
+
+    for (size_t i = 0; i < 4000; i++) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["title"] = "item " + std::to_string(i);
+        doc["product_site"] = 2;
+        doc["product_store"] = i;
+        doc["product_publish_date_timestamp"] = 1770866200;
+        ASSERT_TRUE(coll->add(doc.dump()).ok());
+    }
+
+    const std::string filter_query =
+        "product_site:2"
+        " && product_store:!=1"
+        " && product_store:!=2"
+        " && product_store:!=3"
+        " && product_store:!=4"
+        " && product_store:!=5"
+        " && product_store:!=6"
+        " && product_store:!=7"
+        " && product_store:!=8"
+        " && product_store:!=9"
+        " && product_store:!=10"
+        " && product_store:!=11"
+        " && product_publish_date_timestamp:<=1770866269";
+
+    auto run_query = [&](const std::string& query, size_t repeats, bool add_sort_by) {
+        std::map<std::string, std::string> req_params = {
+            {"collection", collection_name},
+            {"q", query},
+            {"query_by", "title"},
+            {"filter_by", filter_query},
+            {"enable_lazy_filter", "true"}
+        };
+        if (add_sort_by) {
+            req_params["sort_by"] = "product_publish_date_timestamp:desc";
+        }
+
+        for (size_t i = 0; i < repeats; i++) {
+            nlohmann::json embedded_params;
+            std::string json_res;
+            auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+
+            auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+            ASSERT_TRUE(search_op.ok());
+
+            auto res_obj = nlohmann::json::parse(json_res);
+            ASSERT_EQ(3989, res_obj["found"].get<size_t>());
+        }
+    };
+
+    run_query("*", 1, true);
+    run_query("item", 10, false);
+
+    collectionManager.drop_collection(collection_name);
+}
+
+TEST_F(CollectionSpecificMoreTest, ConjunctiveNumericNotEqualsShouldMatchExpectedResults) {
+    std::vector<field> fields = {
+        field("title", field_types::STRING, false),
+        field("product_site", field_types::INT32, false),
+        field("product_store", field_types::INT32, false),
+        field("product_publish_date_timestamp", field_types::INT64, false)
+    };
+    const std::string collection_name = "coll_conjunctive_numeric_not_equals";
+    Collection* coll = collectionManager.create_collection(collection_name, 1, fields).get();
+
+    const std::vector<uint32_t> excluded_values = {
+        34672, 864, 25189, 15209, 25063, 33856, 35174, 34832, 38054, 5088, 33816
+    };
+
+    size_t doc_id = 0;
+    for (size_t i = 0; i < 4000; i++, doc_id++) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(doc_id);
+        doc["title"] = "item " + std::to_string(doc_id);
+        doc["product_site"] = 2;
+        doc["product_store"] = i;
+        doc["product_publish_date_timestamp"] = 1770866200;
+        ASSERT_TRUE(coll->add(doc.dump()).ok());
+    }
+
+    for (auto value : excluded_values) {
+        if (value < 4000) {
+            continue;
+        }
+        nlohmann::json doc;
+        doc["id"] = std::to_string(doc_id++);
+        doc["title"] = "item " + std::to_string(doc_id);
+        doc["product_site"] = 2;
+        doc["product_store"] = value;
+        doc["product_publish_date_timestamp"] = 1770866200;
+        ASSERT_TRUE(coll->add(doc.dump()).ok());
+    }
+
+    const std::string filter_query =
+        "product_site : 2"
+        " && product_store :!= 34672"
+        " && product_store :!= 864"
+        " && product_store :!= 25189"
+        " && product_store :!= 15209"
+        " && product_store :!= 25063"
+        " && product_store :!= 33856"
+        " && product_store :!= 35174"
+        " && product_store :!= 34832"
+        " && product_store :!= 38054"
+        " && product_store :!= 5088"
+        " && product_store :!= 33816"
+        " && product_publish_date_timestamp :<= 1770866269";
+
+    const size_t expected_found = (doc_id - excluded_values.size());
+
+    auto run_query = [&](const std::string& query, size_t repeats, bool add_sort_by) {
+        std::map<std::string, std::string> req_params = {
+            {"collection", collection_name},
+            {"q", query},
+            {"query_by", "title"},
+            {"filter_by", filter_query},
+            {"enable_lazy_filter", "true"}
+        };
+        if (add_sort_by) {
+            req_params["sort_by"] = "product_publish_date_timestamp:desc";
+        }
+
+        for (size_t i = 0; i < repeats; i++) {
+            nlohmann::json embedded_params;
+            std::string json_res;
+            auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+
+            auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+            ASSERT_TRUE(search_op.ok());
+
+            auto res_obj = nlohmann::json::parse(json_res);
+            ASSERT_EQ(expected_found, res_obj["found"].get<size_t>());
+        }
+    };
+
+    run_query("*", 1, true);
+    run_query("item", 10, false);
+
+    collectionManager.drop_collection(collection_name);
+}
+
+TEST_F(CollectionSpecificMoreTest, ExplicitNotEqualsListOnNonRangeIntegerShouldMatchAllDocs) {
+    std::vector<field> fields = {
+        field("title", field_types::STRING, false),
+        field("price", field_types::INT32, false)
+    };
+    const std::string collection_name = "coll_non_range_int_not_equals_list";
+    Collection* coll = collectionManager.create_collection(collection_name, 1, fields).get();
+
+    const size_t num_docs = 3000;
+    for (size_t i = 0; i < num_docs; i++) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["title"] = "item " + std::to_string(i);
+        doc["price"] = i;
+        ASSERT_TRUE(coll->add(doc.dump()).ok());
+    }
+
+    const std::string filter_query = "price:[!=100000, !=100001, !=100002, !=100003, !=100004]";
+
+    std::map<std::string, std::string> req_params = {
+        {"collection", collection_name},
+        {"q", "*"},
+        {"query_by", "title"},
+        {"filter_by", filter_query},
+        {"enable_lazy_filter", "false"}
+    };
+
+    for (size_t i = 0; i < 10; i++) {
+        nlohmann::json embedded_params;
+        std::string json_res;
+        auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+        auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+        ASSERT_TRUE(search_op.ok());
+
+        auto res_obj = nlohmann::json::parse(json_res);
+        ASSERT_EQ(num_docs, res_obj["found"].get<size_t>());
+    }
+
+    collectionManager.drop_collection(collection_name);
+}
+
+TEST_F(CollectionSpecificMoreTest, ExplicitNotEqualsListOnRangeIndexedIntegerShouldMatchAllDocs) {
+    std::vector<field> fields = {
+        field("title", field_types::STRING, false),
+        field("price", field_types::INT32, false, true)
+    };
+    const std::string collection_name = "coll_range_int_not_equals_list";
+    Collection* coll = collectionManager.create_collection(collection_name, 1, fields).get();
+
+    const size_t num_docs = 3000;
+    for (size_t i = 0; i < num_docs; i++) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["title"] = "item " + std::to_string(i);
+        doc["price"] = i;
+        ASSERT_TRUE(coll->add(doc.dump()).ok());
+    }
+
+    const std::string filter_query = "price:[!=100000, !=100001, !=100002, !=100003, !=100004]";
+
+    std::map<std::string, std::string> req_params = {
+        {"collection", collection_name},
+        {"q", "*"},
+        {"query_by", "title"},
+        {"filter_by", filter_query},
+        {"enable_lazy_filter", "false"}
+    };
+
+    for (size_t i = 0; i < 10; i++) {
+        nlohmann::json embedded_params;
+        std::string json_res;
+        auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+        auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+        ASSERT_TRUE(search_op.ok());
+
+        auto res_obj = nlohmann::json::parse(json_res);
+        ASSERT_EQ(num_docs, res_obj["found"].get<size_t>());
+    }
+
+    collectionManager.drop_collection(collection_name);
+}
+
+TEST_F(CollectionSpecificMoreTest, ExplicitNotEqualsListOnRangeIndexedFloatShouldMatchAllDocs) {
+    std::vector<field> fields = {
+        field("title", field_types::STRING, false),
+        field("rating", field_types::FLOAT, false, true)
+    };
+    const std::string collection_name = "coll_range_float_not_equals_list";
+    Collection* coll = collectionManager.create_collection(collection_name, 1, fields).get();
+
+    const size_t num_docs = 3000;
+    for (size_t i = 0; i < num_docs; i++) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["title"] = "item " + std::to_string(i);
+        doc["rating"] = static_cast<float>(i) + 0.25f;
+        ASSERT_TRUE(coll->add(doc.dump()).ok());
+    }
+
+    const std::string filter_query = "rating:[!=100000.1, !=100001.1, !=100002.1, !=100003.1, !=100004.1]";
+
+    std::map<std::string, std::string> req_params = {
+        {"collection", collection_name},
+        {"q", "*"},
+        {"query_by", "title"},
+        {"filter_by", filter_query},
+        {"enable_lazy_filter", "false"}
+    };
+
+    for (size_t i = 0; i < 10; i++) {
+        nlohmann::json embedded_params;
+        std::string json_res;
+        auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+        auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+        ASSERT_TRUE(search_op.ok());
+
+        auto res_obj = nlohmann::json::parse(json_res);
+        ASSERT_EQ(num_docs, res_obj["found"].get<size_t>());
+    }
+
+    collectionManager.drop_collection(collection_name);
 }

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -3817,6 +3817,30 @@ TEST_F(CollectionSpecificMoreTest, PhraseQueryHighlightingShouldNotHighlightPart
     collectionManager.drop_collection("coll1");
 }
 
+TEST_F(CollectionSpecificMoreTest, SingleTokenPhraseQueryShouldHighlightExactMatch) {
+    std::vector<field> fields = {field("speechText", field_types::STRING, false)};
+    Collection* coll1 = collectionManager.create_collection("single_token_phrase_highlight", 1, fields).get();
+
+    nlohmann::json doc1;
+    doc1["id"] = "1";
+    doc1["speechText"] = "AddLife";
+    ASSERT_TRUE(coll1->add(doc1.dump()).ok());
+
+    auto results = coll1->search("\"addlife\"", {"speechText"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, 0,
+                                 spp::sparse_hash_set<std::string>(),
+                                 spp::sparse_hash_set<std::string>(), 10, "", 30, 4, "speechText", 20, {}, {}, {}, 0,
+                                 "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7,
+                                 fallback, 1000).get();
+
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_EQ(1, results["hits"][0]["highlights"].size());
+    ASSERT_EQ("speechText", results["hits"][0]["highlights"][0]["field"].get<std::string>());
+    ASSERT_EQ("<mark>AddLife</mark>", results["hits"][0]["highlights"][0]["snippet"].get<std::string>());
+
+    collectionManager.drop_collection("single_token_phrase_highlight");
+}
+
 TEST_F(CollectionSpecificMoreTest, PhraseQueryHighlightingInNestedFields) {
     nlohmann::json schema = R"({
         "name": "coll1",

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -5611,3 +5611,141 @@ TEST_F(CollectionTest, PerFieldTokenSeparatorsAndSymbolsToIndex) {
     collectionManager.drop_collection("users_1");
     collectionManager.drop_collection("users_2");
 }
+
+// Bug #2798: int32 fields accept values exceeding INT32_MAX on write but reject them on search/filter.
+// The fix validates int32 range at write time, rejecting values outside [-2147483648, 2147483647].
+TEST_F(CollectionTest, Int32FieldRejectsOverflowOnWrite) {
+    Collection* coll;
+    std::vector<field> fields = {
+        field("title", field_types::STRING, false),
+        field("value", field_types::INT32, false)
+    };
+
+    coll = collectionManager.get_collection("int32_overflow_test").get();
+    if (coll == nullptr) {
+        coll = collectionManager.create_collection("int32_overflow_test", 1, fields).get();
+    }
+
+    // Valid int32 values should be accepted
+    nlohmann::json doc;
+    doc["title"] = "valid max";
+    doc["value"] = INT32_MAX;
+    auto add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_TRUE(add_op.ok());
+
+    doc["title"] = "valid min";
+    doc["value"] = INT32_MIN;
+    add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_TRUE(add_op.ok());
+
+    doc["title"] = "valid zero";
+    doc["value"] = 0;
+    add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_TRUE(add_op.ok());
+
+    // Value exceeding INT32_MAX should be rejected
+    doc["title"] = "overflow positive";
+    doc["value"] = (int64_t)INT32_MAX + 1;
+    add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_FALSE(add_op.ok());
+    ASSERT_EQ(400, add_op.code());
+    ASSERT_EQ("Field `value` exceeds maximum value of int32.", add_op.error());
+
+    // Large positive value (millisecond timestamp) should be rejected
+    doc["title"] = "millisecond timestamp";
+    doc["value"] = 1740000000000LL;
+    add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_FALSE(add_op.ok());
+    ASSERT_EQ(400, add_op.code());
+    ASSERT_EQ("Field `value` exceeds maximum value of int32.", add_op.error());
+
+    // Value below INT32_MIN should be rejected
+    doc["title"] = "overflow negative";
+    doc["value"] = (int64_t)INT32_MIN - 1;
+    add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_FALSE(add_op.ok());
+    ASSERT_EQ(400, add_op.code());
+    ASSERT_EQ("Field `value` exceeds maximum value of int32.", add_op.error());
+
+    collectionManager.drop_collection("int32_overflow_test");
+}
+
+TEST_F(CollectionTest, Int32ArrayFieldRejectsOverflowOnWrite) {
+    Collection* coll;
+    std::vector<field> fields = {
+        field("title", field_types::STRING, false),
+        field("values", field_types::INT32_ARRAY, false)
+    };
+
+    coll = collectionManager.get_collection("int32_arr_overflow_test").get();
+    if (coll == nullptr) {
+        coll = collectionManager.create_collection("int32_arr_overflow_test", 1, fields).get();
+    }
+
+    // Valid int32 array should be accepted
+    nlohmann::json doc;
+    doc["title"] = "valid array";
+    doc["values"] = {0, INT32_MAX, INT32_MIN, 100, -100};
+    auto add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_TRUE(add_op.ok());
+
+    // Array with one overflowed element should be rejected
+    doc["title"] = "overflow in array";
+    doc["values"] = {100, (int64_t)INT32_MAX + 1, 200};
+    add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_FALSE(add_op.ok());
+    ASSERT_EQ(400, add_op.code());
+    ASSERT_EQ("Field `values` exceeds maximum value of int32.", add_op.error());
+
+    // Array with negative overflow should be rejected
+    doc["title"] = "negative overflow in array";
+    doc["values"] = {100, (int64_t)INT32_MIN - 1};
+    add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_FALSE(add_op.ok());
+    ASSERT_EQ(400, add_op.code());
+    ASSERT_EQ("Field `values` exceeds maximum value of int32.", add_op.error());
+
+    collectionManager.drop_collection("int32_arr_overflow_test");
+}
+
+TEST_F(CollectionTest, Int32OverflowWithDirtyValuesDropOptional) {
+    Collection* coll;
+    std::vector<field> fields = {
+        field("title", field_types::STRING, false),
+        field("value", field_types::INT32, false, true)  // facet=false, optional=true
+    };
+
+    coll = collectionManager.get_collection("int32_drop_test").get();
+    if (coll == nullptr) {
+        coll = collectionManager.create_collection("int32_drop_test", 1, fields).get();
+    }
+
+    // Optional field with DROP should silently drop overflowed value
+    nlohmann::json doc;
+    doc["title"] = "dropped overflow";
+    doc["value"] = 1740000000000LL;
+    auto add_op = coll->add(doc.dump(), CREATE, "", DIRTY_VALUES::DROP);
+    ASSERT_TRUE(add_op.ok());
+
+    // Verify the document was indexed but without the overflowed field
+    std::vector<sort_by> test_sort = { sort_by(sort_field_const::text_match, "DESC") };
+    auto results = coll->search("dropped overflow", {"title"}, "", {}, test_sort, {0}, 10).get();
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_FALSE(results["hits"][0]["document"].contains("value"));
+
+    // Non-optional field with DROP should still reject
+    collectionManager.drop_collection("int32_drop_test");
+
+    std::vector<field> fields2 = {
+        field("title", field_types::STRING, false),
+        field("value", field_types::INT32, false)  // non-optional
+    };
+    coll = collectionManager.create_collection("int32_drop_test", 1, fields2).get();
+
+    doc["title"] = "rejected overflow";
+    doc["value"] = 1740000000000LL;
+    add_op = coll->add(doc.dump(), CREATE, "", DIRTY_VALUES::DROP);
+    ASSERT_FALSE(add_op.ok());
+
+    collectionManager.drop_collection("int32_drop_test");
+}

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -5649,7 +5649,7 @@ TEST_F(CollectionTest, Int32FieldRejectsOverflowOnWrite) {
     add_op = coll->add(doc.dump(), CREATE);
     ASSERT_FALSE(add_op.ok());
     ASSERT_EQ(400, add_op.code());
-    ASSERT_EQ("Field `value` exceeds maximum value of int32.", add_op.error());
+    ASSERT_EQ("Field `value` is outside the range of int32.", add_op.error());
 
     // Large positive value (millisecond timestamp) should be rejected
     doc["title"] = "millisecond timestamp";
@@ -5657,7 +5657,7 @@ TEST_F(CollectionTest, Int32FieldRejectsOverflowOnWrite) {
     add_op = coll->add(doc.dump(), CREATE);
     ASSERT_FALSE(add_op.ok());
     ASSERT_EQ(400, add_op.code());
-    ASSERT_EQ("Field `value` exceeds maximum value of int32.", add_op.error());
+    ASSERT_EQ("Field `value` is outside the range of int32.", add_op.error());
 
     // Value below INT32_MIN should be rejected
     doc["title"] = "overflow negative";
@@ -5665,7 +5665,7 @@ TEST_F(CollectionTest, Int32FieldRejectsOverflowOnWrite) {
     add_op = coll->add(doc.dump(), CREATE);
     ASSERT_FALSE(add_op.ok());
     ASSERT_EQ(400, add_op.code());
-    ASSERT_EQ("Field `value` exceeds maximum value of int32.", add_op.error());
+    ASSERT_EQ("Field `value` is outside the range of int32.", add_op.error());
 
     collectionManager.drop_collection("int32_overflow_test");
 }
@@ -5695,7 +5695,7 @@ TEST_F(CollectionTest, Int32ArrayFieldRejectsOverflowOnWrite) {
     add_op = coll->add(doc.dump(), CREATE);
     ASSERT_FALSE(add_op.ok());
     ASSERT_EQ(400, add_op.code());
-    ASSERT_EQ("Field `values` exceeds maximum value of int32.", add_op.error());
+    ASSERT_EQ("Field `values` is outside the range of int32.", add_op.error());
 
     // Array with negative overflow should be rejected
     doc["title"] = "negative overflow in array";
@@ -5703,7 +5703,7 @@ TEST_F(CollectionTest, Int32ArrayFieldRejectsOverflowOnWrite) {
     add_op = coll->add(doc.dump(), CREATE);
     ASSERT_FALSE(add_op.ok());
     ASSERT_EQ(400, add_op.code());
-    ASSERT_EQ("Field `values` exceeds maximum value of int32.", add_op.error());
+    ASSERT_EQ("Field `values` is outside the range of int32.", add_op.error());
 
     collectionManager.drop_collection("int32_arr_overflow_test");
 }

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -2082,7 +2082,9 @@ TEST_F(CoreAPIUtilsTest, OverridesPagination) {
                         "remove_matched_tokens":false,
                         "rule":{
                                 "match":"exact",
-                                "query":"not-found"
+                                "query":"not-found",
+                                "stem":false,
+                                "synonyms":false
                         },
                         "stop_processing":true
                     }])"_json;

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -284,7 +284,7 @@ TEST_F(CoreAPIUtilsTest, MultiSearchEmbeddedKeys) {
     // try setting max search limit
     req->embedded_params_vec[0]["limit_multi_searches"] = 0;
     ASSERT_FALSE(post_multi_search(req, res));
-    ASSERT_EQ("{\"message\": \"Number of multi searches exceeds `limit_multi_searches` parameter.\"}", res->body);
+    ASSERT_EQ("{\"message\":\"Number of multi searches exceeds `limit_multi_searches` parameter.\"}", res->body);
 
     req->embedded_params_vec[0]["limit_multi_searches"] = 1;
     ASSERT_TRUE(post_multi_search(req, res));
@@ -293,7 +293,7 @@ TEST_F(CoreAPIUtilsTest, MultiSearchEmbeddedKeys) {
     req->embedded_params_vec[0]["limit_multi_searches"] = 0;
     req->params["limit_multi_searches"] = "100";
     ASSERT_FALSE(post_multi_search(req, res));
-    ASSERT_EQ("{\"message\": \"Number of multi searches exceeds `limit_multi_searches` parameter.\"}", res->body);
+    ASSERT_EQ("{\"message\":\"Number of multi searches exceeds `limit_multi_searches` parameter.\"}", res->body);
 
     // use req params if embedded param not present
     req->embedded_params_vec[0].erase("limit_multi_searches");
@@ -2021,14 +2021,14 @@ TEST_F(CoreAPIUtilsTest, CollectionsPagination) {
     get_collections(req, resp);
 
     ASSERT_EQ(400, resp->status_code);
-    ASSERT_EQ("{\"message\": \"Offset param should be unsigned integer.\"}", resp->body);
+    ASSERT_EQ("{\"message\":\"Offset param should be unsigned integer.\"}", resp->body);
 
     //invalid limit string
     req->params["offset"] = "0";
     req->params["limit"] = "-1";
     get_collections(req, resp);
     ASSERT_EQ(400, resp->status_code);
-    ASSERT_EQ("{\"message\": \"Limit param should be unsigned integer.\"}", resp->body);
+    ASSERT_EQ("{\"message\":\"Limit param should be unsigned integer.\"}", resp->body);
 }
 
 TEST_F(CoreAPIUtilsTest, OverridesPagination) {
@@ -2096,14 +2096,14 @@ TEST_F(CoreAPIUtilsTest, OverridesPagination) {
     get_collections(req, resp);
 
     ASSERT_EQ(400, resp->status_code);
-    ASSERT_EQ("{\"message\": \"Offset param should be unsigned integer.\"}", resp->body);
+    ASSERT_EQ("{\"message\":\"Offset param should be unsigned integer.\"}", resp->body);
 
     //invalid limit string
     req->params["offset"] = "0";
     req->params["limit"] = "-1";
     get_collections(req, resp);
     ASSERT_EQ(400, resp->status_code);
-    ASSERT_EQ("{\"message\": \"Limit param should be unsigned integer.\"}", resp->body);
+    ASSERT_EQ("{\"message\":\"Limit param should be unsigned integer.\"}", resp->body);
 }
 
 TEST_F(CoreAPIUtilsTest, SynonymsPagination) {
@@ -2147,14 +2147,14 @@ TEST_F(CoreAPIUtilsTest, SynonymsPagination) {
     get_collections(req, resp);
 
     ASSERT_EQ(400, resp->status_code);
-    ASSERT_EQ("{\"message\": \"Offset param should be unsigned integer.\"}", resp->body);
+    ASSERT_EQ("{\"message\":\"Offset param should be unsigned integer.\"}", resp->body);
 
     //invalid limit string
     req->params["offset"] = "0";
     req->params["limit"] = "-1";
     get_collections(req, resp);
     ASSERT_EQ(400, resp->status_code);
-    ASSERT_EQ("{\"message\": \"Limit param should be unsigned integer.\"}", resp->body);
+    ASSERT_EQ("{\"message\":\"Limit param should be unsigned integer.\"}", resp->body);
 }
 
 
@@ -2430,7 +2430,7 @@ TEST_F(CoreAPIUtilsTest, CollectionUpdateValidation) {
 
     req->body = alter_schema.dump();
     ASSERT_FALSE(patch_update_collection(req, res));
-    ASSERT_EQ("{\"message\": \"Only `fields`, `metadata` and `synonym_sets` can be updated at the moment.\"}", res->body);
+    ASSERT_EQ("{\"message\":\"Only `fields`, `metadata` and `synonym_sets` can be updated at the moment.\"}", res->body);
 
     alter_schema = R"({
         "symbols_to_index":[]
@@ -2438,7 +2438,7 @@ TEST_F(CoreAPIUtilsTest, CollectionUpdateValidation) {
 
     req->body = alter_schema.dump();
     ASSERT_FALSE(patch_update_collection(req, res));
-    ASSERT_EQ("{\"message\": \"Only `fields`, `metadata` and `synonym_sets` can be updated at the moment.\"}", res->body);
+    ASSERT_EQ("{\"message\":\"Only `fields`, `metadata` and `synonym_sets` can be updated at the moment.\"}", res->body);
 
     alter_schema = R"({
         "name": "collection_meta2",
@@ -2450,14 +2450,14 @@ TEST_F(CoreAPIUtilsTest, CollectionUpdateValidation) {
 
     req->body = alter_schema.dump();
     ASSERT_FALSE(patch_update_collection(req, res));
-    ASSERT_EQ("{\"message\": \"Only `fields`, `metadata` and `synonym_sets` can be updated at the moment.\"}", res->body);
+    ASSERT_EQ("{\"message\":\"Only `fields`, `metadata` and `synonym_sets` can be updated at the moment.\"}", res->body);
 
     alter_schema = R"({
     })"_json;
 
     req->body = alter_schema.dump();
     ASSERT_FALSE(patch_update_collection(req, res));
-    ASSERT_EQ("{\"message\": \"Alter payload is empty.\"}", res->body);
+    ASSERT_EQ("{\"message\":\"Alter payload is empty.\"}", res->body);
 }
 
 TEST_F(CoreAPIUtilsTest, DocumentGetIncludeExcludeFields) {

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -2881,6 +2881,159 @@ TEST_F(CoreAPIUtilsTest, StatefulRemoveDocsWithReturnValues) {
     collectionManager.drop_collection("coll1");
 }
 
+TEST_F(CoreAPIUtilsTest, RemoveIfFoundManyBasicBehavior) {
+    Collection *coll1;
+    std::vector<field> fields = {field("title", field_types::STRING, false),
+                                 field("points", field_types::INT32, false),};
+
+    coll1 = collectionManager.get_collection("coll1").get();
+    if(coll1 == nullptr) {
+        coll1 = collectionManager.create_collection("coll1", 2, fields, "points").get();
+    }
+
+    for(size_t i = 0; i < 10; i++) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["title"] = "Title " + std::to_string(i);
+        doc["points"] = i;
+        ASSERT_TRUE(coll1->add(doc.dump()).ok());
+    }
+
+    auto seq_1_op = coll1->doc_id_to_seq_id("1");
+    auto seq_2_op = coll1->doc_id_to_seq_id("2");
+    ASSERT_TRUE(seq_1_op.ok());
+    ASSERT_TRUE(seq_2_op.ok());
+
+    std::vector<uint32_t> seq_ids = {
+        seq_1_op.get(),
+        seq_2_op.get(),
+        static_cast<uint32_t>(seq_2_op.get() + 10000)
+    };
+
+    std::vector<nlohmann::json> removed_docs;
+    auto remove_op = coll1->remove_if_found_many(seq_ids, true, &removed_docs);
+    ASSERT_TRUE(remove_op.ok());
+    ASSERT_EQ(2, remove_op.get());
+    ASSERT_EQ(2, removed_docs.size());
+    ASSERT_EQ(8, coll1->get_num_documents());
+
+    bool found_1 = false;
+    bool found_2 = false;
+    for(const auto& removed_doc: removed_docs) {
+        if(removed_doc["id"] == "1") {
+            found_1 = true;
+        }
+
+        if(removed_doc["id"] == "2") {
+            found_2 = true;
+        }
+    }
+    ASSERT_TRUE(found_1);
+    ASSERT_TRUE(found_2);
+
+    auto get_1_op = coll1->get("1");
+    auto get_2_op = coll1->get("2");
+    auto get_3_op = coll1->get("3");
+    ASSERT_FALSE(get_1_op.ok());
+    ASSERT_FALSE(get_2_op.ok());
+    ASSERT_EQ(404, get_1_op.code());
+    ASSERT_EQ(404, get_2_op.code());
+    ASSERT_TRUE(get_3_op.ok());
+
+    collectionManager.drop_collection("coll1");
+}
+
+TEST_F(CoreAPIUtilsTest, RemoveIfFoundManyWithCascadeReference) {
+    auto products_schema = R"({
+        "name": "Products",
+        "fields": [
+            {"name": "product_id", "type": "string"},
+            {"name": "name", "type": "string"}
+        ]
+    })"_json;
+
+    auto orders_schema = R"({
+        "name": "Orders",
+        "fields": [
+            {"name": "order_id", "type": "string"},
+            {"name": "product_id", "type": "string", "reference": "Products.product_id"}
+        ]
+    })"_json;
+
+    auto products_op = collectionManager.create_collection(products_schema);
+    ASSERT_TRUE(products_op.ok());
+
+    auto orders_op = collectionManager.create_collection(orders_schema);
+    ASSERT_TRUE(orders_op.ok());
+
+    auto products = products_op.get();
+    auto orders = orders_op.get();
+
+    ASSERT_TRUE(products->add(R"({"id":"p1","product_id":"p1","name":"shampoo"})").ok());
+    ASSERT_TRUE(orders->add(R"({"id":"o1","order_id":"o1","product_id":"p1"})").ok());
+
+    auto product_seq_op = products->doc_id_to_seq_id("p1");
+    ASSERT_TRUE(product_seq_op.ok());
+
+    auto remove_op = products->remove_if_found_many({product_seq_op.get()}, true);
+    ASSERT_TRUE(remove_op.ok());
+    ASSERT_EQ(1, remove_op.get());
+
+    auto product_get_op = products->get("p1");
+    auto order_get_op = orders->get("o1");
+    ASSERT_FALSE(product_get_op.ok());
+    ASSERT_FALSE(order_get_op.ok());
+    ASSERT_EQ(404, product_get_op.code());
+    ASSERT_EQ(404, order_get_op.code());
+
+    collectionManager.drop_collection("Orders");
+    collectionManager.drop_collection("Products");
+}
+
+TEST_F(CoreAPIUtilsTest, StatefulRemoveDocsUsesBoundedInternalBatch) {
+    Collection *coll1;
+    std::vector<field> fields = {field("title", field_types::STRING, false),
+                                 field("points", field_types::INT32, false),};
+
+    coll1 = collectionManager.get_collection("coll1").get();
+    if(coll1 == nullptr) {
+        coll1 = collectionManager.create_collection("coll1", 2, fields, "points").get();
+    }
+
+    for(size_t i = 0; i < 1205; i++) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["title"] = "Title " + std::to_string(i);
+        doc["points"] = i;
+        ASSERT_TRUE(coll1->add(doc.dump()).ok());
+    }
+
+    deletion_state_t deletion_state;
+    deletion_state.collection = coll1;
+    deletion_state.num_removed = 0;
+
+    filter_result_t filter_results;
+    auto filter_op = coll1->get_filter_ids("points:>= 0", filter_results);
+    ASSERT_TRUE(filter_op.ok());
+    deletion_state.index_ids.emplace_back(filter_results.count, filter_results.docs);
+    filter_results.docs = nullptr;
+    deletion_state.offsets.push_back(0);
+
+    bool done = false;
+    auto remove_op = stateful_remove_docs(&deletion_state, 1000000000, done);
+    ASSERT_TRUE(remove_op.ok());
+    ASSERT_EQ(1000, deletion_state.num_removed);
+    ASSERT_FALSE(done);
+
+    remove_op = stateful_remove_docs(&deletion_state, 1000000000, done);
+    ASSERT_TRUE(remove_op.ok());
+    ASSERT_EQ(1205, deletion_state.num_removed);
+    ASSERT_TRUE(done);
+    ASSERT_EQ(0, coll1->get_num_documents());
+
+    collectionManager.drop_collection("coll1");
+}
+
 TEST_F(CoreAPIUtilsTest, RemoveDocumentsWithReturnValues) {
     Collection *coll1;
 

--- a/test/filter_test.cpp
+++ b/test/filter_test.cpp
@@ -2738,3 +2738,50 @@ TEST_F(FilterTest, ObjectFitlterIterator) {
 
     delete filter_tree_root;
 }
+
+TEST_F(FilterTest, FilterReferences) {
+    const size_t max_candidates = DEFAULT_FILTER_BY_CANDIDATES;
+    const uint64_t search_begin_us = 0;
+    const uint64_t search_stop_us = UINT64_MAX;
+    auto filter_root = std::make_unique<filter_node_t>();
+    auto left_refs = new std::map<std::string, reference_filter_result_t>[4]{
+                            {{"foo", reference_filter_result_t(1, new uint32_t[1]{101})}},
+                            {{"bar", reference_filter_result_t(1, new uint32_t[1]{102})}},
+                            {{"foo", reference_filter_result_t(1, new uint32_t[1]{104})}},
+                            {{"bar", reference_filter_result_t(1, new uint32_t[1]{105})}}};
+    auto right_refs = new std::map<std::string, reference_filter_result_t>[4]{
+                            {{"bar", reference_filter_result_t(1, new uint32_t[1]{100})}},
+                            {{"foo", reference_filter_result_t(1, new uint32_t[1]{101})}},
+                            {{"bar", reference_filter_result_t(1, new uint32_t[1]{103})}},
+                            {{"bar", reference_filter_result_t(1, new uint32_t[1]{106})}}};
+    auto fit = std::make_unique<filter_result_iterator_t>(
+                                            AND,
+                                            new filter_result_iterator_t(new uint32_t[4]{1, 2, 4, 6}, 4,
+                                                                         max_candidates, search_begin_us, search_stop_us,
+                                                                         left_refs),
+                                            new filter_result_iterator_t(new uint32_t[4]{0, 1, 4, 6}, 4,
+                                                                         max_candidates, search_begin_us, search_stop_us,
+                                                                         right_refs),
+                                            filter_root, new filter_node_t());
+
+    std::vector<uint32_t> expected = {1, 4};
+    std::vector<std::vector<std::string>> collection_names = {{"foo"}, {"foo", "bar"}};
+    std::vector<std::vector<uint32_t>> ref_ids = {{101}, {104, 103}};
+    for (size_t i = 0; i < 2; i++) {
+        ASSERT_EQ(filter_result_iterator_t::valid, fit->validity);
+        const auto& id = expected[i];
+        ASSERT_EQ(id, fit->seq_id);
+
+        for (size_t j = 0; j < collection_names[i].size(); j++) {
+            const auto& name = collection_names[i][j];
+            ASSERT_EQ(1, fit->reference.count(name));
+            ASSERT_EQ(1, fit->reference[name].count);
+
+            const auto& ref_id = ref_ids[i][j];
+            ASSERT_EQ(ref_id, fit->reference[name].docs[0]);
+        }
+
+        fit->next();
+    }
+    ASSERT_EQ(filter_result_iterator_t::invalid, fit->validity);
+}

--- a/test/ratelimit_test.cpp
+++ b/test/ratelimit_test.cpp
@@ -579,7 +579,7 @@ TEST_F(RateLimitManagerTest, TestMultiSearchRateLimiting) {
 
     EXPECT_FALSE(post_multi_search(req, res));
     EXPECT_EQ(res->status_code, 429);
-    EXPECT_EQ(res->body, "{\"message\": \"Rate limit exceeded or blocked\"}");
+    EXPECT_EQ(res->body, "{\"message\":\"Rate limit exceeded or blocked\"}");
 
     body.erase("searches");
     body["searches"] = nlohmann::json::array();

--- a/test/stopwords_manager_test.cpp
+++ b/test/stopwords_manager_test.cpp
@@ -293,7 +293,7 @@ TEST_F(StopwordsManagerTest, StopwordsBasics) {
 
     result = del_stopword(req, res);
     ASSERT_EQ(404, res->status_code);
-    ASSERT_STREQ("{\"message\": \"Stopword `state` not found.\"}", res->body.c_str());
+    ASSERT_STREQ("{\"message\":\"Stopword `state` not found.\"}", res->body.c_str());
 
     req->params.clear();
     json_results.clear();
@@ -360,7 +360,7 @@ TEST_F(StopwordsManagerTest, StopwordsValidation) {
 
     auto result = put_upsert_stopword(req, res);
     ASSERT_EQ(400, res->status_code);
-    ASSERT_STREQ("{\"message\": \"Parameter `stopwords` is required\"}", res->body.c_str());
+    ASSERT_STREQ("{\"message\":\"Parameter `stopwords` is required\"}", res->body.c_str());
 
     //check for value types
     stopword_value = R"(
@@ -373,7 +373,7 @@ TEST_F(StopwordsManagerTest, StopwordsValidation) {
 
     result = put_upsert_stopword(req, res);
     ASSERT_EQ(400, res->status_code);
-    ASSERT_STREQ("{\"message\": \"Parameter `locale` is required as string value\"}", res->body.c_str());
+    ASSERT_STREQ("{\"message\":\"Parameter `locale` is required as string value\"}", res->body.c_str());
 
     stopword_value = R"(
             {"stopwords": [1, 5, 2], "locale": "ko"}
@@ -385,7 +385,7 @@ TEST_F(StopwordsManagerTest, StopwordsValidation) {
 
     result = put_upsert_stopword(req, res);
     ASSERT_EQ(400, res->status_code);
-    ASSERT_STREQ("{\"message\": \"Parameter `stopwords` is required as string array value\"}", res->body.c_str());
+    ASSERT_STREQ("{\"message\":\"Parameter `stopwords` is required as string array value\"}", res->body.c_str());
 
     collectionManager.drop_collection("coll1");
 }

--- a/test/union_test.cpp
+++ b/test/union_test.cpp
@@ -3,6 +3,11 @@
 #include <vector>
 #include <fstream>
 #include <algorithm>
+#include <cstdlib>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <sstream>
 #include <collection_manager.h>
 
 class UnionTest : public ::testing::Test {
@@ -1454,4 +1459,199 @@ TEST_F(UnionTest, GroupingWithUnions) {
     ASSERT_EQ(400, json_res["code"]);
     ASSERT_EQ(1, json_res.count("error"));
     ASSERT_EQ("Invalid group_by searches count. All searches with union search should be uniform.", json_res["error"]);
+}
+
+TEST_F(UnionTest, UnionHighlightingUAFRaceASAN) {
+    nlohmann::json schema = R"({
+        "name": "union_uaf_race",
+        "fields": [
+            {"name": "title", "type": "string"},
+            {"name": "rank", "type": "int32"}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    auto coll = create_op.get();
+
+    constexpr size_t hot_docs = 8;
+    constexpr size_t iterations = 80;
+
+    const std::string volatile_token = "uafsentinelzzzz";
+    std::stringstream dense_ss;
+    for(size_t i = 0; i < 64; i++) {
+        if(i != 0) {
+            dense_ss << " ";
+        }
+        dense_ss << volatile_token;
+    }
+    const std::string dense_token_phrase = dense_ss.str();
+
+    auto build_hot_doc = [&](size_t i, bool dense_doc0) {
+        nlohmann::json doc;
+        doc["id"] = "hot_" + std::to_string(i);
+        doc["title"] = (dense_doc0 && i == 0) ? dense_token_phrase : volatile_token;
+        doc["rank"] = int32_t(i + 1);
+        return doc;
+    };
+
+    for (size_t i = 0; i < hot_docs; i++) {
+        ASSERT_TRUE(coll->add(build_hot_doc(i, true).dump(), UPSERT).ok());
+    }
+
+    std::atomic<size_t> union_calls = 0;
+    std::atomic<size_t> mutation_batches = 0;
+    std::atomic<size_t> total_mutations = 0;
+    std::atomic<size_t> total_mutations_during_search = 0;
+    std::atomic<size_t> union_hit_count = 0;
+    std::atomic<size_t> union_nonempty_highlight_count = 0;
+    std::atomic<size_t> union_title_highlight_count = 0;
+
+    for (size_t i = 0; i < iterations; i++) {
+        // Start each round from low token-offset density.
+        for (size_t j = 0; j < hot_docs; j++) {
+            ASSERT_TRUE(coll->add(build_hot_doc(j, false).dump(), UPSERT).ok());
+        }
+
+        std::map<std::string, std::string> local_req_params = {
+            {"page", "1"},
+            {"per_page", std::to_string(hot_docs)}
+        };
+        std::vector<nlohmann::json> local_embedded_params(2, nlohmann::json::object());
+        nlohmann::json local_searches = R"([
+            {
+                "collection": "union_uaf_race",
+                "q": "uafsentinelzzzz",
+                "query_by": "title",
+                "highlight_fields": "title",
+                "sort_by": "rank:desc"
+            },
+            {
+                "collection": "union_uaf_race",
+                "q": "missing_token_never_indexed",
+                "query_by": "title",
+                "highlight_fields": "title",
+                "sort_by": "rank:desc"
+            }
+        ])"_json;
+        auto req_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+
+        std::atomic<bool> search_done = false;
+        std::atomic<bool> search_ok = false;
+        auto thread_req_params = local_req_params;
+        auto thread_embedded_params = local_embedded_params;
+        auto thread_searches = local_searches;
+        auto search_thread = std::thread([&, thread_req_params, thread_embedded_params, thread_searches, req_ts]() mutable {
+            nlohmann::json thread_res;
+            auto op = collectionManager.do_union(thread_req_params, thread_embedded_params, thread_searches, thread_res, req_ts);
+            if(op.ok() && thread_res.contains("hits") && thread_res["hits"].is_array()) {
+                size_t local_hit_count = thread_res["hits"].size();
+                size_t local_nonempty_highlight_count = 0;
+                size_t local_title_highlight_count = 0;
+
+                for(const auto& hit: thread_res["hits"]) {
+                    if(!hit.contains("highlight") || !hit["highlight"].is_object()) {
+                        continue;
+                    }
+
+                    const auto& highlight_obj = hit["highlight"];
+                    if(!highlight_obj.empty()) {
+                        local_nonempty_highlight_count++;
+                    }
+
+                    auto title_it = highlight_obj.find("title");
+                    if(title_it == highlight_obj.end()) {
+                        continue;
+                    }
+
+                    if(title_it->is_object()) {
+                        bool has_snippet = title_it->contains("snippet") && (*title_it)["snippet"].is_string() &&
+                                           !(*title_it)["snippet"].get<std::string>().empty();
+                        bool has_matched_tokens = title_it->contains("matched_tokens") &&
+                                                  (*title_it)["matched_tokens"].is_array() &&
+                                                  !(*title_it)["matched_tokens"].empty();
+                        if(has_snippet || has_matched_tokens) {
+                            local_title_highlight_count++;
+                        }
+                    } else if(title_it->is_array() && !title_it->empty()) {
+                        local_title_highlight_count++;
+                    }
+                }
+
+                union_hit_count.fetch_add(local_hit_count, std::memory_order_relaxed);
+                union_nonempty_highlight_count.fetch_add(local_nonempty_highlight_count, std::memory_order_relaxed);
+                union_title_highlight_count.fetch_add(local_title_highlight_count, std::memory_order_relaxed);
+            }
+            search_ok.store(op.ok(), std::memory_order_relaxed);
+            search_done.store(true, std::memory_order_release);
+        });
+
+        // Give do_union a head-start to enter run_search/process_highlight_fields_with_lock.
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+        size_t local_mutations = 0;
+        size_t local_mutations_during_search = 0;
+        bool dense_doc0 = false;
+        constexpr size_t max_mutations_while_searching = 512;
+        for(size_t mutation_attempt = 0; mutation_attempt < max_mutations_while_searching; mutation_attempt++) {
+            if(search_done.load(std::memory_order_acquire)) {
+                break;
+            }
+
+            dense_doc0 = !dense_doc0;
+            const bool search_running_before_add = !search_done.load(std::memory_order_acquire);
+            ASSERT_TRUE(coll->add(build_hot_doc(0, dense_doc0).dump(), UPSERT).ok());
+            local_mutations++;
+            const bool search_running_after_add = !search_done.load(std::memory_order_acquire);
+            if(search_running_before_add && search_running_after_add) {
+                local_mutations_during_search++;
+            }
+
+            if(mutation_attempt % 16 == 15) {
+                std::this_thread::sleep_for(std::chrono::microseconds(200));
+            } else {
+                std::this_thread::yield();
+            }
+        }
+
+        if(!search_done.load(std::memory_order_acquire)) {
+            const auto wait_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(20);
+            while(!search_done.load(std::memory_order_acquire) &&
+                  std::chrono::steady_clock::now() < wait_deadline) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+        }
+
+        if(!search_done.load(std::memory_order_acquire)) {
+            search_thread.detach();
+            FAIL() << "Timed out waiting for union search to complete after pausing mutations. "
+                   << "local_mutations=" << local_mutations
+                   << ", local_mutations_during_search=" << local_mutations_during_search;
+        }
+
+        search_thread.join();
+        ASSERT_TRUE(search_ok.load(std::memory_order_relaxed));
+
+        // Restore compact low-offset form for next iteration.
+        ASSERT_TRUE(coll->add(build_hot_doc(0, false).dump(), UPSERT).ok());
+        local_mutations++;
+
+        if (local_mutations > 0) {
+            mutation_batches.fetch_add(1, std::memory_order_relaxed);
+            total_mutations.fetch_add(local_mutations, std::memory_order_relaxed);
+        }
+        if(local_mutations_during_search > 0) {
+            total_mutations_during_search.fetch_add(local_mutations_during_search, std::memory_order_relaxed);
+        }
+        union_calls.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    ASSERT_GT(union_calls.load(std::memory_order_relaxed), 0);
+    ASSERT_GT(mutation_batches.load(std::memory_order_relaxed), 0);
+    ASSERT_GT(total_mutations.load(std::memory_order_relaxed), 0);
+    ASSERT_GT(total_mutations_during_search.load(std::memory_order_relaxed), 0);
+    ASSERT_GT(union_hit_count.load(std::memory_order_relaxed), 0);
+    ASSERT_GT(union_nonempty_highlight_count.load(std::memory_order_relaxed), 0);
+    ASSERT_GT(union_title_highlight_count.load(std::memory_order_relaxed), 0);
 }

--- a/test/union_test.cpp
+++ b/test/union_test.cpp
@@ -9,6 +9,7 @@
 #include <thread>
 #include <sstream>
 #include <collection_manager.h>
+#include "curation_index_manager.h"
 
 class UnionTest : public ::testing::Test {
 protected:
@@ -1243,6 +1244,64 @@ TEST_F(UnionTest, PinnedHits) {
     ASSERT_EQ("W2", json_res["hits"][3]["document"]["id"]);
     ASSERT_EQ("W1", json_res["hits"][4]["document"]["id"]);
     ASSERT_EQ("W0", json_res["hits"][5]["document"]["id"]);
+}
+
+TEST_F(UnionTest, CurationIncludesShouldNotCollapseInUnion) {
+    auto schema_json =
+            R"({
+                "name": "Events",
+                "fields": [
+                    {"name": "title", "type": "string"}
+                ]
+            })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto coll = collection_create_op.get();
+
+    ASSERT_TRUE(coll->add(R"({"id":"0","title":"2026 NCAA Tournament Winner"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"1","title":"2026 Women's NCAA Tournament Winner"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"2","title":"March Madness Sweet 16"})").ok());
+
+    auto& curation_manager = CurationIndexManager::get_instance();
+    curation_manager.init_store(store);
+    auto upsert_set = nlohmann::json::array({
+        nlohmann::json{
+            {"id", "march-madness"},
+            {"rule", {{"query", "march madness"}, {"match", curation_t::MATCH_CONTAINS}}},
+            {"includes", nlohmann::json::array({
+                nlohmann::json{{"id", "0"}, {"position", 1}},
+                nlohmann::json{{"id", "1"}, {"position", 2}}
+            })}
+        }
+    });
+    ASSERT_TRUE(curation_manager.upsert_curation_set("events_curations", upsert_set).ok());
+    ASSERT_TRUE(coll->set_curation_sets({"events_curations"}).ok());
+
+    req_params = {};
+    embedded_params = std::vector<nlohmann::json>(2, nlohmann::json::object());
+    searches = R"([
+                    {
+                        "collection": "Events",
+                        "q": "march madness",
+                        "query_by": "title"
+                    },
+                    {
+                        "collection": "Events",
+                        "q": "march madness",
+                        "query_by": "title"
+                    }
+                ])"_json;
+
+    auto search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    ASSERT_EQ(3, json_res["found"].get<size_t>());
+    ASSERT_EQ(3, json_res["hits"].size());
+    ASSERT_TRUE(json_res["hits"][0]["curated"].get<bool>());
+    ASSERT_TRUE(json_res["hits"][1]["curated"].get<bool>());
+    ASSERT_EQ("0", json_res["hits"][0]["document"]["id"]);
+    ASSERT_EQ("1", json_res["hits"][1]["document"]["id"]);
 }
 
 TEST_F(UnionTest, HybridSearchHasVectorDistance) {


### PR DESCRIPTION
## Summary

Fixes #2798

**Bug:** int32 fields silently accept values exceeding `INT32_MAX` (e.g., millisecond timestamps like `1740000000000`) on document write, but reject them with HTTP 400 on search/filter. This causes a confusing experience where documents are indexed successfully but become unfilterable.

**Root cause:** In `validator.cpp`, when a JSON value is already a `number_integer`, the validator skips `coerce_int32_t` (which contains the range check) and accepts the value as-is. The range validation only fires when the value needs type coercion (e.g., from string or float).

**Fix:**
- Added explicit range validation in the `else` branch of the `is_number_integer()` check, for both scalar `INT32` and `INT32_ARRAY` fields. Values outside `[INT32_MIN, INT32_MAX]` are now rejected at write time with a clear 400 error, or silently dropped when `dirty_values` is `DROP`/`COERCE_OR_DROP` and the field is optional.
- Fixed the existing `coerce_int32_t` function to also check `INT32_MIN` bounds (previously only checked `INT32_MAX`).

## Test plan

- [x] **Scalar overflow test** (`Int32FieldRejectsOverflowOnWrite`): verifies valid boundary values are accepted, and values exceeding `INT32_MAX` or below `INT32_MIN` are rejected with 400
- [x] **Array overflow test** (`Int32ArrayFieldRejectsOverflowOnWrite`): verifies array elements exceeding int32 range are rejected
- [x] **dirty_values DROP test** (`Int32OverflowWithDirtyValuesDropOptional`): verifies optional fields with `DROP` silently discard overflowed values, while non-optional fields still reject
- [x] Full test suite passes (665.8s, all existing tests green)