### PR TITLE
fix stemming curations when search field is having them enabled

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -690,7 +690,8 @@ private:
                                   std::string& sort_by_clause,
                                   bool enable_typos_for_numerical_tokens=true,
                                   bool enable_typos_for_alpha_numerical_tokens=true,
-                                  const bool& validate_field_names = true) const;
+                                  const bool& validate_field_names = true,
+                                  std::shared_ptr<Stemmer> stemmer = nullptr) const;
 
     static void populate_text_match_info(nlohmann::json& info, uint64_t match_score, const text_match_type_t match_type,
                                          const size_t total_tokens);

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -1171,7 +1171,8 @@ Option<bool> Collection::curate_results(string& actual_query, const string& filt
           if(actual_query == "*") {
               query = "*";
           } else {
-              query = tokenize_query();
+              actual_query = tokenize_query();
+              query = actual_query;
           }
 
           if(!tags.empty()) {
@@ -1180,6 +1181,8 @@ Option<bool> Collection::curate_results(string& actual_query, const string& filt
                   // exact AND match only when multiple tags are sent
                   for(const auto* ov : curation_set_curations) {
                       if(ov->rule.tags == tags) {
+                          query = actual_query;
+
                           if(ov->rule.stem) {
                             query = tokenize_query(true, ov->rule.locale, ov->rule.stemming_dictionary);
                           }
@@ -1207,6 +1210,7 @@ Option<bool> Collection::curate_results(string& actual_query, const string& filt
                                             tags.begin(), tags.end(),
                                             std::inserter(matching_tags, matching_tags.begin()));
                       if(matching_tags.empty()) { continue; }
+                      query = actual_query;
 
                       if(ov->rule.stem) {
                           query = tokenize_query(true, ov->rule.locale, ov->rule.stemming_dictionary);
@@ -1244,6 +1248,8 @@ Option<bool> Collection::curate_results(string& actual_query, const string& filt
           } else {
               // no curation tags given
               for(const auto* ov : curation_set_curations) {
+                  query = actual_query;
+
                   bool wildcard_tag = ov->rule.tags.size() == 1 && *ov->rule.tags.begin() == "*";
                   if(ov->rule.stem) {
                       query = tokenize_query(true, ov->rule.locale, ov->rule.stemming_dictionary);
@@ -2736,7 +2742,7 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
         // included_ids, excluded_ids
         process_filter_sort_curations(filter_sort_curations, q_include_tokens, token_order, filter_tree_root_guard,
                                  included_ids, excluded_ids, curation_metadata, curated_sort_by, enable_typos_for_numerical_tokens,
-                                 enable_typos_for_alpha_numerical_tokens, validate_field_names);
+                                 enable_typos_for_alpha_numerical_tokens, validate_field_names, most_weighted_field.get_stemmer());
 
         for(size_t i = 0; i < q_include_tokens.size(); i++) {
             auto& q_include_token = q_include_tokens[i];
@@ -4463,10 +4469,11 @@ void Collection::process_filter_sort_curations(std::vector<const curation_t*>& f
                                           std::string& sort_by_clause,
                                           bool enable_typos_for_numerical_tokens,
                                           bool enable_typos_for_alpha_numerical_tokens,
-                                          const bool& validate_field_names) const {
+                                          const bool& validate_field_names,
+                                          std::shared_ptr<Stemmer> stemmer) const {
 
     std::vector<const curation_t*> matched_dynamic_curations;
-    auto compute_normalized_query = [this](const std::string& query) {
+    auto compute_normalized_query = [&](const std::string& query) {
       auto symbols = symbols_to_index;
       symbols.push_back('{');
       symbols.push_back('}');
@@ -4474,7 +4481,8 @@ void Collection::process_filter_sort_curations(std::vector<const curation_t*>& f
       symbols.push_back('.');
 
       std::vector<std::string> tokens;
-      Tokenizer tokenizer(query, true, false, "", symbols, token_separators, nullptr, true);
+      Tokenizer tokenizer(query, true, false, "", symbols, token_separators,
+                          stemmer, true);
       tokenizer.tokenize(tokens);
       auto query_normalized = StringUtils::join(tokens, " ");
       size_t i = 0;

--- a/test/collection_curation_test.cpp
+++ b/test/collection_curation_test.cpp
@@ -6186,12 +6186,15 @@ TEST_F(CollectionCurationTest, StemmingWithCuration) {
     ASSERT_TRUE(coll1->add(R"({"id":"3","title":"Children Notebooks","categoryType":"Electronics","region":"act","popularity":90})").ok());
     ASSERT_TRUE(coll1->add(R"({"id":"4","title":"Person Info","categoryType":"Office","region":"nsw","popularity":60})").ok());
     ASSERT_TRUE(coll1->add(R"({"id":"5","title":"People Info","categoryType":"Office","region":"nsw","popularity":60})").ok());
+    ASSERT_TRUE(coll1->add(R"({"id":"6","title":"Diabetes","categoryType":"Office","region":"nsw","popularity":60})").ok());
 
     //check with stemming dictionary for irregular plurals
     std::vector<std::string> json_lines;
     std::string json_line = "{\"word\": \"people\", \"root\":\"person\"}";
     json_lines.push_back(json_line);
     json_line = "{\"word\": \"children\", \"root\":\"child\"}";
+    json_lines.push_back(json_line);
+    json_line = "{\"word\": \"diabetes\", \"root\":\"diabet\"}";
     json_lines.push_back(json_line);
 
     ASSERT_TRUE(stemmerManager.upsert_stemming_dictionary("set1", json_lines).ok());
@@ -6265,6 +6268,34 @@ TEST_F(CollectionCurationTest, StemmingWithCuration) {
     ASSERT_EQ(2, results["found"].get<size_t>());
     ASSERT_EQ("1", results["hits"][0]["document"]["id"].get<std::string>()); //added by curation rule
     ASSERT_EQ("5", results["hits"][1]["document"]["id"].get<std::string>());
+
+    //curations rule should match, if search field has stemming enabled and curation rule has disabled
+    curation_json = R"OVR(
+        {
+        "id": "stemmer3",
+        "rule": {
+            "query": "Diabetes",
+            "match": "contains",
+            "stem" : false,
+            "stemming_dictionary": "set1"
+          },
+          "includes": [
+                {"id": "1", "position": 1}
+         ]
+        }
+    )OVR"_json;
+
+    parse_op = curation_t::parse(curation_json, "stemming3", ov);
+    ASSERT_TRUE(parse_op.ok());
+    ov_manager.upsert_curation_item("index", curation_json);
+
+    results.clear();
+    res_op = coll1->search("Diabetes", {"title"}, "", {}, {}, {0});
+    ASSERT_TRUE(res_op.ok());
+    results = res_op.get();
+    ASSERT_EQ(2, results["found"].get<size_t>());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"].get<std::string>()); //added by curation rule
+    ASSERT_EQ("6", results["hits"][1]["document"]["id"].get<std::string>());
 }
 
 TEST_F(CollectionCurationTest, SynonymsMatchWithCuration) {


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- Fix stemming curation when curation rule is having `stem:false` but search field is having `stem:true`
## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
