### PR TITLE
dynamic faceting based on occurrence ratio

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -795,10 +795,11 @@ private:
                                         const facet_query_t& facet_query, size_t highlight_affix_num_tokens,
                                         size_t snippet_threshold, const std::string& highlight_start_tag,
                                         const std::string& highlight_end_tag, const std::string& raw_query,
-                                        nlohmann::json& results, size_t found_docs, float facet_min_occurrence_ratio,
-                                        bool is_union = false) const;
+                                        nlohmann::json& results, bool is_union = false) const;
 
     static Option<bool> merge_facet_results(nlohmann::json& result);
+    static Option<bool> filter_dynamic_facets_by_occurrence(nlohmann::json& facet_counts, size_t found_docs,
+                                                            float facet_min_occurrence_ratio);
 
 public:
 

--- a/include/collection.h
+++ b/include/collection.h
@@ -163,6 +163,7 @@ struct collection_search_args_t {
     static constexpr auto FACET_SAMPLE_PERCENT = "facet_sample_percent";
     static constexpr auto FACET_SAMPLE_THRESHOLD = "facet_sample_threshold";
     static constexpr auto FACET_SAMPLE_SLOPE = "facet_sample_slope";
+    static constexpr auto FACET_MIN_OCCURRENCE_RATIO = "facet_min_occurrence_ratio";
 
     static constexpr auto CONVERSATION = "conversation";
     static constexpr auto CONVERSATION_ID = "conversation_id";
@@ -255,6 +256,7 @@ struct collection_search_args_t {
     size_t facet_sample_percent;
     size_t facet_sample_threshold;
     size_t facet_sample_slope;
+    float facet_min_occurrence_ratio;
     size_t offset;
     std::string facet_strategy;
     size_t remote_embedding_timeout_ms;
@@ -313,7 +315,8 @@ struct collection_search_args_t {
                              size_t max_extra_prefix, size_t max_extra_suffix, size_t facet_query_num_typos,
                              bool filter_curated_hits_option, bool prioritize_token_position, std::string vector_query,
                              bool enable_highlight_v1, uint64_t start_ts, text_match_type_t match_type,
-                             size_t facet_sample_percent, size_t facet_sample_threshold, size_t facet_sample_slope, size_t offset,
+                             size_t facet_sample_percent, size_t facet_sample_threshold, size_t facet_sample_slope,
+                             float facet_min_occurrence_ratio, size_t offset,
                              std::string facet_strategy, size_t remote_embedding_timeout_ms, size_t remote_embedding_num_tries,
                              std::string stopwords_set, std::vector<std::string> facet_return_parent,
                              std::vector<ref_include_exclude_fields> ref_include_exclude_fields_vec,
@@ -346,7 +349,8 @@ struct collection_search_args_t {
             max_extra_prefix(max_extra_prefix), max_extra_suffix(max_extra_suffix), facet_query_num_typos(facet_query_num_typos),
             filter_curated_hits_option(filter_curated_hits_option), prioritize_token_position(prioritize_token_position), vector_query(std::move(vector_query)),
             enable_highlight_v1(enable_highlight_v1), start_ts(start_ts), match_type(match_type),
-            facet_sample_percent(facet_sample_percent), facet_sample_threshold(facet_sample_threshold), facet_sample_slope(facet_sample_slope), offset(offset),
+            facet_sample_percent(facet_sample_percent), facet_sample_threshold(facet_sample_threshold), facet_sample_slope(facet_sample_slope),
+            facet_min_occurrence_ratio(facet_min_occurrence_ratio), offset(offset),
             facet_strategy(std::move(facet_strategy)), remote_embedding_timeout_ms(remote_embedding_timeout_ms), remote_embedding_num_tries(remote_embedding_num_tries),
             stopwords_set(std::move(stopwords_set)), facet_return_parent(std::move(facet_return_parent)),
             ref_include_exclude_fields_vec(std::move(ref_include_exclude_fields_vec)),
@@ -791,7 +795,8 @@ private:
                                         const facet_query_t& facet_query, size_t highlight_affix_num_tokens,
                                         size_t snippet_threshold, const std::string& highlight_start_tag,
                                         const std::string& highlight_end_tag, const std::string& raw_query,
-                                        nlohmann::json& results, bool is_union = false) const;
+                                        nlohmann::json& results, size_t found_docs, float facet_min_occurrence_ratio,
+                                        bool is_union = false) const;
 
     static Option<bool> merge_facet_results(nlohmann::json& result);
 
@@ -1065,7 +1070,8 @@ public:
                                   const std::vector<std::string>& search_synonym_sets = {},
                                   float diversity_lamda = diversity_t::DEFAULT_LAMDA_VALUE,
                                   size_t group_max_candidates = Index::DEFAULT_TOPSTER_SIZE,
-                                  size_t diversity_limit = Index::DEFAULT_TOPSTER_SIZE);
+                                  size_t diversity_limit = Index::DEFAULT_TOPSTER_SIZE,
+                                  const float facet_min_occurrence_ratio = 0.5f);
 
     Option<bool> parse_and_validate_personalization_query(const std::string& personalization_user_id,
                                                           const std::string& personalization_model_id,

--- a/include/field.h
+++ b/include/field.h
@@ -808,6 +808,8 @@ struct facet {
 
     bool is_wildcard_match = false;
     
+    bool is_dynamic = false;
+    
     bool is_intersected = false;
 
     bool is_sort_by_alpha = false;

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -2914,7 +2914,8 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
                                           const std::vector<std::string>& search_synonym_sets,
                                           float diversity_lamda,
                                           size_t group_max_candidates,
-                                          size_t diversity_limit) {
+                                          size_t diversity_limit,
+                                          const float facet_min_occurrence_ratio) {
     auto args = collection_search_args_t(query, search_fields, filter_query,
                                          facet_fields, sort_fields,
                                          num_typos, per_page, page, token_order,
@@ -2932,7 +2933,8 @@ Option<nlohmann::json> Collection::search(std::string query, const std::vector<s
                                          max_extra_prefix, max_extra_suffix, facet_query_num_typos,
                                          filter_curated_hits_option, prioritize_token_position, vector_query_str,
                                          enable_highlight_v1, search_time_start_us, match_type,
-                                         facet_sample_percent, facet_sample_threshold, facet_sample_slope, page_offset,
+                                         facet_sample_percent, facet_sample_threshold, facet_sample_slope,
+                                         facet_min_occurrence_ratio, page_offset,
                                          facet_index_type, remote_embedding_timeout_ms, remote_embedding_num_tries,
                                          stopwords_set, facet_return_parent,
                                          ref_include_exclude_fields_vec,
@@ -3403,7 +3405,8 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
     populate_facets(search_params->facets, coll_args.max_facet_values, coll_args.facet_return_parent,
                     search_params->facet_query, coll_args.highlight_affix_num_tokens,
                     coll_args.snippet_threshold,
-                    coll_args.highlight_start_tag, coll_args.highlight_end_tag, raw_query, result["facet_counts"]);
+                    coll_args.highlight_start_tag, coll_args.highlight_end_tag, raw_query,
+                    result["facet_counts"], total, coll_args.facet_min_occurrence_ratio);
 
     result["search_cutoff"] = search_cutoff;
 
@@ -4076,7 +4079,7 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
                                   search_params->facet_query, coll_args.highlight_affix_num_tokens,
                                   coll_args.snippet_threshold,
                                   coll_args.highlight_start_tag, coll_args.highlight_end_tag, coll_args.raw_query,
-                                  result["facet_counts"], true);
+                                  result["facet_counts"], total, coll_args.facet_min_occurrence_ratio, true);
         }
     }
 
