### PR TITLE
fix: guard multi_search preset type during auth extraction

### DIFF
--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -166,7 +166,7 @@ void get_collections_for_auth(std::map<std::string, std::string>& req_params,
                         coll_name = req_params["collection"];
                     } else {
                         // if preset exists, that should be the lowest priority
-                        if(el.count("preset") != 0) {
+                        if(el.count("preset") != 0 && el["preset"].is_string()) {
                             nlohmann::json preset_obj;
                             auto preset_op = CollectionManager::get_instance().
                                     get_preset(el["preset"].get<std::string>(), preset_obj);

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -475,6 +475,25 @@ TEST_F(CoreAPIUtilsTest, ExtractCollectionsFromRequestBody) {
     ASSERT_EQ(1, collections.size());
     ASSERT_EQ("", collections[0].collection);
     ASSERT_EQ("bar", collections[0].api_key);
+
+    // when preset type is bad, should not throw during auth collection extraction
+    collections.clear();
+    embedded_params_vec.clear();
+    body = R"(
+        {"searches":[
+              {
+                "query_by": "concat",
+                "q": "battery",
+                "preset": 123
+              }
+          ]
+        }
+    )";
+
+    EXPECT_NO_THROW(get_collections_for_auth(req_params, body, rpath, "foo", collections, embedded_params_vec));
+    ASSERT_EQ(1, collections.size());
+    ASSERT_EQ("", collections[0].collection);
+    ASSERT_EQ("foo", collections[0].api_key);
 }
 
 TEST_F(CoreAPIUtilsTest, ExtractCollectionsFromRequestBodyExtended) {


### PR DESCRIPTION
## Summary
- guard searches[].preset with is_string() inside get_collections_for_auth
- avoid calling get<std::string>() on non-string JSON values during multi-search auth extraction
- add regression test for malformed preset type to ensure no throw and safe fallback

## Files
- src/core_api.cpp
- 	est/core_api_utils_test.cpp

## Why
A malformed preset type in POST /multi_search can flow into auth collection extraction before normal request validation. This change hardens that path against type mismatch.

## Testing
- Added regression assertions in CoreAPIUtilsTest.ExtractCollectionsFromRequestBody.
- Full local build/test is currently blocked in this environment by external dependency fetch (onnxruntime -> Eigen GitLab URL returns HTTP 403 challenge).