### PR TITLE
Fix race conditions in processing concurrent requests of related collections.

### DIFF
--- a/api_tests/bun.lock
+++ b/api_tests/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "api_tests",

--- a/api_tests/src/index.ts
+++ b/api_tests/src/index.ts
@@ -5,6 +5,7 @@ export class TypesenseTestRunner {
   private manager: TypesenseProcessManager;
   private static instance: TypesenseTestRunner;
   private exit_code: number = 0;
+  private readonly decoder = new TextDecoder();
 
   constructor() {
     this.manager = new TypesenseProcessManager();
@@ -86,15 +87,37 @@ export class TypesenseTestRunner {
     return cmd;
   }
 
+  private runPhaseTests(phase: Phases, pattern: string, testFile: string | null) {
+    const proc = Bun.spawnSync({
+      cmd: this.buildTestCommand(pattern, testFile),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const stdout = proc.stdout ? this.decoder.decode(proc.stdout) : "";
+    const stderr = proc.stderr ? this.decoder.decode(proc.stderr) : "";
+
+    if (stdout) {
+      process.stdout.write(stdout);
+    }
+
+    if (stderr) {
+      process.stderr.write(stderr);
+    }
+
+    const noTestsMatched = testFile !== null && proc.exitCode !== 0 && `${stdout}\n${stderr}`.includes(`regex "${pattern}" matched 0 tests`);
+    if (noTestsMatched) {
+      console.log(`\n=== ⏭️ Skipping phase: ${phase} (no matching tests in ${testFile}) ===\n`);
+      return true;
+    }
+
+    return proc.exitCode === 0;
+  }
+
   async noPhase(filters: Filters[], testFile: string | null = null) {
     console.log(`\n=== ⭐ Running phase: ${Phases.NO_PHASE} ===\n`);
     const pattern = this.getTestNamePattern(Phases.NO_PHASE, filters);
-    const proc = Bun.spawnSync({
-      cmd: this.buildTestCommand(pattern, testFile),
-      stderr: "inherit",
-      stdout: "inherit",
-    });
-    if (proc.exitCode !== 0) {
+    if (!this.runPhaseTests(Phases.NO_PHASE, pattern, testFile)) {
       console.error(`\n=== ❌ Phase ${Phases.NO_PHASE} failed ===\n`);
       this.exit_code = 1;
     }
@@ -104,12 +127,7 @@ export class TypesenseTestRunner {
     await this.manager.startSingleNode();
     console.log(`\n=== ⭐ Running phase: ${Phases.SINGLE_FRESH} ===\n`);
     const pattern = this.getTestNamePattern(Phases.SINGLE_FRESH, filters);
-    const proc = Bun.spawnSync({
-      cmd: this.buildTestCommand(pattern, testFile),
-      stderr: "inherit",
-      stdout: "inherit",
-    });
-    if (proc.exitCode !== 0) {
+    if (!this.runPhaseTests(Phases.SINGLE_FRESH, pattern, testFile)) {
       console.error(`\n=== ❌ Phase ${Phases.SINGLE_FRESH} failed ===\n`);
       this.exit_code = 1;
     }
@@ -119,12 +137,7 @@ export class TypesenseTestRunner {
     await this.manager.restartSingleNode();
     console.log(`\n=== ⭐ Running phase: ${Phases.SINGLE_RESTARTED} ===\n`);
     const pattern = this.getTestNamePattern(Phases.SINGLE_RESTARTED, filters);
-    const proc = Bun.spawnSync({
-      cmd: this.buildTestCommand(pattern, testFile),
-      stderr: "inherit",
-      stdout: "inherit",
-    });
-    if (proc.exitCode !== 0) {
+    if (!this.runPhaseTests(Phases.SINGLE_RESTARTED, pattern, testFile)) {
       console.error(`\n=== ❌ Phase ${Phases.SINGLE_RESTARTED} failed ===\n`);
       this.exit_code = 1;
     }
@@ -135,12 +148,7 @@ export class TypesenseTestRunner {
     await this.manager.restartSingleNode();
     console.log(`\n=== ⭐ Running phase: ${Phases.SINGLE_SNAPSHOT} ===\n`);
     const pattern = this.getTestNamePattern(Phases.SINGLE_SNAPSHOT, filters);
-    const proc = Bun.spawnSync({
-      cmd: this.buildTestCommand(pattern, testFile),
-      stderr: "inherit",
-      stdout: "inherit",
-    });
-    if (proc.exitCode !== 0) {
+    if (!this.runPhaseTests(Phases.SINGLE_SNAPSHOT, pattern, testFile)) {
       console.error(`\n=== ❌ Phase ${Phases.SINGLE_SNAPSHOT} failed ===\n`);
       this.exit_code = 1;
     }
@@ -150,12 +158,7 @@ export class TypesenseTestRunner {
     await this.manager.startMultiNode();
     console.log(`\n=== ⭐ Running phase: ${Phases.MULTI_FRESH} ===\n`);
     const pattern = this.getTestNamePattern(Phases.MULTI_FRESH, filters);
-    const proc = Bun.spawnSync({
-      cmd: this.buildTestCommand(pattern, testFile),
-      stderr: "inherit",
-      stdout: "inherit",
-    });
-    if (proc.exitCode !== 0) {
+    if (!this.runPhaseTests(Phases.MULTI_FRESH, pattern, testFile)) {
       console.error(`\n=== ❌ Phase ${Phases.MULTI_FRESH} failed ===\n`);
       this.exit_code = 1;
     }
@@ -165,12 +168,7 @@ export class TypesenseTestRunner {
     await this.manager.restartMultiNode();
     console.log(`\n=== ⭐ Running phase: ${Phases.MULTI_RESTARTED} ===\n`);
     const pattern = this.getTestNamePattern(Phases.MULTI_RESTARTED, filters);
-    const proc = Bun.spawnSync({
-      cmd: this.buildTestCommand(pattern, testFile),
-      stderr: "inherit",
-      stdout: "inherit",
-    });
-    if (proc.exitCode !== 0) {
+    if (!this.runPhaseTests(Phases.MULTI_RESTARTED, pattern, testFile)) {
       console.error(`\n=== ❌ Phase ${Phases.MULTI_RESTARTED} failed ===\n`);
       this.exit_code = 1;
     }
@@ -181,12 +179,7 @@ export class TypesenseTestRunner {
     await this.manager.restartMultiNode();
     console.log(`\n=== ⭐ Running phase: ${Phases.MULTI_SNAPSHOT} ===\n`);
     const pattern = this.getTestNamePattern(Phases.MULTI_SNAPSHOT, filters);
-    const proc = Bun.spawnSync({
-      cmd: this.buildTestCommand(pattern, testFile),
-      stderr: "inherit",
-      stdout: "inherit",
-    });
-    if (proc.exitCode !== 0) {
+    if (!this.runPhaseTests(Phases.MULTI_SNAPSHOT, pattern, testFile)) {
       console.error(`\n=== ❌ Phase ${Phases.MULTI_SNAPSHOT} failed ===\n`);
       this.exit_code = 1;
     }

--- a/api_tests/src/request.ts
+++ b/api_tests/src/request.ts
@@ -44,11 +44,19 @@ export async function checkCommitedIndex() {
   ]);
 
   const data = await Promise.all(res.map(r => r.json()));
+  const last_indexes = data.map((d: any) => d.last_index);
   const committed_indexes = data.map((d: any) => d.committed_index);
-  if(committed_indexes[0] === committed_indexes[1] && committed_indexes[0] === committed_indexes[2]) {
-    return true;
+  const applied_indexes = data.map((d: any) =>
+    d.applying_index === 0 ? d.known_applied_index : d.applying_index,
+  );
+
+  if(committed_indexes[0] !== committed_indexes[1] || committed_indexes[0] !== committed_indexes[2]) {
+    return false;
   }
-  return false;
+
+  return committed_indexes.every((committed_index: number, index: number) => {
+    return last_indexes[index] === committed_index && committed_index === applied_indexes[index];
+  });
 }
 
 export async function waitForSingleAnalyticsFlush() {

--- a/api_tests/tests/reference_cascade_delete_concurrent.test.ts
+++ b/api_tests/tests/reference_cascade_delete_concurrent.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it } from "bun:test";
+import { z } from "zod";
+import { Phases } from "../src/constants";
+import { fetchMultiNode, fetchMultiNodeRequest } from "../src/request";
+
+const NODE_IDS = [1, 2, 3] as const;
+type NodeId = typeof NODE_IDS[number];
+
+const COLLECTIONS = {
+  products: "products",
+  orders: "orders",
+} as const;
+
+const CATEGORY_COUNT = 5;
+const NUM_PRODUCTS = 100;
+const NUM_RESTAURANTS = 5;
+const IMPORT_BATCH_SIZE = 200;
+const ROUNDS = 10;
+const ORDER_IMPORTER_WORKERS = 3;
+const PRODUCT_UPSERTER_WORKERS = 1;
+const PRODUCT_DELETER_WORKERS = 2;
+
+const CATEGORIES = Array.from({ length: CATEGORY_COUNT }, (_, index) => `cat-${index}`);
+
+const CollectionResponse = z.object({
+  name: z.string(),
+  num_documents: z.number(),
+});
+
+const DeleteDocumentsResponse = z.object({
+  num_deleted: z.number(),
+});
+
+const StatsResponse = z.object({
+  pending_write_batches: z.number(),
+});
+
+const ClusterStateSchema = z.object({
+  products: z.number(),
+  orders: z.number(),
+});
+
+type ClusterState = z.infer<typeof ClusterStateSchema>;
+
+type ProductDocument = {
+  id: string;
+  variant_pack_uuid: string;
+  category: string;
+};
+
+type OrderDocument = {
+  id: string;
+  restaurant_uuid: string;
+  variant_pack_uuid: string;
+  category: string;
+};
+
+type ExecutionStats = {
+  importedDocs: number;
+  productUpsertedDocs: number;
+  productDeleteRequests: number;
+  deletedProductDocs: number;
+};
+
+function portForNode(node: NodeId) {
+  return `${node + 4}108`;
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function categoryForProduct(productIndex: number) {
+  return CATEGORIES[productIndex % CATEGORY_COUNT]!;
+}
+
+function categoryForRound(round: number) {
+  return CATEGORIES[round % CATEGORY_COUNT]!;
+}
+
+function randomItem<T>(items: readonly T[]) {
+  return items[Math.floor(Math.random() * items.length)]!;
+}
+
+function buildProduct(productIndex: number): ProductDocument {
+  return {
+    id: `cascade-product-${productIndex}`,
+    variant_pack_uuid: `cascade-vpuuid-${productIndex}`,
+    category: categoryForProduct(productIndex),
+  };
+}
+
+function buildOrder(round: number, index: number): OrderDocument {
+  const productIndex = (round * IMPORT_BATCH_SIZE + index) % NUM_PRODUCTS;
+
+  return {
+    id: `cascade-order-${round}-${index}`,
+    restaurant_uuid: `rest-${(round + index) % NUM_RESTAURANTS}`,
+    variant_pack_uuid: `cascade-vpuuid-${productIndex}`,
+    category: categoryForProduct(productIndex),
+  };
+}
+
+function jsonl(docs: Array<Record<string, string>>) {
+  return docs.map((doc) => JSON.stringify(doc)).join("\n");
+}
+
+function parseImportSuccessCount(payload: string) {
+  const lines = payload.trim();
+  if (lines.length === 0) {
+    return 0;
+  }
+
+  return lines.split("\n").reduce((count, line) => {
+    const result = z.object({ success: z.boolean() }).safeParse(JSON.parse(line));
+    if (!result.success) {
+      throw new Error(`Unexpected import response line: ${line}`);
+    }
+
+    return result.data.success ? count + 1 : count;
+  }, 0);
+}
+
+function emptyExecutionStats(): ExecutionStats {
+  return {
+    importedDocs: 0,
+    productUpsertedDocs: 0,
+    productDeleteRequests: 0,
+    deletedProductDocs: 0,
+  };
+}
+
+function addExecutionStats(current: ExecutionStats, next: ExecutionStats) {
+  current.importedDocs += next.importedDocs;
+  current.productUpsertedDocs += next.productUpsertedDocs;
+  current.productDeleteRequests += next.productDeleteRequests;
+  current.deletedProductDocs += next.deletedProductDocs;
+}
+
+async function fetchStats(node: NodeId) {
+  const res = await fetch(`http://localhost:${portForNode(node)}/stats.json`, {
+    headers: {
+      "X-TYPESENSE-API-KEY": "xyz",
+    },
+    signal: AbortSignal.timeout(10000),
+  });
+
+  expect(res.ok).toBe(true);
+  return StatsResponse.parse(await res.json());
+}
+
+async function waitForPendingWrites(timeoutMs = 15000) {
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    const stats = await Promise.all(NODE_IDS.map((node) => fetchStats(node)));
+    if (stats.every((entry) => entry.pending_write_batches === 0)) {
+      return;
+    }
+
+    await sleep(100);
+  }
+
+  throw new Error("Timed out waiting for pending write batches to drain");
+}
+
+async function createCollection(node: NodeId, schema: Record<string, unknown>) {
+  const res = await fetchMultiNode(node, "/collections", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(schema),
+  });
+
+  expect(res.ok).toBe(true);
+}
+
+async function createCascadeCollections() {
+  await createCollection(1, {
+    name: COLLECTIONS.products,
+    fields: [
+      { name: "id", type: "string" },
+      { name: "variant_pack_uuid", type: "string" },
+      { name: "category", type: "string", facet: true },
+    ],
+  });
+
+  await createCollection(1, {
+    name: COLLECTIONS.orders,
+    fields: [
+      { name: "id", type: "string" },
+      { name: "restaurant_uuid", type: "string", facet: true },
+      {
+        name: "variant_pack_uuid",
+        type: "string",
+        reference: `${COLLECTIONS.products}.variant_pack_uuid`,
+      },
+    ],
+  });
+}
+
+async function upsertProducts(node: NodeId) {
+  const products = Array.from({ length: NUM_PRODUCTS }, (_, index) => buildProduct(index));
+  const res = await fetchMultiNodeRequest(
+    node,
+    `/collections/${COLLECTIONS.products}/documents/import?action=upsert`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "text/plain",
+      },
+      body: jsonl(products),
+    },
+  );
+
+  expect(res.ok).toBe(true);
+  return parseImportSuccessCount(await res.text());
+}
+
+async function importOrders(node: NodeId, round: number) {
+  const orders = Array.from({ length: IMPORT_BATCH_SIZE }, (_, index) => buildOrder(round, index));
+  const payload = orders.map(({ id, restaurant_uuid, variant_pack_uuid }) => ({
+    id,
+    restaurant_uuid,
+    variant_pack_uuid,
+  }));
+
+  const res = await fetchMultiNodeRequest(
+    node,
+    `/collections/${COLLECTIONS.orders}/documents/import?action=upsert`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "text/plain",
+      },
+      body: jsonl(payload),
+    },
+  );
+
+  expect(res.ok).toBe(true);
+  return parseImportSuccessCount(await res.text());
+}
+
+async function deleteProductsByCategory(node: NodeId, category: string) {
+  const params = new URLSearchParams({
+    filter_by: `category:=\`${category}\``,
+  });
+
+  const res = await fetchMultiNodeRequest(
+    node,
+    `/collections/${COLLECTIONS.products}/documents?${params.toString()}`,
+    {
+      method: "DELETE",
+    },
+  );
+
+  expect(res.ok).toBe(true);
+  return DeleteDocumentsResponse.parse(await res.json()).num_deleted;
+}
+
+async function collectionCount(node: NodeId, name: string) {
+  const res = await fetchMultiNodeRequest(node, `/collections/${name}`);
+  expect(res.ok).toBe(true);
+  return CollectionResponse.parse(await res.json()).num_documents;
+}
+
+async function verifyClusterConsistency() {
+  await waitForPendingWrites();
+
+  let counts = await Promise.all(NODE_IDS.map((node) => collectionCount(node, COLLECTIONS.products)));
+  expect(new Set(counts).size).toBe(1);
+  expect(counts[0]!).toBeGreaterThan(0);
+
+  counts = await Promise.all(NODE_IDS.map((node) => collectionCount(node, COLLECTIONS.orders)));
+  expect(new Set(counts).size).toBe(1);
+  expect(counts[0]!).toBeGreaterThan(0);
+}
+
+async function runOrderImporter(workerId: number) {
+  for (let round = workerId; round < ROUNDS; round += ORDER_IMPORTER_WORKERS) {
+    const node = NODE_IDS[(round + workerId + 1) % NODE_IDS.length]!;
+    await importOrders(node, round);
+  }
+}
+
+async function runProductUpserter(workerId: number) {
+  for (let round = workerId; round < ROUNDS; round += PRODUCT_UPSERTER_WORKERS) {
+    const node = NODE_IDS[(round + workerId) % NODE_IDS.length]!;
+    await upsertProducts(node);
+  }
+}
+
+async function runProductDeleter(workerId: number) {
+  for (let round = workerId; round < ROUNDS; round += PRODUCT_DELETER_WORKERS) {
+    const node = randomItem(NODE_IDS);
+    const deletedCategory = randomItem(CATEGORIES);
+    await deleteProductsByCategory(node, deletedCategory);
+  }
+}
+
+describe(Phases.MULTI_FRESH, () => {
+  it("keeps cascade deletes consistent under concurrent imports, upserts, and deletes", async () => {
+    await createCascadeCollections();
+    await waitForPendingWrites();
+
+    const seededProducts = await upsertProducts(1);
+    expect(seededProducts).toBe(NUM_PRODUCTS);
+    await waitForPendingWrites();
+
+    await Promise.all([
+      ...Array.from({ length: ORDER_IMPORTER_WORKERS }, (_, workerId) => runOrderImporter(workerId)),
+      ...Array.from({ length: PRODUCT_UPSERTER_WORKERS }, (_, workerId) => runProductUpserter(workerId)),
+      ...Array.from({ length: PRODUCT_DELETER_WORKERS }, (_, workerId) => runProductDeleter(workerId)),
+    ]);
+
+    await verifyClusterConsistency();
+  });
+});
+
+describe(Phases.MULTI_RESTARTED, () => {
+  it("preserves the cascade test state after restart", async () => {
+    await verifyClusterConsistency();
+  });
+});
+
+describe(Phases.MULTI_SNAPSHOT, () => {
+  it("preserves the cascade test state after snapshot restore", async () => {
+    await verifyClusterConsistency();
+  });
+});

--- a/api_tests/tests/reference_cascade_delete_concurrent.test.ts
+++ b/api_tests/tests/reference_cascade_delete_concurrent.test.ts
@@ -7,8 +7,8 @@ const NODE_IDS = [1, 2, 3] as const;
 type NodeId = typeof NODE_IDS[number];
 
 const COLLECTIONS = {
-  products: "products",
-  orders: "orders",
+  products: "cascade_delete_products",
+  orders: "cascade_delete_orders",
 } as const;
 
 const CATEGORY_COUNT = 5;

--- a/api_tests/tests/reference_cascade_delete_concurrent.test.ts
+++ b/api_tests/tests/reference_cascade_delete_concurrent.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { z } from "zod";
 import { Phases } from "../src/constants";
-import { fetchMultiNode, fetchMultiNodeRequest } from "../src/request";
+import { checkCommitedIndex, fetchMultiNode, fetchMultiNodeRequest } from "../src/request";
 
 const NODE_IDS = [1, 2, 3] as const;
 type NodeId = typeof NODE_IDS[number];
@@ -153,15 +153,18 @@ async function waitForPendingWrites(timeoutMs = 15000) {
   const start = Date.now();
 
   while (Date.now() - start < timeoutMs) {
-    const stats = await Promise.all(NODE_IDS.map((node) => fetchStats(node)));
-    if (stats.every((entry) => entry.pending_write_batches === 0)) {
+    const [isCommitted, stats] = await Promise.all([
+      checkCommitedIndex(),
+      Promise.all(NODE_IDS.map((node) => fetchStats(node))),
+    ]);
+    if (isCommitted && stats.every((entry) => entry.pending_write_batches === 0)) {
       return;
     }
 
     await sleep(100);
   }
 
-  throw new Error("Timed out waiting for pending write batches to drain");
+  throw new Error("Timed out waiting for committed index sync and pending write batches to drain");
 }
 
 async function createCollection(node: NodeId, schema: Record<string, unknown>) {
@@ -269,12 +272,23 @@ async function verifyClusterConsistency() {
   await waitForPendingWrites();
 
   let counts = await Promise.all(NODE_IDS.map((node) => collectionCount(node, COLLECTIONS.products)));
-  expect(new Set(counts).size).toBe(1);
-  expect(counts[0]!).toBeGreaterThan(0);
+  expect(counts.length).toBe(3);
+  // All the nodes must have same count.
+  let set = new Set(counts);
+  if (set.size > 1) {
+    console.log(counts);
+  }
+  expect(set.size).toBe(1);
+
 
   counts = await Promise.all(NODE_IDS.map((node) => collectionCount(node, COLLECTIONS.orders)));
-  expect(new Set(counts).size).toBe(1);
-  expect(counts[0]!).toBeGreaterThan(0);
+  expect(counts.length).toBe(3);
+  // All the nodes must have same count.
+  set = new Set(counts);
+  if (set.size > 1) {
+    console.log(counts);
+  }
+  expect(set.size).toBe(1);
 }
 
 async function runOrderImporter(workerId: number) {

--- a/include/batched_indexer.h
+++ b/include/batched_indexer.h
@@ -57,6 +57,7 @@ private:
     await_t* qmutuxes;
     std::vector<std::deque<uint64_t>> queues;
 
+    std::unordered_map<std::string, std::unordered_set<std::string>> coll_to_references;
     await_t refq_wait;
     std::list<refq_entry> reference_q;
 
@@ -96,8 +97,16 @@ private:
 
     static std::string get_req_suffix_key(uint64_t req_id);
 
+    std::unordered_set<uint64_t> get_requests_to_wait_on_with_lock(const std::shared_ptr<http_req>& req,
+                                                                   const std::string& coll_name);
+
     std::unordered_set<uint64_t> get_requests_to_wait_on(const std::shared_ptr<http_req>& req,
                                                          const std::string& coll_name);
+
+    void update_coll_to_references(const std::shared_ptr<http_req>& req, const std::string& coll_name);
+
+    void update_coll_to_references_after_request(const std::shared_ptr<http_req>& req,
+                                                 const std::string& coll_name);
 
 public:
 
@@ -130,6 +139,4 @@ public:
     std::string get_collection_name(const std::shared_ptr<http_req>& req);
 
     std::shared_mutex& get_pause_mutex();
-
-    size_t get_reference_q_size();
 };

--- a/include/batched_indexer.h
+++ b/include/batched_indexer.h
@@ -97,8 +97,7 @@ private:
     static std::string get_req_suffix_key(uint64_t req_id);
 
     std::unordered_set<uint64_t> get_requests_to_wait_on(const std::shared_ptr<http_req>& req,
-                                                         const std::string& coll_name,
-                                                         const bool& is_live_req);
+                                                         const std::string& coll_name);
 
 public:
 

--- a/include/batched_indexer.h
+++ b/include/batched_indexer.h
@@ -41,6 +41,7 @@ private:
     struct refq_entry {
         uint64_t queue_id;
         uint64_t start_ts;
+        std::unordered_set<uint64_t> waiting_on_requests{};
 
         refq_entry(uint64_t qid, uint64_t sts): queue_id(qid), start_ts(sts) {
 
@@ -56,7 +57,6 @@ private:
     await_t* qmutuxes;
     std::vector<std::deque<uint64_t>> queues;
 
-    std::unordered_map<std::string, std::unordered_set<std::string>> coll_to_references;
     await_t refq_wait;
     std::list<refq_entry> reference_q;
 
@@ -65,9 +65,6 @@ private:
 
     std::mutex mutex;
     std::map<uint64_t, req_res_t> req_res_map;
-
-    // used in tracking references
-    std::map<uint64_t, std::string> req_colls;
 
     std::atomic<int64_t> queued_writes = 0;
 
@@ -98,6 +95,10 @@ private:
     static std::string get_req_prefix_key(uint64_t req_id);
 
     static std::string get_req_suffix_key(uint64_t req_id);
+
+    std::unordered_set<uint64_t> get_requests_to_wait_on(const std::shared_ptr<http_req>& req,
+                                                         const std::string& coll_name,
+                                                         const bool& is_live_req);
 
 public:
 

--- a/include/collection.h
+++ b/include/collection.h
@@ -805,6 +805,12 @@ private:
     static Option<bool> filter_dynamic_facets_by_occurrence(nlohmann::json& facet_counts, size_t found_docs,
                                                             float facet_min_occurrence_ratio);
 
+    void reset_referencing_documents(const std::string& field_name, const std::vector<index_record>& docs);
+
+    // Called to reset the reference helper fields to sentinel value when a referenced document fails to index.
+    static void reset_referencing_documents(const spp::sparse_hash_map<std::string, std::set<reference_pair_t>>& found_async_referenced_ins,
+                                            const std::vector<index_record>& docs);
+
 public:
 
     enum {MAX_ARRAY_MATCHES = 5};
@@ -1110,11 +1116,6 @@ public:
 
     void cascade_remove_doc_with_lock(const std::string& field_name, const uint32_t& ref_seq_id,
                                       const nlohmann::json& ref_doc, bool remove_from_store = true);
-
-    void reset_referencing_documents(const std::string& field_name, const std::vector<index_record>& docs);
-
-    static void reset_referencing_documents(const spp::sparse_hash_map<std::string, std::set<reference_pair_t>>& found_async_referenced_ins,
-                                            const std::vector<index_record>& docs);
 
     Option<std::string> remove(const std::string & id, bool remove_from_store = true);
 

--- a/include/collection.h
+++ b/include/collection.h
@@ -963,7 +963,8 @@ public:
     nlohmann::json get_summary_json() const;
 
     size_t batch_index_in_memory(std::vector<index_record>& index_records, const size_t remote_embedding_batch_size,
-                                 const size_t remote_embedding_timeout_ms, const size_t remote_embedding_num_tries, const bool generate_embeddings);
+                                 const size_t remote_embedding_timeout_ms, const size_t remote_embedding_num_tries, const bool generate_embeddings,
+                                 std::unordered_set<std::string>& found_fields);
 
     Option<nlohmann::json> add(const std::string & json_str,
                                const index_operation_t& operation=CREATE, const std::string& id="",

--- a/include/collection.h
+++ b/include/collection.h
@@ -1097,6 +1097,9 @@ public:
     Option<bool> get_filter_ids(const std::string & filter_query, filter_result_t& filter_result,
                                 const bool& should_timeout = true, const bool& validate_field_names = true) const;
 
+    Option<bool> get_filter_ids_with_lock(const std::string & filter_query, filter_result_t& filter_result,
+                                          const bool& should_timeout = true, const bool& validate_field_names = true) const;
+
     Option<bool> get_reference_filter_ids(const std::string& filter_query,
                                           filter_result_t& filter_result,
                                           const std::string& reference_field_name,
@@ -1105,8 +1108,13 @@ public:
 
     Option<nlohmann::json> get(const std::string & id) const;
 
-    void cascade_remove_docs(const std::string& field_name, const uint32_t& ref_seq_id,
-                             const nlohmann::json& ref_doc, bool remove_from_store = true);
+    void cascade_remove_doc_with_lock(const std::string& field_name, const uint32_t& ref_seq_id,
+                                      const nlohmann::json& ref_doc, bool remove_from_store = true);
+
+    void reset_referencing_documents(const std::string& field_name, const std::vector<index_record>& docs);
+
+    static void reset_referencing_documents(const spp::sparse_hash_map<std::string, std::set<reference_pair_t>>& found_async_referenced_ins,
+                                            const std::vector<index_record>& docs);
 
     Option<std::string> remove(const std::string & id, bool remove_from_store = true);
 
@@ -1306,6 +1314,10 @@ public:
                                       const tsl::htrie_set<char>& ref_exclude_fields_full,
                                       const nlohmann::json& original_doc,
                                       const ref_include_exclude_fields& ref_include_exclude) const;
+
+    std::shared_mutex& get_mutex() const {
+        return mutex;
+    }
 };
 
 template<class T>

--- a/include/collection.h
+++ b/include/collection.h
@@ -571,7 +571,8 @@ private:
                          nlohmann::json& wrapper_doc,
                          const std::vector<std::vector<std::string>>& q_phrases = {}) const;
 
-    void remove_document(nlohmann::json & document, const uint32_t seq_id, bool remove_from_store);
+    void remove_document(nlohmann::json & document, const uint32_t seq_id, bool remove_from_store,
+                         const bool& cascade_remove = true);
 
     void process_remove_field_for_embedding_fields(const field& del_field, std::vector<field>& garbage_embed_fields);
 
@@ -810,6 +811,17 @@ private:
     // Called to reset the reference helper fields to sentinel value when a referenced document fails to index.
     static void reset_referencing_documents(const spp::sparse_hash_map<std::string, std::set<reference_pair_t>>& found_async_referenced_ins,
                                             const std::vector<index_record>& docs);
+
+    static void cascade_remove_helper(const std::vector<index_record>& records, cascade_remove_node_t* cascade_node,
+                                      const bool remove_from_store = true);
+
+    // Called to recursively deleted all the documents that directly or indirectly reference the documents.
+    static void cascade_remove(const std::string& coll_name, const std::vector<index_record>& records,
+                               const bool remove_from_store = true);
+
+    void cascade_remove(const std::vector<index_record>& records, const reference_info_t& ref_info,
+                        const std::string& ref_coll_name, std::vector<index_record>& removed_records,
+                        const bool remove_from_store = true);
 
 public:
 
@@ -1113,9 +1125,6 @@ public:
                                           const bool& validate_field_names = true) const;
 
     Option<nlohmann::json> get(const std::string & id) const;
-
-    void cascade_remove_doc_with_lock(const std::string& field_name, const uint32_t& ref_seq_id,
-                                      const nlohmann::json& ref_doc, bool remove_from_store = true);
 
     Option<std::string> remove(const std::string & id, bool remove_from_store = true);
 

--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -252,4 +252,11 @@ public:
     static Option<bool> process_ref_include_fields_sort(const std::string& collection_name,
                                                         const std::string& sort_by_str, size_t limit,
                                                         std::vector<uint32_t>& doc_ids);
+
+    void lock_nested_referencing_collections_helper(const std::string& coll_name,
+                                                    cascade_remove_node_t* cascade_node,
+                                                    std::set<std::string>& referencing_collections);
+
+    void lock_nested_referencing_collections(const std::string& coll_name,
+                                             cascade_remove_node_t*& cascade_tree);
 };

--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -203,6 +203,8 @@ public:
 
     std::unordered_set<std::string> get_collection_references(const std::string& coll_name);
 
+    std::unordered_set<std::string> get_nested_referencing_collections(const std::string& coll_name);
+
     bool is_valid_api_key_collection(const std::vector<std::string>& api_key_collections, std::shared_ptr<Collection> coll) const;
 
     Option<bool> update_collection_metadata(const std::string& collection, const nlohmann::json& metadata);
@@ -223,6 +225,8 @@ public:
     static Option<bool> get_filter_ids(const std::string collection, const std::string & filter_query,
                                        filter_result_t& filter_result,
                                        const bool& should_timeout = true, const bool& validate_field_names = true);
+
+    bool is_referenced_in_any(const std::string& referenced_coll_name) const;
 
     Option<reference_info_t> is_referenced_in(const std::string& referenced_coll_name,
                                               const std::string& referring_coll_name) const;

--- a/include/index.h
+++ b/include/index.h
@@ -840,11 +840,9 @@ public:
                                      const std::vector<char>& symbols_to_index,
                                      std::unordered_set<std::string>& found_fields,
                                      const bool use_addition_fields = false,
-                                     const tsl::htrie_map<char, field>& addition_fields = tsl::htrie_map<char, field>(),
-                                     const std::string& collection_name = "");
+                                     const tsl::htrie_map<char, field>& addition_fields = tsl::htrie_map<char, field>());
 
-    void index_field_in_memory(const std::string& collection_name, const field& afield,
-                               std::vector<index_record>& iter_batch);
+    void index_field_in_memory(const field& afield, std::vector<index_record>& iter_batch);
 
     template<class T>
     void iterate_and_index_numerical_field(std::vector<index_record>& iter_batch, const field& afield, T func);

--- a/include/index.h
+++ b/include/index.h
@@ -1227,9 +1227,9 @@ public:
 
     Option<bool> process_ref_include_fields_sort(std::vector<sort_by>& sort_fields_std, size_t limit, std::vector<uint32_t>& doc_ids);
 
-    static void update_async_references(const std::string& collection_name, std::vector<index_record>& iter_batch,
-                                        const spp::sparse_hash_map<std::string, std::set<reference_pair_t>>& async_referenced_ins =
-                                        spp::sparse_hash_map<std::string, std::set<reference_pair_t>>());
+    static Option<bool> update_async_references(const std::string& collection_name, const bool& return_doc, const bool& return_id,
+                                                const spp::sparse_hash_map<std::string, std::set<reference_pair_t>>& async_referenced_ins,
+                                                index_record& record, std::vector<std::string>& json_out);
 
     Option<bool> diversify_text_score_buckets(const std::vector<std::pair<size_t, size_t>>& bucket_indexes,
                                               const diversity_t& diversity,

--- a/include/join.h
+++ b/include/join.h
@@ -83,6 +83,13 @@ struct negate_left_join_t {
     negate_left_join_t() = default;
 };
 
+struct cascade_remove_node_t {
+    std::shared_ptr<Collection> coll_ptr;
+    std::unique_lock<std::shared_mutex> lock;
+    std::vector<reference_info_t> ref_infos{};
+    std::vector<cascade_remove_node_t*> nested_references{};
+};
+
 class Join {
 public:
 

--- a/src/batched_indexer.cpp
+++ b/src/batched_indexer.cpp
@@ -3,6 +3,7 @@
 #include "thread_local_vars.h"
 #include "cached_resource_stat.h"
 #include "collection_manager.h"
+#include <queue>
 
 BatchedIndexer::BatchedIndexer(HttpServer* server, Store* store, Store* meta_store, const size_t num_threads,
                                const Config& config, const std::atomic<bool>& skip_writes):
@@ -14,22 +15,31 @@ BatchedIndexer::BatchedIndexer(HttpServer* server, Store* store, Store* meta_sto
     skip_index_iter_upper_bound = new rocksdb::Slice(skip_index_upper_bound_key);
 }
 
-std::string get_ref_coll_names(const std::string& body, std::unordered_set<std::string>& referenced_collections) {
+std::string get_ref_coll_names(const std::string& body, std::unordered_set<std::string>& referenced_collections,
+                               std::unordered_set<std::string>& dropped_referenced_collections) {
     std::string collection_name;
     auto const& obj = nlohmann::json::parse(body, nullptr, false);
 
-    if (!obj.is_discarded() && obj.is_object() && obj.contains("name") && obj["name"].is_string() &&
-     obj.contains("fields")) {
-        collection_name = obj["name"];
+    if (!obj.is_discarded() && obj.is_object()) {
+        if (obj.contains("name") && obj["name"].is_string()) {
+            collection_name = obj["name"];
+        }
 
-        for (const auto &field: obj["fields"]) {
-            if (!field.contains("reference")) {
-                continue;
+        if (obj.contains("fields") && obj["fields"].is_array()) {
+            for (const auto &field: obj["fields"]) {
+                if (!field.contains("reference") || !field["reference"].is_string()) {
+                    continue;
+                }
+
+                std::vector<std::string> split_result;
+                StringUtils::split(field["reference"], split_result, ".");
+
+                if (field.contains("drop") && field["drop"]) {
+                    dropped_referenced_collections.insert(split_result.front());
+                } else {
+                    referenced_collections.insert(split_result.front());
+                }
             }
-
-            std::vector<std::string> split_result;
-            StringUtils::split(field["reference"], split_result, ".");
-            referenced_collections.insert(split_result.front());
         }
     }
 
@@ -71,8 +81,6 @@ void BatchedIndexer::enqueue(const std::shared_ptr<http_req>& req, const std::sh
 
     bool is_old_serialized_request = (req->start_ts == 0);
     bool read_more_input = (req->_req != nullptr && req->_req->proceed_req);
-    bool is_live_req = res->is_alive;
-
     if(req->last_chunk_aggregate) {
         //LOG(INFO) << "Last chunk for req_id: " << req->start_ts;
         queued_writes += (chunk_sequence + 1);
@@ -81,13 +89,14 @@ void BatchedIndexer::enqueue(const std::shared_ptr<http_req>& req, const std::sh
             const std::string& coll_name = get_collection_name(req);
             uint64_t queue_id = StringUtils::hash_wy(coll_name.c_str(), coll_name.size()) % num_threads;
             req->params["collection"] = coll_name;
+            update_coll_to_references(req, coll_name);
 
             {
                 std::unique_lock lk2(mutex);
                 req_res_map[req->start_ts].is_complete = true;
             }
 
-            auto wait_on_request_ids = get_requests_to_wait_on(req, coll_name);
+            auto wait_on_request_ids = get_requests_to_wait_on_with_lock(req, coll_name);
             if(wait_on_request_ids.empty()) {
                 std::unique_lock qlk(qmutuxes[queue_id].mcv);
                 queues[queue_id].emplace_back(req->start_ts);
@@ -316,6 +325,8 @@ void BatchedIndexer::run() {
 
                 std::unique_lock lk(mutex);
 
+                update_coll_to_references_after_request(orig_req, get_collection_name(orig_req));
+
                 req_res_map.erase(req_id);
                 lk.unlock();
                 refq_wait.cv.notify_one();
@@ -519,6 +530,10 @@ void BatchedIndexer::serialize_state(nlohmann::json& state) {
         nlohmann::json ref_req_obj;
         ref_req_obj["queue_id"] = ref_req.queue_id;
         ref_req_obj["start_ts"] = ref_req.start_ts;
+        ref_req_obj["waiting_on_requests"] = nlohmann::json::array();
+        for (const auto& waiting_on_req_id : ref_req.waiting_on_requests) {
+            ref_req_obj["waiting_on_requests"].push_back(waiting_on_req_id);
+        }
         state["reference_q"].push_back(ref_req_obj);
     }
 
@@ -530,6 +545,14 @@ void BatchedIndexer::load_state(const nlohmann::json& state) {
 
     size_t num_reqs_restored = 0;
     std::set<uint64_t> queue_ids;
+    std::unordered_set<uint64_t> reference_q_start_ts;
+
+    if(state.contains("reference_q")) {
+        for(const auto& item: state["reference_q"].items()) {
+            const nlohmann::json& ref_entry = item.value();
+            reference_q_start_ts.insert(ref_entry["start_ts"].get<uint64_t>());
+        }
+    }
 
     for(auto& kv: state["req_res_map"].items()) {
         std::shared_ptr<http_req> req = std::make_shared<http_req>();
@@ -548,10 +571,12 @@ void BatchedIndexer::load_state(const nlohmann::json& state) {
             req_res_map.emplace(std::stoull(kv.key()), req_res);
         }
 
+        update_coll_to_references(req, get_collection_name(req));
+
         // add only completed requests to their respective collection-based queues
         // the rest will be added by enqueue() when raft log is completely read
 
-        if(req_res.is_complete) {
+        if(req_res.is_complete && reference_q_start_ts.count(req->start_ts) == 0) {
             const std::string& coll_name = get_collection_name(req);
             uint64_t queue_id = StringUtils::hash_wy(coll_name.c_str(), coll_name.size()) % num_threads;
             queue_ids.insert(queue_id);
@@ -563,18 +588,61 @@ void BatchedIndexer::load_state(const nlohmann::json& state) {
     }
 
     if(state.contains("reference_q")) {
+        std::unique_lock lk(mutex);
         for(const auto& item: state["reference_q"].items()) {
             const nlohmann::json& ref_entry = item.value();
-            reference_q.emplace_back(ref_entry["queue_id"], ref_entry["start_ts"]);
+            refq_entry ref(ref_entry["queue_id"], ref_entry["start_ts"]);
+            if (ref_entry.contains("waiting_on_requests")) {
+                for (const auto& waiting_on_req_id : ref_entry["waiting_on_requests"]) {
+                    ref.waiting_on_requests.insert(waiting_on_req_id.get<uint64_t>());
+                }
+            } else {
+                // For backwards compatibility since `ref_entry["waiting_on_requests"]` will not be present for previous
+                // versions.
+                auto req_res_it = req_res_map.find(ref.start_ts);
+                if (req_res_it != req_res_map.end()) {
+                    const auto& req = req_res_it->second.req;
+                    const std::string& coll_name = get_collection_name(req);
+                    ref.waiting_on_requests = get_requests_to_wait_on(req, coll_name);
+                }
+            }
+            reference_q.emplace_back(std::move(ref));
         }
 
+        lk.unlock();
         refq_wait.cv.notify_one();
     }
 
-    // need to sort on `start_ts` to preserve original order before notifying queues
+    std::unordered_map<uint64_t, std::pair<uint64_t, uint64_t>> restored_request_order;
+    {
+        std::unique_lock lk(mutex);
+        for (const auto& [req_id, req_res] : req_res_map) {
+            const uint64_t log_index = (req_res.req != nullptr) ? req_res.req->log_index : 0;
+            restored_request_order.emplace(req_id, std::make_pair(log_index, req_id));
+        }
+    }
+
+    // Replay the restored per-collection queues in the same order as live writes: prefer raft log order when
+    // present, and fall back to start_ts for older serialized requests that do not have log indices.
     for(auto queue_id: queue_ids) {
         std::unique_lock lk(qmutuxes[queue_id].mcv);
-        std::sort(queues[queue_id].begin(), queues[queue_id].end());
+        std::sort(queues[queue_id].begin(), queues[queue_id].end(),
+                  [&restored_request_order](const uint64_t lhs, const uint64_t rhs) {
+                      const auto lhs_it = restored_request_order.find(lhs);
+                      const auto rhs_it = restored_request_order.find(rhs);
+
+                      const auto [lhs_log_order, lhs_req_id] = (lhs_it != restored_request_order.end()) ?
+                                             lhs_it->second : std::make_pair(UINT64_MAX, lhs);
+                      const auto [rhs_log_order, rhs_req_id] = (rhs_it != restored_request_order.end()) ?
+                                             rhs_it->second : std::make_pair(UINT64_MAX, rhs);
+
+                      const bool has_log_order = lhs_log_order != UINT64_MAX && rhs_log_order != UINT64_MAX;
+                      if (has_log_order && lhs_log_order != rhs_log_order) {
+                          return lhs_log_order < rhs_log_order;
+                      }
+
+                      return lhs_req_id < rhs_req_id;
+                  });
         qmutuxes[queue_id].cv.notify_one();
     }
 
@@ -597,29 +665,124 @@ void BatchedIndexer::clear_skip_indices() {
     meta_store->flush();
 }
 
-size_t BatchedIndexer::get_reference_q_size() {
-    std::lock_guard lk(refq_wait.mcv);
-    return reference_q.size();
+void BatchedIndexer::update_coll_to_references(const std::shared_ptr<http_req>& req, const std::string& coll_name) {
+    route_path* found_rpath = nullptr;
+    const bool route_found = server->get_route(req->route_hash, &found_rpath);
+    if (!route_found || (found_rpath->handler != post_create_collection &&
+                         found_rpath->handler != patch_update_collection &&
+                         found_rpath->handler != post_import_documents)) {
+        std::unique_lock lk(mutex);
+        if (!coll_name.empty() && coll_to_references.count(coll_name) == 0) {
+            coll_to_references[coll_name] = CollectionManager::get_instance().get_collection_references(coll_name);
+        }
+        return;
+    }
+
+    std::unordered_set<std::string> referenced_collections;
+    std::unordered_set<std::string> dropped_referenced_collections;
+    std::string parsed_coll_name = coll_name;
+    if (found_rpath->handler == post_import_documents) {
+        std::unique_lock lk(mutex);
+        auto it = coll_to_references.find(parsed_coll_name);
+        if (it != coll_to_references.end()) {
+            return;
+        }
+        referenced_collections = std::move(CollectionManager::get_instance().get_collection_references(parsed_coll_name));
+    } else {
+        parsed_coll_name = get_ref_coll_names(req->body, referenced_collections, dropped_referenced_collections);
+    }
+
+    if (parsed_coll_name.empty()) {
+        return;
+    }
+
+    if (found_rpath->handler == patch_update_collection) {
+        std::unique_lock lk(mutex);
+        auto it = coll_to_references.find(parsed_coll_name);
+        if (it != coll_to_references.end()) {
+            auto& existing_references = it->second;
+            for (const auto& ref_coll_name: dropped_referenced_collections) {
+                existing_references.erase(ref_coll_name);
+            }
+            existing_references.insert(referenced_collections.begin(), referenced_collections.end());
+        } else {
+            coll_to_references[parsed_coll_name] = std::move(referenced_collections);
+        }
+        return;
+    }
+
+    std::unique_lock lk(mutex);
+    coll_to_references[parsed_coll_name] = std::move(referenced_collections);
+}
+
+void BatchedIndexer::update_coll_to_references_after_request(const std::shared_ptr<http_req>& req,
+                                                             const std::string& coll_name) {
+    if (coll_name.empty()) {
+        return;
+    }
+
+    route_path* found_rpath = nullptr;
+    const bool route_found = server->get_route(req->route_hash, &found_rpath);
+    if (!route_found || (found_rpath->handler != post_create_collection &&
+                         found_rpath->handler != patch_update_collection &&
+                         found_rpath->handler != del_drop_collection)) {
+        return;
+    }
+
+    auto it = coll_to_references.find(coll_name);
+    if (it == coll_to_references.end()) {
+        return;
+    }
+
+    it->second = CollectionManager::get_instance().get_collection_references(coll_name);
+}
+
+std::unordered_set<uint64_t> BatchedIndexer::get_requests_to_wait_on_with_lock(const std::shared_ptr<http_req>& req,
+                                                                               const std::string& coll_name) {
+    std::unique_lock lk(mutex);
+    return get_requests_to_wait_on(req, coll_name);
 }
 
 std::unordered_set<uint64_t> BatchedIndexer::get_requests_to_wait_on(const std::shared_ptr<http_req>& req,
                                                                      const std::string& coll_name) {
-    std::unordered_set<std::string> wait_for_collections;
-
-    if (is_coll_create_route(req->route_hash)) {
-        get_ref_coll_names(req->body, wait_for_collections);
-    } else {
-        // If this request involves a collection that references other collection(s) or is referenced by other
-        // collection(s), we have to wait for the other request(s) that arrived before this request to finish by pushing
-        // this request onto a waiting queue.
-        auto& cm = CollectionManager::get_instance();
-        auto temp = cm.get_collection_references(coll_name);
-        wait_for_collections.insert(temp.begin(), temp.end());
-
-        temp = cm.get_nested_referencing_collections(coll_name);
-        wait_for_collections.insert(temp.begin(), temp.end());
+    auto coll_to_ref_it = coll_to_references.find(coll_name);
+    if (coll_to_ref_it == coll_to_references.end()) {
+        return {};
     }
 
+    // Wait for all the referenced collections.
+    std::unordered_set<std::string> wait_for_collections(coll_to_ref_it->second.begin(), coll_to_ref_it->second.end());
+    std::unordered_set<std::string> processed_collections;
+    std::queue<std::string> pending_collections;
+    for (const auto& item: wait_for_collections) {
+        pending_collections.push(item);
+    }
+
+    // Also wait for the all the referencing collections.
+    for (const auto& [ref_coll_name, references] : coll_to_references) {
+        if (references.count(coll_name) != 0 && processed_collections.insert(ref_coll_name).second) {
+            pending_collections.push(ref_coll_name);
+        }
+    }
+
+    // Handle nested references.
+    while (!pending_collections.empty()) {
+        const auto referenced_coll_name = pending_collections.front();
+        pending_collections.pop();
+
+        coll_to_ref_it = coll_to_references.find(referenced_coll_name);
+        if (coll_to_ref_it == coll_to_references.end()) {
+            continue;
+        }
+
+        for (const auto& nested_ref_coll_name: coll_to_ref_it->second) {
+            if (processed_collections.insert(nested_ref_coll_name).second) {
+                pending_collections.push(nested_ref_coll_name);
+            }
+        }
+    }
+
+    wait_for_collections.insert(processed_collections.begin(), processed_collections.end());
     if (wait_for_collections.empty()) {
         return {};
     }
@@ -629,7 +792,6 @@ std::unordered_set<uint64_t> BatchedIndexer::get_requests_to_wait_on(const std::
     wait_for_collections.insert(coll_name);
 
     std::unordered_set<uint64_t> wait_on_request_ids;
-    std::unique_lock lk(mutex);
     for (const auto& [req_id, req_res] : req_res_map) {
         const auto& ref_req = req_res.req;
         const bool has_log_order = req->log_index != 0 && ref_req->log_index != 0;

--- a/src/batched_indexer.cpp
+++ b/src/batched_indexer.cpp
@@ -85,46 +85,22 @@ void BatchedIndexer::enqueue(const std::shared_ptr<http_req>& req, const std::sh
             {
                 std::unique_lock lk2(mutex);
                 req_res_map[req->start_ts].is_complete = true;
-                req_colls.emplace(req->start_ts, coll_name);
             }
 
-            bool queue_write = true;
-
-            if(!is_live_req) {
-                if (is_coll_create_route(req->route_hash)) {
-                    // Save reference mapping to take care of ordering of requests
-                    std::unordered_set<std::string> referenced_collections;
-                    get_ref_coll_names(req->body, referenced_collections);
-                    if (!referenced_collections.empty()) {
-                        std::lock_guard lock(mutex);
-                        coll_to_references[coll_name] = std::move(referenced_collections);
-                    }
-                } else if (is_drop_collection_route(req->route_hash)) {
-                    std::lock_guard lock(mutex);
-                    coll_to_references.erase(coll_name);
-                } else {
-                    auto ref_colls_it = coll_to_references.find(coll_name);
-                    const auto& ref_collections = (ref_colls_it != coll_to_references.end()) ? ref_colls_it->second :
-                                                  CollectionManager::get_instance().get_collection_references(coll_name);
-
-                    if(!ref_collections.empty()) {
-                        // If this request involves a collection that references other collection(s), we have to wait
-                        // for the other collection(s) request(s) that arrived before this request to finish by pushing
-                        // this request onto a waiting queue.
-                        std::unique_lock lk(refq_wait.mcv);
-                        reference_q.emplace_back(queue_id, req->start_ts);
-                        lk.unlock();
-                        refq_wait.cv.notify_one();
-                        queue_write = false;
-                    }
-                }
-            }
-
-            if(queue_write) {
+            auto wait_on_request_ids = get_requests_to_wait_on(req, coll_name, is_live_req);
+            if(wait_on_request_ids.empty()) {
                 std::unique_lock qlk(qmutuxes[queue_id].mcv);
                 queues[queue_id].emplace_back(req->start_ts);
                 qlk.unlock();
                 qmutuxes[queue_id].cv.notify_one();
+            } else {
+                refq_entry ref(queue_id, req->start_ts);
+                ref.waiting_on_requests = std::move(wait_on_request_ids);
+
+                std::unique_lock lk(refq_wait.mcv);
+                reference_q.emplace_back(std::move(ref));
+                lk.unlock();
+                refq_wait.cv.notify_one();
             }
         }
 
@@ -341,7 +317,6 @@ void BatchedIndexer::run() {
                 std::unique_lock lk(mutex);
 
                 req_res_map.erase(req_id);
-                req_colls.erase(req_id);
                 lk.unlock();
                 refq_wait.cv.notify_one();
             }
@@ -368,48 +343,22 @@ void BatchedIndexer::run() {
             // sent prior to this request.
             auto reference_q_it = reference_q.begin();
             while(reference_q_it != reference_q.end()) {
-                bool found_ref_coll = false;
-
-                auto req_colls_it = req_colls.find(reference_q_it->start_ts);
-                if(req_colls_it == req_colls.end()) {
-                    reference_q_it = reference_q.erase(reference_q_it);
-                    continue;
-                }
-
-                const std::string& coll_name = req_colls_it->second;
-
-                auto ref_colls_it = coll_to_references.find(coll_name);
-                const auto& ref_collections = (ref_colls_it != coll_to_references.end()) ? ref_colls_it->second :
-                                              CollectionManager::get_instance().get_collection_references(coll_name);
-
-                if(ref_collections.empty()) {
-                    // This request is not dependent on any other request. Push this request onto main processing queue
-                    // and remove node from queue.
-                    std::unique_lock qlk(qmutuxes[reference_q_it->queue_id].mcv);
-                    queues[reference_q_it->queue_id].emplace_back(reference_q_it->start_ts);
-                    qlk.unlock();
-                    qmutuxes[reference_q_it->queue_id].cv.notify_one();
-                    reference_q_it = reference_q.erase(reference_q_it);
-                    continue;
-                }
-
-                for (auto it = req_colls.begin(); it != req_colls_it; it++) {
-                    auto const& req_coll_name = it->second;
-                    if(ref_collections.count(req_coll_name) != 0) {
-                        found_ref_coll = true;
-                        break;
+                std::unordered_set<uint64_t> waiting_on_requests_updated;
+                for (const auto& waiting_on_req_id : reference_q_it->waiting_on_requests) {
+                    if (req_res_map.count(waiting_on_req_id) != 0) {
+                        waiting_on_requests_updated.insert(waiting_on_req_id);
                     }
                 }
-
-                if(!found_ref_coll) {
+                if (waiting_on_requests_updated.empty()) {
                     // All the dependent requests have been completed. Push this request onto main processing queue and
-                    // remove node from queue.
+                    // remove node from reference_q.
                     std::unique_lock qlk(qmutuxes[reference_q_it->queue_id].mcv);
                     queues[reference_q_it->queue_id].emplace_back(reference_q_it->start_ts);
                     qlk.unlock();
                     qmutuxes[reference_q_it->queue_id].cv.notify_one();
                     reference_q_it = reference_q.erase(reference_q_it);
                 } else {
+                    reference_q_it->waiting_on_requests = std::move(waiting_on_requests_updated);
                     reference_q_it++;
                 }
             }
@@ -651,4 +600,47 @@ void BatchedIndexer::clear_skip_indices() {
 size_t BatchedIndexer::get_reference_q_size() {
     std::lock_guard lk(refq_wait.mcv);
     return reference_q.size();
+}
+
+std::unordered_set<uint64_t> BatchedIndexer::get_requests_to_wait_on(const std::shared_ptr<http_req>& req,
+                                                                     const std::string& coll_name,
+                                                                     const bool& is_live_req) {
+    std::unordered_set<std::string> wait_for_collections;
+    std::unordered_set<uint64_t> wait_on_request_ids;
+    // We also have to serialize reference request if it results in cascade deletion of documents of referencing
+    // collections. Apart from this specific scenario, the user is responsible for serialization of requests
+    // of related collections.
+    const bool serialize_cascade_delete_request = CollectionManager::get_instance().is_referenced_in_any(coll_name) &&
+                                                  is_doc_del_route(req->route_hash);
+    if (is_live_req && !serialize_cascade_delete_request) {
+        return wait_on_request_ids;
+    }
+
+    if (serialize_cascade_delete_request) {
+        wait_for_collections = CollectionManager::get_instance().get_nested_referencing_collections(coll_name);
+    } else if (is_coll_create_route(req->route_hash)) {
+        get_ref_coll_names(req->body, wait_for_collections);
+    } else {
+        // If this request involves a collection that references other collection(s), we have to wait
+        // for the other collection(s) request(s) that arrived before this request to finish by pushing
+        // this request onto a waiting queue.
+        wait_for_collections = CollectionManager::get_instance().get_collection_references(coll_name);
+    }
+
+    if (wait_for_collections.empty()) {
+        return wait_on_request_ids;
+    }
+
+    std::unique_lock lk(mutex);
+    const auto it_end = req_res_map.lower_bound(req->start_ts);
+    for (auto it = req_res_map.begin(); it != it_end; it++) {
+        const auto& ref_req = it->second.req;
+        const auto& ref_coll_name = get_collection_name(ref_req);
+        if (wait_for_collections.count(ref_coll_name) == 0) {
+            continue;
+        }
+        wait_on_request_ids.insert(it->first);
+    }
+
+    return wait_on_request_ids;
 }

--- a/src/batched_indexer.cpp
+++ b/src/batched_indexer.cpp
@@ -87,7 +87,7 @@ void BatchedIndexer::enqueue(const std::shared_ptr<http_req>& req, const std::sh
                 req_res_map[req->start_ts].is_complete = true;
             }
 
-            auto wait_on_request_ids = get_requests_to_wait_on(req, coll_name, is_live_req);
+            auto wait_on_request_ids = get_requests_to_wait_on(req, coll_name);
             if(wait_on_request_ids.empty()) {
                 std::unique_lock qlk(qmutuxes[queue_id].mcv);
                 queues[queue_id].emplace_back(req->start_ts);
@@ -603,43 +603,47 @@ size_t BatchedIndexer::get_reference_q_size() {
 }
 
 std::unordered_set<uint64_t> BatchedIndexer::get_requests_to_wait_on(const std::shared_ptr<http_req>& req,
-                                                                     const std::string& coll_name,
-                                                                     const bool& is_live_req) {
+                                                                     const std::string& coll_name) {
     std::unordered_set<std::string> wait_for_collections;
-    std::unordered_set<uint64_t> wait_on_request_ids;
-    // We also have to serialize reference request if it results in cascade deletion of documents of referencing
-    // collections. Apart from this specific scenario, the user is responsible for serialization of requests
-    // of related collections.
-    const bool serialize_cascade_delete_request = CollectionManager::get_instance().is_referenced_in_any(coll_name) &&
-                                                  is_doc_del_route(req->route_hash);
-    if (is_live_req && !serialize_cascade_delete_request) {
-        return wait_on_request_ids;
-    }
 
-    if (serialize_cascade_delete_request) {
-        wait_for_collections = CollectionManager::get_instance().get_nested_referencing_collections(coll_name);
-    } else if (is_coll_create_route(req->route_hash)) {
+    if (is_coll_create_route(req->route_hash)) {
         get_ref_coll_names(req->body, wait_for_collections);
     } else {
-        // If this request involves a collection that references other collection(s), we have to wait
-        // for the other collection(s) request(s) that arrived before this request to finish by pushing
+        // If this request involves a collection that references other collection(s) or is referenced by other
+        // collection(s), we have to wait for the other request(s) that arrived before this request to finish by pushing
         // this request onto a waiting queue.
-        wait_for_collections = CollectionManager::get_instance().get_collection_references(coll_name);
+        auto& cm = CollectionManager::get_instance();
+        auto temp = cm.get_collection_references(coll_name);
+        wait_for_collections.insert(temp.begin(), temp.end());
+
+        temp = cm.get_nested_referencing_collections(coll_name);
+        wait_for_collections.insert(temp.begin(), temp.end());
     }
 
     if (wait_for_collections.empty()) {
-        return wait_on_request_ids;
+        return {};
     }
 
+    // Requests waiting in `reference_q` temporarily leave the collection's main queue, so later writes to the
+    // same collection must wait on them as well to preserve per-collection ordering.
+    wait_for_collections.insert(coll_name);
+
+    std::unordered_set<uint64_t> wait_on_request_ids;
     std::unique_lock lk(mutex);
-    const auto it_end = req_res_map.lower_bound(req->start_ts);
-    for (auto it = req_res_map.begin(); it != it_end; it++) {
-        const auto& ref_req = it->second.req;
+    for (const auto& [req_id, req_res] : req_res_map) {
+        const auto& ref_req = req_res.req;
+        const bool has_log_order = req->log_index != 0 && ref_req->log_index != 0;
+        const bool is_earlier_request = has_log_order ? (ref_req->log_index < req->log_index)
+                                                      : (req_id < req->start_ts);
+        if (!is_earlier_request) {
+            continue;
+        }
+
         const auto& ref_coll_name = get_collection_name(ref_req);
         if (wait_for_collections.count(ref_coll_name) == 0) {
             continue;
         }
-        wait_on_request_ids.insert(it->first);
+        wait_on_request_ids.insert(req_id);
     }
 
     return wait_on_request_ids;

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -856,7 +856,7 @@ void Collection::batch_index(std::vector<index_record>& index_records, std::vect
                 if(!write_ok) {
                     // we will attempt to reindex the old doc on a best-effort basis
                     LOG(ERROR) << "Update to disk failed. Will restore old document";
-                    remove_document(index_record.new_doc, index_record.seq_id, false);
+                    remove_document(index_record.new_doc, index_record.seq_id, false, false);
                     index_in_memory(index_record.old_doc, index_record.seq_id, index_record.operation, index_record.dirty_values);
                     index_record.index_failure(500, "Could not write to on-disk storage.");
                 }
@@ -881,7 +881,7 @@ void Collection::batch_index(std::vector<index_record>& index_records, std::vect
                 if(!write_ok) {
                     // remove from in-memory store to keep the state synced
                     LOG(ERROR) << "Write to disk failed, removing the document from in-memory index.";
-                    remove_document(index_record.doc, index_record.seq_id, false);
+                    remove_document(index_record.doc, index_record.seq_id, false, false);
                     index_record.index_failure(500, "Could not write to on-disk storage.");
                 }
 
@@ -896,7 +896,7 @@ void Collection::batch_index(std::vector<index_record>& index_records, std::vect
                         remove_async_reference_docs.emplace_back(index_record.position, index_record.seq_id,
                                                                  index_record.doc, index_record.operation,
                                                                  index_record.dirty_values);
-                        remove_document(index_record.doc, index_record.seq_id, false);
+                        remove_document(index_record.doc, index_record.seq_id, false, false);
                     }
                 }
             }
@@ -5872,22 +5872,18 @@ Option<nlohmann::json> Collection::get(const std::string & id) const {
     return Option<nlohmann::json>(document);
 }
 
-void Collection::remove_document(nlohmann::json & document, const uint32_t seq_id, bool remove_from_store) {
+void Collection::remove_document(nlohmann::json & document, const uint32_t seq_id, bool remove_from_store,
+                                 const bool& cascade_remove) {
     spp::sparse_hash_map<std::string, std::string> referenced_in_copy;
     {
         std::unique_lock lock(mutex);
         referenced_in_copy = referenced_in;
     }
 
-    // Cascade delete all the references.
-    if (!referenced_in_copy.empty()) {
-        CollectionManager& collectionManager = CollectionManager::get_instance();
-        for (const auto &item: referenced_in_copy) {
-            auto coll = collectionManager.get_collection(item.first);
-            if (coll != nullptr) {
-                coll->cascade_remove_doc_with_lock(item.second, seq_id, document, remove_from_store);
-            }
-        }
+    if (cascade_remove) {
+        std::vector<index_record> records;
+        records.emplace_back(0, seq_id, document, index_operation_t::DELETE, DIRTY_VALUES::COERCE_OR_REJECT);
+        Collection::cascade_remove(name, records, remove_from_store);
     }
 
     {
@@ -6098,202 +6094,6 @@ void Collection::reset_referencing_documents(const std::string& field_name, cons
                                                    token_separators, symbols_to_index, dummy_set);
 }
 
-void Collection::cascade_remove_doc_with_lock(const std::string& field_name, const uint32_t& ref_seq_id,
-                                               const nlohmann::json& ref_doc, bool remove_from_store) {
-    bool is_field_singular, is_field_optional, cascade_delete;
-    {
-        std::unique_lock lock(mutex);
-
-        auto it = search_schema.find(field_name);
-        if (it == search_schema.end()) {
-            return;
-        }
-        auto& field = it.value();
-
-        is_field_singular = field.is_singular();
-        is_field_optional = field.optional;
-        cascade_delete = field.cascade_delete;
-    }
-
-    auto const ref_helper_field_name = field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX;
-
-    filter_result_t filter_result;
-    get_filter_ids_with_lock(ref_helper_field_name + ":" + std::to_string(ref_seq_id), filter_result, false);
-
-    if (filter_result.count == 0) {
-        return;
-    }
-
-    std::vector<std::string> buffer;
-    buffer.reserve(filter_result.count);
-
-    if (is_field_singular) {
-        // Delete all the docs where reference helper field has value `seq_id`.
-        for (uint32_t i = 0; i < filter_result.count; i++) {
-            auto const& seq_id = filter_result.docs[i];
-
-            nlohmann::json existing_document;
-            auto get_doc_op = get_document_from_store(get_seq_id_key(seq_id), existing_document);
-
-            if (!get_doc_op.ok()) {
-                if (get_doc_op.code() == 404) {
-                    LOG(ERROR) << "`" << name << "` collection: Sequence ID `" << seq_id << "` exists, but document is missing.";
-                    continue;
-                }
-
-                LOG(ERROR) << "`" << name << "` collection: " << get_doc_op.error();
-                continue;
-            }
-
-            bool multiple_ref_fields = existing_document.contains(fields::reference_helper_fields) &&
-                                       existing_document[fields::reference_helper_fields].size() > 1;
-
-            // If `cascade_delete` is false, only update the reference helper field to sentinel value.
-            // If there are other references present and the reference of an optional field is removed, don't delete the
-            // document.
-            if (!cascade_delete || (multiple_ref_fields && is_field_optional)) {
-                auto const id = existing_document["id"].get<std::string>();
-
-                nlohmann::json update_document;
-                update_document["id"] = id;
-                if (cascade_delete) {
-                    update_document[field_name] = nullptr;
-                } else {
-                    update_document[ref_helper_field_name] = Join::reference_helper_sentinel_value;
-                }
-
-                buffer.push_back(update_document.dump());
-            } else {
-                remove_document(existing_document, seq_id, remove_from_store);
-            }
-        }
-    } else {
-        std::string ref_coll_name, ref_field_name;
-        {
-            std::unique_lock lock(mutex);
-
-            auto ref_it = reference_fields.find(field_name);
-            if (ref_it == reference_fields.end()) {
-                return;
-            }
-            ref_coll_name = ref_it->second.collection;
-            ref_field_name = ref_it->second.field;
-        }
-
-        if (ref_doc.count(ref_field_name) == 0) {
-            LOG(ERROR) << "`" << ref_coll_name << "` collection doc `" << ref_doc.dump() << "` is missing `" <<
-                       ref_field_name << "` field.";
-            return;
-        } else if (ref_doc.at(ref_field_name).is_array()) {
-            LOG(ERROR) << "`" << ref_coll_name << "` collection doc `" << ref_doc.dump() << "` field `" <<
-                                 ref_field_name << "` is an array.";
-            return;
-        }
-
-        // If `cascade_delete` is false, update the reference helper field to sentinel value.
-        // Otherwise, delete all references to `seq_id` in the docs.
-        for (uint32_t i = 0; i < filter_result.count; i++) {
-            auto const& seq_id = filter_result.docs[i];
-
-            nlohmann::json existing_document;
-            auto get_doc_op = get_document_from_store(get_seq_id_key(seq_id), existing_document);
-
-            if (!get_doc_op.ok()) {
-                if (get_doc_op.code() == 404) {
-                    LOG(ERROR) << "`" << name << "` collection: Sequence ID `" << seq_id << "` exists, but document is missing.";
-                    continue;
-                }
-
-                LOG(ERROR) << "`" << name << "` collection: " << get_doc_op.error();
-                continue;
-            }
-
-            if (existing_document.count("id") == 0) {
-                LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` is missing `id` field.";
-            } else if (existing_document.count(field_name) == 0) {
-                LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` is missing `" <<
-                                field_name << "` field.";
-            } else if (!existing_document.at(field_name).is_array()) {
-                LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` field `" <<
-                                field_name << "` is not an array.";
-            } else if (existing_document.at(field_name).empty()) {
-                LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` field `" <<
-                                field_name << "` is empty.";
-            } else if (existing_document.at(field_name)[0].type() != ref_doc.at(ref_field_name).type()) {
-                LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() <<
-                                "` at field `" << field_name << "` elements do not match the type of `" << ref_coll_name <<
-                                "` collection doc `"<< ref_doc.dump() << "` at field `" << ref_field_name << "`.";
-            } else if (existing_document.count(ref_helper_field_name) == 0) {
-                LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` is missing `" <<
-                                ref_helper_field_name << "` field.";
-            } else if (!existing_document.at(ref_helper_field_name).is_array()) {
-                LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` field `" <<
-                                ref_helper_field_name << "` is not an array.";
-            } else if (existing_document[field_name].size() != existing_document[ref_helper_field_name].size()) {
-                LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` reference field `" <<
-                           field_name << "` values and its reference helper field `" << ref_helper_field_name <<
-                           "` values differ in count.";
-            }
-            // If there are more than one references present in this document, we cannot delete the whole doc. Only remove
-            // `ref_seq_id` from reference helper field or update it to sentinel value if `cascade_delete` is false.
-            else if (existing_document.at(field_name).size() > 1) {
-                nlohmann::json update_document;
-                update_document["id"] = existing_document["id"].get<std::string>();
-                update_document[field_name] = nlohmann::json::array();
-
-                auto removed_ref_value_found = false;
-
-                // We assume here that the value in reference field at a particular index corresponds to the value
-                // present at the same index in the reference helper field.
-                for (uint32_t j = 0; j < existing_document[field_name].size(); j++) {
-                    auto const& ref_value = existing_document[field_name][j];
-                    if (ref_value == ref_doc.at(ref_field_name)) {
-                        removed_ref_value_found = true;
-
-                        if (!cascade_delete) {
-                            update_document[field_name] += ref_value;
-                            update_document[ref_helper_field_name] += Join::reference_helper_sentinel_value;
-                        }
-                        continue;
-                    }
-
-                    update_document[field_name] += ref_value;
-                    update_document[ref_helper_field_name] += existing_document[ref_helper_field_name][j];
-                }
-
-                if (removed_ref_value_found) {
-                    buffer.push_back(update_document.dump());
-                }
-            } else {
-                bool multiple_ref_fields = existing_document.contains(fields::reference_helper_fields) &&
-                                           existing_document[fields::reference_helper_fields].size() > 1;
-
-                // If `cascade_delete` is false, only update the reference helper field to sentinel value.
-                // If there are other references present and the reference of an optional field is removed, don't delete the
-                // document.
-                if (!cascade_delete || (multiple_ref_fields && is_field_optional)) {
-                    auto const id = existing_document["id"].get<std::string>();
-
-                    nlohmann::json update_document;
-                    update_document["id"] = id;
-                    if (cascade_delete) {
-                        update_document[field_name] = nullptr;
-                    } else {
-                        update_document[ref_helper_field_name] = Join::reference_helper_sentinel_value;
-                    }
-
-                    buffer.push_back(update_document.dump());
-                } else {
-                    remove_document(existing_document, seq_id, remove_from_store);
-                }
-            }
-        }
-    }
-
-    nlohmann::json dummy;
-    add_many(buffer, dummy, index_operation_t::UPDATE);
-}
-
 Option<std::string> Collection::remove(const std::string & id, const bool remove_from_store) {
     std::string seq_id_str;
     StoreStatus seq_id_status = store->get(get_doc_id_key(id), seq_id_str);
@@ -6352,43 +6152,9 @@ Option<size_t> Collection::remove_if_found_many(const std::vector<uint32_t>& seq
         return Option<size_t>(0);
     }
 
-    bool has_referenced_in = false;
-    {
-        std::shared_lock lock(mutex);
-        has_referenced_in = !referenced_in.empty();
-    }
-
-    // If this collection is referenced by another collection, keep per-doc semantics
-    // so cascaded deletes can short-circuit subsequent IDs safely.
-    if(has_referenced_in) {
-        size_t removed_count = 0;
-
-        for(const auto seq_id: seq_ids) {
-            nlohmann::json document;
-            auto get_doc_op = get_document_from_store(get_seq_id_key(seq_id), document);
-            if(!get_doc_op.ok()) {
-                if(get_doc_op.code() == 404) {
-                    continue;
-                }
-                return Option<size_t>(500, "Error while fetching the document with seq id: " +
-                                           std::to_string(seq_id));
-            }
-
-            remove_document(document, seq_id, remove_from_store);
-            removed_count++;
-
-            if(removed_docs != nullptr) {
-                removed_docs->emplace_back(std::move(document));
-            }
-        }
-
-        return Option<size_t>(removed_count);
-    }
-
-    std::vector<uint32_t> found_seq_ids;
-    std::vector<nlohmann::json> found_documents;
-    found_seq_ids.reserve(seq_ids.size());
-    found_documents.reserve(seq_ids.size());
+    std::vector<index_record> records;
+    records.reserve(seq_ids.size());
+    size_t record_index = 0;
 
     for(const auto seq_id: seq_ids) {
         nlohmann::json document;
@@ -6401,18 +6167,20 @@ Option<size_t> Collection::remove_if_found_many(const std::vector<uint32_t>& seq
                                        std::to_string(seq_id));
         }
 
-        found_seq_ids.emplace_back(seq_id);
-        found_documents.emplace_back(std::move(document));
+        records.emplace_back(record_index++, seq_id, std::move(document), index_operation_t::DELETE,
+                             DIRTY_VALUES::COERCE_OR_REJECT);
     }
 
-    if(found_seq_ids.empty()) {
+    if(records.empty()) {
         return Option<size_t>(0);
     }
 
+    Collection::cascade_remove(name, records, remove_from_store);
+
     {
         std::unique_lock lock(mutex);
-        for(size_t i = 0; i < found_seq_ids.size(); i++) {
-            index->remove(found_seq_ids[i], found_documents[i], {}, false);
+        for(auto& record: records) {
+            index->remove(record.seq_id, record.doc, {}, false);
             if (num_documents != 0) {
                 num_documents -= 1;
             }
@@ -6420,20 +6188,20 @@ Option<size_t> Collection::remove_if_found_many(const std::vector<uint32_t>& seq
     }
 
     if(remove_from_store) {
-        for(size_t i = 0; i < found_seq_ids.size(); i++) {
-            const auto id = found_documents[i]["id"].get<std::string>();
+        for(auto& record: records) {
+            const auto id = record.doc["id"].get<std::string>();
             store->remove(get_doc_id_key(id));
-            store->remove(get_seq_id_key(found_seq_ids[i]));
+            store->remove(get_seq_id_key(record.seq_id));
         }
     }
 
     if(removed_docs != nullptr) {
-        for(auto& document: found_documents) {
-            removed_docs->emplace_back(std::move(document));
+        for(auto& record: records) {
+            removed_docs->emplace_back(std::move(record.doc));
         }
     }
 
-    return Option<size_t>(found_seq_ids.size());
+    return Option<size_t>(records.size());
 }
 
 uint32_t Collection::get_seq_id_from_key(const std::string & key) {
@@ -8508,7 +8276,6 @@ void Collection::hide_credential(nlohmann::json& json, const std::string& creden
     }
 }
 
-// todo
 Option<bool> Collection::truncate_after_top_k(const string &field_name, size_t k) {
     std::shared_lock slock(mutex);
 
@@ -8938,7 +8705,6 @@ Option<nlohmann::json> Collection::get_alter_schema_status() const {
     return Option<nlohmann::json>(status_json);
 }
 
-// todo
 Option<size_t> Collection::remove_all_docs() {
     size_t num_docs_removed = 0;
 
@@ -10120,4 +9886,286 @@ Option<bool> Collection::fix_broken_reference(const std::string& seq_id_key, con
                      field_order_kv->reference_filter_results,
                      get_name(), seq_id,
                      ref_include_exclude_fields_vec);
+}
+
+void Collection::cascade_remove_helper(const std::vector<index_record>& records, cascade_remove_node_t* cascade_node,
+                                       const bool remove_from_store) {
+    if (cascade_node == nullptr) {
+        return;
+    }
+
+    for (size_t i = 0; i < cascade_node->ref_infos.size(); i++) {
+        auto& nested_reference = cascade_node->nested_references[i];
+        if (nested_reference == nullptr) {
+            continue;
+        }
+
+        std::vector<index_record> nested_records;
+        nested_reference->coll_ptr->cascade_remove(records, cascade_node->ref_infos[i], cascade_node->coll_ptr->name,
+                                                   nested_records, remove_from_store);
+        cascade_remove_helper(nested_records, nested_reference, remove_from_store);
+
+        // Eagerly release the locks.
+        delete nested_reference;
+        nested_reference = nullptr;
+    }
+}
+
+void Collection::cascade_remove(const string& coll_name, const std::vector<index_record>& records,
+                                const bool remove_from_store) {
+    cascade_remove_node_t* cascade_tree = nullptr;
+    CollectionManager::get_instance().lock_nested_referencing_collections(coll_name, cascade_tree);
+    if (cascade_tree == nullptr) {
+        return;
+    }
+
+    cascade_remove_helper(records, cascade_tree, remove_from_store);
+    delete cascade_tree;
+}
+
+void Collection::cascade_remove(const std::vector<index_record>& records, const reference_info_t& ref_info,
+                                const std::string& ref_coll_name, std::vector<index_record>& removed_records,
+                                const bool remove_from_store) {
+    const auto& field_name = ref_info.field;
+    auto it = search_schema.find(field_name);
+    if (it == search_schema.end()) {
+        return;
+    }
+    auto& field = it.value();
+
+    const bool is_field_singular = field.is_singular();
+    const bool is_field_optional = field.optional;
+    const bool cascade_delete = field.cascade_delete;
+
+    auto const ref_helper_field_name = field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX;
+    const auto& ref_field_name = ref_info.referenced_field_name;
+
+    const auto dirty_values = DIRTY_VALUES::COERCE_OR_REJECT;
+    // In case the document has multiple reference fields or `cascade_delete` option is false, we will only update its
+    // reference helper field to sentinel value otherwise we will remove the document from the index.
+    std::vector<index_record> update_records;
+    size_t remove_index = 0, update_index = 0;
+    for (const auto& ref_record: records) {
+        const auto& ref_seq_id = ref_record.seq_id;
+        const auto& ref_doc = ref_record.doc;
+
+        if (ref_doc.count(ref_field_name) == 0) {
+            LOG(ERROR) << "`" << ref_coll_name << "` collection doc `" << ref_doc.dump() << "` is missing `" <<
+                       ref_field_name << "` field.";
+            continue;
+        } else if (ref_doc.at(ref_field_name).is_array()) {
+            LOG(ERROR) << "`" << ref_coll_name << "` collection doc `" << ref_doc.dump() << "` field `" <<
+                       ref_field_name << "` is an array.";
+            continue;
+        }
+
+        filter_result_t filter_result;
+        get_filter_ids(ref_helper_field_name + ":" + std::to_string(ref_seq_id), filter_result, false);
+
+        if (filter_result.count == 0) {
+            continue;
+        }
+
+        if (is_field_singular) {
+            // Delete all the docs where reference helper field has value `seq_id`.
+            for (uint32_t i = 0; i < filter_result.count; i++) {
+                auto const& seq_id = filter_result.docs[i];
+
+                nlohmann::json existing_document;
+                auto get_doc_op = get_document_from_store(get_seq_id_key(seq_id), existing_document);
+
+                if (!get_doc_op.ok()) {
+                    if (get_doc_op.code() == 404) {
+                        LOG(ERROR) << "`" << name << "` collection: Sequence ID `" << seq_id << "` exists, but document is missing.";
+                        continue;
+                    }
+
+                    LOG(ERROR) << "`" << name << "` collection: " << get_doc_op.error();
+                    continue;
+                }
+
+                bool multiple_ref_fields = existing_document.contains(fields::reference_helper_fields) &&
+                                           existing_document[fields::reference_helper_fields].size() > 1;
+
+                // If `cascade_delete` is false, only update the reference helper field to sentinel value.
+                // If there are other references present and the reference of an optional field is removed, don't delete the
+                // document.
+                if (!cascade_delete || (multiple_ref_fields && is_field_optional)) {
+                    auto const id = existing_document["id"].get<std::string>();
+
+                    nlohmann::json update_document;
+                    update_document["id"] = id;
+                    if (cascade_delete) {
+                        update_document[field_name] = nullptr;
+                    } else {
+                        update_document[ref_helper_field_name] = Join::reference_helper_sentinel_value;
+                    }
+
+                    index_record record(update_index++, seq_id, update_document, index_operation_t::UPDATE,
+                                        dirty_values);
+                    record.old_doc = existing_document;
+                    record.is_update = true;
+                    update_records.emplace_back(std::move(record));
+                } else {
+                    removed_records.emplace_back(remove_index++, seq_id, existing_document, index_operation_t::DELETE,
+                                                 dirty_values);
+                }
+            }
+        } else {
+            // If `cascade_delete` is false, update the reference helper field to sentinel value.
+            // Otherwise, delete all references to `seq_id` in the docs.
+            for (uint32_t i = 0; i < filter_result.count; i++) {
+                auto const& seq_id = filter_result.docs[i];
+
+                nlohmann::json existing_document;
+                auto get_doc_op = get_document_from_store(get_seq_id_key(seq_id), existing_document);
+
+                if (!get_doc_op.ok()) {
+                    if (get_doc_op.code() == 404) {
+                        LOG(ERROR) << "`" << name << "` collection: Sequence ID `" << seq_id << "` exists, but document is missing.";
+                        continue;
+                    }
+
+                    LOG(ERROR) << "`" << name << "` collection: " << get_doc_op.error();
+                    continue;
+                }
+
+                if (existing_document.count("id") == 0) {
+                    LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` is missing `id` field.";
+                } else if (existing_document.count(field_name) == 0) {
+                    LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` is missing `" <<
+                               field_name << "` field.";
+                } else if (!existing_document.at(field_name).is_array()) {
+                    LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` field `" <<
+                               field_name << "` is not an array.";
+                } else if (existing_document.at(field_name).empty()) {
+                    LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` field `" <<
+                               field_name << "` is empty.";
+                } else if (existing_document.at(field_name)[0].type() != ref_doc.at(ref_field_name).type()) {
+                    LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() <<
+                               "` at field `" << field_name << "` elements do not match the type of `" << ref_coll_name <<
+                               "` collection doc `"<< ref_doc.dump() << "` at field `" << ref_field_name << "`.";
+                } else if (existing_document.count(ref_helper_field_name) == 0) {
+                    LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` is missing `" <<
+                               ref_helper_field_name << "` field.";
+                } else if (!existing_document.at(ref_helper_field_name).is_array()) {
+                    LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` field `" <<
+                               ref_helper_field_name << "` is not an array.";
+                } else if (existing_document[field_name].size() != existing_document[ref_helper_field_name].size()) {
+                    LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` reference field `" <<
+                               field_name << "` values and its reference helper field `" << ref_helper_field_name <<
+                               "` values differ in count.";
+                }
+                // If there are more than one references present in this document, we cannot delete the whole doc. Only remove
+                // `ref_seq_id` from reference helper field or update it to sentinel value if `cascade_delete` is false.
+                else if (existing_document.at(field_name).size() > 1) {
+                    nlohmann::json update_document;
+                    update_document["id"] = existing_document["id"].get<std::string>();
+                    update_document[field_name] = nlohmann::json::array();
+
+                    auto removed_ref_value_found = false;
+
+                    // We assume here that the value in reference field at a particular index corresponds to the value
+                    // present at the same index in the reference helper field.
+                    for (uint32_t j = 0; j < existing_document[field_name].size(); j++) {
+                        auto const& ref_value = existing_document[field_name][j];
+                        if (ref_value == ref_doc.at(ref_field_name)) {
+                            removed_ref_value_found = true;
+
+                            if (!cascade_delete) {
+                                update_document[field_name] += ref_value;
+                                update_document[ref_helper_field_name] += Join::reference_helper_sentinel_value;
+                            }
+                            continue;
+                        }
+
+                        update_document[field_name] += ref_value;
+                        update_document[ref_helper_field_name] += existing_document[ref_helper_field_name][j];
+                    }
+
+                    if (removed_ref_value_found) {
+                        index_record record(update_index++, seq_id, update_document, index_operation_t::UPDATE,
+                                            dirty_values);
+                        record.old_doc = existing_document;
+                        record.is_update = true;
+                        update_records.emplace_back(std::move(record));
+                    }
+                } else {
+                    bool multiple_ref_fields = existing_document.contains(fields::reference_helper_fields) &&
+                                               existing_document[fields::reference_helper_fields].size() > 1;
+
+                    // If `cascade_delete` is false, only update the reference helper field to sentinel value.
+                    // If there are other references present and the reference of an optional field is removed, don't delete the
+                    // document.
+                    if (!cascade_delete || (multiple_ref_fields && is_field_optional)) {
+                        auto const id = existing_document["id"].get<std::string>();
+
+                        nlohmann::json update_document;
+                        update_document["id"] = id;
+                        if (cascade_delete) {
+                            update_document[field_name] = nullptr;
+                        } else {
+                            update_document[ref_helper_field_name] = Join::reference_helper_sentinel_value;
+                        }
+
+                        index_record record(update_index++, seq_id, update_document, index_operation_t::UPDATE,
+                                            dirty_values);
+                        record.old_doc = existing_document;
+                        record.is_update = true;
+                        update_records.emplace_back(std::move(record));
+                    } else {
+                        removed_records.emplace_back(remove_index++, seq_id, existing_document, index_operation_t::DELETE,
+                                                     dirty_values);
+                    }
+                }
+            }
+        }
+    }
+
+    std::shared_lock alter_shlock(alter_mutex);
+    if (!update_records.empty()) {
+        for (auto& update_record: update_records) {
+            Join::populate_reference_helper_fields(update_record.doc, search_schema, reference_fields,
+                                                   object_reference_fields, true);
+        }
+        Index::batch_validate_and_preprocess(index, update_records, default_sorting_field, search_schema, embedding_fields,
+                                             fallback_field_type, token_separators, symbols_to_index, true);
+
+        std::unordered_set<std::string> dummy_set;
+        size_t num_indexed = Index::batch_memory_index(index, update_records, default_sorting_field,
+                                                       search_schema, embedding_fields, fallback_field_type,
+                                                       token_separators, symbols_to_index, dummy_set);
+        for (auto& update_record: update_records) {
+            remove_flat_fields(update_record.new_doc);
+            for(auto& f: fields) {
+                if(!f.store) {
+                    update_record.new_doc.erase(f.name);
+                }
+            }
+            const std::string& serialized_json = update_record.new_doc.dump(-1, ' ', false, nlohmann::detail::error_handler_t::ignore);
+
+            bool write_ok = store->insert(get_seq_id_key(update_record.seq_id), serialized_json);
+
+            if(!write_ok) {
+                // we will attempt to reindex the old doc on a best-effort basis
+                LOG(ERROR) << "Update to disk failed. Will restore old document";
+                remove_document(update_record.new_doc, update_record.seq_id, false, false);
+                index_in_memory(update_record.old_doc, update_record.seq_id, update_record.operation, update_record.dirty_values);
+                update_record.index_failure(500, "Could not write to on-disk storage.");
+            }
+        }
+    }
+
+    for(auto& record: removed_records) {
+        index->remove(record.seq_id, record.doc, {}, false);
+        if (num_documents != 0) {
+            num_documents -= 1;
+        }
+
+        if (remove_from_store) {
+            const auto id = record.doc["id"].get<std::string>();
+            store->remove(get_doc_id_key(id));
+            store->remove(get_seq_id_key(record.seq_id));
+        }
+    }
 }

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -233,7 +233,7 @@ Option<bool> Collection::update_async_references_with_lock(const std::string& re
 
     // Update reference helper field of the docs matching the filter.
     filter_result_t filter_result;
-    get_filter_ids(filter, filter_result, false);
+    get_filter_ids_with_lock(filter, filter_result, false);
     if (filter_result.count == 0) {
         return Option<bool>(true);
     }
@@ -784,7 +784,7 @@ Option<nlohmann::json> Collection::update_matching_filter(const std::string& fil
         delete it;
     } else {
         filter_result_t filter_result;
-        auto filter_ids_op = get_filter_ids(_filter_query, filter_result, false, validate_field_names);
+        auto filter_ids_op = get_filter_ids_with_lock(_filter_query, filter_result, false, validate_field_names);
         if(!filter_ids_op.ok()) {
             return Option<nlohmann::json>(filter_ids_op.code(), filter_ids_op.error());
         }
@@ -834,6 +834,8 @@ void Collection::batch_index(std::vector<index_record>& index_records, std::vect
             }
         }
     }
+    // We will remove all references to a document that has failed to index.
+    std::vector<index_record> remove_async_reference_docs;
 
     // store only documents that were indexed in-memory successfully
     for(auto& index_record: index_records) {
@@ -890,6 +892,10 @@ void Collection::batch_index(std::vector<index_record>& index_records, std::vect
                     if (!async_update_op.ok()) {
                         // remove from in-memory store to keep the state synced
                         LOG(ERROR) << "Updating references failed, removing the document from in-memory index.";
+
+                        remove_async_reference_docs.emplace_back(index_record.position, index_record.seq_id,
+                                                                 index_record.doc, index_record.operation,
+                                                                 index_record.dirty_values);
                         remove_document(index_record.doc, index_record.seq_id, false);
                     }
                 }
@@ -946,6 +952,8 @@ void Collection::batch_index(std::vector<index_record>& index_records, std::vect
         json_out[index_record.position] = res.dump(-1, ' ', false,
                                                    nlohmann::detail::error_handler_t::ignore);
     }
+
+    Collection::reset_referencing_documents(found_async_referenced_ins, remove_async_reference_docs);
 }
 
 Option<uint32_t> Collection::index_in_memory(nlohmann::json &document, uint32_t seq_id,
@@ -993,7 +1001,7 @@ size_t Collection::batch_index_in_memory(std::vector<index_record>& index_record
     size_t num_indexed = Index::batch_memory_index(index, index_records, default_sorting_field,
                                                    search_schema, embedding_fields, fallback_field_type,
                                                    token_separators, symbols_to_index, found_fields,
-                                                   false, tsl::htrie_map<char, field>(), collection_name);
+                                                   false, tsl::htrie_map<char, field>());
     num_documents += num_indexed;
 
     return num_indexed;
@@ -4771,8 +4779,6 @@ void Collection::parse_search_query(const std::string &query, std::vector<std::s
 
 Option<bool> Collection::get_filter_ids(const std::string& filter_query, filter_result_t& filter_result,
                                         const bool& should_timeout, const bool& validate_field_names) const {
-    std::shared_lock lock(mutex);
-
     const std::string doc_id_prefix = std::to_string(collection_id) + "_" + DOC_ID_PREFIX + "_";
     filter_node_t* filter_tree_root = nullptr;
     Option<bool> filter_op = filter::parse_filter_query(filter_query, search_schema,
@@ -4782,9 +4788,14 @@ Option<bool> Collection::get_filter_ids(const std::string& filter_query, filter_
     if(!filter_op.ok()) {
         return filter_op;
     }
-    lock.unlock();
 
     return index->do_filtering_with_lock(filter_tree_root, filter_result, name, should_timeout, validate_field_names);
+}
+
+Option<bool> Collection::get_filter_ids_with_lock(const std::string& filter_query, filter_result_t& filter_result,
+                                                  const bool& should_timeout, const bool& validate_field_names) const {
+    std::shared_lock lock(mutex);
+    return get_filter_ids(filter_query, filter_result, should_timeout, validate_field_names);
 }
 
 Option<bool> Collection::get_related_ids_with_lock(const std::string& field_name, const std::vector<uint32_t>& seq_id_vec,
@@ -5874,7 +5885,7 @@ void Collection::remove_document(nlohmann::json & document, const uint32_t seq_i
         for (const auto &item: referenced_in_copy) {
             auto coll = collectionManager.get_collection(item.first);
             if (coll != nullptr) {
-                coll->cascade_remove_docs(item.second, seq_id, document, remove_from_store);
+                coll->cascade_remove_doc_with_lock(item.second, seq_id, document, remove_from_store);
             }
         }
     }
@@ -5896,8 +5907,209 @@ void Collection::remove_document(nlohmann::json & document, const uint32_t seq_i
     }
 }
 
-void Collection::cascade_remove_docs(const std::string& field_name, const uint32_t& ref_seq_id,
-                                     const nlohmann::json& ref_doc, bool remove_from_store) {
+void Collection::reset_referencing_documents(const spp::sparse_hash_map<std::string, std::set<reference_pair_t>>& async_referenced_ins,
+                                             const std::vector<index_record>& docs) {
+    if (docs.empty()) {
+        return;
+    }
+
+    // Lock all collections which reference the document that failed to index.
+    std::vector<std::unique_lock<std::shared_mutex>> collection_locks;
+    for (const auto& pair: async_referenced_ins) {
+        for (const auto& ref_info: pair.second) {
+            auto const& referencing_collection_name = ref_info.collection;
+
+            auto& cm = CollectionManager::get_instance();
+            auto referencing_coll = cm.get_collection(referencing_collection_name);
+            if (referencing_coll == nullptr) {
+                continue;
+            }
+            collection_locks.emplace_back(referencing_coll->mutex);
+        }
+    }
+
+    if (collection_locks.empty()) {
+        return;
+    }
+
+    for (const auto& pair: async_referenced_ins) {
+        const auto& referenced_field = pair.first;
+
+        for (const auto& ref_info: pair.second) {
+            auto const& referencing_collection_name = ref_info.collection;
+            auto const& referencing_field_name = ref_info.field;
+
+            auto& cm = CollectionManager::get_instance();
+            auto referencing_coll = cm.get_collection(referencing_collection_name);
+            if (referencing_coll == nullptr) {
+                continue;
+            }
+            referencing_coll->reset_referencing_documents(referencing_field_name, docs);
+        }
+    }
+}
+
+void Collection::reset_referencing_documents(const std::string& field_name, const std::vector<index_record>& ref_docs) {
+    const auto it = search_schema.find(field_name);
+    if (it == search_schema.end()) {
+        return;
+    }
+    auto& field = it.value();
+    const auto is_field_singular = field.is_singular();
+    const auto is_field_optional = field.optional;
+
+    const auto ref_it = reference_fields.find(field_name);
+    if (ref_it == reference_fields.end()) {
+        return;
+    }
+    std::string ref_coll_name = ref_it->second.collection;
+    std::string ref_field_name = ref_it->second.field;
+
+    auto const ref_helper_field_name = field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX;
+
+    nlohmann::json dummy;
+    const auto operation = index_operation_t::UPDATE;
+    const auto dirty_values = DIRTY_VALUES::COERCE_OR_REJECT;
+    size_t document_index = 0;
+    std::vector<index_record> index_records;
+
+    for (const auto& ref_record: ref_docs) {
+        const auto& ref_seq_id = ref_record.seq_id;
+
+        const auto& ref_doc = ref_record.doc;
+        if (ref_doc.count(ref_field_name) == 0) {
+            LOG(ERROR) << "`" << ref_coll_name << "` collection doc `" << ref_doc.dump() << "` is missing `" <<
+                       ref_field_name << "` field.";
+            continue;
+        } else if (ref_doc.at(ref_field_name).is_array()) {
+            LOG(ERROR) << "`" << ref_coll_name << "` collection doc `" << ref_doc.dump() << "` field `" <<
+                       ref_field_name << "` is an array.";
+            continue;
+        }
+
+        filter_result_t filter_result;
+        get_filter_ids(ref_helper_field_name + ":" + std::to_string(ref_seq_id), filter_result, false);
+
+        if (filter_result.count == 0) {
+            continue;
+        }
+
+        if (is_field_singular) {
+            // Reset the value of the reference helper field of every document having value `seq_id`.
+            for (uint32_t i = 0; i < filter_result.count; i++) {
+                auto const& seq_id = filter_result.docs[i];
+
+                nlohmann::json existing_document;
+                auto get_doc_op = get_document_from_store(get_seq_id_key(seq_id), existing_document);
+
+                if (!get_doc_op.ok()) {
+                    if (get_doc_op.code() == 404) {
+                        LOG(ERROR) << "`" << name << "` collection: Sequence ID `" << seq_id << "` exists, but document is missing.";
+                        continue;
+                    }
+
+                    LOG(ERROR) << "`" << name << "` collection: " << get_doc_op.error();
+                    continue;
+                }
+
+                // Only set reference helper fields to sentinel value.
+                nlohmann::json update_document;
+                update_document["id"] = existing_document["id"].get<std::string>();;
+                update_document[ref_helper_field_name] = Join::reference_helper_sentinel_value;
+
+                index_record record(document_index++, seq_id, update_document, operation, dirty_values);
+                record.old_doc = existing_document;
+                index_records.emplace_back(std::move(record));
+            }
+        } else {
+            // Only update the reference helper field to sentinel value.
+            for (uint32_t i = 0; i < filter_result.count; i++) {
+                auto const& seq_id = filter_result.docs[i];
+
+                nlohmann::json existing_document;
+                auto get_doc_op = get_document_from_store(get_seq_id_key(seq_id), existing_document);
+
+                if (!get_doc_op.ok()) {
+                    if (get_doc_op.code() == 404) {
+                        LOG(ERROR) << "`" << name << "` collection: Sequence ID `" << seq_id << "` exists, but document is missing.";
+                        continue;
+                    }
+
+                    LOG(ERROR) << "`" << name << "` collection: " << get_doc_op.error();
+                    continue;
+                }
+
+                if (existing_document.count("id") == 0) {
+                    LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` is missing `id` field.";
+                } else if (existing_document.count(field_name) == 0) {
+                    LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` is missing `" <<
+                               field_name << "` field.";
+                } else if (!existing_document.at(field_name).is_array()) {
+                    LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` field `" <<
+                               field_name << "` is not an array.";
+                } else if (existing_document.at(field_name).empty()) {
+                    LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` field `" <<
+                               field_name << "` is empty.";
+                } else if (existing_document.at(field_name)[0].type() != ref_doc.at(ref_field_name).type()) {
+                    LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() <<
+                               "` at field `" << field_name << "` elements do not match the type of `" << ref_coll_name <<
+                               "` collection doc `"<< ref_doc.dump() << "` at field `" << ref_field_name << "`.";
+                } else if (existing_document.count(ref_helper_field_name) == 0) {
+                    LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` is missing `" <<
+                               ref_helper_field_name << "` field.";
+                } else if (!existing_document.at(ref_helper_field_name).is_array()) {
+                    LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` field `" <<
+                               ref_helper_field_name << "` is not an array.";
+                } else if (existing_document[field_name].size() != existing_document[ref_helper_field_name].size()) {
+                    LOG(ERROR) << "`" << name << "` collection doc `" << existing_document.dump() << "` reference field `" <<
+                               field_name << "` values and its reference helper field `" << ref_helper_field_name <<
+                               "` values differ in count.";
+                } else {
+                    nlohmann::json update_document;
+                    update_document["id"] = existing_document["id"].get<std::string>();
+                    update_document[field_name] = nlohmann::json::array();
+
+                    auto removed_ref_value_found = false;
+
+                    // We assume here that the value in reference field at a particular index corresponds to the value
+                    // present at the same index in the reference helper field.
+                    for (uint32_t j = 0; j < existing_document[field_name].size(); j++) {
+                        auto const& ref_value = existing_document[field_name][j];
+                        if (ref_value == ref_doc.at(ref_field_name)) {
+                            removed_ref_value_found = true;
+                            update_document[field_name] += ref_value;
+                            update_document[ref_helper_field_name] += Join::reference_helper_sentinel_value;
+                            continue;
+                        }
+
+                        update_document[field_name] += ref_value;
+                        update_document[ref_helper_field_name] += existing_document[ref_helper_field_name][j];
+                    }
+
+                    if (removed_ref_value_found) {
+                        index_record record(document_index++, seq_id, update_document, operation, dirty_values);
+                        record.old_doc = existing_document;
+                        index_records.emplace_back(std::move(record));
+                    }
+                }
+            }
+        }
+    }
+
+    if (index_records.empty()) {
+        return;
+    }
+
+    std::shared_lock alter_shlock(alter_mutex);
+
+    std::unordered_set<std::string> dummy_set;
+    size_t num_indexed = Index::batch_memory_index(index, index_records, default_sorting_field,
+                                                   search_schema, embedding_fields, fallback_field_type,
+                                                   token_separators, symbols_to_index, dummy_set);
+}
+
+void Collection::cascade_remove_doc_with_lock(const std::string& field_name, const uint32_t& ref_seq_id,
+                                               const nlohmann::json& ref_doc, bool remove_from_store) {
     bool is_field_singular, is_field_optional, cascade_delete;
     {
         std::unique_lock lock(mutex);
@@ -5916,7 +6128,7 @@ void Collection::cascade_remove_docs(const std::string& field_name, const uint32
     auto const ref_helper_field_name = field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX;
 
     filter_result_t filter_result;
-    get_filter_ids(ref_helper_field_name + ":" + std::to_string(ref_seq_id), filter_result, false);
+    get_filter_ids_with_lock(ref_helper_field_name + ":" + std::to_string(ref_seq_id), filter_result, false);
 
     if (filter_result.count == 0) {
         return;
@@ -6062,29 +6274,28 @@ void Collection::cascade_remove_docs(const std::string& field_name, const uint32
                 if (removed_ref_value_found) {
                     buffer.push_back(update_document.dump());
                 }
-                continue;
-            }
-
-            bool multiple_ref_fields = existing_document.contains(fields::reference_helper_fields) &&
-                                       existing_document[fields::reference_helper_fields].size() > 1;
-
-            // If `cascade_delete` is false, only update the reference helper field to sentinel value.
-            // If there are other references present and the reference of an optional field is removed, don't delete the
-            // document.
-            if (!cascade_delete || (multiple_ref_fields && is_field_optional)) {
-                auto const id = existing_document["id"].get<std::string>();
-
-                nlohmann::json update_document;
-                update_document["id"] = id;
-                if (cascade_delete) {
-                    update_document[field_name] = nullptr;
-                } else {
-                    update_document[ref_helper_field_name] = Join::reference_helper_sentinel_value;
-                }
-
-                buffer.push_back(update_document.dump());
             } else {
-                remove_document(existing_document, seq_id, remove_from_store);
+                bool multiple_ref_fields = existing_document.contains(fields::reference_helper_fields) &&
+                                           existing_document[fields::reference_helper_fields].size() > 1;
+
+                // If `cascade_delete` is false, only update the reference helper field to sentinel value.
+                // If there are other references present and the reference of an optional field is removed, don't delete the
+                // document.
+                if (!cascade_delete || (multiple_ref_fields && is_field_optional)) {
+                    auto const id = existing_document["id"].get<std::string>();
+
+                    nlohmann::json update_document;
+                    update_document["id"] = id;
+                    if (cascade_delete) {
+                        update_document[field_name] = nullptr;
+                    } else {
+                        update_document[ref_helper_field_name] = Join::reference_helper_sentinel_value;
+                    }
+
+                    buffer.push_back(update_document.dump());
+                } else {
+                    remove_document(existing_document, seq_id, remove_from_store);
+                }
             }
         }
     }

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -5915,6 +5915,7 @@ void Collection::reset_referencing_documents(const spp::sparse_hash_map<std::str
 
     // Lock all collections which reference the document that failed to index.
     std::vector<std::unique_lock<std::shared_mutex>> collection_locks;
+    std::vector<std::pair<std::shared_ptr<Collection>, reference_pair_t>> collections;
     for (const auto& pair: async_referenced_ins) {
         for (const auto& ref_info: pair.second) {
             auto const& referencing_collection_name = ref_info.collection;
@@ -5925,27 +5926,16 @@ void Collection::reset_referencing_documents(const spp::sparse_hash_map<std::str
                 continue;
             }
             collection_locks.emplace_back(referencing_coll->mutex);
+            collections.emplace_back(referencing_coll, ref_info);
         }
     }
 
-    if (collection_locks.empty()) {
+    if (collections.empty()) {
         return;
     }
 
-    for (const auto& pair: async_referenced_ins) {
-        const auto& referenced_field = pair.first;
-
-        for (const auto& ref_info: pair.second) {
-            auto const& referencing_collection_name = ref_info.collection;
-            auto const& referencing_field_name = ref_info.field;
-
-            auto& cm = CollectionManager::get_instance();
-            auto referencing_coll = cm.get_collection(referencing_collection_name);
-            if (referencing_coll == nullptr) {
-                continue;
-            }
-            referencing_coll->reset_referencing_documents(referencing_field_name, docs);
-        }
+    for (const auto& [coll_ptr, ref_info]: collections) {
+        coll_ptr->reset_referencing_documents(ref_info.field, docs);
     }
 }
 

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -814,11 +814,26 @@ Option<nlohmann::json> Collection::update_matching_filter(const std::string& fil
     resp_summary["num_updated"] = docs_updated_count;
     return Option(resp_summary);
 }
+
 void Collection::batch_index(std::vector<index_record>& index_records, std::vector<std::string>& json_out,
                              size_t &num_indexed, const bool& return_doc, const bool& return_id, const size_t remote_embedding_batch_size,
                              const size_t remote_embedding_timeout_ms, const size_t remote_embedding_num_tries) {
+    std::unordered_set<std::string> found_fields;
+    batch_index_in_memory(index_records, remote_embedding_batch_size, remote_embedding_timeout_ms,
+                          remote_embedding_num_tries, true, found_fields);
 
-    batch_index_in_memory(index_records, remote_embedding_batch_size, remote_embedding_timeout_ms, remote_embedding_num_tries, true);
+    // Only update the referencing collections for the documents that have successfully been indexed in-memory and on disk.
+    spp::sparse_hash_map<std::string, std::set<reference_pair_t>> found_async_referenced_ins;
+    {
+        std::shared_lock lock(mutex);
+        for (const auto& field_name: found_fields) {
+            // We will update all the referencing collections that have referenced `field_name`.
+            auto it = async_referenced_ins.find(field_name);
+            if (it != async_referenced_ins.end()) {
+                found_async_referenced_ins.insert(std::make_pair(it->first, it->second));
+            }
+        }
+    }
 
     // store only documents that were indexed in-memory successfully
     for(auto& index_record: index_records) {
@@ -842,9 +857,6 @@ void Collection::batch_index(std::vector<index_record>& index_records, std::vect
                     remove_document(index_record.new_doc, index_record.seq_id, false);
                     index_in_memory(index_record.old_doc, index_record.seq_id, index_record.operation, index_record.dirty_values);
                     index_record.index_failure(500, "Could not write to on-disk storage.");
-                } else {
-                    num_indexed++;
-                    index_record.index_success();
                 }
 
             } else {
@@ -866,36 +878,50 @@ void Collection::batch_index(std::vector<index_record>& index_records, std::vect
 
                 if(!write_ok) {
                     // remove from in-memory store to keep the state synced
-                    LOG(ERROR) << "Write to disk failed. Will restore old document";
+                    LOG(ERROR) << "Write to disk failed, removing the document from in-memory index.";
                     remove_document(index_record.doc, index_record.seq_id, false);
                     index_record.index_failure(500, "Could not write to on-disk storage.");
-                } else {
-                    num_indexed++;
-                    index_record.index_success();
+                }
+
+                if (!found_async_referenced_ins.empty() && index_record.indexed.ok()) {
+                    auto async_update_op = Index::update_async_references(name, return_doc, return_id,
+                                                                          found_async_referenced_ins,  index_record,
+                                                                          json_out);
+                    if (!async_update_op.ok()) {
+                        // remove from in-memory store to keep the state synced
+                        LOG(ERROR) << "Updating references failed, removing the document from in-memory index.";
+                        remove_document(index_record.doc, index_record.seq_id, false);
+                    }
                 }
             }
 
             res["success"] = index_record.indexed.ok();
 
-            if (return_doc & index_record.indexed.ok()) {
-                res["document"] = index_record.is_update ? index_record.new_doc : index_record.doc;
-            }
+            if (index_record.indexed.ok()) {
+                num_indexed++;
+                index_record.index_success();
 
-            if (return_id & index_record.indexed.ok()) {
-                res["id"] = index_record.is_update ? index_record.new_doc["id"] : index_record.doc["id"];
-            }
+                if (return_doc) {
+                    res["document"] = index_record.is_update ? index_record.new_doc : index_record.doc;
+                }
+                if (return_id) {
+                    res["id"] = index_record.is_update ? index_record.new_doc["id"] : index_record.doc["id"];
+                }
+            } else {
+                res["error"] = index_record.indexed.error();
+                res["code"] = index_record.indexed.code();
 
-          if(!index_record.indexed.ok()) {
                 if(return_doc) {
                     res["document"] = json_out[index_record.position];
                 }
-                res["error"] = index_record.indexed.error();
+                if (return_id && index_record.doc.contains("id")) {
+                    res["id"] = index_record.doc["id"];
+                }
                 if (!index_record.embedding_res.empty()) {
                     res["embedding_error"] = nlohmann::json::object();
                     res["embedding_error"] = index_record.embedding_res;
                     res["error"] = index_record.embedding_res["error"];
                 }
-                res["code"] = index_record.indexed.code();
             }
         } else {
             res["success"] = false;
@@ -953,7 +979,8 @@ Option<uint32_t> Collection::index_in_memory(nlohmann::json &document, uint32_t 
 }
 
 size_t Collection::batch_index_in_memory(std::vector<index_record>& index_records, const size_t remote_embedding_batch_size,
-                                         const size_t remote_embedding_timeout_ms, const size_t remote_embedding_num_tries, const bool generate_embeddings) {
+                                         const size_t remote_embedding_timeout_ms, const size_t remote_embedding_num_tries,
+                                         const bool generate_embeddings, std::unordered_set<std::string>& found_fields) {
     std::shared_lock alter_shlock(alter_mutex);
     std::shared_lock shlock(mutex);
     Index::batch_validate_and_preprocess(index, index_records, default_sorting_field, search_schema, embedding_fields,
@@ -962,25 +989,13 @@ size_t Collection::batch_index_in_memory(std::vector<index_record>& index_record
     shlock.unlock();
     std::unique_lock lock(mutex);
     const auto collection_name = name;
-    std::unordered_set<std::string> found_fields;
+
     size_t num_indexed = Index::batch_memory_index(index, index_records, default_sorting_field,
                                                    search_schema, embedding_fields, fallback_field_type,
                                                    token_separators, symbols_to_index, found_fields,
                                                    false, tsl::htrie_map<char, field>(), collection_name);
     num_documents += num_indexed;
 
-    spp::sparse_hash_map<std::string, std::set<reference_pair_t>> found_async_referenced_ins;
-    for (const auto& field_name: found_fields) {
-        // We will update all the referencing collections that have referenced `field_name`.
-        auto it = async_referenced_ins.find(field_name);
-        if (it != async_referenced_ins.end()) {
-            found_async_referenced_ins.insert(std::make_pair(it->first, it->second));
-        }
-    }
-
-    lock.unlock();
-
-    Index::update_async_references(collection_name, index_records, found_async_referenced_ins);
     return num_indexed;
 }
 
@@ -8292,6 +8307,7 @@ void Collection::hide_credential(nlohmann::json& json, const std::string& creden
     }
 }
 
+// todo
 Option<bool> Collection::truncate_after_top_k(const string &field_name, size_t k) {
     std::shared_lock slock(mutex);
 
@@ -8721,6 +8737,7 @@ Option<nlohmann::json> Collection::get_alter_schema_status() const {
     return Option<nlohmann::json>(status_json);
 }
 
+// todo
 Option<size_t> Collection::remove_all_docs() {
     size_t num_docs_removed = 0;
 

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -2475,6 +2475,42 @@ std::unordered_set<std::string> CollectionManager::get_collection_references(con
     return references;
 }
 
+std::unordered_set<std::string> CollectionManager::get_nested_referencing_collections(const std::string& coll_name) {
+    std::shared_lock lock(mutex);
+
+    auto it = referenced_ins.find(coll_name);
+    if (it == referenced_ins.end()) {
+        return {};
+    }
+
+    std::unordered_set<std::string> referencing_collections;
+    std::queue<std::string> pending_collections;
+
+    for (const auto& [ref_coll_name, _] : it->second) {
+        if (referencing_collections.insert(ref_coll_name).second) {
+            pending_collections.push(ref_coll_name);
+        }
+    }
+
+    while (!pending_collections.empty()) {
+        auto nested_ref_coll = pending_collections.front();
+        pending_collections.pop();
+
+        auto nested_it = referenced_ins.find(nested_ref_coll);
+        if (nested_it == referenced_ins.end()) {
+            continue;
+        }
+
+        for (const auto& [nested_ref_coll_name, _] : nested_it->second) {
+            if (referencing_collections.insert(nested_ref_coll_name).second) {
+                pending_collections.push(nested_ref_coll_name);
+            }
+        }
+    }
+
+    return referencing_collections;
+}
+
 bool CollectionManager::is_valid_api_key_collection(const std::vector<std::string>& api_collections,
                                                     std::shared_ptr<Collection> coll) const {
     for(const auto& api_collection : api_collections) {
@@ -2666,8 +2702,14 @@ Option<reference_info_t> CollectionManager::is_referenced_in(const std::string& 
 
 Option<reference_info_t> CollectionManager::is_referenced_in_with_lock(const std::string& referenced_coll_name,
                                                                        const std::string& referring_coll_name) const {
-    std::unique_lock lock(mutex);
+    std::shared_lock lock(mutex);
     return is_referenced_in(referenced_coll_name, referring_coll_name);
+}
+
+bool CollectionManager::is_referenced_in_any(const std::string& referenced_coll_name) const {
+    std::shared_lock lock(mutex);
+    const auto it = referenced_ins.find(referenced_coll_name);
+    return it != referenced_ins.end();
 }
 
 Option<bool> CollectionManager::populate_include_exclude_fields(const std::string& collection_name,

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1,5 +1,7 @@
 #include <string>
 #include <vector>
+#include <queue>
+#include <set>
 #include <json.hpp>
 #include <app_metrics.h>
 #include <analytics_manager.h>
@@ -2643,7 +2645,7 @@ Option<bool> CollectionManager::get_filter_ids(const std::string collection_name
         return Option<bool>(400, "Collection `" + collection_name + "` not found.");
     }
 
-    return collection->get_filter_ids(filter_query, filter_result, should_timeout, validate_field_names);
+    return collection->get_filter_ids_with_lock(filter_query, filter_result, should_timeout, validate_field_names);
 }
 
 Option<reference_info_t> CollectionManager::is_referenced_in(const std::string& referenced_coll_name,
@@ -2733,4 +2735,55 @@ Option<bool> CollectionManager::process_ref_include_fields_sort(const std::strin
     }
 
     return collection->process_ref_include_fields_sort(sort_by_str, limit, doc_ids);
+}
+
+void CollectionManager::lock_nested_referencing_collections_helper(const std::string& coll_name,
+                                                                   cascade_remove_node_t* cascade_node,
+                                                                   std::set<std::string>& referencing_collections) {
+    if (cascade_node == nullptr) {
+        return;
+    }
+
+    auto it = referenced_ins.find(coll_name);
+    if (it == referenced_ins.end()) {
+        return;
+    }
+
+    for (const auto& [ref_coll_name, ref_info]: it->second) {
+        if (!referencing_collections.insert(ref_coll_name).second) {
+            continue;
+        }
+
+        auto red_coll_it = collections.find(ref_coll_name);
+        if (red_coll_it == collections.end()) {
+            continue;
+        }
+
+        cascade_node->ref_infos.emplace_back(ref_info);
+        cascade_node->nested_references.emplace_back(new cascade_remove_node_t({red_coll_it->second,
+                                                            std::unique_lock<std::shared_mutex>(red_coll_it->second->get_mutex())}));
+        lock_nested_referencing_collections_helper(ref_coll_name, cascade_node->nested_references.back(),
+                                                   referencing_collections);
+    }
+}
+
+void CollectionManager::lock_nested_referencing_collections(const std::string& coll_name,
+                                                            cascade_remove_node_t*& cascade_tree) {
+    std::shared_lock lock(mutex);
+
+    auto coll_it = collections.find(coll_name);
+    if (coll_it == collections.end()) {
+        return;
+    }
+
+    auto it = referenced_ins.find(coll_name);
+    if (it == referenced_ins.end()) {
+        return;
+    }
+
+    cascade_tree = new cascade_remove_node_t({coll_it->second,
+                                              std::unique_lock<std::shared_mutex>(coll_it->second->get_mutex())});
+
+    std::set<std::string> referencing_collections{coll_name};
+    lock_nested_referencing_collections_helper(coll_name, cascade_tree, referencing_collections);
 }

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -2158,7 +2158,8 @@ Option<bool> CollectionManager::load_collection(const nlohmann::json &collection
         // batch must match atleast the number of shards
          if(exceeds_batch_mem_threshold || (num_valid_docs % batch_size == 0) || last_record) {
             size_t num_records = index_records.size();
-            size_t num_indexed = collection->batch_index_in_memory(index_records, 200, 60000, 2, false);
+            std::unordered_set<std::string> dummy;
+            size_t num_indexed = collection->batch_index_in_memory(index_records, 200, 60000, 2, false, dummy);
             batch_doc_str_size = 0;
 
             if(num_indexed != num_records) {

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -1467,8 +1467,8 @@ bool get_export_documents(const std::shared_ptr<http_req>& req, const std::share
                 validate_field_names = false;
             }
 
-            auto filter_ids_op = collection->get_filter_ids(filter_query, export_state->filter_result, false,
-                                                            validate_field_names);
+            auto filter_ids_op = collection->get_filter_ids_with_lock(filter_query, export_state->filter_result, false,
+                                                                      validate_field_names);
 
             if(!filter_ids_op.ok()) {
                 res->set(filter_ids_op.code(), filter_ids_op.error());
@@ -2138,8 +2138,8 @@ bool del_remove_documents(const std::shared_ptr<http_req>& req, const std::share
         }
 
         filter_result_t filter_result;
-        auto filter_ids_op = collection->get_filter_ids(simple_filter_query, filter_result, false,
-                                                        validate_field_names);
+        auto filter_ids_op = collection->get_filter_ids_with_lock(simple_filter_query, filter_result, false,
+                                                                  validate_field_names);
 
         if (!filter_ids_op.ok()) {
             res->set(filter_ids_op.code(), filter_ids_op.error());

--- a/src/core_api_utils.cpp
+++ b/src/core_api_utils.cpp
@@ -48,6 +48,7 @@ Option<bool> stateful_remove_docs(deletion_state_t* deletion_state, size_t batch
         for(auto& doc: removed_docs_batch) {
             if(deletion_state->return_doc) {
                 Collection::remove_flat_fields(doc);
+                Collection::remove_reference_helper_fields(doc);
                 deletion_state->removed_docs.push_back(doc);
             }
 

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -1035,8 +1035,8 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation, const bo
             // Get the doc ids of reference collection matching the filter then apply filter on the current collection's
             // reference helper field.
             filter_result_t result;
-            auto reference_filter_op = ref_collection->get_filter_ids(a_filter.field_name, result, true,
-                                                                      validate_field_names);
+            auto reference_filter_op = ref_collection->get_filter_ids_with_lock(a_filter.field_name, result, true,
+                                                                                validate_field_names);
             if (!reference_filter_op.ok()) {
                 status = Option<bool>(400, "Failed to join on `" + a_filter.referenced_collection_name
                                            + "` collection: " + reference_filter_op.error());

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -636,8 +636,7 @@ size_t Index::batch_memory_index(Index *index,
                                  const std::vector<char>& token_separators,
                                  const std::vector<char>& symbols_to_index,
                                  std::unordered_set<std::string>& found_fields,
-                                 const bool use_addition_fields, const tsl::htrie_map<char, field>& addition_fields,
-                                 const std::string& collection_name) {
+                                 const bool use_addition_fields, const tsl::htrie_map<char, field>& addition_fields) {
     const size_t concurrency = Config::get_instance().get_max_indexing_concurrency();
     const size_t num_threads = std::min(concurrency, iter_batch.size());
     const size_t window_size = (num_threads == 0) ? 0 :
@@ -689,7 +688,7 @@ size_t Index::batch_memory_index(Index *index,
             const field& f = (field_name == "id") ?
                              field("id", field_types::STRING, false) : indexable_schema.at(field_name);
             try {
-                index->index_field_in_memory(collection_name, f, iter_batch);
+                index->index_field_in_memory(f, iter_batch);
             } catch(std::exception& e) {
                 LOG(ERROR) << "Unhandled Typesense error: " << e.what();
                 for(auto& record: iter_batch) {
@@ -711,8 +710,7 @@ size_t Index::batch_memory_index(Index *index,
     return num_indexed;
 }
 
-void Index::index_field_in_memory(const std::string& collection_name, const field& afield,
-                                  std::vector<index_record>& iter_batch) {
+void Index::index_field_in_memory(const field& afield, std::vector<index_record>& iter_batch) {
     // indexes a given field of all documents in the batch
 
     if(afield.name == "id") {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1207,59 +1207,41 @@ void Index::index_field_in_memory(const std::string& collection_name, const fiel
     }
 }
 
-void Index::update_async_references(const std::string& collection_name, std::vector<index_record>& iter_batch,
-                                    const spp::sparse_hash_map<std::string, std::set<reference_pair_t>>& async_referenced_ins) {
-    for (auto& record: iter_batch) {
-        if (!record.indexed.ok() || record.is_update) {
+Option<bool> Index::update_async_references(const std::string& collection_name, const bool& return_doc, const bool& return_id,
+                                            const spp::sparse_hash_map<std::string, std::set<reference_pair_t>>& async_referenced_ins,
+                                            index_record& record, std::vector<std::string>& json_out) {
+    auto const& document = record.doc;
+    auto const& seq_id = record.seq_id;
+
+    for (const auto& pair: async_referenced_ins) {
+        if (!record.indexed.ok()) {
+            break;
+        }
+        const auto& referenced_field = pair.first;
+        if (document.count(referenced_field) != 1) {
             continue;
         }
-        auto const& document = record.doc;
-        auto const& is_update = record.is_update;
-        auto const& seq_id = record.seq_id;
+        for (const auto& ref_info: pair.second) {
+            auto const& referencing_collection_name = ref_info.collection;
+            auto const& referencing_field_name = ref_info.field;
 
-        for (const auto& pair: async_referenced_ins) {
-            const auto& referenced_field = pair.first;
-            if (document.count(referenced_field) != 1) {
+            auto& cm = CollectionManager::get_instance();
+            auto referencing_coll = cm.get_collection(referencing_collection_name);
+            if (referencing_coll == nullptr) {
+                // Since the collections get created and indexed in parallel on server restart, we might run into a
+                // scenario where the referencing collection hasn't yet been created. We can safely skip update of
+                // referencing collection as the references will be created normally.
                 continue;
             }
-            for (const auto& ref_info: pair.second) {
-                auto const& referencing_collection_name = ref_info.collection;
-                auto const& referencing_field_name = ref_info.field;
 
-                auto& cm = CollectionManager::get_instance();
-                auto referencing_coll = cm.get_collection(referencing_collection_name);
-                if (referencing_coll == nullptr) {
-                    // Since the collections get created and indexed in parallel on server restart, we might run into a
-                    // scenario where the referencing collection hasn't yet been created. We can safely skip update of
-                    // referencing collection as the references will be created normally.
-                    continue;
-                }
+            // After collecting the value(s) present in the field referenced by the other collection(ref_coll), we will add
+            // this document's seq_id as a reference where the value(s) match.
+            std::string ref_filter_value;
+            std::set<std::string> values;
+            if (document.at(referenced_field).is_array()) {
+                ref_filter_value = "[";
 
-                // After collecting the value(s) present in the field referenced by the other collection(ref_coll), we will add
-                // this document's seq_id as a reference where the value(s) match.
-                std::string ref_filter_value;
-                std::set<std::string> values;
-                if (document.at(referenced_field).is_array()) {
-                    ref_filter_value = "[";
-
-                    for (auto const& value: document[referenced_field]) {
-                        if (value.is_number_integer()) {
-                            auto const& v = std::to_string(value.get<int64_t>());
-                            ref_filter_value += v;
-                            values.insert(v);
-                        } else if (value.is_string()) {
-                            auto const& v = value.get<std::string>();
-                            ref_filter_value += v;
-                            values.insert(v);
-                        } else {
-                            record.index_failure(400, "Field `" + referenced_field + "` must only have string/int32/int64 values.");
-                            continue;
-                        }
-                        ref_filter_value += ",";
-                    }
-                    ref_filter_value[ref_filter_value.size() - 1] = ']';
-                } else {
-                    auto const& value = document[referenced_field];
+                for (auto const& value: document[referenced_field]) {
                     if (value.is_number_integer()) {
                         auto const& v = std::to_string(value.get<int64_t>());
                         ref_filter_value += v;
@@ -1269,40 +1251,57 @@ void Index::update_async_references(const std::string& collection_name, std::vec
                         ref_filter_value += v;
                         values.insert(v);
                     } else {
-                        record.index_failure(400, "Field `" + referenced_field + "` must only have string/int32/int64 values.");
+                        LOG(ERROR) << "Field `" + referenced_field + "` must only have string/int32/int64 values.";
                         continue;
                     }
+                    ref_filter_value += ",";
                 }
-
-                if (values.empty()) {
+                ref_filter_value[ref_filter_value.size() - 1] = ']';
+            } else {
+                auto const& value = document[referenced_field];
+                if (value.is_number_integer()) {
+                    auto const& v = std::to_string(value.get<int64_t>());
+                    ref_filter_value += v;
+                    values.insert(v);
+                } else if (value.is_string()) {
+                    auto const& v = value.get<std::string>();
+                    ref_filter_value += v;
+                    values.insert(v);
+                } else {
+                    LOG(ERROR) << "Field `" + referenced_field + "` must only have string/int32/int64 values.";
                     continue;
                 }
+            }
 
-                // The value must be unique in this collection.
-                filter_result_t filter_result;
-                auto op = CollectionManager::get_filter_ids(collection_name, referenced_field + ":=" += ref_filter_value,
-                                                            filter_result);
-                if (!op.ok()) {
-                    continue;
-                } else if (filter_result.count > 1) {
-                    record.index_failure(400, "Error while updating async reference field `" + referencing_field_name +
-                                              "` of collection `" += referencing_collection_name + "`: The value `" +=
-                                              ref_filter_value + "` of the field `" += referenced_field +
-                                              "` is not unique in `" += collection_name + "` collection.");
-                    break;
-                }
+            if (values.empty()) {
+                continue;
+            }
 
-                auto const ref_filter = referencing_field_name + ":= " += ref_filter_value;
-                auto update_op = referencing_coll->update_async_references_with_lock(collection_name, ref_filter, values, seq_id,
-                                                                                     referencing_field_name);
-                if (!update_op.ok()) {
-                    record.index_failure(400, "Error while updating async reference field `" + referencing_field_name +
-                                              "` of collection `" += referencing_collection_name + "`: " += update_op.error());
-                    break;
-                }
+            // The value must be unique in this collection.
+            filter_result_t filter_result;
+            auto op = CollectionManager::get_filter_ids(collection_name, referenced_field + ":=" += ref_filter_value,
+                                                        filter_result);
+            if (!op.ok()) {
+                continue;
+            } else if (filter_result.count > 1) {
+                record.index_failure(400, "Error while updating async reference field `" + referencing_field_name +
+                                          "` of collection `" += referencing_collection_name + "`: The value `" +=
+                                                                 ref_filter_value + "` of the field `" += referenced_field +
+                                                                                                          "` is not unique in `" += collection_name + "` collection.");
+                return Option<bool>(400, "");
+            }
+
+            auto const ref_filter = referencing_field_name + ":= " += ref_filter_value;
+            auto update_op = referencing_coll->update_async_references_with_lock(collection_name, ref_filter, values, seq_id,
+                                                                                 referencing_field_name);
+            if (!update_op.ok()) {
+                record.index_failure(400, "Error while updating async reference field `" + referencing_field_name +
+                                          "` of collection `" += referencing_collection_name + "`: " += update_op.error());
+                return update_op;
             }
         }
     }
+    return Option<bool>(true);
 }
 
 void Index::tokenize_string(const std::string& text, const field& a_field,

--- a/src/raft_server.cpp
+++ b/src/raft_server.cpp
@@ -1050,10 +1050,15 @@ void ReplicationState::shutdown() {
     LOG(INFO) << "Set shutting_down = true";
     shutting_down = true;
 
-    // wait for pending writes to drop to zero
     LOG(INFO) << "Waiting for in-flight writes to finish...";
-    while(pending_writes.load() != 0) {
-        LOG(INFO) << "pending_writes: " << pending_writes;
+    while(true) {
+        const auto pending = pending_writes.load();
+        const auto queued = batched_indexer->get_queued_writes();
+        if(pending == 0 && queued == 0) {
+            break;
+        }
+
+        LOG(INFO) << "pending_writes: " << pending << ", queued_writes: " << queued;
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     }
 
@@ -1115,7 +1120,10 @@ nlohmann::json ReplicationState::get_status() {
     lock.unlock();
 
     status["state"] = braft::state2str(node_status.state);
+    status["last_index"] = node_status.last_index;
     status["committed_index"] = node_status.committed_index;
+    status["known_applied_index"] = node_status.known_applied_index;
+    status["applying_index"] = node_status.applying_index;
     status["queued_writes"] = batched_indexer->get_queued_writes();
 
     return status;

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -2604,9 +2604,9 @@ TEST_F(CollectionJoinTest, FilterByReference_SingleMatch) {
     auto customers_coll = collectionManager.get_collection_unsafe("Customers");
     customers_coll->remove("0");
     customers_coll->remove("2");
-    // product_a has no references now. `get_filter_ids` should still include reference of product_b in the result.
+    // product_a has no references now. `get_filter_ids_with_lock` should still include reference of product_b in the result.
     filter_result_t filter_result;
-    collectionManager.get_collection_unsafe("Products")->get_filter_ids("id:* || $Customers(id:*)", filter_result);
+    collectionManager.get_collection_unsafe("Products")->get_filter_ids_with_lock("id:* || $Customers(id:*)", filter_result);
     ASSERT_NE(nullptr, filter_result.coll_to_references);
     ASSERT_EQ(2, filter_result.count);
     ASSERT_EQ(0, filter_result.docs[0]);

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -103,7 +103,7 @@ TEST_F(CoreAPIUtilsTest, StatefulRemoveDocs) {
     // single document match
 
     filter_result_t filter_results;
-    coll1->get_filter_ids("points: 99", filter_results);
+    coll1->get_filter_ids_with_lock("points: 99", filter_results);
     deletion_state.index_ids.emplace_back(filter_results.count, filter_results.docs);
     filter_results.docs = nullptr;
     for(size_t i=0; i<deletion_state.index_ids.size(); i++) {
@@ -122,7 +122,7 @@ TEST_F(CoreAPIUtilsTest, StatefulRemoveDocs) {
     deletion_state.offsets.clear();
     deletion_state.num_removed = 0;
 
-    coll1->get_filter_ids("points:< 11", filter_results);
+    coll1->get_filter_ids_with_lock("points:< 11", filter_results);
     deletion_state.index_ids.emplace_back(filter_results.count, filter_results.docs);
     filter_results.docs = nullptr;
     for(size_t i=0; i<deletion_state.index_ids.size(); i++) {
@@ -149,7 +149,7 @@ TEST_F(CoreAPIUtilsTest, StatefulRemoveDocs) {
     deletion_state.offsets.clear();
     deletion_state.num_removed = 0;
 
-    coll1->get_filter_ids("points:< 20", filter_results);
+    coll1->get_filter_ids_with_lock("points:< 20", filter_results);
     deletion_state.index_ids.emplace_back(filter_results.count, filter_results.docs);
     filter_results.docs = nullptr;
     for(size_t i=0; i<deletion_state.index_ids.size(); i++) {
@@ -182,7 +182,7 @@ TEST_F(CoreAPIUtilsTest, StatefulRemoveDocs) {
     deletion_state.offsets.clear();
     deletion_state.num_removed = 0;
 
-    coll1->get_filter_ids("id:[0, 1, 2]", filter_results);
+    coll1->get_filter_ids_with_lock("id:[0, 1, 2]", filter_results);
     deletion_state.index_ids.emplace_back(filter_results.count, filter_results.docs);
     filter_results.docs = nullptr;
     for(size_t i=0; i<deletion_state.index_ids.size(); i++) {
@@ -202,7 +202,7 @@ TEST_F(CoreAPIUtilsTest, StatefulRemoveDocs) {
     deletion_state.offsets.clear();
     deletion_state.num_removed = 0;
 
-    coll1->get_filter_ids("id :10", filter_results);
+    coll1->get_filter_ids_with_lock("id :10", filter_results);
     deletion_state.index_ids.emplace_back(filter_results.count, filter_results.docs);
     filter_results.docs = nullptr;
     for(size_t i=0; i<deletion_state.index_ids.size(); i++) {
@@ -222,18 +222,18 @@ TEST_F(CoreAPIUtilsTest, StatefulRemoveDocs) {
 
     filter_results = filter_result_t(0, nullptr);
     // bad filter query
-    auto op = coll1->get_filter_ids("bad filter", filter_results);
+    auto op = coll1->get_filter_ids_with_lock("bad filter", filter_results);
     ASSERT_FALSE(op.ok());
     ASSERT_STREQ("Could not parse the filter query.", op.error().c_str());
 
     bool should_timeout = true;
     bool validate_field_names = true;
-    op = coll1->get_filter_ids("foo: 99", filter_results, should_timeout, validate_field_names);
+    op = coll1->get_filter_ids_with_lock("foo: 99", filter_results, should_timeout, validate_field_names);
     ASSERT_FALSE(op.ok());
     ASSERT_EQ("Could not find a filter field named `foo` in the schema.", op.error());
 
     validate_field_names = false;
-    op = coll1->get_filter_ids("foo: 99", filter_results, should_timeout, validate_field_names);
+    op = coll1->get_filter_ids_with_lock("foo: 99", filter_results, should_timeout, validate_field_names);
     ASSERT_TRUE(op.ok());
     ASSERT_EQ(0, filter_results.count);
     ASSERT_EQ(nullptr, filter_results.docs);
@@ -1372,7 +1372,7 @@ TEST_F(CoreAPIUtilsTest, ExportWithFilter) {
 
     export_state_t export_state;
     filter_result_t filter_result;
-    coll1->get_filter_ids("points:>=0", export_state.filter_result);
+    coll1->get_filter_ids_with_lock("points:>=0", export_state.filter_result);
 
     export_state.collection = coll1;
     export_state.res_body = &res_body;
@@ -1483,7 +1483,7 @@ TEST_F(CoreAPIUtilsTest, ExportWithJoin) {
 
     export_state_t export_state;
     auto coll1 = collectionManager.get_collection_unsafe("Products");
-    coll1->get_filter_ids("$Customers(customer_id:customer_a)", export_state.filter_result);
+    coll1->get_filter_ids_with_lock("$Customers(customer_id:customer_a)", export_state.filter_result);
     export_state.collection = coll1.get();
     export_state.res_body = &res_body;
     export_state.include_fields.insert("product_name");
@@ -3177,7 +3177,7 @@ TEST_F(CoreAPIUtilsTest, StatefulRemoveDocsWithReturnValues) {
 
     // Single document match with return values
     filter_result_t filter_results;
-    coll1->get_filter_ids("points: 5", filter_results);
+    coll1->get_filter_ids_with_lock("points: 5", filter_results);
     deletion_state.index_ids.emplace_back(filter_results.count, filter_results.docs);
     filter_results.docs = nullptr;
     for(size_t i=0; i<deletion_state.index_ids.size(); i++) {
@@ -3205,7 +3205,7 @@ TEST_F(CoreAPIUtilsTest, StatefulRemoveDocsWithReturnValues) {
     deletion_state.removed_docs.clear();
     deletion_state.removed_ids.clear();
 
-    coll1->get_filter_ids("points:>= 6", filter_results);
+    coll1->get_filter_ids_with_lock("points:>= 6", filter_results);
     deletion_state.index_ids.emplace_back(filter_results.count, filter_results.docs);
     filter_results.docs = nullptr;
     for(size_t i=0; i<deletion_state.index_ids.size(); i++) {
@@ -3247,7 +3247,7 @@ TEST_F(CoreAPIUtilsTest, StatefulRemoveDocsWithReturnValues) {
         coll1->add(doc.dump());
     }
 
-    coll1->get_filter_ids("points: 3", filter_results);
+    coll1->get_filter_ids_with_lock("points: 3", filter_results);
     deletion_state.index_ids.emplace_back(filter_results.count, filter_results.docs);
     filter_results.docs = nullptr;
     for(size_t i=0; i<deletion_state.index_ids.size(); i++) {
@@ -3284,7 +3284,7 @@ TEST_F(CoreAPIUtilsTest, StatefulRemoveDocsWithReturnValues) {
         coll1->add(doc.dump());
     }
 
-    coll1->get_filter_ids("points: 4", filter_results);
+    coll1->get_filter_ids_with_lock("points: 4", filter_results);
     deletion_state.index_ids.emplace_back(filter_results.count, filter_results.docs);
     filter_results.docs = nullptr;
     for(size_t i=0; i<deletion_state.index_ids.size(); i++) {
@@ -3433,7 +3433,7 @@ TEST_F(CoreAPIUtilsTest, StatefulRemoveDocsUsesBoundedInternalBatch) {
     deletion_state.num_removed = 0;
 
     filter_result_t filter_results;
-    auto filter_op = coll1->get_filter_ids("points:>= 0", filter_results);
+    auto filter_op = coll1->get_filter_ids_with_lock("points:>= 0", filter_results);
     ASSERT_TRUE(filter_op.ok());
     deletion_state.index_ids.emplace_back(filter_results.count, filter_results.docs);
     filter_results.docs = nullptr;


### PR DESCRIPTION
## Change Summary
The core logic of the fix is in `std::unordered_set<uint64_t> BatchedIndexer::get_requests_to_wait_on`. It returns the set of requests that a particular request should wait for before being processed. This helps to avoid concurrent cross-collection access of indexes that results in an inconsistent and undeterministic state. This inconsistency is clearly observable in multi-node clusters and it results in drifting of counts of `num_documents` of collections over time.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