@@ -7787,6 +7790,7 @@ Option<bool> Collection::parse_facet(const std::string& facet_field, std::vector
         } else if (facet_field[i] == '*') {
             if (i == facet_field.size() - 1) {
                 auto prefix = facet_field.substr(0, facet_field.size() - 1);
+                const bool is_dynamic_facet = prefix.empty();
                 auto pair = search_schema.equal_prefix_range(prefix);
 
                 if (pair.first == pair.second) {
@@ -7800,6 +7804,7 @@ Option<bool> Collection::parse_facet(const std::string& facet_field, std::vector
                     if (field->facet) {
                         facets.emplace_back(facet(field->name, facets.size()));
                         facets.back().is_wildcard_match = true;
+                        facets.back().is_dynamic = is_dynamic_facet;
                     }
                 }
                 i++;
@@ -8872,6 +8877,7 @@ Option<bool> collection_search_args_t::init(std::map<std::string, std::string>& 
     size_t facet_sample_percent = 100;
     size_t facet_sample_threshold = 0;
     size_t facet_sample_slope = 0;
+    float facet_min_occurrence_ratio = 0.5f;
 
     bool conversation = false;
     std::string conversation_id;
@@ -8991,7 +8997,8 @@ Option<bool> collection_search_args_t::init(std::map<std::string, std::string>& 
     };
 
     std::unordered_map<std::string, float*> float_values = {
-            {DIVERSITY_LAMBDA, &diversity_lamda}
+            {DIVERSITY_LAMBDA, &diversity_lamda},
+            {FACET_MIN_OCCURRENCE_RATIO, &facet_min_occurrence_ratio}
     };
 
     for(const auto& kv: req_params) {
@@ -9153,6 +9160,10 @@ Option<bool> collection_search_args_t::init(std::map<std::string, std::string>& 
         diversity_lamda = diversity_t::DEFAULT_LAMDA_VALUE;
     }
 
+    if (facet_min_occurrence_ratio < 0.0f || facet_min_occurrence_ratio > 1.0f) {
+        return Option<bool>(400, "Parameter `" + std::string(FACET_MIN_OCCURRENCE_RATIO) + "` must be between 0.0 and 1.0.");
+    }
+
     args = collection_search_args_t(raw_query, search_fields, filter_query,
                                     facet_fields, sort_fields,
                                     num_typos, per_page, page, token_order,
@@ -9170,7 +9181,8 @@ Option<bool> collection_search_args_t::init(std::map<std::string, std::string>& 
                                     max_extra_prefix, max_extra_suffix, facet_query_num_typos,
                                     filter_curated_hits_option, prioritize_token_position, vector_query,
                                     enable_highlight_v1, start_ts, match_type,
-                                    facet_sample_percent, facet_sample_threshold, facet_sample_slope, offset,
+                                    facet_sample_percent, facet_sample_threshold, facet_sample_slope,
+                                    facet_min_occurrence_ratio, offset,
                                     facet_strategy, remote_embedding_timeout_ms, remote_embedding_num_tries,
                                     stopwords_set, facet_return_parent,
                                     ref_include_exclude_fields_vec,
@@ -9253,7 +9265,8 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
                                          const facet_query_t& facet_query,size_t highlight_affix_num_tokens,
                                          size_t snippet_threshold, const std::string& highlight_start_tag,
                                          const std::string& highlight_end_tag, const std::string& raw_query,
-                                         nlohmann::json& results, bool is_union) const {
+                                         nlohmann::json& results, size_t found_docs,
+                                         float facet_min_occurrence_ratio, bool is_union) const {
     const auto read_state = get_read_state_snapshot();
     const auto& search_schema_snapshot = read_state ? read_state->search_schema : search_schema;
     const auto& symbols_to_index_snapshot = read_state ? read_state->symbols_to_index : symbols_to_index;
@@ -9523,6 +9536,22 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
                              });
         } else {
             std::stable_sort(facet_values.begin(), facet_values.end(), Collection::facet_count_str_compare);
+        }
+
+        if (a_facet.is_dynamic && facet_min_occurrence_ratio > 0.0f && found_docs > 0) {
+            std::vector<facet_value_t> filtered_facet_values;
+            filtered_facet_values.reserve(facet_values.size());
+            for (const auto& facet_value : facet_values) {
+                const auto occurrence_ratio = static_cast<float>(facet_value.count) / static_cast<float>(found_docs);
+                if (occurrence_ratio >= facet_min_occurrence_ratio) {
+                    filtered_facet_values.push_back(facet_value);
+                }
+            }
+            facet_values = std::move(filtered_facet_values);
+        }
+
+        if (a_facet.is_dynamic && facet_values.empty()) {
+            continue;
         }
 
         for(const auto & facet_count: facet_values) {

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -3406,7 +3406,8 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
                     search_params->facet_query, coll_args.highlight_affix_num_tokens,
                     coll_args.snippet_threshold,
                     coll_args.highlight_start_tag, coll_args.highlight_end_tag, raw_query,
-                    result["facet_counts"], total, coll_args.facet_min_occurrence_ratio);
+                    result["facet_counts"]);
+    filter_dynamic_facets_by_occurrence(result["facet_counts"], total, coll_args.facet_min_occurrence_ratio);
 
     result["search_cutoff"] = search_cutoff;
 
@@ -4079,11 +4080,13 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
                                   search_params->facet_query, coll_args.highlight_affix_num_tokens,
                                   coll_args.snippet_threshold,
                                   coll_args.highlight_start_tag, coll_args.highlight_end_tag, coll_args.raw_query,
-                                  result["facet_counts"], total, coll_args.facet_min_occurrence_ratio, true);
+                                  result["facet_counts"], true);
         }
     }
 
     merge_facet_results(result);
