### PR TITLE
feat: Infix filtering support #2685

### DIFF
--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <memory>
 #include <queue>
 #include <id_list.h>
@@ -1723,7 +1724,25 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
 
         for (uint32_t i = 0; i < a_filter.values.size(); i++) {
             auto filter_value = a_filter.values[i];
-            auto is_prefix_match = filter_value.size() > 1 && filter_value[filter_value.size() - 1] == '*';
+
+            // Detect infix (*value*) before prefix (value*) to avoid misdetection
+            auto is_infix_match = filter_value.size() > 2
+                && filter_value[0] == '*'
+                && filter_value[filter_value.size() - 1] == '*';
+            auto is_prefix_match = !is_infix_match
+                && filter_value.size() > 1
+                && filter_value[filter_value.size() - 1] == '*';
+
+            if (is_infix_match) {
+                if (!f.infix) {
+                    status = Option<bool>(400, "Error with filter field `" + f.name +
+                        "`: Infix filtering requires the field to have `infix: true` in the schema.");
+                    validity = invalid;
+                    return;
+                }
+                filter_value.erase(0, 1);
+                filter_value.erase(filter_value.size() - 1);
+            }
             if (is_prefix_match) {
                 filter_value.erase(filter_value.size() - 1);
             }
@@ -1748,7 +1767,7 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
                 }
                 str_tokens.push_back(str_token);
 
