### PR TITLE
feat: add bucket_auto_size parameter for _text_match sorting

### DIFF
--- a/include/field.h
+++ b/include/field.h
@@ -622,6 +622,7 @@ struct sort_by {
     // for text_match score bucketing
     uint32_t text_match_buckets;
     uint32_t text_match_bucket_size;
+    float text_match_bucket_auto_size;
 
     uint32_t vector_search_buckets = 0;
     uint32_t vector_search_bucket_size = 0;
@@ -652,12 +653,12 @@ struct sort_by {
     uint32_t union_search_index{};
 
     sort_by(const std::string & name, const std::string & order):
-            name(name), order(order), text_match_buckets(0), text_match_bucket_size(0), geopoint(0), exclude_radius(0),
-            geo_precision(0), missing_values(normal) {
+            name(name), order(order), text_match_buckets(0), text_match_bucket_size(0), text_match_bucket_auto_size(0.0f),
+            geopoint(0), exclude_radius(0), geo_precision(0), missing_values(normal) {
     }
 
     sort_by(std::vector<std::string> eval_expressions, std::vector<int64_t> scores, std::string  order):
-            eval_expressions(std::move(eval_expressions)), order(std::move(order)), text_match_buckets(0), text_match_bucket_size(0),
+            eval_expressions(std::move(eval_expressions)), order(std::move(order)), text_match_buckets(0), text_match_bucket_size(0), text_match_bucket_auto_size(0.0f), 
             geopoint(0), exclude_radius(0), geo_precision(0), missing_values(normal) {
         name = sort_field_const::eval;
         eval.scores = std::move(scores);
@@ -666,7 +667,7 @@ struct sort_by {
 
     sort_by(const std::string &name, const std::string &order, uint32_t text_match_buckets, int64_t geopoint,
             uint32_t exclude_radius, uint32_t geo_precision) :
-            name(name), order(order), text_match_buckets(text_match_buckets), text_match_bucket_size(0),
+            name(name), order(order), text_match_buckets(text_match_buckets), text_match_bucket_size(0), text_match_bucket_auto_size(0.0f),
             geopoint(geopoint), exclude_radius(exclude_radius), geo_precision(geo_precision),
             missing_values(normal) {
         type = geopoint_field;
@@ -680,6 +681,7 @@ struct sort_by {
         order = other.order;
         text_match_buckets = other.text_match_buckets;
         text_match_bucket_size = other.text_match_bucket_size;
+        text_match_bucket_auto_size = other.text_match_bucket_auto_size;
         vector_search_buckets = other.vector_search_buckets;
         vector_search_bucket_size = other.vector_search_bucket_size;
         geopoint = other.geopoint;
@@ -709,6 +711,7 @@ struct sort_by {
         order = other.order;
         text_match_buckets = other.text_match_buckets;
         text_match_bucket_size = other.text_match_bucket_size;
+        text_match_bucket_auto_size = other.text_match_bucket_auto_size;
         vector_search_buckets = other.vector_search_buckets;
         vector_search_bucket_size = other.vector_search_bucket_size;
         geopoint = other.geopoint;

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -1334,22 +1334,35 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
                 std::vector<std::string> match_parts;
                 const std::string& match_config = sort_field_std.name.substr(paran_start+1, sort_field_std.name.size() - paran_start - 2);
                 StringUtils::split(match_config, match_parts, ":");
-                if(match_parts.size() != 2 || (match_parts[0] != "buckets" && match_parts[0] != "bucket_size")) {
+                if(match_parts.size() != 2 || (match_parts[0] != "buckets" && match_parts[0] != "bucket_size" && match_parts[0] != "bucket_auto_size")) {
                     return Option<bool>(400, "Invalid sorting parameter passed for _text_match.");
                 }
 
-                if(!StringUtils::is_uint32_t(match_parts[1])) {
-                    return Option<bool>(400, "Invalid value passed for _text_match `buckets` or `bucket_size` configuration.");
-                }
+                // bucket_auto_size requires float, check first
+                if(match_parts[0] == "bucket_auto_size") {
+                    try {
+                        float val = std::stof(match_parts[1]);
+                        if(val <= 0.0f || val > 1.0f) {
+                            return Option<bool>(400, "Value for `bucket_auto_size` must be between 0 and 1.");
+                        }
+                        sort_field_std.text_match_bucket_auto_size = val;
+                    } catch(const std::exception& e) {
+                        return Option<bool>(400, "Invalid value passed for _text_match `bucket_auto_size` configuration.");
+                    }
+                } else {
+                    if(!StringUtils::is_uint32_t(match_parts[1])) {
+                        return Option<bool>(400, "Invalid value passed for _text_match `buckets` or `bucket_size` configuration.");
+                    }
 
+                    if(match_parts[0] == "buckets") {
+                        sort_field_std.text_match_buckets = std::stoll(match_parts[1]);
+                    } else if(match_parts[0] == "bucket_size") {
+                        sort_field_std.text_match_bucket_size = std::stoll(match_parts[1]);
+                    }
+                }
                 sort_field_std.name = actual_field_name;
                 sort_field_std.type = sort_by::text_match;
 
-                if(match_parts[0] == "buckets") {
-                    sort_field_std.text_match_buckets = std::stoll(match_parts[1]);
-                } else if(match_parts[0] == "bucket_size") {
-                    sort_field_std.text_match_bucket_size = std::stoll(match_parts[1]);
-                }
             } else if(actual_field_name == sort_field_const::vector_query) {
                 const std::string& vector_query_str = sort_field_std.name.substr(paran_start + 1,
                                                                               sort_field_std.name.size() - paran_start -
@@ -2937,36 +2950,62 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
     int match_score_index = -1;
     for(size_t i = 0; i < sort_fields_std.size(); i++) {
         if(sort_fields_std[i].name == sort_field_const::text_match &&
-        (sort_fields_std[i].text_match_buckets != 0 || sort_fields_std[i].text_match_bucket_size != 0)) {
+        (sort_fields_std[i].text_match_buckets != 0 || sort_fields_std[i].text_match_bucket_size != 0 ||
+        sort_fields_std[i].text_match_bucket_auto_size != 0.0f)) {
             match_score_index = i;
             break;
         }
     }
 
     if(match_score_index >= 0 && (sort_fields_std[match_score_index].text_match_buckets > 0
-        || sort_fields_std[match_score_index].text_match_bucket_size > 0)) {
+        || sort_fields_std[match_score_index].text_match_bucket_size > 0
+        || sort_fields_std[match_score_index].text_match_bucket_auto_size > 0.0f)) {
 
         size_t num_buckets = sort_fields_std[match_score_index].text_match_buckets;
         size_t bucket_size = sort_fields_std[match_score_index].text_match_bucket_size;
+        float bucket_auto_size = sort_fields_std[match_score_index].text_match_bucket_auto_size;
 
         const size_t max_kvs_bucketed = std::min<size_t>(Index::DEFAULT_TOPSTER_SIZE, raw_result_kvs.size());
 
-        if((num_buckets > 0 && max_kvs_bucketed >= num_buckets) || (bucket_size > 0 && max_kvs_bucketed >= bucket_size)) {
+        if((num_buckets > 0 && max_kvs_bucketed >= num_buckets) || (bucket_size > 0 && max_kvs_bucketed >= bucket_size) ||
+            (bucket_auto_size > 0.0f)) {
             spp::sparse_hash_map<uint64_t, int64_t> result_scores;
-
-            // only first `max_kvs_bucketed` elements are bucketed to prevent pagination issues past 250 records
-            size_t block_len = num_buckets > 0 ? ceil((double(max_kvs_bucketed) / (double)(num_buckets))) : bucket_size;
             size_t i = 0;
-            while(i < max_kvs_bucketed) {
-                size_t j = 0;
-                while(j < block_len && i+j < max_kvs_bucketed) {
-                    result_scores[raw_result_kvs[i+j][0]->key] = raw_result_kvs[i+j][0]->scores[raw_result_kvs[i+j][0]->match_score_index];
-                    // use the bucket sequence as the sorting order (descending)
-                    raw_result_kvs[i+j][0]->scores[raw_result_kvs[i+j][0]->match_score_index] = -i;
-                    j++;
+
+            if(bucket_auto_size > 0.0f) {
+                // dynamic bucketing logic
+                while(i < max_kvs_bucketed) {
+                    // use first item in bucket as auto_size anchor
+                    int64_t anchor = raw_result_kvs[i][0]->scores[raw_result_kvs[i][0]->match_score_index];
+                    int64_t bucket_diff = (int64_t)(std::abs(anchor) * bucket_auto_size);
+                    size_t j = 0;
+                    while(i+j < max_kvs_bucketed && std::abs(raw_result_kvs[i+j][0]->scores[raw_result_kvs[i+j][0]->match_score_index] - anchor) <= bucket_diff) {
+                        result_scores[raw_result_kvs[i+j][0]->key] = raw_result_kvs[i+j][0]->scores[raw_result_kvs[i+j][0]->match_score_index];
+                        // use the bucket sequence as the sorting order (descending)
+                        raw_result_kvs[i+j][0]->scores[raw_result_kvs[i+j][0]->match_score_index] = -i;
+                        j++;
+                    }
+                    i += j;
                 }
 
-                i += j;
+            } else {
+                // fixed bucketing logic
+                // only first `max_kvs_bucketed` elements are bucketed to prevent pagination issues past 250 records
+                size_t block_len = num_buckets > 0
+                    ? ceil((double(max_kvs_bucketed) / (double)(num_buckets)))
+                    : bucket_size;
+
+                while(i < max_kvs_bucketed) {
+                    size_t j = 0;
+                    while(j < block_len && i+j < max_kvs_bucketed) {
+                        result_scores[raw_result_kvs[i+j][0]->key] = raw_result_kvs[i+j][0]->scores[raw_result_kvs[i+j][0]->match_score_index];
+                        // use the bucket sequence as the sorting order (descending)
+                        raw_result_kvs[i+j][0]->scores[raw_result_kvs[i+j][0]->match_score_index] = -i;
+                        j++;
+                    }
+
+                    i += j;
+                }
             }
 
             // sort again based on bucketed match score

--- a/test/collection_sorting_test.cpp
+++ b/test/collection_sorting_test.cpp
@@ -3441,6 +3441,160 @@ TEST_F(CollectionSortingTest, TextMatchBucketSizeRanking) {
     ASSERT_EQ("1", results["hits"][5]["document"]["id"].get<std::string>());
 }
 
+TEST_F(CollectionSortingTest, TextMatchAutoSizeBucketRanking) {
+    std::vector<field> fields = {field("title", field_types::STRING, false),
+                                 field("description", field_types::STRING, false),
+                                 field("points", field_types::INT32, false),};
+
+    Collection *coll1 = collectionManager.create_collection("coll1", 1, fields, "points").get();
+
+    nlohmann::json doc1;
+    doc1["id"] = "0";
+    doc1["title"] = "Mark Antony";
+    doc1["description"] = "Counsellor";
+    doc1["points"] = 100;
+
+    nlohmann::json doc2;
+    doc2["id"] = "1";
+    doc2["title"] = "Marks Spencer";
+    doc2["description"] = "Sales Expert";
+    doc2["points"] = 200;
+
+    nlohmann::json doc3;
+    doc3["id"] = "2";
+    doc3["title"] = "Mark Anderson";
+    doc3["description"] = "Writer";
+    doc3["points"] = 100;
+
+    nlohmann::json doc4;
+    doc4["id"] = "3";
+    doc4["title"] = "Mark Anatoly";
+    doc4["description"] = "Entrepreneur";
+    doc4["points"] = 300;
+
+    nlohmann::json doc5;
+    doc5["id"] = "4";
+    doc5["title"] = "Marks Henry";
+    doc5["description"] = "Wrestler";
+    doc5["points"] = 200;
+
+    nlohmann::json doc6;
+    doc6["id"] = "5";
+    doc6["title"] = "Mark Archer";
+    doc6["description"] = "Football Coach";
+    doc6["points"] = 200;
+
+    ASSERT_TRUE(coll1->add(doc1.dump()).ok());
+    ASSERT_TRUE(coll1->add(doc2.dump()).ok());
+    ASSERT_TRUE(coll1->add(doc3.dump()).ok());
+    ASSERT_TRUE(coll1->add(doc4.dump()).ok());
+    ASSERT_TRUE(coll1->add(doc5.dump()).ok());
+    ASSERT_TRUE(coll1->add(doc6.dump()).ok());
+
+    // threshold 0.05: exact-match "Mark A" docs and typo-match "Marks" docs are far enough apart in score
+    // with 5% bucket_diff should get two separate buckets, each sorted by points
+    sort_fields = {
+            sort_by("_text_match(bucket_auto_size:0.05)", "DESC"),
+            sort_by("points", "DESC"),
+    };
+
+    auto results = coll1->search("mark a*", {"title"},
+                                 "", {}, sort_fields, {2}, 10,
+                                 1, FREQUENCY, {true},
+                                 10, spp::sparse_hash_set<std::string>(),
+                                 spp::sparse_hash_set<std::string>(), 10, "", 30, 4, "title", 20, {}, {}, {}, 0,
+                                 "<mark>", "</mark>", {3}, 1000, true).get();
+
+    ASSERT_EQ(6, results["hits"].size());
+    ASSERT_EQ("3", results["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_EQ("5", results["hits"][1]["document"]["id"].get<std::string>());
+    ASSERT_EQ("2", results["hits"][2]["document"]["id"].get<std::string>());
+    ASSERT_EQ("0", results["hits"][3]["document"]["id"].get<std::string>());
+    ASSERT_EQ("4", results["hits"][4]["document"]["id"].get<std::string>());
+    ASSERT_EQ("1", results["hits"][5]["document"]["id"].get<std::string>());
+
+    // threshold 1.0: bucket_diff == anchor, all non-negative scores qualify — one bucket,
+    // full result set re-sorted by points DESC
+    sort_fields = {
+            sort_by("_text_match(bucket_auto_size:1.0)", "DESC"),
+            sort_by("points", "DESC"),
+    };
+
+    results = coll1->search("mark", {"title"},
+                            "", {}, sort_fields, {2}, 10,
+                            1, FREQUENCY, {true},
+                            10, spp::sparse_hash_set<std::string>(),
+                            spp::sparse_hash_set<std::string>(), 10, "", 30, 4, "title", 20, {}, {}, {}, 0,
+                            "<mark>", "</mark>", {3}, 1000, true).get();
+
+    ASSERT_EQ(6, results["hits"].size());
+    ASSERT_EQ("3", results["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_EQ("5", results["hits"][1]["document"]["id"].get<std::string>());
+    ASSERT_EQ("4", results["hits"][2]["document"]["id"].get<std::string>());
+    ASSERT_EQ("1", results["hits"][3]["document"]["id"].get<std::string>());
+    ASSERT_EQ("2", results["hits"][4]["document"]["id"].get<std::string>());
+    ASSERT_EQ("0", results["hits"][5]["document"]["id"].get<std::string>());
+
+    collectionManager.drop_collection("coll1");
+}
+
+TEST_F(CollectionSortingTest, TextMatchAutoSizeBucketValidation) {
+    std::vector<field> fields = {field("title", field_types::STRING, false),
+                                 field("points", field_types::INT32, false),};
+
+    Collection *coll1 = collectionManager.create_collection("coll1", 1, fields, "points").get();
+
+    nlohmann::json doc1;
+    doc1["id"] = "0";
+    doc1["title"] = "Mark Antony";
+    doc1["points"] = 100;
+
+    nlohmann::json doc2;
+    doc2["id"] = "1";
+    doc2["title"] = "Marks Spencer";
+    doc2["points"] = 200;
+
+    ASSERT_TRUE(coll1->add(doc1.dump()).ok());
+    ASSERT_TRUE(coll1->add(doc2.dump()).ok());
+
+    // reject zero (lower exclusive bound)
+    sort_fields = { sort_by("_text_match(bucket_auto_size:0)", "DESC") };
+    auto res_op = coll1->search("mark", {"title"}, "", {}, sort_fields, {2}, 10, 1, FREQUENCY, {true});
+    ASSERT_FALSE(res_op.ok());
+    ASSERT_EQ("Value for `bucket_auto_size` must be between 0 and 1.", res_op.error());
+
+    // reject values above 1.0
+    sort_fields[0] = sort_by("_text_match(bucket_auto_size:1.5)", "DESC");
+    res_op = coll1->search("mark", {"title"}, "", {}, sort_fields, {2}, 10, 1, FREQUENCY, {true});
+    ASSERT_FALSE(res_op.ok());
+    ASSERT_EQ("Value for `bucket_auto_size` must be between 0 and 1.", res_op.error());
+
+    // reject negative values
+    sort_fields[0] = sort_by("_text_match(bucket_auto_size:-0.5)", "DESC");
+    res_op = coll1->search("mark", {"title"}, "", {}, sort_fields, {2}, 10, 1, FREQUENCY, {true});
+    ASSERT_FALSE(res_op.ok());
+    ASSERT_EQ("Value for `bucket_auto_size` must be between 0 and 1.", res_op.error());
+
+    // reject non-numeric values
+    sort_fields[0] = sort_by("_text_match(bucket_auto_size:abc)", "DESC");
+    res_op = coll1->search("mark", {"title"}, "", {}, sort_fields, {2}, 10, 1, FREQUENCY, {true});
+    ASSERT_FALSE(res_op.ok());
+    ASSERT_EQ("Invalid value passed for _text_match `bucket_auto_size` configuration.", res_op.error());
+
+    // reject malformed combined expression (4 colon-split parts, fails size != 2 guard)
+    sort_fields[0] = sort_by("_text_match(bucket_auto_size:0.5:buckets:2)", "DESC");
+    res_op = coll1->search("mark", {"title"}, "", {}, sort_fields, {2}, 10, 1, FREQUENCY, {true});
+    ASSERT_FALSE(res_op.ok());
+    ASSERT_EQ("Invalid sorting parameter passed for _text_match.", res_op.error());
+
+    // 1.0 is the valid upper boundary
+    sort_fields[0] = sort_by("_text_match(bucket_auto_size:1.0)", "DESC");
+    res_op = coll1->search("mark", {"title"}, "", {}, sort_fields, {2}, 10, 1, FREQUENCY, {true});
+    ASSERT_TRUE(res_op.ok());
+
+    collectionManager.drop_collection("coll1");
+}
+
 
 TEST_F(CollectionSortingTest, VectorSearchBucketRanking) {
     nlohmann::json schema = nlohmann::json::parse(R"({


### PR DESCRIPTION
## Add `bucket_auto_size` parameter for `_text_match` sorting
Adds a new `bucket_auto_size` parameter to `_text_match` sort expressions that groups results into variable sized buckets based on a score similarity threshold rather than fixed positional boundaries. The threshold is passed in as a percentage and is calculated using the `text_match` score of the first item in the bucket. 

Fixes issue #2610 , which claimed that two documents with nearly identical text match scores could end up in different buckets simply because they straddle a positional boundary, while two documents with wildly different relevance could land in the same bucket if the batch happens to be uniform. The issue originally proposed passing in a direct `text_match` value threshold, but I've implemented it as a percentage instead. Let me know if this solution isn't ideal, I've also added a comment on the original issue about it.

**Syntax Example:**
```
sort_by=_text_match(bucket_auto_size:0.25):desc,popularity:desc
```

Here, a threshold of `0.25` means any result within 25% of the top score in the current bucket is grouped with it. When a result falls outside that range, a new bucket starts. Secondary sort fields apply within each bucket.

**Compared to existing parameters:**
  - `buckets:N` - splits top N results into N equal-width positional buckets
  - `bucket_size:N` - each bucket holds exactly N consecutive results                                
  - `bucket_auto_size:T` -  bucket boundaries are determined by actual score differences, not position

  **Valid range:** `(0, 1]`. Zero and values above 1.0 are rejected with HTTP 400.

**Files changed:**
  - `include/field.h` -  added `float text_match_bucket_auto_size` to `sort_by` struct
  - `src/collection.cpp` - parsing in `validate_and_standardize_sort_fields`, bucketing logic in `search`                                                                                           
  - `test/collection_sorting_test.cpp` - correctness and validation tests

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
