### PR TITLE
feat: Infix filtering support #2685

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -945,6 +945,10 @@ public:
     Option<bool> search_infix(const std::string& query, const std::string& field_name, std::vector<uint32_t>& ids,
                               size_t max_extra_prefix, size_t max_extra_suffix) const;
 
+    Option<bool> search_infix_leaves(const std::string& query, const std::string& field_name,
+                                     std::vector<art_leaf*>& leaves,
+                                     size_t max_extra_prefix, size_t max_extra_suffix) const;
+
     void curate_filtered_ids(const uint32_t* exclude_token_ids, size_t exclude_token_ids_size, uint32_t*& filter_ids,
                              uint32_t& filter_ids_length, const std::vector<uint32_t>& curated_ids_sorted) const;
 

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <memory>
 #include <queue>
 #include <id_list.h>
@@ -1723,7 +1724,25 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
 
         for (uint32_t i = 0; i < a_filter.values.size(); i++) {
             auto filter_value = a_filter.values[i];
-            auto is_prefix_match = filter_value.size() > 1 && filter_value[filter_value.size() - 1] == '*';
+
+            // Detect infix (*value*) before prefix (value*) to avoid misdetection
+            auto is_infix_match = filter_value.size() > 2
+                && filter_value[0] == '*'
+                && filter_value[filter_value.size() - 1] == '*';
+            auto is_prefix_match = !is_infix_match
+                && filter_value.size() > 1
+                && filter_value[filter_value.size() - 1] == '*';
+
+            if (is_infix_match) {
+                if (!f.infix) {
+                    status = Option<bool>(400, "Error with filter field `" + f.name +
+                        "`: Infix filtering requires the field to have `infix: true` in the schema.");
+                    validity = invalid;
+                    return;
+                }
+                filter_value.erase(0, 1);
+                filter_value.erase(filter_value.size() - 1);
+            }
             if (is_prefix_match) {
                 filter_value.erase(filter_value.size() - 1);
             }
@@ -1748,7 +1767,7 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
                 }
                 str_tokens.push_back(str_token);
 
