### PR TITLE
fix: update logic for skipping embedding generation when it is provided

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -8121,8 +8121,10 @@ void Index::batch_embed_fields(std::vector<index_record*>& records,
                 continue;
             }
 
-            if(document->contains(field.name) && !record->is_update) {
-                // embedding already exists (could be a restore from export)
+            if((document->contains(field.name) && !record->is_update) ||
+               (record->is_update && record->doc.contains(field.name))) {
+                // skip embedding if vector already exists (create/restore) or
+                // pre-computed vector was provided in update/upsert request
                 continue;
             }
 

--- a/test/collection_vector_search_test.cpp
+++ b/test/collection_vector_search_test.cpp
@@ -2117,6 +2117,92 @@ TEST_F(CollectionVectorTest, SkipEmbeddingOpWhenValueExists) {
     ASSERT_EQ("Field `embedding` contains invalid float values.", add_op.error());
 }
 
+TEST_F(CollectionVectorTest, SkipEmbeddingOpWhenValueExistsOnUpsert) {
+    // Pre-computed embedding vectors should be honored on upsert/update of existing documents
+    nlohmann::json schema = R"({
+        "name": "objects",
+        "fields": [
+            {"name": "name", "type": "string"},
+            {"name": "embedding", "type":"float[]", "embed":{"from": ["name"], "model_config": {"model_name": "ts/e5-small"}}}
+        ]
+    })"_json;
+
+    EmbedderManager::set_model_dir("/tmp/typesense_test/models");
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+    Collection* coll = op.get();
+
+    // Step 1: Create a document with a pre-computed embedding
+    nlohmann::json doc;
+    doc["id"] = "0";
+    doc["name"] = "butter";
+
+    std::vector<float> original_vec;
+    for(size_t i = 0; i < 384; i++) {
+        original_vec.push_back(0.345);
+    }
+    doc["embedding"] = original_vec;
+
+    auto add_op = coll->add(doc.dump(), CREATE);
+    ASSERT_TRUE(add_op.ok());
+
+    auto res = coll->search("*", {}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}).get();
+    ASSERT_NEAR(0.345, res["hits"][0]["document"]["embedding"][0].get<float>(), 0.01);
+
+    //Upsert with BOTH changed source field AND new pre-computed embedding, the pre-computed 
+    // embedding should be used, not auto-computed from the new name.
+    std::vector<float> new_vec;
+    for(size_t i = 0; i < 384; i++) {
+        new_vec.push_back(0.500);
+    }
+
+    nlohmann::json upsert_doc;
+    upsert_doc["id"] = "0";
+    upsert_doc["name"] = "ghee";
+    upsert_doc["embedding"] = new_vec;
+
+    auto upsert_op = coll->add(upsert_doc.dump(), UPSERT);
+    ASSERT_TRUE(upsert_op.ok());
+
+    res = coll->search("*", {}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}).get();
+    ASSERT_NEAR(0.500, res["hits"][0]["document"]["embedding"][0].get<float>(), 0.01);
+
+    // Update (PATCH) with BOTH changed source field AND new pre-computed embedding
+    std::vector<float> update_vec;
+    for(size_t i = 0; i < 384; i++) {
+        update_vec.push_back(0.700);
+    }
+
+    nlohmann::json update_doc;
+    update_doc["id"] = "0";
+    update_doc["name"] = "milk";
+    update_doc["embedding"] = update_vec;
+
+    auto update_op = coll->add(update_doc.dump(), UPDATE);
+    ASSERT_TRUE(update_op.ok());
+
+    res = coll->search("*", {}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}).get();
+    ASSERT_NEAR(0.700, res["hits"][0]["document"]["embedding"][0].get<float>(), 0.01);
+
+    // Emplace with BOTH changed source field AND new pre-computed embedding
+    std::vector<float> emplace_vec;
+    for(size_t i = 0; i < 384; i++) {
+        emplace_vec.push_back(0.900);
+    }
+
+    nlohmann::json emplace_doc;
+    emplace_doc["id"] = "0";
+    emplace_doc["name"] = "cheese";
+    emplace_doc["embedding"] = emplace_vec;
+
+    auto emplace_op = coll->add(emplace_doc.dump(), EMPLACE);
+    ASSERT_TRUE(emplace_op.ok());
+
+    res = coll->search("*", {}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}).get();
+    ASSERT_NEAR(0.900, res["hits"][0]["document"]["embedding"][0].get<float>(), 0.01);
+}
+
 TEST_F(CollectionVectorTest, SemanticSearchReturnOnlyVectorDistance) {
     auto schema_json =
         R"({

--- a/test/collection_vector_search_test.cpp
+++ b/test/collection_vector_search_test.cpp
@@ -2133,15 +2133,22 @@ TEST_F(CollectionVectorTest, SkipEmbeddingOpWhenValueExistsOnUpsert) {
     ASSERT_TRUE(op.ok());
     Collection* coll = op.get();
 
-    // Step 1: Create a document with a pre-computed embedding
+    // Get num_dim from the collection's embedding field
+    size_t num_dim = 0;
+    for(const auto& f : coll->get_fields()) {
+        if(f.name == "embedding") {
+            num_dim = f.num_dim;
+            break;
+        }
+    }
+    ASSERT_GT(num_dim, 0);
+
+    // Create a document with a pre-computed embedding
     nlohmann::json doc;
     doc["id"] = "0";
     doc["name"] = "butter";
 
-    std::vector<float> original_vec;
-    for(size_t i = 0; i < 384; i++) {
-        original_vec.push_back(0.345);
-    }
+    std::vector<float> original_vec(num_dim, 0.345f);
     doc["embedding"] = original_vec;
 
     auto add_op = coll->add(doc.dump(), CREATE);
@@ -2150,12 +2157,9 @@ TEST_F(CollectionVectorTest, SkipEmbeddingOpWhenValueExistsOnUpsert) {
     auto res = coll->search("*", {}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}).get();
     ASSERT_NEAR(0.345, res["hits"][0]["document"]["embedding"][0].get<float>(), 0.01);
 
-    //Upsert with BOTH changed source field AND new pre-computed embedding, the pre-computed 
-    // embedding should be used, not auto-computed from the new name.
-    std::vector<float> new_vec;
-    for(size_t i = 0; i < 384; i++) {
-        new_vec.push_back(0.500);
-    }
+    // Upsert with BOTH changed source field AND new pre-computed embedding.
+    // The pre-computed embedding should be used, not auto-computed from the new name.
+    std::vector<float> new_vec(num_dim, 0.500f);
 
     nlohmann::json upsert_doc;
     upsert_doc["id"] = "0";
@@ -2169,10 +2173,7 @@ TEST_F(CollectionVectorTest, SkipEmbeddingOpWhenValueExistsOnUpsert) {
     ASSERT_NEAR(0.500, res["hits"][0]["document"]["embedding"][0].get<float>(), 0.01);
 
     // Update (PATCH) with BOTH changed source field AND new pre-computed embedding
-    std::vector<float> update_vec;
-    for(size_t i = 0; i < 384; i++) {
-        update_vec.push_back(0.700);
-    }
+    std::vector<float> update_vec(num_dim, 0.700f);
 
     nlohmann::json update_doc;
     update_doc["id"] = "0";
@@ -2186,10 +2187,7 @@ TEST_F(CollectionVectorTest, SkipEmbeddingOpWhenValueExistsOnUpsert) {
     ASSERT_NEAR(0.700, res["hits"][0]["document"]["embedding"][0].get<float>(), 0.01);
 
     // Emplace with BOTH changed source field AND new pre-computed embedding
-    std::vector<float> emplace_vec;
-    for(size_t i = 0; i < 384; i++) {
-        emplace_vec.push_back(0.900);
-    }
+    std::vector<float> emplace_vec(num_dim, 0.900f);
 
     nlohmann::json emplace_doc;
     emplace_doc["id"] = "0";


### PR DESCRIPTION
## Change Summary
When upserting or updating an existing document with an embed-configured field, we are ignoring any user-provided embedding vector and always called the external embedding API to regenerate it.

The skip logic in `batch_embed_fields()` only takes account pre-computed vectors for new documents `(!record->is_update)`. 

This change extends the condition to also skip embedding when the user's original request contains a pre-computed vector during an update/upsert.

Fixes #2794 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
