### PR TITLE
fix: shared int32 bounds validation on write (alt to #2801)

### DIFF
--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -1,6 +1,66 @@
 #include "validator.h"
 #include "field.h"
 
+namespace {
+bool should_drop_field(const field& a_field, const DIRTY_VALUES& dirty_values) {
+    return a_field.optional &&
+           (dirty_values == DIRTY_VALUES::DROP || dirty_values == DIRTY_VALUES::COERCE_OR_DROP);
+}
+
+Option<uint32_t> handle_int32_out_of_range(const field& a_field, const DIRTY_VALUES& dirty_values,
+                                           nlohmann::json& document, const std::string& field_name,
+                                           nlohmann::json::iterator& array_iter, bool is_array,
+                                           bool& array_ele_erased) {
+    if(!should_drop_field(a_field, dirty_values)) {
+        return Option<>(400, "Field `" + field_name  + "` is outside the range of int32.");
+    }
+
+    if(!is_array) {
+        document.erase(field_name);
+    } else {
+        array_iter = document[field_name].erase(array_iter);
+        array_ele_erased = true;
+    }
+
+    return Option<uint32_t>(200);
+}
+
+Option<uint32_t> validate_int32_bounds(const field& a_field, const DIRTY_VALUES& dirty_values,
+                                       nlohmann::json& document, const std::string& field_name,
+                                       nlohmann::json::iterator& array_iter, bool is_array,
+                                       bool& array_ele_erased) {
+    if(!is_array && document.count(field_name) == 0) {
+        return Option<uint32_t>(200);
+    }
+
+    auto& item = is_array ? array_iter.value() : document[field_name];
+
+    if(!item.is_number_integer()) {
+        return Option<uint32_t>(200);
+    }
+
+    // nlohmann::json treats unsigned/signed integers as "number_integer", so guard both cases explicitly.
+    if(item.is_number_unsigned()) {
+        if(item.get<uint64_t>() > static_cast<uint64_t>(INT32_MAX)) {
+            return handle_int32_out_of_range(a_field, dirty_values, document, field_name,
+                                             array_iter, is_array, array_ele_erased);
+        }
+
+        // Normalize to signed to keep downstream int32 reads consistent.
+        item = static_cast<int32_t>(item.get<uint64_t>());
+        return Option<uint32_t>(200);
+    }
+
+    const int64_t val = item.get<int64_t>();
+    if(val > INT32_MAX || val < INT32_MIN) {
+        return handle_int32_out_of_range(a_field, dirty_values, document, field_name,
+                                         array_iter, is_array, array_ele_erased);
+    }
+
+    return Option<uint32_t>(200);
+}
+}
+
 Option<uint32_t> validator_t::coerce_element(const field& a_field, nlohmann::json& document,
                                        nlohmann::json& doc_ele,
                                        const std::string& fallback_field_type,
@@ -24,6 +84,12 @@ Option<uint32_t> validator_t::coerce_element(const field& a_field, nlohmann::jso
             if(!coerce_op.ok()) {
                 return coerce_op;
             }
+        }
+
+        Option<uint32_t> range_op = validate_int32_bounds(a_field, dirty_values, document, field_name,
+                                                          dummy_iter, false, array_ele_erased);
+        if(!range_op.ok()) {
+            return range_op;
         }
     } else if(a_field.type == field_types::INT64) {
         if(!doc_ele.is_number_integer()) {
@@ -124,10 +190,20 @@ Option<uint32_t> validator_t::coerce_element(const field& a_field, nlohmann::jso
                 if (!coerce_op.ok()) {
                     return coerce_op;
                 }
-            } else if (a_field.type == field_types::INT32_ARRAY && !item.is_number_integer()) {
-                Option<uint32_t> coerce_op = coerce_int32_t(dirty_values, a_field, document, field_name, it, true, array_ele_erased);
-                if (!coerce_op.ok()) {
-                    return coerce_op;
+            } else if (a_field.type == field_types::INT32_ARRAY) {
+                if(!item.is_number_integer()) {
+                    Option<uint32_t> coerce_op = coerce_int32_t(dirty_values, a_field, document, field_name, it, true, array_ele_erased);
+                    if (!coerce_op.ok()) {
+                        return coerce_op;
+                    }
+                }
+
+                if(!array_ele_erased) {
+                    Option<uint32_t> range_op = validate_int32_bounds(a_field, dirty_values, document, field_name,
+                                                                      it, true, array_ele_erased);
+                    if(!range_op.ok()) {
+                        return range_op;
+                    }
                 }
             } else if (a_field.type == field_types::INT64_ARRAY && !item.is_number_integer()) {
                 Option<uint32_t> coerce_op = coerce_int64_t(dirty_values, a_field, document, field_name, it, true, array_ele_erased);
@@ -317,14 +393,6 @@ Option<uint32_t> validator_t::coerce_int32_t(const DIRTY_VALUES& dirty_values, c
                                       "Hint: field inside an array of objects must be an array type as well.");
             }
             return Option<>(400, "Field `" + field_name  + "` must be " + suffix + " int32.");
-        }
-    }
-
-    if(document.contains(field_name) && document[field_name].get<int64_t>() > INT32_MAX) {
-        if(a_field.optional && (dirty_values == DIRTY_VALUES::DROP || dirty_values == DIRTY_VALUES::COERCE_OR_REJECT)) {
-            document.erase(field_name);
-        } else {
-            return Option<>(400, "Field `" + field_name  + "` exceeds maximum value of int32.");
         }
     }
 

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -5611,3 +5611,131 @@ TEST_F(CollectionTest, PerFieldTokenSeparatorsAndSymbolsToIndex) {
     collectionManager.drop_collection("users_1");
     collectionManager.drop_collection("users_2");
 }
+
+// Bug #2798: int32 fields accepted out-of-range values on write.
+TEST_F(CollectionTest, Int32FieldRejectsOverflowOnWrite) {
+    Collection* coll;
+    std::vector<field> fields = {
+        field("title", field_types::STRING, false),
+        field("value", field_types::INT32, false)
+    };
+
+    coll = collectionManager.get_collection("int32_overflow_test").get();
+    if (coll == nullptr) {
+        coll = collectionManager.create_collection("int32_overflow_test", 1, fields).get();
+    }
+
+    nlohmann::json doc;
+
+    doc["title"] = "valid max";
+    doc["value"] = INT32_MAX;
+    auto add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_TRUE(add_op.ok());
+
+    doc["title"] = "valid min";
+    doc["value"] = INT32_MIN;
+    add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_TRUE(add_op.ok());
+
+    doc["title"] = "valid zero";
+    doc["value"] = 0;
+    add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_TRUE(add_op.ok());
+
+    doc["title"] = "overflow positive";
+    doc["value"] = (int64_t)INT32_MAX + 1;
+    add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_FALSE(add_op.ok());
+    ASSERT_EQ(400, add_op.code());
+    ASSERT_EQ("Field `value` is outside the range of int32.", add_op.error());
+
+    doc["title"] = "millisecond timestamp";
+    doc["value"] = 1740000000000LL;
+    add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_FALSE(add_op.ok());
+    ASSERT_EQ(400, add_op.code());
+    ASSERT_EQ("Field `value` is outside the range of int32.", add_op.error());
+
+    doc["title"] = "overflow negative";
+    doc["value"] = (int64_t)INT32_MIN - 1;
+    add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_FALSE(add_op.ok());
+    ASSERT_EQ(400, add_op.code());
+    ASSERT_EQ("Field `value` is outside the range of int32.", add_op.error());
+
+    collectionManager.drop_collection("int32_overflow_test");
+}
+
+TEST_F(CollectionTest, Int32ArrayFieldRejectsOverflowOnWrite) {
+    Collection* coll;
+    std::vector<field> fields = {
+        field("title", field_types::STRING, false),
+        field("values", field_types::INT32_ARRAY, false)
+    };
+
+    coll = collectionManager.get_collection("int32_arr_overflow_test").get();
+    if (coll == nullptr) {
+        coll = collectionManager.create_collection("int32_arr_overflow_test", 1, fields).get();
+    }
+
+    nlohmann::json doc;
+    doc["title"] = "valid array";
+    doc["values"] = {0, INT32_MAX, INT32_MIN, 100, -100};
+    auto add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_TRUE(add_op.ok());
+
+    doc["title"] = "overflow in array";
+    doc["values"] = {100, (int64_t)INT32_MAX + 1, 200};
+    add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_FALSE(add_op.ok());
+    ASSERT_EQ(400, add_op.code());
+    ASSERT_EQ("Field `values` is outside the range of int32.", add_op.error());
+
+    doc["title"] = "negative overflow in array";
+    doc["values"] = {100, (int64_t)INT32_MIN - 1};
+    add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_FALSE(add_op.ok());
+    ASSERT_EQ(400, add_op.code());
+    ASSERT_EQ("Field `values` is outside the range of int32.", add_op.error());
+
+    collectionManager.drop_collection("int32_arr_overflow_test");
+}
+
+TEST_F(CollectionTest, Int32OverflowWithDirtyValuesDropOptional) {
+    Collection* coll;
+    std::vector<field> fields = {
+        field("title", field_types::STRING, false),
+        field("value", field_types::INT32, false, true)  // facet=false, optional=true
+    };
+
+    coll = collectionManager.get_collection("int32_drop_test").get();
+    if (coll == nullptr) {
+        coll = collectionManager.create_collection("int32_drop_test", 1, fields).get();
+    }
+
+    nlohmann::json doc;
+    doc["title"] = "dropped overflow";
+    doc["value"] = 1740000000000LL;
+    auto add_op = coll->add(doc.dump(), CREATE, "", DIRTY_VALUES::DROP);
+    ASSERT_TRUE(add_op.ok());
+
+    std::vector<sort_by> test_sort = { sort_by(sort_field_const::text_match, "DESC") };
+    auto results = coll->search("dropped overflow", {"title"}, "", {}, test_sort, {0}, 10).get();
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_FALSE(results["hits"][0]["document"].contains("value"));
+
+    collectionManager.drop_collection("int32_drop_test");
+
+    std::vector<field> fields2 = {
+        field("title", field_types::STRING, false),
+        field("value", field_types::INT32, false)
+    };
+    coll = collectionManager.create_collection("int32_drop_test", 1, fields2).get();
+
+    doc["title"] = "rejected overflow";
+    doc["value"] = 1740000000000LL;
+    add_op = coll->add(doc.dump(), CREATE, "", DIRTY_VALUES::DROP);
+    ASSERT_FALSE(add_op.ok());
+
+    collectionManager.drop_collection("int32_drop_test");
+}


### PR DESCRIPTION
Alternative to #2801 for issue #2798.

Fixes #2798

**Bug:** int32 fields silently accept values exceeding `INT32_MAX` (e.g., millisecond timestamps like `1740000000000`) on document write, but reject them with HTTP 400 on search/filter. This causes a confusing experience where documents are indexed successfully but become unfilterable.


This variant keeps int32 bounds checking on a shared validation path:
- Coerce type only when needed.
- Always run shared int32 bounds validation afterward for scalar and array fields.
- Explicitly handle unsigned JSON integers so values > INT32_MAX are rejected/dropped correctly.

This avoids per-branch bypass checks and centralizes int32 range enforcement.

Includes same regression coverage as #2801:
- Int32FieldRejectsOverflowOnWrite
- Int32ArrayFieldRejectsOverflowOnWrite
- Int32OverflowWithDirtyValuesDropOptional

## Test plan

- [x] **Scalar overflow test** (`Int32FieldRejectsOverflowOnWrite`): verifies valid boundary values are accepted, and values exceeding `INT32_MAX` or below `INT32_MIN` are rejected with 400
- [x] **Array overflow test** (`Int32ArrayFieldRejectsOverflowOnWrite`): verifies array elements exceeding int32 range are rejected
- [x] **dirty_values DROP test** (`Int32OverflowWithDirtyValuesDropOptional`): verifies optional fields with `DROP` silently discard overflowed values, while non-optional fields still reject
- [x] Full test suite passes (665.8s, all existing tests green)