-                if (is_prefix_match) {
+                if (is_prefix_match || is_infix_match) {
                     continue;
                 }
 
@@ -1767,6 +1786,47 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
                 status = Option<bool>(400, "Error with filter field `" + f.name + "`: Filter value cannot be empty.");
                 validity = invalid;
                 return;
+            }
+
+            if (is_infix_match) {
+                // Use existing search_infix() per token, intersect for multi-token, OR across values
+                std::vector<uint32_t> infix_ids;
+                bool first_token = true;
+
+                for (const auto& token : str_tokens) {
+                    std::vector<uint32_t> token_ids;
+                    auto infix_op = index->search_infix(token, a_filter.field_name,
+                                                         token_ids, INT16_MAX, INT16_MAX);
+                    if (!infix_op.ok()) {
+                        status = Option<bool>(infix_op.code(), infix_op.error());
+                        validity = invalid;
+                        return;
+                    }
+
+                    if (first_token) {
+                        infix_ids = std::move(token_ids);
+                        first_token = false;
+                    } else {
+                        std::vector<uint32_t> intersected;
+                        std::set_intersection(infix_ids.begin(), infix_ids.end(),
+                                              token_ids.begin(), token_ids.end(),
+                                              std::back_inserter(intersected));
+                        infix_ids = std::move(intersected);
+                    }
+
+                    if (infix_ids.empty()) break;
+                }
+
+                if (!infix_ids.empty()) {
+                    uint32_t* out = nullptr;
+                    filter_result.count = ArrayUtils::or_scalar(
+                        &infix_ids[0], infix_ids.size(),
+                        filter_result.docs, filter_result.count, &out);
+                    delete[] filter_result.docs;
+                    filter_result.docs = out;
+                }
+
+                continue;
             }
 
             if (is_prefix_match) {
@@ -1872,6 +1932,50 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
 
             // Multiple filter values get OR.
             approx_filter_ids_length += approx_filter_value_match;
+        }
+
+        // If infix filter values populated filter_result, finalize as flat ID result
+        bool has_infix_results = (filter_result.count > 0);
+        if (has_infix_results) {
+            if (!posting_lists.empty()) {
+                // Mixed infix + exact/prefix: flatten posting lists, then OR with infix results
+                uint32_t* infix_docs = filter_result.docs;
+                uint32_t infix_count = filter_result.count;
+                filter_result.docs = nullptr;
+                filter_result.count = 0;
+
+                compute_iterators();  // flattens posting_lists -> filter_result
+
+                uint32_t* out = nullptr;
+                filter_result.count = ArrayUtils::or_scalar(
+                    infix_docs, infix_count,
+                    filter_result.docs, filter_result.count, &out);
+                delete[] infix_docs;
+                delete[] filter_result.docs;
+                filter_result.docs = out;
+            }
+
+            if (a_filter.apply_not_equals) {
+                auto all_ids = index->seq_ids->uncompress();
+                auto all_ids_len = index->seq_ids->num_ids();
+                uint32_t* excluded = nullptr;
+                auto excluded_len = ArrayUtils::exclude_scalar(
+                    all_ids, all_ids_len,
+                    filter_result.docs, filter_result.count, &excluded);
+                delete[] all_ids;
+                delete[] filter_result.docs;
+                filter_result.docs = excluded;
+                filter_result.count = excluded_len;
+            }
+
+            is_filter_result_initialized = true;
+            if (filter_result.count == 0) {
+                validity = invalid;
+                return;
+            }
+            seq_id = filter_result.docs[result_index];
+            approx_filter_ids_length = filter_result.count;
+            return;
         }
 
         if (a_filter.apply_not_equals) {
@@ -3157,7 +3261,11 @@ bool filter_result_iterator_t::validate_object_filter_helper(Index const* const 
                                 filter_exp.comparators[0] : filter_exp.comparators[i];
 
             if (f.is_string()) {
-                if(val.at(val.size() - 1) == '*' && comparator == CONTAINS) {//prefix match
+                bool is_infix = val.size() > 2 && val.front() == '*' && val.back() == '*' && comparator == CONTAINS;
+                if (is_infix) {
+                    val.erase(0, 1);
+                    val.pop_back();
+                } else if(val.at(val.size() - 1) == '*' && comparator == CONTAINS) {//prefix match
                     val.pop_back();
                 }
 

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -1,4 +1,3 @@
-#include <algorithm>
 #include <memory>
 #include <queue>
 #include <id_list.h>
@@ -2076,41 +2075,47 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
             }
 
             if (is_infix_match) {
-                // Use existing search_infix() per token, intersect for multi-token, OR across values
-                std::vector<uint32_t> infix_ids;
-                bool first_token = true;
-
-                for (const auto& token : str_tokens) {
-                    std::vector<uint32_t> token_ids;
-                    auto infix_op = index->search_infix(token, a_filter.field_name,
-                                                         token_ids, INT16_MAX, INT16_MAX);
+                if (str_tokens.size() == 1) {
+                    // Lazy path: one posting_list_iterators entry per matching vocab token.
+                    // The CONTAINS comparator branch in get_string_filter_next_match ORs all entries
+                    // without position verification, which is correct for infix substring matching.
+                    std::vector<art_leaf*> infix_leaves;
+                    auto infix_op = index->search_infix_leaves(str_tokens[0], a_filter.field_name,
+                                                               infix_leaves, INT16_MAX, INT16_MAX);
                     if (!infix_op.ok()) {
                         status = Option<bool>(infix_op.code(), infix_op.error());
                         validity = invalid;
                         return;
                     }
 
-                    if (first_token) {
-                        infix_ids = std::move(token_ids);
-                        first_token = false;
-                    } else {
-                        std::vector<uint32_t> intersected;
-                        std::set_intersection(infix_ids.begin(), infix_ids.end(),
-                                              token_ids.begin(), token_ids.end(),
-                                              std::back_inserter(intersected));
-                        infix_ids = std::move(intersected);
+                    for (auto* leaf : infix_leaves) {
+                        std::vector<void*> raw = {leaf->values};
+                        std::vector<posting_list_t*> plists;
+                        posting_t::to_expanded_plists(raw, plists, expanded_plists);
+                        if (plists.empty()) {
+                            continue;
+                        }
+
+                        posting_lists.push_back(plists);
+                        posting_list_iterators.emplace_back(std::vector<posting_list_t::iterator_t>());
+                        for (auto const& plist : plists) {
+                            posting_list_iterators.back().push_back(plist->new_iterator());
+                        }
+
+                        // Multiple filter values get OR; accumulate approx count (may overcount
+                        // since the same doc can appear in multiple vocab token posting lists).
+                        approx_filter_ids_length += posting_t::num_ids(leaf->values);
                     }
-
-                    if (infix_ids.empty()) break;
-                }
-
-                if (!infix_ids.empty()) {
-                    uint32_t* out = nullptr;
-                    filter_result.count = ArrayUtils::or_scalar(
-                        &infix_ids[0], infix_ids.size(),
-                        filter_result.docs, filter_result.count, &out);
-                    delete[] filter_result.docs;
-                    filter_result.docs = out;
+                } else {
+                    // Multi-token infix (e.g. *foo bar*) is not supported: the infix index stores
+                    // individual word tokens only, so substring search across word boundaries is
+                    // structurally impossible. Use separate conditions instead, e.g. field:*foo* && field:*bar*.
+                    status = Option<bool>(400, "Error with filter field `" + f.name +
+                        "`: Infix filter value must be a single token. "
+                        "To match multiple substrings use separate conditions, "
+                        "e.g. `field:*foo* && field:*bar*`.");
+                    validity = invalid;
+                    return;
                 }
 
                 continue;
@@ -2221,50 +2226,6 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
 
             // Multiple filter values get OR.
             approx_filter_ids_length += approx_filter_value_match;
-        }
-
-        // If infix filter values populated filter_result, finalize as flat ID result
-        bool has_infix_results = (filter_result.count > 0);
-        if (has_infix_results) {
-            if (!posting_lists.empty()) {
-                // Mixed infix + exact/prefix: flatten posting lists, then OR with infix results
-                uint32_t* infix_docs = filter_result.docs;
-                uint32_t infix_count = filter_result.count;
-                filter_result.docs = nullptr;
-                filter_result.count = 0;
-
-                compute_iterators();  // flattens posting_lists -> filter_result
-
-                uint32_t* out = nullptr;
-                filter_result.count = ArrayUtils::or_scalar(
-                    infix_docs, infix_count,
-                    filter_result.docs, filter_result.count, &out);
-                delete[] infix_docs;
-                delete[] filter_result.docs;
-                filter_result.docs = out;
-            }
-
-            if (a_filter.apply_not_equals) {
-                auto all_ids = index->seq_ids->uncompress();
-                auto all_ids_len = index->seq_ids->num_ids();
-                uint32_t* excluded = nullptr;
-                auto excluded_len = ArrayUtils::exclude_scalar(
-                    all_ids, all_ids_len,
-                    filter_result.docs, filter_result.count, &excluded);
-                delete[] all_ids;
-                delete[] filter_result.docs;
-                filter_result.docs = excluded;
-                filter_result.count = excluded_len;
-            }
-
-            is_filter_result_initialized = true;
-            if (filter_result.count == 0) {
-                validity = invalid;
-                return;
-            }
-            seq_id = filter_result.docs[result_index];
-            approx_filter_ids_length = filter_result.count;
-            return;
         }
 
         if (a_filter.apply_not_equals) {

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -2077,8 +2077,6 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
             if (is_infix_match) {
                 if (str_tokens.size() == 1) {
                     // Lazy path: one posting_list_iterators entry per matching vocab token.
-                    // The CONTAINS comparator branch in get_string_filter_next_match ORs all entries
-                    // without position verification, which is correct for infix substring matching.
                     std::vector<art_leaf*> infix_leaves;
                     auto infix_op = index->search_infix_leaves(str_tokens[0], a_filter.field_name,
                                                                infix_leaves, INT16_MAX, INT16_MAX);
@@ -2107,9 +2105,7 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
                         approx_filter_ids_length += posting_t::num_ids(leaf->values);
                     }
                 } else {
-                    // Multi-token infix (e.g. *foo bar*) is not supported: the infix index stores
-                    // individual word tokens only, so substring search across word boundaries is
-                    // structurally impossible. Use separate conditions instead, e.g. field:*foo* && field:*bar*.
+                    // Multi-token infix (e.g. *foo bar*) is not supported
                     status = Option<bool>(400, "Error with filter field `" + f.name +
                         "`: Infix filter value must be a single token. "
                         "To match multiple substrings use separate conditions, "

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3344,8 +3344,9 @@ bool Index::check_for_curations(const token_ordering& token_order, const string&
     return false;
 }
 
-Option<bool> Index::search_infix(const std::string& query, const std::string& field_name, std::vector<uint32_t>& ids,
-                                 const size_t max_extra_prefix, const size_t max_extra_suffix) const {
+Option<bool> Index::search_infix_leaves(const std::string& query, const std::string& field_name,
+                                        std::vector<art_leaf*>& leaves,
+                                        const size_t max_extra_prefix, const size_t max_extra_suffix) const {
 
     auto infix_maps_it = infix_index.find(field_name);
 
@@ -3355,7 +3356,6 @@ Option<bool> Index::search_infix(const std::string& query, const std::string& fi
     }
 
     auto infix_sets = infix_maps_it->second;
-    std::vector<art_leaf*> leaves;
 
     size_t num_processed = 0;
     std::mutex m_process;
@@ -3416,6 +3416,18 @@ Option<bool> Index::search_infix(const std::string& query, const std::string& fi
     std::unique_lock<std::mutex> lock_process(m_process);
     cv_process.wait(lock_process, [&](){ return num_processed == infix_sets.size(); });
     search_cutoff = parent_search_cutoff;
+
+    return Option<bool>(true);
+}
+
+Option<bool> Index::search_infix(const std::string& query, const std::string& field_name, std::vector<uint32_t>& ids,
+                                 const size_t max_extra_prefix, const size_t max_extra_suffix) const {
+
+    std::vector<art_leaf*> leaves;
+    auto op = search_infix_leaves(query, field_name, leaves, max_extra_prefix, max_extra_suffix);
+    if (!op.ok()) {
+        return op;
+    }
 
     for(auto leaf: leaves) {
         posting_t::merge({leaf->values}, ids);

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -3397,7 +3397,8 @@ TEST_F(CollectionFilteringTest, InfixFilterOnTextFields) {
     auto res_op = coll->search("*", {}, "name_no_infix: *foo*", {}, {}, {0}, 10, 1, FREQUENCY, {false});
     ASSERT_FALSE(res_op.ok());
     ASSERT_EQ(400, res_op.code());
-    ASSERT_NE(std::string::npos, res_op.error().find("infix"));
+    ASSERT_EQ("Error with filter field `name_no_infix`: Infix filtering requires the field to have "
+              "`infix: true` in the schema.", res_op.error());
 
     // Test 6: Mixed infix + exact in OR - [*ris*, Martin]
     results = coll->search("*", {}, "cast: [*ris*, Martin]", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -3437,6 +3437,52 @@ TEST_F(CollectionFilteringTest, InfixFilterOnTextFields) {
     results = coll->search("*", {}, "title: *unt*", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
     ASSERT_EQ(1, results["hits"].size());
     ASSERT_EQ("Good Will Hunting", results["hits"][0]["document"]["title"]);
+
+    // Test 10: enable_lazy_filter=true + OR of infix values, cast:[*an*,*in*] with q:"will".
+    {
+        std::map<std::string, std::string> req_params = {
+            {"collection", "InfixFilterColl"},
+            {"q", "will"},
+            {"query_by", "title"},
+            {"filter_by", "cast: [*an*, *in*]"},
+            {"enable_lazy_filter", "true"}
+        };
+        nlohmann::json embedded_params;
+        std::string json_res;
+        auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+        auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+        ASSERT_TRUE(search_op.ok());
+        auto res_obj = nlohmann::json::parse(json_res);
+        ASSERT_EQ(1, res_obj["found"].get<size_t>());
+        ASSERT_EQ("2", res_obj["hits"][0]["document"]["id"].get<std::string>());
+    }
+
+    // Test 11: enable_lazy_filter=true + negated OR of infix values, cast:![*an*,*in*] with q:"will".
+    // NOT({0,2,4,5}) = {1,3}. "will" in title: {2,3}. Result = {3}.
+    {
+        std::map<std::string, std::string> req_params = {
+            {"collection", "InfixFilterColl"},
+            {"q", "will"},
+            {"query_by", "title"},
+            {"filter_by", "cast: ! [*an*, *in*]"},
+            {"enable_lazy_filter", "true"}
+        };
+        nlohmann::json embedded_params;
+        std::string json_res;
+        auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+        auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+        ASSERT_TRUE(search_op.ok());
+        auto res_obj = nlohmann::json::parse(json_res);
+        ASSERT_EQ(1, res_obj["found"].get<size_t>());
+        ASSERT_EQ("3", res_obj["hits"][0]["document"]["id"].get<std::string>());
+    }
+
+    // Test 12: Exact-match operator (:=) with infix-style value — cast:= *in*.
+    // No exact matches to "in" in our cast so should return 0
+    results = coll->search("*", {}, "cast:= *in*", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
+    ASSERT_EQ(0, results["hits"].size());
 }
 
 TEST_F(CollectionFilteringTest, ExactFilterOnLongField) {

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -3330,6 +3330,114 @@ TEST_F(CollectionFilteringTest, PrefixFilterOnTextFields) {
     ASSERT_EQ("Steve Reiley", res_obj["hits"][3]["document"]["names"][0]);
 }
 
+TEST_F(CollectionFilteringTest, InfixFilterOnTextFields) {
+    // Create collection with infix: true on string fields
+    auto schema_json =
+            R"({
+                "name": "InfixFilterColl",
+                "fields": [
+                    {"name": "title", "type": "string", "infix": true},
+                    {"name": "cast", "type": "string[]", "infix": true},
+                    {"name": "name_no_infix", "type": "string"},
+                    {"name": "points", "type": "int32"}
+                ],
+                "default_sorting_field": "points"
+            })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto coll = collection_create_op.get();
+
+    std::vector<nlohmann::json> documents = {
+        R"({"title": "Captain America", "cast": ["Chris Evans", "Scarlett Johansson"], "name_no_infix": "foo", "points": 78})"_json,
+        R"({"title": "Anchorman", "cast": ["Chris Parnell", "Josh Lawson"], "name_no_infix": "bar", "points": 63})"_json,
+        R"({"title": "There Will Be Blood", "cast": ["Martin Stringer", "Jacob Stringer"], "name_no_infix": "baz", "points": 81})"_json,
+        R"({"title": "Good Will Hunting", "cast": ["Matt Damon", "Ben Affleck"], "name_no_infix": "qux", "points": 83})"_json,
+        R"({"title": "Percy Jackson", "cast": ["Logan Lerman", "Alexandra Daddario"], "name_no_infix": "quux", "points": 59})"_json,
+        R"({"title": "Quantum Quest", "cast": ["Chris Pine"], "name_no_infix": "corge", "points": 52})"_json,
+    };
+
+    for (auto const& json : documents) {
+        auto add_op = coll->add(json.dump());
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    // Test 1: Basic single-token infix on array field - *ris* should match "Chris" (Evans, Parnell, Pine)
+    auto results = coll->search("*", {}, "cast: *ris*", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
+    ASSERT_EQ(3, results["hits"].size());
+    std::set<std::string> result_ids;
+    for (size_t i = 0; i < results["hits"].size(); i++) {
+        result_ids.insert(results["hits"][i]["document"]["id"].get<std::string>());
+    }
+    ASSERT_TRUE(result_ids.count("0"));
+    ASSERT_TRUE(result_ids.count("1"));
+    ASSERT_TRUE(result_ids.count("5"));
+
+    // Test 2: Infix on string field - *pta* should match "Captain America"
+    results = coll->search("*", {}, "title: *pta*", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("Captain America", results["hits"][0]["document"]["title"]);
+
+    // Test 3: Infix with no matches
+    results = coll->search("*", {}, "cast: *zzz*", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
+    ASSERT_EQ(0, results["hits"].size());
+
+    // Test 4: OR of infix values - [*ris*, *art*] matches Chris* and Martin
+    results = coll->search("*", {}, "cast: [*ris*, *art*]", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
+    result_ids.clear();
+    for (size_t i = 0; i < results["hits"].size(); i++) {
+        result_ids.insert(results["hits"][i]["document"]["id"].get<std::string>());
+    }
+    ASSERT_TRUE(result_ids.count("0"));
+    ASSERT_TRUE(result_ids.count("1"));
+    ASSERT_TRUE(result_ids.count("2"));
+    ASSERT_TRUE(result_ids.count("5"));
+
+    // Test 5: Error when field lacks infix: true
+    auto res_op = coll->search("*", {}, "name_no_infix: *foo*", {}, {}, {0}, 10, 1, FREQUENCY, {false});
+    ASSERT_FALSE(res_op.ok());
+    ASSERT_EQ(400, res_op.code());
+    ASSERT_NE(std::string::npos, res_op.error().find("infix"));
+
+    // Test 6: Mixed infix + exact in OR - [*ris*, Martin]
+    results = coll->search("*", {}, "cast: [*ris*, Martin]", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
+    result_ids.clear();
+    for (size_t i = 0; i < results["hits"].size(); i++) {
+        result_ids.insert(results["hits"][i]["document"]["id"].get<std::string>());
+    }
+    ASSERT_TRUE(result_ids.count("0"));
+    ASSERT_TRUE(result_ids.count("1"));
+    ASSERT_TRUE(result_ids.count("2"));
+    ASSERT_TRUE(result_ids.count("5"));
+
+    // Test 7: Mixed infix + prefix in OR - [*ris*, Ma*]
+    results = coll->search("*", {}, "cast: [*ris*, Ma*]", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
+    result_ids.clear();
+    for (size_t i = 0; i < results["hits"].size(); i++) {
+        result_ids.insert(results["hits"][i]["document"]["id"].get<std::string>());
+    }
+    ASSERT_TRUE(result_ids.count("0"));
+    ASSERT_TRUE(result_ids.count("1"));
+    ASSERT_TRUE(result_ids.count("2"));
+    ASSERT_TRUE(result_ids.count("3"));
+    ASSERT_TRUE(result_ids.count("5"));
+
+    // Test 8: Infix combined with AND on another field
+    results = coll->search("*", {}, "cast: *ris* && points: >60", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
+    result_ids.clear();
+    for (size_t i = 0; i < results["hits"].size(); i++) {
+        result_ids.insert(results["hits"][i]["document"]["id"].get<std::string>());
+    }
+    ASSERT_EQ(2, results["hits"].size());
+    ASSERT_TRUE(result_ids.count("0"));
+    ASSERT_TRUE(result_ids.count("1"));
+
+    // Test 9: Infix on title (non-array string field) - *unt* matches "Good Will Hunting"
+    results = coll->search("*", {}, "title: *unt*", {}, {}, {0}, 10, 1, FREQUENCY, {false}).get();
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("Good Will Hunting", results["hits"][0]["document"]["title"]);
+}
+
 TEST_F(CollectionFilteringTest, ExactFilterOnLongField) {
     nlohmann::json schema = R"({
          "name": "companies",

--- a/test/filter_test.cpp
+++ b/test/filter_test.cpp
@@ -2984,7 +2984,29 @@ TEST_F(FilterTest, InfixLazyEvaluation) {
     delete filter_tree_root;
     filter_tree_root = nullptr;
 
-    // Test 5: Multi-token infix must return 400 — *ris pin* tokenizes to ["ris", "pin"].
+    // Test 5: AND of two single-token infix conditions — cast:*ris* && cast:*in*.
+    // *ris*: docs {0, 1, 5} (via "chris"); *in*: docs {2, 5} (via "martin"/"stringer" and "pine").
+    // Intersection = {5}.
+    filter_op = filter::parse_filter_query("cast: *ris* && cast: *in*", coll->get_schema(), store,
+                                           doc_id_prefix, filter_tree_root);
+    ASSERT_TRUE(filter_op.ok());
+
+    auto iter_two_infix_and = filter_result_iterator_t(coll->get_name(), coll->_get_index(),
+                                                       filter_tree_root, enable_lazy_evaluation);
+    ASSERT_TRUE(iter_two_infix_and.init_status().ok());
+
+    expected = {5};
+    for (auto const& id : expected) {
+        ASSERT_EQ(filter_result_iterator_t::valid, iter_two_infix_and.validity);
+        ASSERT_EQ(id, iter_two_infix_and.seq_id);
+        iter_two_infix_and.next();
+    }
+    ASSERT_EQ(filter_result_iterator_t::invalid, iter_two_infix_and.validity);
+
+    delete filter_tree_root;
+    filter_tree_root = nullptr;
+
+    // Test 6: Multi-token infix must return 400 — *ris pin* tokenizes to ["ris", "pin"].
     // The infix index stores individual word tokens only; substring search across word
     // boundaries is structurally impossible. Users should write cast:*ris* && cast:*pin* instead.
     filter_op = filter::parse_filter_query("cast: *ris pin*", coll->get_schema(), store,
@@ -2995,7 +3017,9 @@ TEST_F(FilterTest, InfixLazyEvaluation) {
                                                      filter_tree_root, enable_lazy_evaluation);
     ASSERT_FALSE(iter_multi_token.init_status().ok());
     ASSERT_EQ(400, iter_multi_token.init_status().code());
-    ASSERT_NE(std::string::npos, iter_multi_token.init_status().error().find("single token"));
+    ASSERT_EQ("Error with filter field `cast`: Infix filter value must be a single token. "
+              "To match multiple substrings use separate conditions, "
+              "e.g. `field:*foo* && field:*bar*`.", iter_multi_token.init_status().error());
 
     delete filter_tree_root;
     filter_tree_root = nullptr;

--- a/test/filter_test.cpp
+++ b/test/filter_test.cpp
@@ -2865,3 +2865,138 @@ TEST_F(FilterTest, FilterReferences) {
     }
     ASSERT_EQ(filter_result_iterator_t::invalid, fit->validity);
 }
+
+TEST_F(FilterTest, InfixLazyEvaluation) {
+    // Collection with infix: true on cast (string[]) and points (int32).
+    // Documents match the same schema used in CollectionFilteringTest.InfixFilterOnTextFields.
+    nlohmann::json schema =
+            R"({
+                "name": "InfixLazyColl",
+                "fields": [
+                    {"name": "cast",   "type": "string[]", "infix": true},
+                    {"name": "points", "type": "int32"}
+                ]
+            })"_json;
+
+    Collection* coll = collectionManager.create_collection(schema).get();
+
+    // seq_id 0: cast contains "chris" and "evans"
+    // seq_id 1: cast contains "chris" and "parnell"
+    // seq_id 2: cast contains "martin" and "stringer"
+    // seq_id 3: cast contains "matt" and "damon"
+    // seq_id 4: cast contains "logan" and "lerman"
+    // seq_id 5: cast contains "chris" and "pine"
+    std::vector<std::string> docs = {
+        R"({"cast": ["Chris Evans", "Scarlett Johansson"], "points": 78})",
+        R"({"cast": ["Chris Parnell", "Josh Lawson"],      "points": 63})",
+        R"({"cast": ["Martin Stringer", "Jacob Stringer"], "points": 81})",
+        R"({"cast": ["Matt Damon", "Ben Affleck"],         "points": 83})",
+        R"({"cast": ["Logan Lerman", "Alexandra Daddario"],"points": 59})",
+        R"({"cast": ["Chris Pine"],                        "points": 52})",
+    };
+
+    for (auto const& d : docs) {
+        auto add_op = coll->add(d);
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    const std::string doc_id_prefix = std::to_string(coll->get_collection_id()) + "_" +
+                                       Collection::DOC_ID_PREFIX + "_";
+    auto const enable_lazy_evaluation = true;
+    filter_node_t* filter_tree_root = nullptr;
+
+    // Test 1: Basic infix *ris* — "chris" matches docs 0, 1, 5.
+    // approx_filter_ids_length = 3 (docs in "chris" posting list).
+    // In TEST_BUILD string_filter_ids_threshold = 3, so 3 < 3 is false → lazy path.
+    auto filter_op = filter::parse_filter_query("cast: *ris*", coll->get_schema(), store,
+                                                doc_id_prefix, filter_tree_root);
+    ASSERT_TRUE(filter_op.ok());
+
+    auto iter_infix_basic = filter_result_iterator_t(coll->get_name(), coll->_get_index(),
+                                                     filter_tree_root, enable_lazy_evaluation);
+    ASSERT_TRUE(iter_infix_basic.init_status().ok());
+
+    std::vector<uint32_t> expected = {0, 1, 5};
+    for (auto const& id : expected) {
+        ASSERT_EQ(filter_result_iterator_t::valid, iter_infix_basic.validity);
+        ASSERT_EQ(id, iter_infix_basic.seq_id);
+        iter_infix_basic.next();
+    }
+    ASSERT_EQ(filter_result_iterator_t::invalid, iter_infix_basic.validity);
+
+    delete filter_tree_root;
+    filter_tree_root = nullptr;
+
+    // Test 2: No-match infix — iterator immediately invalid.
+    filter_op = filter::parse_filter_query("cast: *zzz*", coll->get_schema(), store,
+                                           doc_id_prefix, filter_tree_root);
+    ASSERT_TRUE(filter_op.ok());
+
+    auto iter_infix_no_match = filter_result_iterator_t(coll->get_name(), coll->_get_index(),
+                                                        filter_tree_root, enable_lazy_evaluation);
+    ASSERT_TRUE(iter_infix_no_match.init_status().ok());
+    ASSERT_EQ(filter_result_iterator_t::invalid, iter_infix_no_match.validity);
+
+    delete filter_tree_root;
+    filter_tree_root = nullptr;
+
+    // Test 3: OR of two infix values — [*ris*, *art*].
+    // *ris*: "chris" → docs {0, 1, 5}
+    // *art*: "martin" → docs {2}
+    // approx_filter_ids_length = 3 + 1 = 4 > threshold=3 → lazy.
+    filter_op = filter::parse_filter_query("cast: [*ris*, *art*]", coll->get_schema(), store,
+                                           doc_id_prefix, filter_tree_root);
+    ASSERT_TRUE(filter_op.ok());
+
+    auto iter_infix_or = filter_result_iterator_t(coll->get_name(), coll->_get_index(),
+                                                  filter_tree_root, enable_lazy_evaluation);
+    ASSERT_TRUE(iter_infix_or.init_status().ok());
+
+    expected = {0, 1, 2, 5};
+    for (auto const& id : expected) {
+        ASSERT_EQ(filter_result_iterator_t::valid, iter_infix_or.validity);
+        ASSERT_EQ(id, iter_infix_or.seq_id);
+        iter_infix_or.next();
+    }
+    ASSERT_EQ(filter_result_iterator_t::invalid, iter_infix_or.validity);
+
+    delete filter_tree_root;
+    filter_tree_root = nullptr;
+
+    // Test 4: Infix AND numeric — cast:*ris* && points:>60.
+    // *ris*: docs {0, 1, 5}; points>60: docs {0, 1, 2, 3} → intersection = {0, 1}.
+    filter_op = filter::parse_filter_query("cast: *ris* && points: >60", coll->get_schema(), store,
+                                           doc_id_prefix, filter_tree_root);
+    ASSERT_TRUE(filter_op.ok());
+
+    auto iter_infix_and_numeric = filter_result_iterator_t(coll->get_name(), coll->_get_index(),
+                                                           filter_tree_root, enable_lazy_evaluation);
+    ASSERT_TRUE(iter_infix_and_numeric.init_status().ok());
+
+    expected = {0, 1};
+    for (auto const& id : expected) {
+        ASSERT_EQ(filter_result_iterator_t::valid, iter_infix_and_numeric.validity);
+        ASSERT_EQ(id, iter_infix_and_numeric.seq_id);
+        iter_infix_and_numeric.next();
+    }
+    ASSERT_EQ(filter_result_iterator_t::invalid, iter_infix_and_numeric.validity);
+
+    delete filter_tree_root;
+    filter_tree_root = nullptr;
+
+    // Test 5: Multi-token infix must return 400 — *ris pin* tokenizes to ["ris", "pin"].
+    // The infix index stores individual word tokens only; substring search across word
+    // boundaries is structurally impossible. Users should write cast:*ris* && cast:*pin* instead.
+    filter_op = filter::parse_filter_query("cast: *ris pin*", coll->get_schema(), store,
+                                           doc_id_prefix, filter_tree_root);
+    ASSERT_TRUE(filter_op.ok());  // parse succeeds — parser stores raw value, unaware of token count
+
+    auto iter_multi_token = filter_result_iterator_t(coll->get_name(), coll->_get_index(),
+                                                     filter_tree_root, enable_lazy_evaluation);
+    ASSERT_FALSE(iter_multi_token.init_status().ok());
+    ASSERT_EQ(400, iter_multi_token.init_status().code());
+    ASSERT_NE(std::string::npos, iter_multi_token.init_status().error().find("single token"));
+
+    delete filter_tree_root;
+    filter_tree_root = nullptr;
+}


### PR DESCRIPTION
  ---                                                                                                                                                              
  feat: infix filtering support (field:*value*) #2685
                                                                                                                                                                   
  Closes #2685                                    

  ---
  Typesense supports exact (field:value) and prefix (field:value*) filtering on string fields, but had no way to filter by substring , users couldn't express "give me all docs where this field _contains_ this value."

  This PR adds field:*value* syntax to filter_by, enabling infix/contains filtering on string and string array fields that have `infix: true` in their schema.

  Changes:

  - Detection (filter_result_iterator.cpp): *value* is now detected as an infix pattern before the existing prefix (value*) check, avoiding misidentification.
  - Validation: Returns a 400 error if the field does not have infix: true... the infix index is only built when explicitly enabled.
  - Lookup: Reuses the existing Index::search_infix() function (already used for query-time infix search). For multi-token filter values (e.g. *Chris P*), results
  are intersected (AND). Multiple filter values in a list (e.g. [*foo*, *bar*]) are OR'd together.
  - Result assembly: Results are stored as a flat filter_result_t (sorted uint32_t[]) -> the same pattern used by numeric and geo filters. Mixed infix + exact/prefix in a single OR list is handled by flattening posting lists and OR'ing with infix results before returning.

  Tesing (CollectionFilteringTest.InfixFilterOnTextFields)

  - Basic single-token infix on string[] field (*ris* matches "Chris Evans", "Chris Parnell", "Chris Pine")
  - Infix on string field
  - No matches case
  - OR of multiple infix values ([*ris*, *art*])
  - Error on field without infix: true (400 response)
  - Mixed infix + exact in OR ([*ris*, Martin])
  - Mixed infix + prefix in OR ([*ris*, Ma*])
  - Infix combined with AND on another field (cast: *ris* && points: >60)