### PR TITLE
fix: handle Gemini streamed responses across curl buffer boundaries

### DIFF
--- a/include/conversation_model.h
+++ b/include/conversation_model.h
@@ -9,6 +9,7 @@
 
 struct async_conversation_t {
     std::string response;
+    std::string stream_remainder;
     std::mutex mutex;
     std::condition_variable cv;
     long status_code;

--- a/src/conversation_model.cpp
+++ b/src/conversation_model.cpp
@@ -1,5 +1,6 @@
 #include <regex>
 #include <iterator>
+#include <cctype>
 #include "conversation_model.h"
 #include "embedder_manager.h"
 #include "text_embedder_remote.h"
@@ -8,6 +9,87 @@
 #include "http_proxy.h"
 #include "string_utils.h"
 
+static std::vector<std::string> consume_gemini_stream_objects(async_conversation_t& async_conversation, const std::string& chunk) {
+    async_conversation.stream_remainder += chunk;
+
+    std::vector<std::string> objects;
+    size_t cursor = 0;
+    bool malformed_prefix = false;
+
+    while(cursor < async_conversation.stream_remainder.size()) {
+        while(cursor < async_conversation.stream_remainder.size()) {
+            const char c = async_conversation.stream_remainder[cursor];
+            if(c == '[' || c == ']' || c == ',' || std::isspace(static_cast<unsigned char>(c))) {
+                cursor++;
+                continue;
+            }
+            break;
+        }
+
+        if(cursor >= async_conversation.stream_remainder.size()) {
+            break;
+        }
+
+        if(async_conversation.stream_remainder[cursor] != '{') {
+            malformed_prefix = true;
+            break;
+        }
+
+        size_t object_end = std::string::npos;
+        size_t depth = 0;
+        bool in_string = false;
+        bool escaped = false;
+
+        for(size_t i = cursor; i < async_conversation.stream_remainder.size(); i++) {
+            const char c = async_conversation.stream_remainder[i];
+
+            if(escaped) {
+                escaped = false;
+                continue;
+            }
+
+            if(c == '\\' && in_string) {
+                escaped = true;
+                continue;
+            }
+
+            if(c == '"') {
+                in_string = !in_string;
+                continue;
+            }
+
+            if(in_string) {
+                continue;
+            }
+
+            if(c == '{') {
+                depth++;
+            } else if(c == '}') {
+                depth--;
+                if(depth == 0) {
+                    object_end = i;
+                    break;
+                }
+            }
+        }
+
+        if(object_end == std::string::npos) {
+            break;
+        }
+
+        objects.push_back(async_conversation.stream_remainder.substr(cursor, object_end - cursor + 1));
+        cursor = object_end + 1;
+    }
+
+    if(cursor > 0) {
+        async_conversation.stream_remainder.erase(0, cursor);
+    } else if(malformed_prefix) {
+        LOG(ERROR) << "Malformed Gemini stream chunk: " << async_conversation.stream_remainder;
+        async_conversation.stream_remainder.clear();
+    }
+
+    return objects;
+}
 
 static const std::string get_model_namespace(const std::string& model_name) {
     if(model_name.find("/") != std::string::npos) {
@@ -1695,40 +1777,42 @@ void GeminiConversationModel::async_res_write_callback(std::string& response, co
         return;
     }
 
+    auto& async_conversation = async_conversations[req];
     try {
-        if(!response.empty()) {
-            if(response[0] == '[' || response[0] == ',') {
-                response.erase(0, 1);
+        const auto objects = consume_gemini_stream_objects(async_conversation, response);
+        std::string parsed_response;
+        bool found_done = false;
+
+        for(const auto& object : objects) {
+            auto json_res = nlohmann::json::parse(object);
+            if(json_res.count("candidates") == 0 || json_res["candidates"].size() == 0) {
+                continue;
             }
-            if(response.back() == ',' || response.back() == ']') {
-                response.pop_back();
+            if(json_res["candidates"][0].count("content") == 0 || json_res["candidates"][0]["content"].count("parts") == 0) {
+                continue;
+            }
+            if(json_res["candidates"][0]["content"]["parts"].size() == 0) {
+                continue;
+            }
+
+            parsed_response += json_res["candidates"][0]["content"]["parts"][0]["text"].get<std::string>();
+            if(json_res["candidates"][0].count("finishReason") != 0 &&
+               json_res["candidates"][0]["finishReason"] == "STOP") {
+                found_done = true;
             }
         }
 
-        if(response.empty()) {
-            response = "data: \n\n";
-            return;
+        response.clear();
+        if(!parsed_response.empty()) {
+            nlohmann::json json_actual_res;
+            json_actual_res["message"] = parsed_response;
+            json_actual_res["conversation_id"] = async_conversation.conversation_id;
+            response = "data: " + json_actual_res.dump(-1) + "\n\n";
+            async_conversation.response += parsed_response;
         }
-        auto json_res = nlohmann::json::parse(response);
-        if(json_res.count("candidates") == 0 || json_res["candidates"].size() == 0) {
-            return;
-        }
-        if(json_res["candidates"][0].count("content") == 0 || json_res["candidates"][0]["content"].count("parts") == 0) {
-            return;
-        }
-        if(json_res["candidates"][0]["content"]["parts"].size() == 0) {
-            return;
-        }
-        std::string parsed_response = json_res["candidates"][0]["content"]["parts"][0]["text"].get<std::string>();
-        nlohmann::json json_actual_res;
-        json_actual_res["message"] = parsed_response;
-        json_actual_res["conversation_id"] = async_conversations[req].conversation_id;
-        response = "data: " + json_actual_res.dump(-1) + "\n\n";
-        async_conversations[req].response += parsed_response;
-        if(json_res["candidates"][0].count("finishReason") != 0) {
-            if(json_res["candidates"][0]["finishReason"] == "STOP") {
-                response += "data: [DONE]\n\n";
-            }
+
+        if(found_done) {
+            response += "data: [DONE]\n\n";
         }
     } catch (const std::exception& e) {
         LOG(ERROR) << e.what();
@@ -1742,8 +1826,12 @@ bool GeminiConversationModel::async_res_done_callback(const std::shared_ptr<http
         return false;
     }
 
-    async_conversations[req].ready = true;
-    async_conversations[req].cv.notify_one();
+    auto& async_conversation = async_conversations[req];
+    {
+        std::lock_guard<std::mutex> lock(async_conversation.mutex);
+        async_conversation.ready = true;
+    }
+    async_conversation.cv.notify_one();
     return false;
 }
 

--- a/test/conversation_test.cpp
+++ b/test/conversation_test.cpp
@@ -392,6 +392,118 @@ TEST_F(ConversationTest, TestGeminiStreamManipulation) {
     ASSERT_EQ(test, expected);
 }
 
+TEST_F(ConversationTest, TestGeminiStreamSplitObjectAcrossCallbacks) {
+    std::shared_ptr<http_req> req = std::make_shared<http_req>();
+    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
+    ConversationModel::_add_async_conversation(req, "test");
+
+    std::string test = R"([
+    {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "text": "Hel)";
+    std::string expected = "";
+    GeminiConversationModel::_async_write_callback(test, req, res);
+    ASSERT_EQ(test, expected);
+
+    test = R"(lo"
+                        }
+                    ],
+                    "role": "model"
+                }
+            }
+        ],
+        "modelVersion": "gemini-2.0-flash"
+    })";
+    expected = "data: {\"conversation_id\":\"test\",\"message\":\"Hello\"}\n\n";
+    GeminiConversationModel::_async_write_callback(test, req, res);
+    ASSERT_EQ(test, expected);
+
+    test = R"(,
+    {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "text": " world"
+                        }
+                    ],
+                    "role": "model"
+                },
+                "finishReason": "STOP"
+            }
+        ],
+        "modelVersion": "gemini-2.0-flash"
+    }
+])";
+    expected = "data: {\"conversation_id\":\"test\",\"message\":\" world\"}\n\n";
+    expected += "data: [DONE]\n\n";
+    GeminiConversationModel::_async_write_callback(test, req, res);
+    ASSERT_EQ(test, expected);
+}
+
+TEST_F(ConversationTest, TestGeminiStreamSplitArrayDelimitersAcrossCallbacks) {
+    std::shared_ptr<http_req> req = std::make_shared<http_req>();
+    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
+    ConversationModel::_add_async_conversation(req, "test");
+
+    std::string test = R"([
+    {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "text": "One"
+                        }
+                    ],
+                    "role": "model"
+                }
+            }
+        ],
+        "modelVersion": "gemini-2.0-flash"
+    })";
+    std::string expected = "data: {\"conversation_id\":\"test\",\"message\":\"One\"}\n\n";
+    GeminiConversationModel::_async_write_callback(test, req, res);
+    ASSERT_EQ(test, expected);
+
+    test = ",";
+    expected = "";
+    GeminiConversationModel::_async_write_callback(test, req, res);
+    ASSERT_EQ(test, expected);
+
+    test = R"(
+    {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "text": "Two"
+                        }
+                    ],
+                    "role": "model"
+                },
+                "finishReason": "STOP"
+            }
+        ],
+        "modelVersion": "gemini-2.0-flash"
+    })";
+    expected = "data: {\"conversation_id\":\"test\",\"message\":\"Two\"}\n\n";
+    expected += "data: [DONE]\n\n";
+    GeminiConversationModel::_async_write_callback(test, req, res);
+    ASSERT_EQ(test, expected);
+
+    test = "]";
+    expected = "";
+    GeminiConversationModel::_async_write_callback(test, req, res);
+    ASSERT_EQ(test, expected);
+}
+
 TEST_F(ConversationTest, TestAzureStreamManipulation) {
     std::shared_ptr<http_req> req = std::make_shared<http_req>();
     std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);


### PR DESCRIPTION
## Change Summary
  Fixes Gemini conversation streaming when a streamed JSON object is split across curl callback boundaries.

  This change adds per-request buffering for Gemini stream chunks, incrementally extracts complete JSON objects from the streamed array response, and only
  parses full objects once they are complete. That prevents dropped tokens when an object spans multiple callback invocations.

  It also adds regression coverage for:
  - a Gemini object split across callbacks
  - array delimiter chunks arriving separately, including , and trailing ]


## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
