### PR TITLE
fix: proxy ACL rejects all requests on dual-stack (IPv6) sockets

### DIFF
--- a/include/api_acl.h
+++ b/include/api_acl.h
@@ -134,9 +134,25 @@ private:
   }
 
   // ---- IPv4 + CIDR helpers ----
+  static constexpr const char* IPV4_MAPPED_PREFIX = "::ffff:";
+  static constexpr std::size_t IPV4_MAPPED_PREFIX_LEN = 7;
+
+  // Strips the "::ffff:" prefix from IPv4-mapped IPv6 addresses so that
+  // the remaining dotted-quad can be parsed by inet_pton(AF_INET, ...).
+  // On dual-stack sockets (common on macOS), the HTTP server reports
+  // client IPs in this mapped form even for pure IPv4 connections.
+  static std::string normalize_ipv4(const std::string& ip) {
+    if (ip.size() > IPV4_MAPPED_PREFIX_LEN &&
+        ip.compare(0, IPV4_MAPPED_PREFIX_LEN, IPV4_MAPPED_PREFIX) == 0) {
+      return ip.substr(IPV4_MAPPED_PREFIX_LEN);
+    }
+    return ip;
+  }
+
   static bool parse_ipv4(const std::string& ip, uint32_t& out_host_order) {
+    const std::string normalized = normalize_ipv4(ip);
     in_addr a;
-    if (::inet_pton(AF_INET, ip.c_str(), &a) != 1) return false;
+    if (::inet_pton(AF_INET, normalized.c_str(), &a) != 1) return false;
     out_host_order = ntohl(a.s_addr);
     return true;
   }

--- a/test/api_acl_test.cpp
+++ b/test/api_acl_test.cpp
@@ -222,3 +222,36 @@ TEST_F(APIAclTest, DisablingRateLimitAllowsRequestsAgain) {
     acl.set_rate_limit_10s(0);
     EXPECT_TRUE(acl.is_allowed("8.8.1.1", "http://192.169.1.200", allowed_src_ips));
 }
+
+TEST_F(APIAclTest, AllowsIpv4MappedIpv6SourceAddress) {
+    auto& acl = APIAcl::instance();
+    acl.set_rate_limit_10s(0);
+    acl.set_disallowed_dest_cidrs("");
+
+    // On dual-stack sockets (e.g. macOS), client IPs are reported as
+    // IPv4-mapped IPv6 addresses like "::ffff:192.168.1.28".
+    const std::vector<std::string> allowed_src_ips;
+    EXPECT_TRUE(acl.is_allowed("::ffff:192.168.1.28", "https://api.openai.com/v1/embeddings", allowed_src_ips));
+    EXPECT_TRUE(acl.is_allowed("::ffff:127.0.0.1", "https://example.com", allowed_src_ips));
+}
+
+TEST_F(APIAclTest, Ipv4MappedSrcMatchesAllowedList) {
+    auto& acl = APIAcl::instance();
+    acl.set_rate_limit_10s(0);
+    acl.set_disallowed_dest_cidrs("");
+
+    // A mapped source should match its IPv4 equivalent in allowed_src_ips.
+    const std::vector<std::string> allowed_src_ips = {"192.168.1.28"};
+    EXPECT_TRUE(acl.is_allowed("::ffff:192.168.1.28", "https://example.com", allowed_src_ips));
+    EXPECT_FALSE(acl.is_allowed("::ffff:10.0.0.1", "https://example.com", allowed_src_ips));
+}
+
+TEST_F(APIAclTest, Ipv4MappedSrcStillBlockedByDisallowedDest) {
+    auto& acl = APIAcl::instance();
+    acl.set_rate_limit_10s(0);
+    acl.set_disallowed_dest_cidrs("127.0.0.0/8");
+
+    const std::vector<std::string> allowed_src_ips = {"1.2.3.4"};
+    EXPECT_FALSE(acl.is_allowed("::ffff:1.2.3.4", "http://127.0.0.1:80", allowed_src_ips));
+    EXPECT_TRUE(acl.is_allowed("::ffff:1.2.3.4", "http://8.8.8.8:80", allowed_src_ips));
+}


### PR DESCRIPTION
## Problem

Fixes #2744

On systems where the HTTP server listens on an IPv6 socket (default on macOS Homebrew installs), **every request to the `/proxy` endpoint fails with `{"message": "Bad request."}`**.

This breaks server-side embedding validation during collection creation. When a collection schema includes an `embed` field with a remote model (e.g. `openai/text-embedding-3-small`), Typesense validates the model by calling the remote API through its internal `/proxy` endpoint. The ACL rejects the request before it ever reaches the remote API, producing a misleading error:

```
OpenAI API error: {"message": "Bad request."}
```

**Note:** The bug does **not** reproduce in Docker (`typesense/typesense:30.1` on Linux), where the socket is pure IPv4. It is specific to environments where the OS creates a dual-stack IPv6 socket — confirmed on macOS with Homebrew `typesense-server@30.1`.

### Root cause

On dual-stack sockets, the HTTP server reports client IPs as IPv4-mapped IPv6 addresses (e.g. `::ffff:192.168.1.28` instead of `192.168.1.28`). `APIAcl::parse_ipv4()` uses `inet_pton(AF_INET, ...)` which rejects this format, so `is_allowed()` returns `false` for every proxy request.

### How to reproduce

1. Install Typesense via Homebrew on macOS: `brew install typesense-server@30.1`
2. Verify the server listens on an IPv6 socket: `lsof -i :8108` shows `IPv6`
3. Any `/proxy` request fails:
   ```bash
   curl -X POST http://localhost:8108/proxy \
     -H "X-TYPESENSE-API-KEY: xyz" \
     -H "Content-Type: application/json" \
     -d '{"url":"https://example.com","method":"GET","headers":{}}'
   ```
   → Always returns `{"message": "Bad request."}` (400)
4. The same request succeeds against Docker `typesense/typesense:30.1` (200, returns example.com HTML)

## Fix

Strip the `::ffff:` prefix from source IPs in `parse_ipv4()` before passing to `inet_pton`, so IPv4-mapped IPv6 addresses are treated as their IPv4 equivalents.

### Changes
- **`include/api_acl.h`** — Add `normalize_ipv4()` helper, apply it in `parse_ipv4()`
- **`test/api_acl_test.cpp`** — 3 new test cases: mapped source with empty allow list, mapped source matching an allow list entry, and mapped source with disallowed destination CIDRs