+    filter_dynamic_facets_by_occurrence(result["facet_counts"], total,
+                                        searches.empty() ? 0.0f : searches[0].facet_min_occurrence_ratio);
 
     for (auto& request: request_json_list) {
         result["union_request_params"] += std::move(request);
@@ -9265,8 +9268,7 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
                                          const facet_query_t& facet_query,size_t highlight_affix_num_tokens,
                                          size_t snippet_threshold, const std::string& highlight_start_tag,
                                          const std::string& highlight_end_tag, const std::string& raw_query,
-                                         nlohmann::json& results, size_t found_docs,
-                                         float facet_min_occurrence_ratio, bool is_union) const {
+                                         nlohmann::json& results, bool is_union) const {
     const auto read_state = get_read_state_snapshot();
     const auto& search_schema_snapshot = read_state ? read_state->search_schema : search_schema;
     const auto& symbols_to_index_snapshot = read_state ? read_state->symbols_to_index : symbols_to_index;
@@ -9538,22 +9540,6 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
             std::stable_sort(facet_values.begin(), facet_values.end(), Collection::facet_count_str_compare);
         }
 
-        if (a_facet.is_dynamic && facet_min_occurrence_ratio > 0.0f && found_docs > 0) {
-            std::vector<facet_value_t> filtered_facet_values;
-            filtered_facet_values.reserve(facet_values.size());
-            for (const auto& facet_value : facet_values) {
-                const auto occurrence_ratio = static_cast<float>(facet_value.count) / static_cast<float>(found_docs);
-                if (occurrence_ratio >= facet_min_occurrence_ratio) {
-                    filtered_facet_values.push_back(facet_value);
-                }
-            }
-            facet_values = std::move(filtered_facet_values);
-        }
-
-        if (a_facet.is_dynamic && facet_values.empty()) {
-            continue;
-        }
-
         for(const auto & facet_count: facet_values) {
             nlohmann::json facet_value_count = nlohmann::json::object();
             const std::string & value = facet_count.value;
@@ -9584,6 +9570,8 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
 
         facet_result["stats"]["total_values"] = facet_counts.size();
 
+        facet_result["is_dynamic"] = a_facet.is_dynamic;
+
         if(is_union) {
             facet_result["is_sortby_alpha"] = a_facet.is_sort_by_alpha;
             facet_result["sort_order"] = a_facet.sort_order;
@@ -9610,6 +9598,11 @@ Option<bool> Collection::merge_facet_results(nlohmann::json& result) {
                     field_to_facet_counts[field_name]["sampled"] = facet_count["sampled"];
                     field_to_facet_counts[field_name]["is_sortby_alpha"] = facet_count["is_sortby_alpha"];
                     field_to_facet_counts[field_name]["sort_order"] = facet_count["sort_order"];
+                    field_to_facet_counts[field_name]["is_dynamic"] = facet_count.value("is_dynamic", false);
+                } else {
+                    field_to_facet_counts[field_name]["is_dynamic"] =
+                        field_to_facet_counts[field_name]["is_dynamic"].get<bool>() &&
+                        facet_count.value("is_dynamic", false);
                 }
 
                 field_to_facet_counts[field_name]["counts"].push_back(count);
@@ -9673,6 +9666,49 @@ Option<bool> Collection::merge_facet_results(nlohmann::json& result) {
             }
         }
     }
