### PR TITLE
fix: prevent token loss in streamed conversation responses across curl buffer boundaries

### DIFF
--- a/include/conversation_model.h
+++ b/include/conversation_model.h
@@ -9,6 +9,7 @@
 
 struct async_conversation_t {
     std::string response;
+    std::string sse_remainder;
     std::mutex mutex;
     std::condition_variable cv;
     long status_code;
@@ -64,6 +65,10 @@ class OpenAIConversationModel : public ConversationModel {
         )";
         // prevent instantiation
         OpenAIConversationModel() = delete;
+        static void _async_write_callback(std::string& response, const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
+            // for testing purposes
+            return async_res_write_callback(response, req, res);
+        }
     private:
         static constexpr char* OPENAI_URL = "https://api.openai.com";
         static constexpr char* OPENAI_LIST_MODELS = "/v1/models";
@@ -94,6 +99,10 @@ class CFConversationModel : public ConversationModel {
         static const inline std::string INFO_PROMPT = "You are an assistant for question-answering tasks. Use the following pieces of retrieved context to answer the question. If you don't know the answer, just say that you don't know. Use three sentences maximum and do not mention provided context directly, act like already knowing the context.";
         // prevent instantiation
         CFConversationModel() = delete;
+        static void _async_write_callback(std::string& response, const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
+            // for testing purposes
+            return async_res_write_callback(response, req, res);
+        }
         static const size_t get_minimum_required_bytes() {
             return CONTEXT_INFO.size() + SPLITTER_STR.size() + QUERY_STR.size() + ANSWER_STR.size();
         }
@@ -121,6 +130,10 @@ class vLLMConversationModel : public ConversationModel {
         )";
         // prevent instantiation
         vLLMConversationModel() = delete;
+        static void _async_write_callback(std::string& response, const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
+            // for testing purposes
+            return async_res_write_callback(response, req, res);
+        }
         // max_bytes must be greater than or equal to the minimum required bytes
         static const size_t get_minimum_required_bytes() {
             return  DATA_STR.size() + QUESTION_STR.size() + ANSWER_STR.size();

--- a/src/conversation_model.cpp
+++ b/src/conversation_model.cpp
@@ -8,6 +8,95 @@
 #include "http_proxy.h"
 #include "string_utils.h"
 
+static size_t find_next_sse_delimiter(const std::string& buffer, size_t start, size_t& delimiter_len) {
+    const auto lf_pos = buffer.find("\n\n", start);
+    const auto crlf_pos = buffer.find("\r\n\r\n", start);
+
+    if(lf_pos == std::string::npos && crlf_pos == std::string::npos) {
+        delimiter_len = 0;
+        return std::string::npos;
+    }
+
+    if(crlf_pos == std::string::npos || (lf_pos != std::string::npos && lf_pos < crlf_pos)) {
+        delimiter_len = 2;
+        return lf_pos;
+    }
+
+    delimiter_len = 4;
+    return crlf_pos;
+}
+
+static std::vector<std::string> consume_sse_payloads(async_conversation_t& async_conversation, const std::string& chunk) {
+    async_conversation.sse_remainder += chunk;
+
+    std::vector<std::string> payloads;
+    size_t cursor = 0;
+
+    while(cursor < async_conversation.sse_remainder.size()) {
+        size_t delimiter_len = 0;
+        const auto event_end = find_next_sse_delimiter(async_conversation.sse_remainder, cursor, delimiter_len);
+        if(event_end == std::string::npos) {
+            break;
+        }
+
+        const auto event = async_conversation.sse_remainder.substr(cursor, event_end - cursor);
+        cursor = event_end + delimiter_len;
+
+        std::string payload;
+        bool found_data_line = false;
+        size_t line_start = 0;
+
+        while(line_start <= event.size()) {
+            const auto line_end = event.find('\n', line_start);
+            auto line = event.substr(line_start, line_end == std::string::npos ? std::string::npos : line_end - line_start);
+            if(!line.empty() && line.back() == '\r') {
+                line.pop_back();
+            }
+
+            if(line.rfind("data:", 0) == 0) {
+                size_t data_start = 5;
+                if(data_start < line.size() && line[data_start] == ' ') {
+                    data_start++;
+                }
+
+                if(found_data_line) {
+                    payload += "\n";
+                }
+                payload += line.substr(data_start);
+                found_data_line = true;
+            }
+
+            if(line_end == std::string::npos) {
+                break;
+            }
+
+            line_start = line_end + 1;
+        }
+
+        if(found_data_line) {
+            payloads.emplace_back(std::move(payload));
+        }
+    }
+
+    // No complete event was consumed, so keep the accumulated remainder intact.
+    if(cursor == 0) {
+        return payloads;
+    }
+
+    async_conversation.sse_remainder.erase(0, cursor);
+    return payloads;
+}
+
+static void append_message_event(std::string& response, const std::string& conversation_id, const std::string& message) {
+    if(message.empty()) {
+        return;
+    }
+
+    nlohmann::json json_res;
+    json_res["message"] = message;
+    json_res["conversation_id"] = conversation_id;
+    response += "data: " + json_res.dump(-1) + "\n\n";
+}
 
 static const std::string get_model_namespace(const std::string& model_name) {
     if(model_name.find("/") != std::string::npos) {
@@ -533,31 +622,33 @@ void OpenAIConversationModel::async_res_write_callback(std::string& response, co
         return;
     }
 
+    auto& async_conversation = async_conversations[req];
     try {
         bool found_done = false;
         std::string parsed_response;
-        std::regex data_regex("data: (.*?)\\n\\n");
-        auto begin = std::sregex_iterator(response.begin(), response.end(), data_regex);
-        auto end = std::sregex_iterator();
-        for (std::sregex_iterator i = begin; i != end; ++i) {
-            std::string substr_line = i->str().substr(6, i->str().size() - 8);
-            if(substr_line.find("[DONE]") != std::string::npos) {
-                found_done = true;  
-                break;
-            }
-            nlohmann::json json_line;
-            json_line = nlohmann::json::parse(substr_line);
-            if(json_line.count("choices") == 0 || json_line["choices"][0].count("delta") == 0 || json_line["choices"][0]["delta"].count("content") == 0) {
+        const auto payloads = consume_sse_payloads(async_conversation, response);
+
+        for(const auto& payload : payloads) {
+            if(payload.find("[DONE]") != std::string::npos) {
+                found_done = true;
                 continue;
             }
-            parsed_response += json_line["choices"][0]["delta"]["content"].get<std::string>();
+
+            try {
+                auto json_line = nlohmann::json::parse(payload);
+                if(json_line.count("choices") == 0 || json_line["choices"][0].count("delta") == 0 || json_line["choices"][0]["delta"].count("content") == 0) {
+                    continue;
+                }
+                parsed_response += json_line["choices"][0]["delta"]["content"].get<std::string>();
+            } catch (const std::exception& e) {
+                LOG(ERROR) << e.what();
+                LOG(ERROR) << "Response: " << payload;
+            }
         }
 
-        async_conversations[req].response += parsed_response;
-        nlohmann::json json_res;
-        json_res["message"] = parsed_response;
-        json_res["conversation_id"] = async_conversations[req].conversation_id;
-        response = "data: " + json_res.dump(-1) + "\n\n";
+        async_conversation.response += parsed_response;
+        response.clear();
+        append_message_event(response, async_conversation.conversation_id, parsed_response);
         if(found_done) {
             response += "data: [DONE]\n\n";
         }
@@ -573,8 +664,12 @@ bool OpenAIConversationModel::async_res_done_callback(const std::shared_ptr<http
         return false;
     }
 
-    async_conversations[req].ready = true;
-    async_conversations[req].cv.notify_one();
+    auto& async_conversation = async_conversations[req];
+    {
+        std::lock_guard<std::mutex> lock(async_conversation.mutex);
+        async_conversation.ready = true;
+    }
+    async_conversation.cv.notify_one();
     return false;
 }
 
@@ -1002,31 +1097,33 @@ void CFConversationModel::async_res_write_callback(std::string& response, const 
         return;
     }
 
+    auto& async_conversation = async_conversations[req];
     try {
         bool found_done = false;
         std::string parsed_response;
-        std::regex data_regex("data: (.*?)\\n\\n");
-        auto begin = std::sregex_iterator(response.begin(), response.end(), data_regex);
-        auto end = std::sregex_iterator();
-        for (std::sregex_iterator i = begin; i != end; ++i) {
-            std::string substr_line = i->str().substr(6, i->str().size() - 8);
-            if(substr_line.find("[DONE]") != std::string::npos) {
-                found_done = true;  
-                break;
-            }
-            nlohmann::json json_line;
-            json_line = nlohmann::json::parse(substr_line);
-            if(json_line.count("response") == 0) {
+        const auto payloads = consume_sse_payloads(async_conversation, response);
+
+        for(const auto& payload : payloads) {
+            if(payload.find("[DONE]") != std::string::npos) {
+                found_done = true;
                 continue;
             }
-            parsed_response += json_line["response"].get<std::string>();
+
+            try {
+                auto json_line = nlohmann::json::parse(payload);
+                if(json_line.count("response") == 0) {
+                    continue;
+                }
+                parsed_response += json_line["response"].get<std::string>();
+            } catch (const std::exception& e) {
+                LOG(ERROR) << e.what();
+                LOG(ERROR) << "Response: " << payload;
+            }
         }
 
-        async_conversations[req].response += parsed_response;
-        nlohmann::json json_res;
-        json_res["message"] = parsed_response;
-        json_res["conversation_id"] = async_conversations[req].conversation_id;
-        response = "data: " + json_res.dump(-1) + "\n\n";
+        async_conversation.response += parsed_response;
+        response.clear();
+        append_message_event(response, async_conversation.conversation_id, parsed_response);
         if(found_done) {
             response += "data: [DONE]\n\n";
         }
@@ -1042,8 +1139,12 @@ bool CFConversationModel::async_res_done_callback(const std::shared_ptr<http_req
         return false;
     }
 
-    async_conversations[req].ready = true;
-    async_conversations[req].cv.notify_one();
+    auto& async_conversation = async_conversations[req];
+    {
+        std::lock_guard<std::mutex> lock(async_conversation.mutex);
+        async_conversation.ready = true;
+    }
+    async_conversation.cv.notify_one();
     return false;
 }
 
@@ -1410,31 +1511,33 @@ void vLLMConversationModel::async_res_write_callback(std::string& response, cons
         return;
     }
 
+    auto& async_conversation = async_conversations[req];
     try {
         bool found_done = false;
         std::string parsed_response;
-        std::regex data_regex("data: (.*?)\\n\\n");
-        auto begin = std::sregex_iterator(response.begin(), response.end(), data_regex);
-        auto end = std::sregex_iterator();
-        for (std::sregex_iterator i = begin; i != end; ++i) {
-            std::string substr_line = i->str().substr(6, i->str().size() - 8);
-            if(substr_line.find("[DONE]") != std::string::npos) {
-                found_done = true;  
-                break;
-            }
-            nlohmann::json json_line;
-            json_line = nlohmann::json::parse(substr_line);
-            if(json_line.count("choices") == 0 || json_line["choices"][0].count("delta") == 0 || json_line["choices"][0]["delta"].count("content") == 0) {
+        const auto payloads = consume_sse_payloads(async_conversation, response);
+
+        for(const auto& payload : payloads) {
+            if(payload.find("[DONE]") != std::string::npos) {
+                found_done = true;
                 continue;
             }
-            parsed_response += json_line["choices"][0]["delta"]["content"].get<std::string>();
+
+            try {
+                auto json_line = nlohmann::json::parse(payload);
+                if(json_line.count("choices") == 0 || json_line["choices"][0].count("delta") == 0 || json_line["choices"][0]["delta"].count("content") == 0) {
+                    continue;
+                }
+                parsed_response += json_line["choices"][0]["delta"]["content"].get<std::string>();
+            } catch (const std::exception& e) {
+                LOG(ERROR) << e.what();
+                LOG(ERROR) << "Response: " << payload;
+            }
         }
 
-        async_conversations[req].response += parsed_response;
-        nlohmann::json json_res;
-        json_res["message"] = parsed_response;
-        json_res["conversation_id"] = async_conversations[req].conversation_id;
-        response = "data: " + json_res.dump(-1) + "\n\n";
+        async_conversation.response += parsed_response;
+        response.clear();
+        append_message_event(response, async_conversation.conversation_id, parsed_response);
         if(found_done) {
             response += "data: [DONE]\n\n";
         }
@@ -1450,8 +1553,12 @@ bool vLLMConversationModel::async_res_done_callback(const std::shared_ptr<http_r
         return false;
     }
 
-    async_conversations[req].ready = true;
-    async_conversations[req].cv.notify_one();
+    auto& async_conversation = async_conversations[req];
+    {
+        std::lock_guard<std::mutex> lock(async_conversation.mutex);
+        async_conversation.ready = true;
+    }
+    async_conversation.cv.notify_one();
     return false;
 }
 
@@ -1742,8 +1849,12 @@ bool GeminiConversationModel::async_res_done_callback(const std::shared_ptr<http
         return false;
     }
 
-    async_conversations[req].ready = true;
-    async_conversations[req].cv.notify_one();
+    auto& async_conversation = async_conversations[req];
+    {
+        std::lock_guard<std::mutex> lock(async_conversation.mutex);
+        async_conversation.ready = true;
+    }
+    async_conversation.cv.notify_one();
     return false;
 }
 
@@ -1991,9 +2102,9 @@ Option<nlohmann::json> AzureConversationModel::format_answer(const std::string& 
 }
 
 bool AzureConversationModel::async_res_set_headers_callback(const std::string& response, 
-                                                           const std::shared_ptr<http_req> req, 
-                                                           long status_code, 
-                                                           std::string& content_type) {
+                                                          const std::shared_ptr<http_req> req, 
+                                                          long status_code, 
+                                                          std::string& content_type) {
     auto& async_conversations = ConversationModel::async_conversations;
     if(async_conversations.find(req) == async_conversations.end()) {
         return false;
@@ -2001,9 +2112,13 @@ bool AzureConversationModel::async_res_set_headers_callback(const std::string& r
     
     async_conversations[req].status_code = status_code;
     if(status_code != 200) {
-        async_conversations[req].response = response;
-        async_conversations[req].ready = true;
-        async_conversations[req].cv.notify_one();
+        auto& async_conversation = async_conversations[req];
+        async_conversation.response = response;
+        {
+            std::lock_guard<std::mutex> lock(async_conversation.mutex);
+            async_conversation.ready = true;
+        }
+        async_conversation.cv.notify_one();
         return false;
     }
     
@@ -2017,99 +2132,88 @@ void AzureConversationModel::async_res_write_callback(std::string& response, con
         return;
     }
 
+    auto& async_conversation = async_conversations[req];
     try {
         bool found_done = false;
         std::string parsed_response;
-        std::regex data_regex("data: (.*?)\\n\\n");
-        auto begin = std::sregex_iterator(response.begin(), response.end(), data_regex);
-        auto end = std::sregex_iterator();
-        
-        
-        // Track if we've seen any non-empty content
-        bool has_content = false;
-        
-        for (std::sregex_iterator i = begin; i != end; ++i) {
-            std::string substr_line = i->str().substr(6, i->str().size() - 8);
-            
+        const auto payloads = consume_sse_payloads(async_conversation, response);
+
+        for(const auto& payload : payloads) {
             // Handle [DONE] signal
-            if(substr_line.find("[DONE]") != std::string::npos) {
+            if(payload.find("[DONE]") != std::string::npos) {
                 found_done = true;
-                continue;  
+                continue;
             }
-            
+
             // Skip empty messages
-            if(substr_line.empty() || substr_line == "{}") {
+            if(payload.empty() || payload == "{}") {
                 continue;
             }
-            
-            nlohmann::json json_line;
+
             try {
-                json_line = nlohmann::json::parse(substr_line);
+                auto json_line = nlohmann::json::parse(payload);
+
+                // Skip content filter results and empty messages
+                if(json_line.contains("prompt_filter_results") ||
+                   (json_line.contains("choices") && json_line["choices"].empty())) {
+                    continue;
+                }
+
+                // Skip role assignment messages
+                if(json_line.contains("choices") && !json_line["choices"].empty() &&
+                   json_line["choices"][0].contains("delta") &&
+                   json_line["choices"][0]["delta"].contains("role")) {
+                    continue;
+                }
+
+                // Handle content chunks
+                if(json_line.contains("choices") && !json_line["choices"].empty() &&
+                   json_line["choices"][0].contains("delta") &&
+                   json_line["choices"][0]["delta"].contains("content")) {
+                    std::string content = json_line["choices"][0]["delta"]["content"].get<std::string>();
+                    if(!content.empty()) {
+                        parsed_response += content;
+                    }
+                }
+
+                // Handle finish reason
+                if(json_line.contains("choices") && !json_line["choices"].empty() &&
+                   json_line["choices"][0].contains("finish_reason") &&
+                   !json_line["choices"][0]["finish_reason"].is_null()) {
+                    std::string finish_reason = json_line["choices"][0]["finish_reason"].get<std::string>();
+                    if(finish_reason == "stop") {
+                        found_done = true;
+                    }
+                }
             } catch (const std::exception& e) {
-                LOG(ERROR) << "Azure callback: Failed to parse JSON: " << substr_line << " Error: " << e.what();
+                LOG(ERROR) << "Azure callback: Failed to parse JSON: " << payload << " Error: " << e.what();
                 continue;
-            }
-            
-            // Skip content filter results and empty messages
-            if (json_line.contains("prompt_filter_results") || 
-                (json_line.contains("choices") && json_line["choices"].empty())) {
-                continue;
-            }
-
-            // Skip role assignment messages
-            if (json_line.contains("choices") && !json_line["choices"].empty() && 
-                json_line["choices"][0].contains("delta") && 
-                json_line["choices"][0]["delta"].contains("role")) {
-                continue;
-            }
-
-            // Handle content chunks
-            if (json_line.contains("choices") && !json_line["choices"].empty() && 
-                json_line["choices"][0].contains("delta") && 
-                json_line["choices"][0]["delta"].contains("content")) {
-                std::string content = json_line["choices"][0]["delta"]["content"].get<std::string>();
-                if (!content.empty()) {
-                    parsed_response += content;
-                    has_content = true;
-                }
-            }
-
-            // Handle finish reason
-            if (json_line.contains("choices") && !json_line["choices"].empty() && 
-                json_line["choices"][0].contains("finish_reason") && 
-                !json_line["choices"][0]["finish_reason"].is_null()) {
-                std::string finish_reason = json_line["choices"][0]["finish_reason"].get<std::string>();
-                if (finish_reason == "stop") {
-                    found_done = true;
-                }
             }
         }
 
-        // Only send response if we have content
-        if (has_content) {
-            async_conversations[req].response += parsed_response;
-            nlohmann::json json_res;
-            json_res["message"] = parsed_response;
-            json_res["conversation_id"] = async_conversations[req].conversation_id;
-            response = "data: " + json_res.dump(-1) + "\n\n";
-        } else {
-            response = "";  // Don't send empty responses
-        }
+        async_conversation.response += parsed_response;
+        response.clear();
+        append_message_event(response, async_conversation.conversation_id, parsed_response);
 
-        // Send [DONE] if we've found it and we have content
-        if(found_done && has_content) {
+        if(found_done) {
             response += "data: [DONE]\n\n";
-            async_conversations[req].ready = true;
-            async_conversations[req].cv.notify_one();
-        } 
+            {
+                std::lock_guard<std::mutex> lock(async_conversation.mutex);
+                async_conversation.ready = true;
+            }
+            async_conversation.cv.notify_one();
+        }
 
     } catch (const std::exception& e) {
         LOG(ERROR) << "Azure callback: Exception caught: " << e.what();
         LOG(ERROR) << "Azure callback: Response that caused error: " << response;
         // Set error response
-        async_conversations[req].response = "{\"error\":{\"message\":\"" + std::string(e.what()) + "\"}}";
-        async_conversations[req].ready = true;
-        async_conversations[req].cv.notify_one();
+        async_conversation.response = "{\"error\":{\"message\":\"" + std::string(e.what()) + "\"}}";
+        {
+            std::lock_guard<std::mutex> lock(async_conversation.mutex);
+            async_conversation.ready = true;
+        }
+        async_conversation.cv.notify_one();
     }
 }
 
@@ -2120,10 +2224,19 @@ bool AzureConversationModel::async_res_done_callback(const std::shared_ptr<http_
         return false;
     }
 
-    // Only mark as done if not already marked by write callback
-    if (!async_conversations[req].ready) {
-        async_conversations[req].ready = true;
-        async_conversations[req].cv.notify_one();
+    auto& async_conversation = async_conversations[req];
+    bool should_notify = false;
+
+    {
+        std::lock_guard<std::mutex> lock(async_conversation.mutex);
+        if(!async_conversation.ready) {
+            async_conversation.ready = true;
+            should_notify = true;
+        }
+    }
+
+    if(should_notify) {
+        async_conversation.cv.notify_one();
     }
     return false;
 }

--- a/test/conversation_test.cpp
+++ b/test/conversation_test.cpp
@@ -8,6 +8,7 @@ class ConversationTest : public ::testing::Test {
         CollectionManager & collectionManager = CollectionManager::get_instance();
         Store* store;
         std::atomic<bool> quit = false;
+        static constexpr const char* conversation_id = "test";
         nlohmann::json model = R"({
             "id": "0",
             "history_collection": "conversation_store",
@@ -57,6 +58,22 @@ class ConversationTest : public ::testing::Test {
         void TearDown() override {
             collectionManager.dispose();
             delete store;
+        }
+
+        std::pair<std::shared_ptr<http_req>, std::shared_ptr<http_res>> make_async_context() {
+            auto req = std::make_shared<http_req>();
+            auto res = std::make_shared<http_res>(nullptr);
+            ConversationModel::_add_async_conversation(req, conversation_id);
+            return {req, res};
+        }
+
+        void expect_stream_output(void (*callback)(std::string&, const std::shared_ptr<http_req>&, const std::shared_ptr<http_res>&),
+                                  std::string input,
+                                  const std::string& expected,
+                                  const std::shared_ptr<http_req>& req,
+                                  const std::shared_ptr<http_res>& res) {
+            callback(input, req, res);
+            ASSERT_EQ(input, expected);
         }
 };
 
@@ -285,9 +302,7 @@ TEST_F(ConversationTest, TestGettingFullConversation) {
 }
 
 TEST_F(ConversationTest, TestGeminiStreamManipulation) {
-    std::shared_ptr<http_req> req = std::make_shared<http_req>();
-    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
-    ConversationModel::_add_async_conversation(req, "test");
+    auto [req, res] = make_async_context();
     // test JSON to SSE
     std::string test = R"([
     {
@@ -317,8 +332,7 @@ TEST_F(ConversationTest, TestGeminiStreamManipulation) {
     })";
 
     std::string expected = "data: {\"conversation_id\":\"test\",\"message\":\"Hello\"}\n\n";
-    GeminiConversationModel::_async_write_callback(test, req, res);
-    ASSERT_EQ(test, expected);
+    expect_stream_output(GeminiConversationModel::_async_write_callback, test, expected, req, res);
 
     test = R"(,{
         "candidates": [
@@ -347,8 +361,7 @@ TEST_F(ConversationTest, TestGeminiStreamManipulation) {
     })";
 
     expected = "data: {\"conversation_id\":\"test\",\"message\":\"! How can\"}\n\n";
-    GeminiConversationModel::_async_write_callback(test, req, res);
-    ASSERT_EQ(test, expected);
+    expect_stream_output(GeminiConversationModel::_async_write_callback, test, expected, req, res);
 
     test = R"(,
         {
@@ -388,109 +401,146 @@ TEST_F(ConversationTest, TestGeminiStreamManipulation) {
 
     expected = "data: {\"conversation_id\":\"test\",\"message\":\" I help you today?\\n\"}\n\n";
     expected += "data: [DONE]\n\n";
-    GeminiConversationModel::_async_write_callback(test, req, res);
-    ASSERT_EQ(test, expected);
+    expect_stream_output(GeminiConversationModel::_async_write_callback, test, expected, req, res);
+}
+
+TEST_F(ConversationTest, TestOpenAIStreamSplitEventAcrossCallbacks) {
+    auto [req, res] = make_async_context();
+
+    std::string test = std::string(R"(data: {"choices":[{"delta":{"content":"You"}}]})") + "\n\n" +
+                       R"(data: {"choices":[{"delta":{"content":" can)";
+    std::string expected = std::string(R"(data: {"conversation_id":"test","message":"You"})") + "\n\n";
+    expect_stream_output(OpenAIConversationModel::_async_write_callback, test, expected, req, res);
+
+    test = std::string(R"( define"}}]})") + "\n\n" + "data: [DONE]\n\n";
+    expected = std::string(R"(data: {"conversation_id":"test","message":" can define"})") + "\n\n" +
+               "data: [DONE]\n\n";
+    expect_stream_output(OpenAIConversationModel::_async_write_callback, test, expected, req, res);
+}
+
+TEST_F(ConversationTest, TestCFStreamSplitEventAcrossCallbacks) {
+    auto [req, res] = make_async_context();
+
+    std::string test = std::string(R"(data: {"response":"Hello"})") + "\n\n" +
+                       R"(data: {"response":" Wor)";
+    std::string expected = std::string(R"(data: {"conversation_id":"test","message":"Hello"})") + "\n\n";
+    expect_stream_output(CFConversationModel::_async_write_callback, test, expected, req, res);
+
+    test = std::string(R"(ld"})") + "\n\n" + "data: [DONE]\n\n";
+    expected = std::string(R"(data: {"conversation_id":"test","message":" World"})") + "\n\n" +
+               "data: [DONE]\n\n";
+    expect_stream_output(CFConversationModel::_async_write_callback, test, expected, req, res);
+}
+
+TEST_F(ConversationTest, TestVLLMStreamSplitEventAcrossCallbacks) {
+    auto [req, res] = make_async_context();
+
+    std::string test = std::string(R"(data: {"choices":[{"delta":{"content":"Hi"}}]})") + "\n\n" +
+                       R"(data: {"choices":[{"delta":{"content":" ther)";
+    std::string expected = std::string(R"(data: {"conversation_id":"test","message":"Hi"})") + "\n\n";
+    expect_stream_output(vLLMConversationModel::_async_write_callback, test, expected, req, res);
+
+    test = std::string(R"(e"}}]})") + "\n\n" + "data: [DONE]\n\n";
+    expected = std::string(R"(data: {"conversation_id":"test","message":" there"})") + "\n\n" +
+               "data: [DONE]\n\n";
+    expect_stream_output(vLLMConversationModel::_async_write_callback, test, expected, req, res);
 }
 
 TEST_F(ConversationTest, TestAzureStreamManipulation) {
-    std::shared_ptr<http_req> req = std::make_shared<http_req>();
-    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
-    ConversationModel::_add_async_conversation(req, "test");
+    auto [req, res] = make_async_context();
 
     // Test initial prompt filter results
     std::string test = "{\"choices\":[],\"created\":0,\"id\":\"\",\"model\":\"\",\"object\":\"\",\"prompt_filter_results\":[{\"prompt_index\":0,\"content_filter_results\":{\"hate\":{\"filtered\":false,\"severity\":\"safe\"},\"jailbreak\":{\"filtered\":false,\"detected\":false},\"self_harm\":{\"filtered\":false,\"severity\":\"safe\"},\"sexual\":{\"filtered\":false,\"severity\":\"safe\"},\"violence\":{\"filtered\":false,\"severity\":\"safe\"}}}]}";
 
     // This should be ignored as it has no content
     std::string expected = "";
-    AzureConversationModel::_async_write_callback(test, req, res);
-    ASSERT_EQ(test, expected);
+    expect_stream_output(AzureConversationModel::_async_write_callback, test, expected, req, res);
 }
 
 TEST_F(ConversationTest, TestAzureStreamBasicContent) {
-    std::shared_ptr<http_req> req = std::make_shared<http_req>();
-    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
-    ConversationModel::_add_async_conversation(req, "test");
+    auto [req, res] = make_async_context();
 
     // Test basic content streaming
     std::string test = std::string(R"(data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]})") + "\n\n";
     std::string expected = std::string(R"(data: {"conversation_id":"test","message":"Hello"})") + "\n\n";
-    AzureConversationModel::_async_write_callback(test, req, res);
-    ASSERT_EQ(test, expected);
+    expect_stream_output(AzureConversationModel::_async_write_callback, test, expected, req, res);
+}
+
+TEST_F(ConversationTest, TestAzureStreamSplitEventAcrossCallbacks) {
+    auto [req, res] = make_async_context();
+
+    std::string test = std::string(R"(data: {"choices":[{"delta":{"content":"Hel)");
+    std::string expected = "";
+    expect_stream_output(AzureConversationModel::_async_write_callback, test, expected, req, res);
+
+    test = std::string(R"(lo"},"finish_reason":"stop"}]})") + "\n\n";
+    expected = std::string(R"(data: {"conversation_id":"test","message":"Hello"})") + "\n\n" + "data: [DONE]\n\n";
+    expect_stream_output(AzureConversationModel::_async_write_callback, test, expected, req, res);
 }
 
 TEST_F(ConversationTest, TestAzureStreamEmptyMessages) {
-    std::shared_ptr<http_req> req = std::make_shared<http_req>();
-    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
-    ConversationModel::_add_async_conversation(req, "test");
+    auto [req, res] = make_async_context();
 
     // Test empty messages
     std::string test = std::string(R"(data: {"choices":[]})") + "\n\n";
     std::string expected = "";
-    AzureConversationModel::_async_write_callback(test, req, res);
-    ASSERT_EQ(test, expected);
+    expect_stream_output(AzureConversationModel::_async_write_callback, test, expected, req, res);
 
     // Test empty JSON object
     test = std::string(R"(data: {})") + "\n\n";
     expected = "";
-    AzureConversationModel::_async_write_callback(test, req, res);
-    ASSERT_EQ(test, expected);
+    expect_stream_output(AzureConversationModel::_async_write_callback, test, expected, req, res);
+}
+
+TEST_F(ConversationTest, TestAzureStreamDoneWithoutContent) {
+    auto [req, res] = make_async_context();
+
+    std::string test = "data: [DONE]\n\n";
+    std::string expected = "data: [DONE]\n\n";
+    expect_stream_output(AzureConversationModel::_async_write_callback, test, expected, req, res);
 }
 
 TEST_F(ConversationTest, TestAzureStreamRoleAssignment) {
-    std::shared_ptr<http_req> req = std::make_shared<http_req>();
-    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
-    ConversationModel::_add_async_conversation(req, "test");
+    auto [req, res] = make_async_context();
 
     // Test role assignment message
     std::string test = std::string(R"(data: {"choices":[{"delta":{"role":"assistant"},"finish_reason":null}]})") + "\n\n";
     std::string expected = "";
-    AzureConversationModel::_async_write_callback(test, req, res);
-    ASSERT_EQ(test, expected);
+    expect_stream_output(AzureConversationModel::_async_write_callback, test, expected, req, res);
 }
 
 TEST_F(ConversationTest, TestAzureStreamFinishReason) {
-    std::shared_ptr<http_req> req = std::make_shared<http_req>();
-    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
-    ConversationModel::_add_async_conversation(req, "test");
+    auto [req, res] = make_async_context();
 
     // Test finish reason with content
     std::string test = std::string(R"(data: {"choices":[{"delta":{"content":"Goodbye"},"finish_reason":"stop"}]})") + "\n\n";
     std::string expected = std::string(R"(data: {"conversation_id":"test","message":"Goodbye"})") + "\n\n" + "data: [DONE]\n\n";
-    AzureConversationModel::_async_write_callback(test, req, res);
-    ASSERT_EQ(test, expected);
+    expect_stream_output(AzureConversationModel::_async_write_callback, test, expected, req, res);
 }
 
 TEST_F(ConversationTest, TestAzureStreamMultipleChunks) {
-    std::shared_ptr<http_req> req = std::make_shared<http_req>();
-    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
-    ConversationModel::_add_async_conversation(req, "test");
+    auto [req, res] = make_async_context();
 
     // Test multiple content chunks
     std::string test = std::string(R"(data: {"choices":[{"delta":{"content":"Hello "},"finish_reason":null}]})") + "\n\n";
     std::string expected = std::string(R"(data: {"conversation_id":"test","message":"Hello "})") + "\n\n";
-    AzureConversationModel::_async_write_callback(test, req, res);
-    ASSERT_EQ(test, expected);
+    expect_stream_output(AzureConversationModel::_async_write_callback, test, expected, req, res);
 
     test = std::string(R"(data: {"choices":[{"delta":{"content":"World"},"finish_reason":"stop"}]})") + "\n\n";
     expected = std::string(R"(data: {"conversation_id":"test","message":"World"})") + "\n\n" + "data: [DONE]\n\n";
-    AzureConversationModel::_async_write_callback(test, req, res);
-    ASSERT_EQ(test, expected);
+    expect_stream_output(AzureConversationModel::_async_write_callback, test, expected, req, res);
 }
 
 TEST_F(ConversationTest, TestAzureStreamErrorHandling) {
-    std::shared_ptr<http_req> req = std::make_shared<http_req>();
-    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
-    ConversationModel::_add_async_conversation(req, "test");
+    auto [req, res] = make_async_context();
 
     // Test invalid JSON
     std::string test = std::string(R"(data: {invalid json})") + "\n\n";
     std::string expected = "";
-    AzureConversationModel::_async_write_callback(test, req, res);
-    ASSERT_EQ(test, expected);
+    expect_stream_output(AzureConversationModel::_async_write_callback, test, expected, req, res);
 
     // Test malformed content
     test = std::string(R"(data: {"choices":[{"delta":{},"finish_reason":null}]})") + "\n\n";
     expected = "";
-    AzureConversationModel::_async_write_callback(test, req, res);
-    ASSERT_EQ(test, expected);
+    expect_stream_output(AzureConversationModel::_async_write_callback, test, expected, req, res);
 }


### PR DESCRIPTION
## Change Summary
Fixes streamed conversation responses dropping tokens when upstream SSE events span curl callback boundaries.

This change adds per-request buffering for incomplete SSE fragments and updates the OpenAI, Cloudflare, vLLM, and Azure streaming parsers to process only complete SSE events. That prevents partial events from being silently discarded when curl delivers stream data across arbitrary buffer boundaries.

It also adds regression coverage for the split SSE events

Additionally, it tightens async completion signaling in the touched code paths by synchronizing ready updates before notifying the waiting thread.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
