### PR TITLE
feat: update support for patching keys

### DIFF
--- a/include/auth_manager.h
+++ b/include/auth_manager.h
@@ -146,6 +146,8 @@ public:
 
     Option<api_key_t> remove_key(uint32_t id);
 
+    Option<api_key_t> update_key(uint32_t id, api_key_t&& api_key);
+
     bool authenticate(const std::string& action,
                       const std::vector<collection_key_t>& collection_keys,
                       std::map<std::string, std::string>& params,

--- a/include/core_api.h
+++ b/include/core_api.h
@@ -120,6 +120,8 @@ bool get_key(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_re
 
 bool del_key(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 
+bool patch_key(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
+
 // Health + Metrics
 
 bool get_debug(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);

--- a/src/auth_manager.cpp
+++ b/src/auth_manager.cpp
@@ -138,6 +138,34 @@ Option<api_key_t> AuthManager::remove_key(uint32_t id) {
     return Option<api_key_t>(key.truncate_value());
 }
 
+Option<api_key_t> AuthManager::update_key(uint32_t id, api_key_t&& api_key) {
+    Option<api_key_t> existing_key_op = get_key(id, false);
+    
+    if(!existing_key_op.ok()) {
+        return Option<api_key_t>(existing_key_op.code(), existing_key_op.error());
+    }
+
+    api_key_t existing_key = existing_key_op.get();
+
+    if(existing_key.value != api_key.value) {
+        return Option<api_key_t>(400, "API key value cannot be updated.");
+    }
+
+    std::string api_key_store_key = std::string(API_KEYS_PREFIX) + "_" + std::to_string(id);
+    const nlohmann::json & api_key_obj = api_key.to_json();
+
+    bool updated = store->insert(api_key_store_key, api_key_obj.dump());
+    if(!updated) {
+        return Option<api_key_t>(500, "Could not update API key.");
+    }
+
+    std::unique_lock lock(mutex);
+
+    api_keys[api_key.value] = api_key;
+
+    return Option<api_key_t>(api_key.truncate_value());
+}
+
 uint32_t AuthManager::get_next_api_key_id() {
     store->increment(std::string(API_KEY_NEXT_ID_KEY), 1);
     return next_api_key_id++;

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -2327,6 +2327,74 @@ bool post_create_key(const std::shared_ptr<http_req>& req, const std::shared_ptr
     return true;
 }
 
+bool patch_key(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
+    CollectionManager & collectionManager = CollectionManager::get_instance();
+    AuthManager &auth_manager = collectionManager.getAuthManager();
+
+    const std::string& key_id_str = req->params["id"];
+    uint32_t key_id = (uint32_t) std::stoul(key_id_str);
+
+    nlohmann::json req_json;
+
+    try {
+        req_json = nlohmann::json::parse(req->body);
+    } catch(const std::exception& e) {
+        LOG(ERROR) << "JSON error: " << e.what();
+        res->set_400("Bad JSON.");
+        return false;
+    }
+
+    auto get_key_op = auth_manager.get_key(key_id, false);
+    if(!get_key_op.ok()) {
+        res->set(get_key_op.code(), get_key_op.error());
+        return false;
+    }
+
+    const api_key_t& existing_key = get_key_op.get();
+
+    // Merge: start from existing key's JSON representation, then overlay request fields
+    nlohmann::json merged_json = existing_key.to_json();
+    for(auto it = req_json.begin(); it != req_json.end(); ++it) {
+        merged_json[it.key()] = it.value();
+    }
+
+    const Option<uint32_t>& validate_op = api_key_t::validate(merged_json);
+    if(!validate_op.ok()) {
+        res->set(validate_op.code(), validate_op.error());
+        return false;
+    }
+
+    if(merged_json.count("expires_at") == 0) {
+        merged_json["expires_at"] = api_key_t::FAR_FUTURE_TIMESTAMP;
+    }
+
+    if(merged_json.count("autodelete") == 0) {
+        merged_json["autodelete"] = false;
+    }
+
+    api_key_t api_key(
+        existing_key.value,
+        merged_json["description"].get<std::string>(),
+        merged_json["actions"].get<std::vector<std::string>>(),
+        merged_json["collections"].get<std::vector<std::string>>(),
+        merged_json["expires_at"].get<uint64_t>(),
+        merged_json["autodelete"].get<bool>()
+    );
+    api_key.id = existing_key.id; // ensure the id remains the same
+
+    const Option<api_key_t>& update_op = auth_manager.update_key(key_id, std::move(api_key));
+    if(!update_op.ok()) {
+        res->set(update_op.code(), update_op.error());
+        return false;
+    }
+    auto updated_key_obj = update_op.get().to_json();
+    updated_key_obj["value_prefix"] = updated_key_obj["value"];
+    updated_key_obj.erase("value");
+
+    res->set_200(updated_key_obj.dump());
+    return true;
+}
+
 bool get_key(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
     CollectionManager & collectionManager = CollectionManager::get_instance();
     AuthManager &auth_manager = collectionManager.getAuthManager();

--- a/src/main/typesense_server.cpp
+++ b/src/main/typesense_server.cpp
@@ -54,6 +54,7 @@ void master_server_routes() {
     server->get("/keys/:id", get_key);
     server->post("/keys", post_create_key);
     server->del("/keys/:id", del_key);
+    server->patch("/keys/:id", patch_key);
 
     server->get("/presets", get_presets);
     server->get("/presets/:name", get_preset);

--- a/test/auth_manager_test.cpp
+++ b/test/auth_manager_test.cpp
@@ -606,3 +606,266 @@ TEST_F(AuthManagerTest, CollectionsByScope) {
     ASSERT_EQ("collection2", result_json[0]["name"]);
     ASSERT_EQ("collection_1", result_json[1]["name"]);
 }
+
+TEST_F(AuthManagerTest, PatchKeyUpdateSingleField) {
+    // Create a key first
+    std::shared_ptr<http_req> req = std::make_shared<http_req>();
+    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
+
+    auto key_json = R"({
+        "description": "original description",
+        "actions": ["documents:search"],
+        "collections": ["collection1"],
+        "value": "patchtest1"
+    })"_json;
+
+    req->body = key_json.dump();
+    ASSERT_TRUE(post_create_key(req, res));
+    ASSERT_EQ(201, res->status_code);
+
+    auto created_key = nlohmann::json::parse(res->body);
+    std::string key_id = std::to_string(created_key["id"].get<uint32_t>());
+
+    // PATCH only description, other fields should remain unchanged
+    req = std::make_shared<http_req>();
+    res = std::make_shared<http_res>(nullptr);
+    req->params["id"] = key_id;
+    req->body = R"({"description": "updated description"})";
+
+    ASSERT_TRUE(patch_key(req, res));
+    ASSERT_EQ(200, res->status_code);
+
+    auto updated_key = nlohmann::json::parse(res->body);
+    ASSERT_EQ("updated description", updated_key["description"]);
+    ASSERT_EQ(1, updated_key["actions"].size());
+    ASSERT_EQ("documents:search", updated_key["actions"][0]);
+    ASSERT_EQ(1, updated_key["collections"].size());
+    ASSERT_EQ("collection1", updated_key["collections"][0]);
+    // Response should have value_prefix, not value
+    ASSERT_TRUE(updated_key.count("value_prefix") != 0);
+    // id should be preserved
+    ASSERT_EQ(created_key["id"].get<uint32_t>(), updated_key["id"].get<uint32_t>());
+}
+
+TEST_F(AuthManagerTest, PatchKeyUpdateMultipleFields) {
+    std::shared_ptr<http_req> req = std::make_shared<http_req>();
+    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
+
+    auto key_json = R"({
+        "description": "original",
+        "actions": ["documents:search"],
+        "collections": ["collection1"],
+        "value": "patchtest2"
+    })"_json;
+
+    req->body = key_json.dump();
+    ASSERT_TRUE(post_create_key(req, res));
+    auto created_key = nlohmann::json::parse(res->body);
+    std::string key_id = std::to_string(created_key["id"].get<uint32_t>());
+
+    // PATCH actions and collections together
+    req = std::make_shared<http_req>();
+    res = std::make_shared<http_res>(nullptr);
+    req->params["id"] = key_id;
+    req->body = R"({"actions": ["documents:get", "documents:search"], "collections": ["*"]})";
+
+    ASSERT_TRUE(patch_key(req, res));
+    ASSERT_EQ(200, res->status_code);
+
+    auto updated_key = nlohmann::json::parse(res->body);
+    ASSERT_EQ("original", updated_key["description"]);
+    ASSERT_EQ(2, updated_key["actions"].size());
+    ASSERT_EQ("documents:get", updated_key["actions"][0]);
+    ASSERT_EQ("documents:search", updated_key["actions"][1]);
+    ASSERT_EQ(1, updated_key["collections"].size());
+    ASSERT_EQ("*", updated_key["collections"][0]);
+    ASSERT_TRUE(updated_key.count("value_prefix") != 0);
+    ASSERT_EQ(created_key["id"].get<uint32_t>(), updated_key["id"].get<uint32_t>());
+}
+
+TEST_F(AuthManagerTest, PatchKeyEmptyBody) {
+    std::shared_ptr<http_req> req = std::make_shared<http_req>();
+    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
+
+    auto key_json = R"({
+        "description": "stays the same",
+        "actions": ["documents:search"],
+        "collections": ["collection1"],
+        "expires_at": 64723363199,
+        "autodelete": false,
+        "value": "patchtest3"
+    })"_json;
+
+    req->body = key_json.dump();
+    ASSERT_TRUE(post_create_key(req, res));
+    auto created_key = nlohmann::json::parse(res->body);
+    std::string key_id = std::to_string(created_key["id"].get<uint32_t>());
+
+    // PATCH with empty JSON object, all fields should remain unchanged
+    req = std::make_shared<http_req>();
+    res = std::make_shared<http_res>(nullptr);
+    req->params["id"] = key_id;
+    req->body = "{}";
+
+    ASSERT_TRUE(patch_key(req, res));
+    ASSERT_EQ(200, res->status_code);
+
+    auto updated_key = nlohmann::json::parse(res->body);
+    ASSERT_EQ("stays the same", updated_key["description"]);
+    ASSERT_EQ(1, updated_key["actions"].size());
+    ASSERT_EQ("documents:search", updated_key["actions"][0]);
+    ASSERT_EQ(1, updated_key["collections"].size());
+    ASSERT_EQ("collection1", updated_key["collections"][0]);
+    ASSERT_EQ(64723363199, updated_key["expires_at"].get<uint64_t>());
+    ASSERT_EQ(false, updated_key["autodelete"].get<bool>());
+    ASSERT_TRUE(updated_key.count("value_prefix") != 0);
+    ASSERT_EQ(created_key["id"].get<uint32_t>(), updated_key["id"].get<uint32_t>());
+}
+
+TEST_F(AuthManagerTest, PatchKeyNonExistent) {
+    std::shared_ptr<http_req> req = std::make_shared<http_req>();
+    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
+
+    req->params["id"] = "9999";
+    req->body = R"({"description": "does not exist"})";
+
+    ASSERT_FALSE(patch_key(req, res));
+    ASSERT_EQ(404, res->status_code);
+    auto res_json = nlohmann::json::parse(res->body);
+    ASSERT_EQ("Not found.", res_json["message"].get<std::string>());
+}
+
+TEST_F(AuthManagerTest, PatchKeyInvalidFieldFormats) {
+    std::shared_ptr<http_req> req = std::make_shared<http_req>();
+    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
+
+    auto key_json = R"({
+        "description": "test key",
+        "actions": ["documents:search"],
+        "collections": ["collection1"],
+        "value": "patchtest4"
+    })"_json;
+
+    req->body = key_json.dump();
+    ASSERT_TRUE(post_create_key(req, res));
+    auto created_key = nlohmann::json::parse(res->body);
+    std::string key_id = std::to_string(created_key["id"].get<uint32_t>());
+
+    // Invalid description (not a string)
+    req = std::make_shared<http_req>();
+    res = std::make_shared<http_res>(nullptr);
+    req->params["id"] = key_id;
+    req->body = R"({"description": 123})";
+    ASSERT_FALSE(patch_key(req, res));
+    ASSERT_EQ(400, res->status_code);
+    auto res_json = nlohmann::json::parse(res->body);
+    ASSERT_EQ("Key description must be a string.", res_json["message"].get<std::string>());
+
+    // Invalid actions (not an array)
+    req = std::make_shared<http_req>();
+    res = std::make_shared<http_res>(nullptr);
+    req->params["id"] = key_id;
+    req->body = R"({"actions": "not_an_array"})";
+    ASSERT_FALSE(patch_key(req, res));
+    ASSERT_EQ(400, res->status_code);
+    res_json = nlohmann::json::parse(res->body);
+    ASSERT_EQ("Wrong format for `actions`. It should be an array of string.", res_json["message"].get<std::string>());
+
+    // Invalid actions (empty array)
+    req = std::make_shared<http_req>();
+    res = std::make_shared<http_res>(nullptr);
+    req->params["id"] = key_id;
+    req->body = R"({"actions": []})";
+    ASSERT_FALSE(patch_key(req, res));
+    ASSERT_EQ(400, res->status_code);
+    res_json = nlohmann::json::parse(res->body);
+    ASSERT_EQ("Wrong format for `actions`. It should be an array of string.", res_json["message"].get<std::string>());
+
+    // Invalid actions (array with non-string element)
+    req = std::make_shared<http_req>();
+    res = std::make_shared<http_res>(nullptr);
+    req->params["id"] = key_id;
+    req->body = R"({"actions": [123]})";
+    ASSERT_FALSE(patch_key(req, res));
+    ASSERT_EQ(400, res->status_code);
+    res_json = nlohmann::json::parse(res->body);
+    ASSERT_EQ("Wrong format for `actions`. It should be an array of string.", res_json["message"].get<std::string>());
+
+    // Invalid collections (empty array)
+    req = std::make_shared<http_req>();
+    res = std::make_shared<http_res>(nullptr);
+    req->params["id"] = key_id;
+    req->body = R"({"collections": []})";
+    ASSERT_FALSE(patch_key(req, res));
+    ASSERT_EQ(400, res->status_code);
+    res_json = nlohmann::json::parse(res->body);
+    ASSERT_EQ("Wrong format for `collections`. It should be an array of string.", res_json["message"].get<std::string>());
+
+    // Invalid collections (array with non-string element)
+    req = std::make_shared<http_req>();
+    res = std::make_shared<http_res>(nullptr);
+    req->params["id"] = key_id;
+    req->body = R"({"collections": [true]})";
+    ASSERT_FALSE(patch_key(req, res));
+    ASSERT_EQ(400, res->status_code);
+    res_json = nlohmann::json::parse(res->body);
+    ASSERT_EQ("Wrong format for `collections`. It should be an array of string.", res_json["message"].get<std::string>());
+
+    // Invalid expires_at (negative)
+    req = std::make_shared<http_req>();
+    res = std::make_shared<http_res>(nullptr);
+    req->params["id"] = key_id;
+    req->body = R"({"expires_at": -1})";
+    ASSERT_FALSE(patch_key(req, res));
+    ASSERT_EQ(400, res->status_code);
+    res_json = nlohmann::json::parse(res->body);
+    ASSERT_EQ("Wrong format for `expires_at`. It should be an unsigned integer.", res_json["message"].get<std::string>());
+
+    // Invalid expires_at (string instead of int)
+    req = std::make_shared<http_req>();
+    res = std::make_shared<http_res>(nullptr);
+    req->params["id"] = key_id;
+    req->body = R"({"expires_at": "not_a_number"})";
+    ASSERT_FALSE(patch_key(req, res));
+    ASSERT_EQ(400, res->status_code);
+    res_json = nlohmann::json::parse(res->body);
+    ASSERT_EQ("Wrong format for `expires_at`. It should be an unsigned integer.", res_json["message"].get<std::string>());
+}
+
+TEST_F(AuthManagerTest, PatchKeyExpiresAtAndAutodelete) {
+    std::shared_ptr<http_req> req = std::make_shared<http_req>();
+    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
+
+    auto key_json = R"({
+        "description": "test key",
+        "actions": ["documents:search"],
+        "collections": ["collection1"],
+        "expires_at": 64723363199,
+        "autodelete": false,
+        "value": "patchtest5"
+    })"_json;
+
+    req->body = key_json.dump();
+    ASSERT_TRUE(post_create_key(req, res));
+    auto created_key = nlohmann::json::parse(res->body);
+    std::string key_id = std::to_string(created_key["id"].get<uint32_t>());
+
+    // PATCH expires_at and autodelete only
+    req = std::make_shared<http_req>();
+    res = std::make_shared<http_res>(nullptr);
+    req->params["id"] = key_id;
+    req->body = R"({"expires_at": 2222222222, "autodelete": true})";
+
+    ASSERT_TRUE(patch_key(req, res));
+    ASSERT_EQ(200, res->status_code);
+
+    auto updated_key = nlohmann::json::parse(res->body);
+    ASSERT_EQ("test key", updated_key["description"]);
+    ASSERT_EQ("documents:search", updated_key["actions"][0]);
+    ASSERT_EQ("collection1", updated_key["collections"][0]);
+    ASSERT_EQ(2222222222, updated_key["expires_at"].get<uint64_t>());
+    ASSERT_EQ(true, updated_key["autodelete"].get<bool>());
+    ASSERT_TRUE(updated_key.count("value_prefix") != 0);
+    ASSERT_TRUE(updated_key.count("value") == 0);
+    ASSERT_EQ(created_key["id"].get<uint32_t>(), updated_key["id"].get<uint32_t>());
+}


### PR DESCRIPTION
## Change Summary
Add support for patching API key fields except the value as requested in #2775. Supports partial updates. 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