+    return Option<bool>(true);
+}
+
+Option<bool> Collection::filter_dynamic_facets_by_occurrence(nlohmann::json& facet_counts, size_t found_docs,
+                                                             float facet_min_occurrence_ratio) {
+    if (!facet_counts.is_array()) {
+        return Option<bool>(true);
+    }
+
+    nlohmann::json filtered_facet_counts = nlohmann::json::array();
+
+    for (auto& facet_count : facet_counts) {
+        const bool is_dynamic = facet_count.value("is_dynamic", false);
+        if (!is_dynamic) {
+            facet_count.erase("is_dynamic");
+            filtered_facet_counts.push_back(facet_count);
+            continue;
+        }
+
+        if (facet_min_occurrence_ratio <= 0.0f || found_docs == 0) {
+            facet_count.erase("is_dynamic");
+            filtered_facet_counts.push_back(facet_count);
+            continue;
+        }
+
+        nlohmann::json filtered_counts = nlohmann::json::array();
+        for (const auto& count : facet_count["counts"]) {
+            const auto occurrence_ratio =
+                static_cast<float>(count["count"].get<size_t>()) / static_cast<float>(found_docs);
+            if (occurrence_ratio >= facet_min_occurrence_ratio) {
+                filtered_counts.push_back(count);
+            }
+        }
+
+        if (!filtered_counts.empty()) {
+            facet_count["counts"] = std::move(filtered_counts);
+            facet_count["stats"]["total_values"] = facet_count["counts"].size();
+            facet_count.erase("is_dynamic");
+            filtered_facet_counts.push_back(facet_count);
+        }
+    }
+
+    facet_counts = std::move(filtered_facet_counts);
     return Option<bool>(true);
 }
 

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1556,6 +1556,7 @@ Option<bool> CollectionManager::validate_facet_params(const std::vector<collecti
 
     const auto& facet_strategy = coll_searches[0].facet_strategy;
     const auto& simple_facet_query = coll_searches[0].simple_facet_query;
+    const auto& facet_min_occurrence_ratio = coll_searches[0].facet_min_occurrence_ratio;
     spp::sparse_hash_map<std::string, facet_field_parent> field_to_facet_field_map;
     std::string generic_error = " should be uniform across searches for faceting with union search.";
 
@@ -1570,6 +1571,10 @@ Option<bool> CollectionManager::validate_facet_params(const std::vector<collecti
 
         if(args.simple_facet_query != simple_facet_query) {
             return Option<bool>(400, "`facet_query`" + generic_error);
+        }
+
+        if(args.facet_min_occurrence_ratio != facet_min_occurrence_ratio) {
+            return Option<bool>(400, "`facet_min_occurrence_ratio`" + generic_error);
         }
 
         for(const auto& field : args.facet_fields) {

--- a/test/collection_faceting_test.cpp
+++ b/test/collection_faceting_test.cpp
@@ -4118,3 +4118,121 @@ TEST_F(CollectionFacetingTest, FacetByReferenceWithJoinFilter) {
     collectionManager.drop_collection("reports");
     collectionManager.drop_collection("clients");
 }
+
+TEST_F(CollectionFacetingTest, FacetMinOccurrenceRatioDynamicFacetBehavior) {
+    auto schema = R"({
+        "name": "dynamic_facet_ratio_coll",
+        "fields": [
+            {"name": "name_facet", "type": "string", "facet": true},
+            {"name": "optional_facet", "type": "string", "facet": true, "optional": true}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    auto coll = create_op.get();
+
+    ASSERT_TRUE(coll->add(R"({"id":"1","name_facet":"A","optional_facet":"rare"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"2","name_facet":"A"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"3","name_facet":"A"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"4","name_facet":"B"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"5","name_facet":"B"})").ok());
+
+    std::map<std::string, std::string> req_params = {
+        {"collection", "dynamic_facet_ratio_coll"},
+        {"q", "*"},
+        {"facet_by", "*"},
+        {"per_page", "0"},
+        {"max_facet_values", "10"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+
+    // Default ratio is 0.5. Only "name_facet:A" (3/5) should remain.
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    auto result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(5, result["found"].get<size_t>());
+    ASSERT_EQ(1, result["facet_counts"].size());
+    ASSERT_EQ("name_facet", result["facet_counts"][0]["field_name"].get<std::string>());
+    ASSERT_EQ(1, result["facet_counts"][0]["counts"].size());
+    ASSERT_EQ("A", result["facet_counts"][0]["counts"][0]["value"].get<std::string>());
+    ASSERT_EQ(3, result["facet_counts"][0]["counts"][0]["count"].get<size_t>());
+
+    // Ratio 0.0 should keep all dynamic facets and values.
+    req_params["facet_min_occurrence_ratio"] = "0.0";
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, result["facet_counts"].size());
+    std::set<std::string> facet_names;
+    for(const auto& facet_count: result["facet_counts"]) {
+        facet_names.insert(facet_count["field_name"].get<std::string>());
+    }
+    ASSERT_TRUE(facet_names.count("name_facet") != 0);
+    ASSERT_TRUE(facet_names.count("optional_facet") != 0);
+
+    // Ratio 0.9 should filter out all dynamic facets.
+    req_params["facet_min_occurrence_ratio"] = "0.9";
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(0, result["facet_counts"].size());
+
+    // Prefix wildcard facets (e.g. optio*) are static and should not be filtered.
+    req_params["facet_by"] = "optio*";
+    req_params["facet_min_occurrence_ratio"] = "0.9";
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, result["facet_counts"].size());
+    ASSERT_EQ("optional_facet", result["facet_counts"][0]["field_name"].get<std::string>());
+    ASSERT_EQ(1, result["facet_counts"][0]["counts"].size());
+    ASSERT_EQ("rare", result["facet_counts"][0]["counts"][0]["value"].get<std::string>());
+
+    collectionManager.drop_collection("dynamic_facet_ratio_coll");
+}
+
+TEST_F(CollectionFacetingTest, FacetMinOccurrenceRatioValidation) {
+    auto schema = R"({
+        "name": "dynamic_facet_ratio_validation_coll",
+        "fields": [
+            {"name": "name_facet", "type": "string", "facet": true}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    auto coll = create_op.get();
+    ASSERT_TRUE(coll->add(R"({"id":"1","name_facet":"A"})").ok());
+
+    std::map<std::string, std::string> req_params = {
+        {"collection", "dynamic_facet_ratio_validation_coll"},
+        {"q", "*"},
+        {"facet_by", "*"},
+        {"per_page", "0"},
+        {"max_facet_values", "10"},
+        {"facet_min_occurrence_ratio", "1.1"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_FALSE(search_op.ok());
+    ASSERT_EQ("Parameter `facet_min_occurrence_ratio` must be between 0.0 and 1.0.", search_op.error());
+
+    req_params["facet_min_occurrence_ratio"] = "-0.1";
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_FALSE(search_op.ok());
+    ASSERT_EQ("Parameter `facet_min_occurrence_ratio` must be between 0.0 and 1.0.", search_op.error());
+
+    collectionManager.drop_collection("dynamic_facet_ratio_validation_coll");
+}

--- a/test/collection_optimized_faceting_test.cpp
+++ b/test/collection_optimized_faceting_test.cpp
@@ -3659,3 +3659,121 @@ TEST_F(CollectionOptimizedFacetingTest, RangeFacetTestWithGroupBy) {
 
     collectionManager.drop_collection("coll1");
 }
+
+TEST_F(CollectionOptimizedFacetingTest, FacetMinOccurrenceRatioDynamicFacetBehavior) {
+    auto schema = R"({
+        "name": "dynamic_facet_ratio_coll_opt",
+        "fields": [
+            {"name": "name_facet", "type": "string", "facet": true},
+            {"name": "optional_facet", "type": "string", "facet": true, "optional": true}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    auto coll = create_op.get();
+
+    ASSERT_TRUE(coll->add(R"({"id":"1","name_facet":"A","optional_facet":"rare"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"2","name_facet":"A"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"3","name_facet":"A"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"4","name_facet":"B"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"5","name_facet":"B"})").ok());
+
+    std::map<std::string, std::string> req_params = {
+        {"collection", "dynamic_facet_ratio_coll_opt"},
+        {"q", "*"},
+        {"facet_by", "*"},
+        {"per_page", "0"},
+        {"max_facet_values", "10"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+
+    // Default ratio is 0.5. Only "name_facet:A" (3/5) should remain.
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    auto result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(5, result["found"].get<size_t>());
+    ASSERT_EQ(1, result["facet_counts"].size());
+    ASSERT_EQ("name_facet", result["facet_counts"][0]["field_name"].get<std::string>());
+    ASSERT_EQ(1, result["facet_counts"][0]["counts"].size());
+    ASSERT_EQ("A", result["facet_counts"][0]["counts"][0]["value"].get<std::string>());
+    ASSERT_EQ(3, result["facet_counts"][0]["counts"][0]["count"].get<size_t>());
+
+    // Ratio 0.0 should keep all dynamic facets and values.
+    req_params["facet_min_occurrence_ratio"] = "0.0";
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, result["facet_counts"].size());
+    std::set<std::string> facet_names;
+    for(const auto& facet_count: result["facet_counts"]) {
+        facet_names.insert(facet_count["field_name"].get<std::string>());
+    }
+    ASSERT_TRUE(facet_names.count("name_facet") != 0);
+    ASSERT_TRUE(facet_names.count("optional_facet") != 0);
+
+    // Ratio 0.9 should filter out all dynamic facets.
+    req_params["facet_min_occurrence_ratio"] = "0.9";
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(0, result["facet_counts"].size());
+
+    // Prefix wildcard facets (e.g. optio*) are static for ratio filtering.
+    req_params["facet_by"] = "optio*";
+    req_params["facet_min_occurrence_ratio"] = "0.9";
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, result["facet_counts"].size());
+    ASSERT_EQ("optional_facet", result["facet_counts"][0]["field_name"].get<std::string>());
+    ASSERT_EQ(1, result["facet_counts"][0]["counts"].size());
+    ASSERT_EQ("rare", result["facet_counts"][0]["counts"][0]["value"].get<std::string>());
+
+    collectionManager.drop_collection("dynamic_facet_ratio_coll_opt");
+}
+
+TEST_F(CollectionOptimizedFacetingTest, FacetMinOccurrenceRatioValidation) {
+    auto schema = R"({
+        "name": "dynamic_facet_ratio_validation_coll_opt",
+        "fields": [
+            {"name": "name_facet", "type": "string", "facet": true}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    auto coll = create_op.get();
+    ASSERT_TRUE(coll->add(R"({"id":"1","name_facet":"A"})").ok());
+
+    std::map<std::string, std::string> req_params = {
+        {"collection", "dynamic_facet_ratio_validation_coll_opt"},
+        {"q", "*"},
+        {"facet_by", "*"},
+        {"per_page", "0"},
+        {"max_facet_values", "10"},
+        {"facet_min_occurrence_ratio", "1.1"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_FALSE(search_op.ok());
+    ASSERT_EQ("Parameter `facet_min_occurrence_ratio` must be between 0.0 and 1.0.", search_op.error());
+
+    req_params["facet_min_occurrence_ratio"] = "-0.1";
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_FALSE(search_op.ok());
+    ASSERT_EQ("Parameter `facet_min_occurrence_ratio` must be between 0.0 and 1.0.", search_op.error());
+
+    collectionManager.drop_collection("dynamic_facet_ratio_validation_coll_opt");
+}

--- a/test/union_test.cpp
+++ b/test/union_test.cpp
@@ -2361,3 +2361,74 @@ TEST_F(UnionTest, UnionHighlightingUAFRaceASAN) {
   ASSERT_GT(union_nonempty_highlight_count.load(std::memory_order_relaxed), 0);
   ASSERT_GT(union_title_highlight_count.load(std::memory_order_relaxed), 0);
 }
+
+TEST_F(UnionTest, DynamicFacetMinOccurrenceRatioShouldApplyAfterUnionMerge) {
+    auto schema_json =
+            R"({
+                "name": "UnionDynamicFacetsA",
+                "fields": [
+                    {"name": "name", "type": "string"},
+                    {"name": "brand", "type": "string", "facet": true}
+                ]
+            })"_json;
+
+    auto schema_json2 =
+            R"({
+                "name": "UnionDynamicFacetsB",
+                "fields": [
+                    {"name": "name", "type": "string"},
+                    {"name": "brand", "type": "string", "facet": true}
+                ]
+            })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto coll = collection_create_op.get();
+
+    ASSERT_TRUE(coll->add(R"({"id":"1","name":"A1","brand":"shared"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"2","name":"A2","brand":"shared"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"3","name":"A3","brand":"shared"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"4","name":"A4","brand":"left_only_1"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"5","name":"A5","brand":"left_only_2"})").ok());
+
+    collection_create_op = collectionManager.create_collection(schema_json2);
+    ASSERT_TRUE(collection_create_op.ok());
+    coll = collection_create_op.get();
+
+    ASSERT_TRUE(coll->add(R"({"id":"1","name":"B1","brand":"shared"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"2","name":"B2","brand":"shared"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"3","name":"B3","brand":"shared"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"4","name":"B4","brand":"right_only_1"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"5","name":"B5","brand":"right_only_2"})").ok());
+
+    embedded_params = std::vector<nlohmann::json>(2, nlohmann::json::object());
+    req_params.clear();
+    json_res.clear();
+
+    searches = R"OVR([
+                    {
+                        "collection": "UnionDynamicFacetsA",
+                        "q": "*",
+                        "facet_by": "*",
+                        "facet_min_occurrence_ratio": 0.5
+                    },
+                    {
+                        "collection": "UnionDynamicFacetsB",
+                        "q": "*",
+                        "facet_by": "*",
+                        "facet_min_occurrence_ratio": 0.5
+                    }
+                ])OVR"_json;
+
+    auto search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(10, json_res["found"].get<size_t>());
+
+    // "shared" is 3/10 in each individual search and would be filtered too early by the buggy code,
+    // but it is 6/10 after union merge and should therefore be returned.
+    ASSERT_EQ(1, json_res["facet_counts"].size());
+    ASSERT_EQ("brand", json_res["facet_counts"][0]["field_name"]);
+    ASSERT_EQ(1, json_res["facet_counts"][0]["counts"].size());
+    ASSERT_EQ("shared", json_res["facet_counts"][0]["counts"][0]["value"]);
+    ASSERT_EQ(6, json_res["facet_counts"][0]["counts"][0]["count"].get<size_t>());
+}


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
### Dynamic Faceting
`facet_min_occurrence_ratio` controls which **dynamic facets** are returned when faceting with literal wildcard `facet_by=*`.

- Dynamic facets: only facets requested using literal `*`.
- Static facets: explicit facet fields (for example `brand`) and prefix wildcards (for example `sho*`).
- Default value: `0.5`
- Valid range: `0.0` to `1.0` (inclusive)

## Behavior Rules

1. `facet_by=*` is treated as dynamic faceting.
2. For dynamic facets, each facet value is kept only if:
   - `value_count / found >= facet_min_occurrence_ratio`
3. If all values of a dynamic facet are filtered out, that facet field is not returned.
4. Prefix wildcards like `sho*` are static for ratio filtering.
5. Wildcard facet entries with no counts are not returned.

## Parameter Validation

If `facet_min_occurrence_ratio` is outside `[0.0, 1.0]`, search returns an error:

Parameter `facet_min_occurrence_ratio` must be between `0.0` and `1.0.`

## Examples

Assume a collection `products` with facet fields `category` and `brand`.

### 1) Dynamic faceting with default ratio (0.5)

```bash
curl -X GET "http://localhost:8108/collections/products/documents/search?q=*&query_by=name&facet_by=*" \
  -H "X-TYPESENSE-API-KEY: xyz"
```

### 2) Dynamic faceting with stricter ratio

Only high-frequency facet values survive.

```bash
curl -X GET "http://localhost:8108/collections/products/documents/search?q=*&query_by=name&facet_by=*&facet_min_occurrence_ratio=0.8" \
  -H "X-TYPESENSE-API-KEY: xyz"
```

### 3) Dynamic faceting with ratio 0.0

No dynamic facet values are filtered out by ratio.

```bash
curl -X GET "http://localhost:8108/collections/products/documents/search?q=*&query_by=name&facet_by=*&facet_min_occurrence_ratio=0.0" \
  -H "X-TYPESENSE-API-KEY: xyz"
```

### 4) Static faceting with prefix wildcard

`sho*` is static for ratio filtering.

```bash
curl -X GET "http://localhost:8108/collections/products/documents/search?q=*&query_by=name&facet_by=sho*&facet_min_occurrence_ratio=0.9" \
  -H "X-TYPESENSE-API-KEY: xyz"
```

### 5) Mixed static fields

```bash
curl -X GET "http://localhost:8108/collections/products/documents/search?q=*&query_by=name&facet_by=brand,category&facet_min_occurrence_ratio=0.9" \
  -H "X-TYPESENSE-API-KEY: xyz"
```

In this case, `facet_min_occurrence_ratio` does not filter static fields.

## Notes for Union Search

For union faceting, `facet_min_occurrence_ratio` must be uniform across searches.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