-                if (is_prefix_match) {
+                if (is_prefix_match || is_infix_match) {
                     continue;
                 }
 
@@ -1767,6 +1786,47 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
                 status = Option<bool>(400, "Error with filter field `" + f.name + "`: Filter value cannot be empty.");
                 validity = invalid;
                 return;
+            }
+
+            if (is_infix_match) {
+                // Use existing search_infix() per token, intersect for multi-token, OR across values
+                std::vector<uint32_t> infix_ids;
+                bool first_token = true;
+
+                for (const auto& token : str_tokens) {
+                    std::vector<uint32_t> token_ids;
+                    auto infix_op = index->search_infix(token, a_filter.field_name,
+                                                         token_ids, INT16_MAX, INT16_MAX);
+                    if (!infix_op.ok()) {
+                        status = Option<bool>(infix_op.code(), infix_op.error());
+                        validity = invalid;
+                        return;
+                    }
+
+                    if (first_token) {
+                        infix_ids = std::move(token_ids);
+                        first_token = false;
+                    } else {
+                        std::vector<uint32_t> intersected;
+                        std::set_intersection(infix_ids.begin(), infix_ids.end(),
+                                              token_ids.begin(), token_ids.end(),
+                                              std::back_inserter(intersected));
+                        infix_ids = std::move(intersected);
+                    }
+
+                    if (infix_ids.empty()) break;
+                }
+
+                if (!infix_ids.empty()) {
+                    uint32_t* out = nullptr;
+                    filter_result.count = ArrayUtils::or_scalar(
+                        &infix_ids[0], infix_ids.size(),
+                        filter_result.docs, filter_result.count, &out);
+                    delete[] filter_result.docs;
+                    filter_result.docs = out;
+                }
+
+                continue;
             }
 
             if (is_prefix_match) {
@@ -1872,6 +1932,50 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
 
             // Multiple filter values get OR.
             approx_filter_ids_length += approx_filter_value_match;
+        }
+
+        // If infix filter values populated filter_result, finalize as flat ID result
+        bool has_infix_results = (filter_result.count > 0);
+        if (has_infix_results) {
+            if (!posting_lists.empty()) {
+                // Mixed infix + exact/prefix: flatten posting lists, then OR with infix results
+                uint32_t* infix_docs = filter_result.docs;
+                uint32_t infix_count = filter_result.count;
+                filter_result.docs = nullptr;
+                filter_result.count = 0;
+
+                compute_iterators();  // flattens posting_lists -> filter_result
+
+                uint32_t* out = nullptr;
+                filter_result.count = ArrayUtils::or_scalar(
+                    infix_docs, infix_count,
+                    filter_result.docs, filter_result.count, &out);
+                delete[] infix_docs;
+                delete[] filter_result.docs;
+                filter_result.docs = out;
+            }
+
+            if (a_filter.apply_not_equals) {
+                auto all_ids = index->seq_ids->uncompress();
+                auto all_ids_len = index->seq_ids->num_ids();
+                uint32_t* excluded = nullptr;
+                auto excluded_len = ArrayUtils::exclude_scalar(
+                    all_ids, all_ids_len,
+                    filter_result.docs, filter_result.count, &excluded);
+                delete[] all_ids;
+                delete[] filter_result.docs;
+                filter_result.docs = excluded;
+                filter_result.count = excluded_len;
+            }
+
+            is_filter_result_initialized = true;
+            if (filter_result.count == 0) {
+                validity = invalid;
+                return;
+            }
+            seq_id = filter_result.docs[result_index];
+            approx_filter_ids_length = filter_result.count;
+            return;
         }
 
         if (a_filter.apply_not_equals) {
@@ -3157,7 +3261,11 @@ bool filter_result_iterator_t::validate_object_filter_helper(Index const* const 
                                 filter_exp.comparators[0] : filter_exp.comparators[i];
 
             if (f.is_string()) {
-                if(val.at(val.size() - 1) == '*' && comparator == CONTAINS) {//prefix match
+                bool is_infix = val.size() > 2 && val.front() == '*' && val.back() == '*' && comparator == CONTAINS;
+                if (is_infix) {
+                    val.erase(0, 1)
+                    val.pop_back();
+                } else if(val.at(val.size() - 1) == '*' && comparator == CONTAINS) {//prefix match
                     val.pop_back();
                 }
 

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -3263,7 +3263,7 @@ bool filter_result_iterator_t::validate_object_filter_helper(Index const* const 
             if (f.is_string()) {
                 bool is_infix = val.size() > 2 && val.front() == '*' && val.back() == '*' && comparator == CONTAINS;
                 if (is_infix) {
-                    val.erase(0, 1)
+                    val.erase(0, 1);
                     val.pop_back();
                 } else if(val.at(val.size() - 1) == '*' && comparator == CONTAINS) {//prefix match
                     val.pop_back();

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -3330,6 +3330,114 @@ TEST_F(CollectionFilteringTest, PrefixFilterOnTextFields) {
     ASSERT_EQ("Steve Reiley", res_obj["hits"][3]["document"]["names"][0]);
 }
 
+TEST_F(CollectionFilteringTest, InfixFilterOnTextFields) {
+    // Create collection with infix: true on string fields
+    auto schema_json =
+            R"({
+                "name": "InfixFilterColl",
+                "fields": [
+                    {"name": "title", "type": "string", "infix": true},
+                    {"name": "cast", "type": "string[]", "infix": true},
+                    {"name": "name_no_infix", "type": "string"},
+                    {"name": "points", "type": "int32"}
+                ],
+                "default_sorting_field": "points"
+            })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto coll = collection_create_op.get();
+
+    std::vector<nlohmann::json> documents = {
+        R"({"title": "Captain America", "cast": ["Chris Evans", "Scarlett Johansson"], "name_no_infix": "foo", "points": 78})"_json,
+        R"({"title": "Anchorman", "cast": ["Chris Parnell", "Josh Lawson"], "name_no_infix": "bar", "points": 63})"_json,
+        R"({"title": "There Will Be Blood", "cast": ["Martin Stringer", "Jacob Stringer"], "name_no_infix": "baz", "points": 81})"_json,
+        R"({"title": "Good Will Hunting", "cast": ["Matt Damon", "Ben Affleck"], "name_no_infix": "qux", "points": 83})"_json,
+        R"({"title": "Percy Jackson", "cast": ["Logan Lerman", "Alexandra Daddario"], "name_no_infix": "quux", "points": 59})"_json,
+        R"({"title": "Quantum Quest", "cast": ["Chris Pine"], "name_no_infix": "corge", "points": 52})"_json,
+    };
+
+    for (auto const& json : documents) {
+        auto add_op = coll->add(json.dump());
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    // Test 1: Basic single-token infix on array field - *ris* should match "Chris" (Evans, Parnell, Pine)
+    auto results = coll->search("*", {}, "cast: *ris*", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
+    ASSERT_EQ(3, results["hits"].size());
+    std::set<std::string> result_ids;
+    for (size_t i = 0; i < results["hits"].size(); i++) {
+        result_ids.insert(results["hits"][i]["document"]["id"].get<std::string>());
+    }
+    ASSERT_TRUE(result_ids.count("0"));
+    ASSERT_TRUE(result_ids.count("1"));
+    ASSERT_TRUE(result_ids.count("5"));
+
+    // Test 2: Infix on string field - *pta* should match "Captain America"
+    results = coll->search("*", {}, "title: *pta*", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("Captain America", results["hits"][0]["document"]["title"]);
+
+    // Test 3: Infix with no matches
+    results = coll->search("*", {}, "cast: *zzz*", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
+    ASSERT_EQ(0, results["hits"].size());
+
+    // Test 4: OR of infix values - [*ris*, *art*] matches Chris* and Martin
+    results = coll->search("*", {}, "cast: [*ris*, *art*]", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
+    result_ids.clear();
+    for (size_t i = 0; i < results["hits"].size(); i++) {
+        result_ids.insert(results["hits"][i]["document"]["id"].get<std::string>());
+    }
+    ASSERT_TRUE(result_ids.count("0"));
+    ASSERT_TRUE(result_ids.count("1"));
+    ASSERT_TRUE(result_ids.count("2"));
+    ASSERT_TRUE(result_ids.count("5"));
+
+    // Test 5: Error when field lacks infix: true
+    auto res_op = coll->search("*", {}, "name_no_infix: *foo*", {}, {}, {0}, 10, 1, FREQUENCY, {false});
+    ASSERT_FALSE(res_op.ok());
+    ASSERT_EQ(400, res_op.code());
+    ASSERT_NE(std::string::npos, res_op.error().find("infix"));
+
+    // Test 6: Mixed infix + exact in OR - [*ris*, Martin]
+    results = coll->search("*", {}, "cast: [*ris*, Martin]", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
+    result_ids.clear();
+    for (size_t i = 0; i < results["hits"].size(); i++) {
+        result_ids.insert(results["hits"][i]["document"]["id"].get<std::string>());
+    }
+    ASSERT_TRUE(result_ids.count("0"));
+    ASSERT_TRUE(result_ids.count("1"));
+    ASSERT_TRUE(result_ids.count("2"));
+    ASSERT_TRUE(result_ids.count("5"));
+
+    // Test 7: Mixed infix + prefix in OR - [*ris*, Ma*]
+    results = coll->search("*", {}, "cast: [*ris*, Ma*]", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
+    result_ids.clear();
+    for (size_t i = 0; i < results["hits"].size(); i++) {
+        result_ids.insert(results["hits"][i]["document"]["id"].get<std::string>());
+    }
+    ASSERT_TRUE(result_ids.count("0"));
+    ASSERT_TRUE(result_ids.count("1"));
+    ASSERT_TRUE(result_ids.count("2"));
+    ASSERT_TRUE(result_ids.count("3"));
+    ASSERT_TRUE(result_ids.count("5"));
+
+    // Test 8: Infix combined with AND on another field
+    results = coll->search("*", {}, "cast: *ris* && points: >60", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
+    result_ids.clear();
+    for (size_t i = 0; i < results["hits"].size(); i++) {
+        result_ids.insert(results["hits"][i]["document"]["id"].get<std::string>());
+    }
+    ASSERT_EQ(2, results["hits"].size());
+    ASSERT_TRUE(result_ids.count("0"));
+    ASSERT_TRUE(result_ids.count("1"));
+
+    // Test 9: Infix on title (non-array string field) - *unt* matches "Good Will Hunting"
+    results = coll->search("*", {}, "title: *unt*", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("Good Will Hunting", results["hits"][0]["document"]["title"]);
+}
+
 TEST_F(CollectionFilteringTest, ExactFilterOnLongField) {
     nlohmann::json schema = R"({
          "name": "companies",


### PR DESCRIPTION
  ---                                                                                                                                                              
  feat: infix filtering support (field:*value*) #2685
                                                                                                                                                                   
  Closes #2685                                    

  ---
  Typesense supports exact (field:value) and prefix (field:value*) filtering on string fields, but had no way to filter by substring , users couldn't express "give me all docs where this field _contains_ this value."

  This PR adds field:*value* syntax to filter_by, enabling infix/contains filtering on string and string array fields that have `infix: true` in their schema.

  Changes:

  - Detection (filter_result_iterator.cpp): *value* is now detected as an infix pattern before the existing prefix (value*) check, avoiding misidentification.
  - Validation: Returns a 400 error if the field does not have infix: true... the infix index is only built when explicitly enabled.
  - Lookup: Reuses the existing Index::search_infix() function (already used for query-time infix search). For multi-token filter values (e.g. *Chris P*), results
  are intersected (AND). Multiple filter values in a list (e.g. [*foo*, *bar*]) are OR'd together.
  - Result assembly: Results are stored as a flat filter_result_t (sorted uint32_t[]) -> the same pattern used by numeric and geo filters. Mixed infix + exact/prefix in a single OR list is handled by flattening posting lists and OR'ing with infix results before returning.

  Test plan (CollectionFilteringTest.InfixFilterOnTextFields)

  - Basic single-token infix on string[] field (*ris* matches "Chris Evans", "Chris Parnell", "Chris Pine")
  - Infix on string field
  - No matches case
  - OR of multiple infix values ([*ris*, *art*])
  - Error on field without infix: true (400 response)
  - Mixed infix + exact in OR ([*ris*, Martin])
  - Mixed infix + prefix in OR ([*ris*, Ma*])
  - Infix combined with AND on another field (cast: *ris* && points: >60)