### PR TITLE
update deduplicate logic and fix correctness with union search

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -202,8 +202,7 @@ struct search_args {
     bool validate_field_names;
     size_t found_count = 0;
     size_t found_docs = 0;
-    bool populate_union_result_seq_ids = false;
-    std::vector<uint32_t> union_result_seq_ids;
+    id_list_t* union_result_seq_ids = nullptr;
     Collection const *const collection;
 
     diversity_t diversity{};
@@ -228,7 +227,7 @@ struct search_args {
                 std::vector<facet_index_type_t>& facet_index_types, bool enable_typos_for_numerical_tokens,
                 bool enable_synonyms, bool demote_synonym_match, bool synonym_prefix, uint32_t synonym_num_typos,
                 bool enable_typos_for_alpha_numerical_tokens, bool rerank_hybrid_matches, const bool& validate_field_names,
-                bool populate_union_result_seq_ids, Collection const *const collection,
+                id_list_t* union_result_seq_ids, Collection const *const collection,
                 const std::vector<std::string>& synonym_sets, diversity_t&& diversity,
                 size_t group_max_candidates) :
             field_query_tokens(field_query_tokens),
@@ -257,7 +256,7 @@ struct search_args {
             demote_synonym_match(demote_synonym_match), synonym_prefix(synonym_prefix), synonym_num_typos(synonym_num_typos),
             enable_typos_for_alpha_numerical_tokens(enable_typos_for_alpha_numerical_tokens),
             rerank_hybrid_matches(rerank_hybrid_matches), validate_field_names(validate_field_names),
-            populate_union_result_seq_ids(populate_union_result_seq_ids),
+            union_result_seq_ids(union_result_seq_ids),
             collection(collection), synonym_sets(synonym_sets), diversity(diversity), group_max_candidates(group_max_candidates) {
 
     }
@@ -803,8 +802,7 @@ public:
                 std::set<uint32_t>& group_by_missing_value_ids,
                 Collection const *const collection,
                 const std::vector<std::string>& synonym_sets,
-                bool populate_union_result_seq_ids,
-                std::vector<uint32_t>& union_result_seq_ids,
+                id_list_t* union_result_seq_ids,
                 const diversity_t& diversity, const size_t group_max_candidates) const;
 
     void remove_field(uint32_t seq_id, nlohmann::json& document, const std::string& field_name,

--- a/include/index.h
+++ b/include/index.h
@@ -202,6 +202,8 @@ struct search_args {
     bool validate_field_names;
     size_t found_count = 0;
     size_t found_docs = 0;
+    bool populate_union_result_seq_ids = false;
+    std::vector<uint32_t> union_result_seq_ids;
     Collection const *const collection;
 
     diversity_t diversity{};
@@ -226,7 +228,8 @@ struct search_args {
                 std::vector<facet_index_type_t>& facet_index_types, bool enable_typos_for_numerical_tokens,
                 bool enable_synonyms, bool demote_synonym_match, bool synonym_prefix, uint32_t synonym_num_typos,
                 bool enable_typos_for_alpha_numerical_tokens, bool rerank_hybrid_matches, const bool& validate_field_names,
-                Collection const *const collection, const std::vector<std::string>& synonym_sets, diversity_t&& diversity,
+                bool populate_union_result_seq_ids, Collection const *const collection,
+                const std::vector<std::string>& synonym_sets, diversity_t&& diversity,
                 size_t group_max_candidates) :
             field_query_tokens(field_query_tokens),
             search_fields(search_fields), match_type(match_type), facets(facets),
@@ -254,6 +257,7 @@ struct search_args {
             demote_synonym_match(demote_synonym_match), synonym_prefix(synonym_prefix), synonym_num_typos(synonym_num_typos),
             enable_typos_for_alpha_numerical_tokens(enable_typos_for_alpha_numerical_tokens),
             rerank_hybrid_matches(rerank_hybrid_matches), validate_field_names(validate_field_names),
+            populate_union_result_seq_ids(populate_union_result_seq_ids),
             collection(collection), synonym_sets(synonym_sets), diversity(diversity), group_max_candidates(group_max_candidates) {
 
     }
@@ -799,8 +803,10 @@ public:
                 bool is_group_by_first_pass,
                 std::set<uint32_t>& group_by_missing_value_ids,
                 Collection const *const collection,
-               const std::vector<std::string>& synonym_sets,
-               const diversity_t& diversity, const size_t group_max_candidates) const;
+                const std::vector<std::string>& synonym_sets,
+                bool populate_union_result_seq_ids,
+                std::vector<uint32_t>& union_result_seq_ids,
+                const diversity_t& diversity, const size_t group_max_candidates) const;
 
     void remove_field(uint32_t seq_id, nlohmann::json& document, const std::string& field_name,
                       const bool is_update);

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -2832,7 +2832,7 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
                                                facet_index_types, enable_typos_for_numerical_tokens,
                                                enable_synonyms, demote_synonym_match, synonym_prefix, synonyms_num_typos,
                                                enable_typos_for_alpha_numerical_tokens, rerank_hybrid_matches,
-                                               validate_field_names, this, all_synonym_sets, std::move(diversity),
+                                               validate_field_names, is_union_search, this, all_synonym_sets, std::move(diversity),
                                                coll_args.group_max_candidates);
 
     return Option<bool>(true);
@@ -3788,24 +3788,30 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
 
     auto should_remove_duplicates = group_limit ? false : remove_duplicates;
 
+    if(should_remove_duplicates) {
+        std::unordered_set<uint64_t> unique_union_keys;
+        for (size_t search_index = 0; search_index < searches.size(); search_index++) {
+            const auto& seq_ids = search_params_guards[search_index]->union_result_seq_ids;
+            unique_union_keys.reserve(unique_union_keys.size() + seq_ids.size());
+            for(const auto& seq_id : seq_ids) {
+                unique_union_keys.insert(StringUtils::hash_combine(collection_ids[search_index], seq_id));
+            }
+        }
+        total = unique_union_keys.size();
+    }
+
     for (size_t search_index = 0; search_index < searches.size(); search_index++) {
         auto& search_param = search_params_guards[search_index];
 
         for (auto& kvs: search_param->raw_result_kvs) {
             Union_KV kv(*kvs[0], search_index, collection_ids[search_index], should_remove_duplicates);
-            auto ret = union_topster->add(&kv);
-            if(should_remove_duplicates && ret == 0) { //duplicate doc
-                total--;
-            }
+            union_topster->add(&kv);
         }
 
         //populate curations
         for(auto& kvs : search_param->curation_result_kvs) {
             Union_KV kv(*kvs[0], search_index, collection_ids[search_index], should_remove_duplicates);
-            auto ret = curations_topster->add(&kv);
-            if(should_remove_duplicates && ret == 0) { //duplicate doc
-                total--;
-            }
+            curations_topster->add(&kv);
         }
     }
 
@@ -3825,6 +3831,15 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
     std::vector<std::vector<Union_KV*>> merged_result_kvs;
     size_t curation_kv_index = 0;
     size_t raw_results_index = 0;
+    std::unordered_set<uint64_t> curated_union_keys;
+
+    if(should_remove_duplicates) {
+        curated_union_keys.reserve(curation_result_kvs.size());
+        for(const auto& kvs : curation_result_kvs) {
+            const auto* kv = kvs[0];
+            curated_union_keys.insert(StringUtils::hash_combine(kv->collection_id, kv->distinct_key));
+        }
+    }
 
     // merge raw results and curation results
     while(raw_results_index < raw_result_kvs.size()) {
@@ -3836,6 +3851,15 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
                 curation_kv->match_score_index = CURATED_RECORD_IDENTIFIER;
                 merged_result_kvs.push_back(curation_result_kvs[curation_kv_index]);
                 curation_kv_index++;
+                continue;
+            }
+        }
+
+        if(should_remove_duplicates) {
+            const auto* raw_kv = raw_result_kvs[raw_results_index][0];
+            const auto raw_union_key = StringUtils::hash_combine(raw_kv->collection_id, raw_kv->distinct_key);
+            if(curated_union_keys.count(raw_union_key) != 0) {
+                raw_results_index++;
                 continue;
             }
         }

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -2832,7 +2832,7 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
                                                facet_index_types, enable_typos_for_numerical_tokens,
                                                enable_synonyms, demote_synonym_match, synonym_prefix, synonyms_num_typos,
                                                enable_typos_for_alpha_numerical_tokens, rerank_hybrid_matches,
-                                               validate_field_names, is_union_search, this, all_synonym_sets, std::move(diversity),
+                                               validate_field_names, nullptr, this, all_synonym_sets, std::move(diversity),
                                                coll_args.group_max_candidates);
 
     return Option<bool>(true);
@@ -3613,7 +3613,9 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
     spp::sparse_hash_set<uint32_t> unique_collection_ids;
     long totalSearchTime = 0;
     auto group_limit = searches[0].group_limit;
+    auto should_remove_duplicates = group_limit ? false : remove_duplicates;
     auto found_docs = 0;
+    std::unordered_map<uint32_t, std::unique_ptr<id_list_t>> union_result_seq_ids_by_collection;
 
     for (size_t search_index = 0; search_index < searches.size(); search_index++) {
         auto begin = std::chrono::high_resolution_clock::now();
@@ -3649,6 +3651,16 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
                                                                                       true, search_index);
         if (!init_index_search_args_op.ok()) {
             return init_index_search_args_op;
+        }
+
+        if(should_remove_duplicates) {
+            auto [it, inserted] = union_result_seq_ids_by_collection.try_emplace(coll_id);
+            if(inserted) {
+                it->second = std::make_unique<id_list_t>(ids_t::MAX_BLOCK_ELEMENTS);
+            }
+            search_params_guard->union_result_seq_ids = it->second.get();
+        } else {
+            search_params_guard->union_result_seq_ids = nullptr;
         }
 
         const auto search_op = coll->run_search_with_lock(search_params_guard.get());
@@ -3786,18 +3798,11 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
     auto curations_topster = std::make_unique<Topster<Union_KV, Union_KV::get_key, Union_KV::get_distinct_key,
             Union_KV::is_greater, Union_KV::is_smaller>>(std::max<size_t>(union_params.fetch_size, Index::DEFAULT_TOPSTER_SIZE));
 
-    auto should_remove_duplicates = group_limit ? false : remove_duplicates;
-
     if(should_remove_duplicates) {
-        std::unordered_set<uint64_t> unique_union_keys;
-        for (size_t search_index = 0; search_index < searches.size(); search_index++) {
-            const auto& seq_ids = search_params_guards[search_index]->union_result_seq_ids;
-            unique_union_keys.reserve(unique_union_keys.size() + seq_ids.size());
-            for(const auto& seq_id : seq_ids) {
-                unique_union_keys.insert(StringUtils::hash_combine(collection_ids[search_index], seq_id));
-            }
+        total = 0;
+        for(const auto& entry : union_result_seq_ids_by_collection) {
+            total += entry.second->num_ids();
         }
-        total = unique_union_keys.size();
     }
 
     for (size_t search_index = 0; search_index < searches.size(); search_index++) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3640,6 +3640,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                 group_by_field_it_vec = get_group_by_field_iterators(group_by_fields, true);
             }
 
+            const auto comp_size = diversity.similarity_equation.empty() ? fetch_size : topster->MAX_SIZE;
             while (it.valid()) {
                 uint32_t seq_id = it.id();
                 uint64_t distinct_id = seq_id;
@@ -3655,14 +3656,19 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                     }
                 }
 
-                int64_t scores[3] = {0};
-                scores[0] = seq_id;
-                int64_t match_score_index = -1;
-
                 result_ids_size++;
                 if(union_result_seq_ids != nullptr) {
                     union_result_seq_ids->upsert(seq_id);
                 }
+
+                if(union_result_seq_ids != nullptr && group_limit == 0 && result_ids_size > comp_size) {
+                    it.previous();
+                    continue;
+                }
+
+                int64_t scores[3] = {0};
+                scores[0] = seq_id;
+                int64_t match_score_index = -1;
                 KV kv(searched_query_tokens.size(), seq_id, distinct_id, match_score_index, scores);
                 int ret = topster->add(&kv);
 
@@ -3670,7 +3676,6 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                     groups_processed[distinct_id]++;
                 }
 
-                const auto comp_size = diversity.similarity_equation.empty() ? fetch_size : topster->MAX_SIZE;
                 if (union_result_seq_ids == nullptr && result_ids_size == comp_size && group_limit == 0) {
                     break;
                 }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2583,6 +2583,8 @@ Option<bool> Index::run_search(search_args* search_params) {
                           group_by_missing_value_ids,
                           search_params->collection,
                           search_params->synonym_sets,
+                          search_params->populate_union_result_seq_ids,
+                          search_params->union_result_seq_ids,
                           search_params->diversity, search_params->group_max_candidates);
 
         // The filter iterator can be updated in places like `Index::do_phrase_search`.
@@ -2775,6 +2777,8 @@ Option<bool> Index::run_search(search_args* search_params) {
                   group_by_missing_value_ids,
                   search_params->collection,
                   search_params->synonym_sets,
+                  search_params->populate_union_result_seq_ids,
+                  search_params->union_result_seq_ids,
                   search_params->diversity,
                   search_params->group_max_candidates
     );
@@ -3516,7 +3520,8 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                    bool enable_typos_for_alpha_numerical_tokens, const size_t& max_filter_by_candidates,
                    bool rerank_hybrid_matches, const bool& validate_field_names, bool is_group_by_first_pass,
                    std::set<uint32_t>& group_by_missing_value_ids, Collection const *const collection,
-                   const std::vector<std::string>& synonym_sets,
+                   const std::vector<std::string>& synonym_sets, bool populate_union_result_seq_ids,
+                   std::vector<uint32_t>& union_result_seq_ids,
                    const diversity_t& diversity, const size_t group_max_candidates) const {
     std::shared_lock lock(mutex);
 
@@ -3672,6 +3677,9 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                 it.previous();
             }
 
+            if(populate_union_result_seq_ids) {
+                all_result_ids = seq_ids->uncompress();
+            }
             all_result_ids_len = seq_ids->num_ids();
             goto process_search_results;
         }
@@ -4538,6 +4546,22 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                   facet_infos, group_limit, group_by_fields, group_missing_values, top_k_curated_result_ids.data(),
                   top_k_curated_result_ids.size(), max_facet_values, is_wildcard_no_filter_query,
                   facet_index_types, is_group_by_first_pass, group_by_missing_value_ids, collection, &reference_facet_ids);
+    }
+
+    if(populate_union_result_seq_ids) {
+        union_result_seq_ids.clear();
+        union_result_seq_ids.reserve(all_result_ids_len + curated_topster->size);
+        if(all_result_ids_len != 0) {
+            union_result_seq_ids.insert(union_result_seq_ids.end(), all_result_ids, all_result_ids + all_result_ids_len);
+        }
+        for(uint32_t t = 0; t < curated_topster->size; t++) {
+            union_result_seq_ids.push_back(curated_topster->getKV(t)->key);
+        }
+        std::sort(union_result_seq_ids.begin(), union_result_seq_ids.end());
+        union_result_seq_ids.erase(std::unique(union_result_seq_ids.begin(), union_result_seq_ids.end()),
+                                   union_result_seq_ids.end());
+    } else {
+        union_result_seq_ids.clear();
     }
 
     all_result_ids_len += (is_group_by_first_pass ? 0 : curated_topster->size);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2584,7 +2584,6 @@ Option<bool> Index::run_search(search_args* search_params) {
                           group_by_missing_value_ids,
                           search_params->collection,
                           search_params->synonym_sets,
-                          search_params->populate_union_result_seq_ids,
                           search_params->union_result_seq_ids,
                           search_params->diversity, search_params->group_max_candidates);
 
@@ -2778,7 +2777,6 @@ Option<bool> Index::run_search(search_args* search_params) {
                   group_by_missing_value_ids,
                   search_params->collection,
                   search_params->synonym_sets,
-                  search_params->populate_union_result_seq_ids,
                   search_params->union_result_seq_ids,
                   search_params->diversity,
                   search_params->group_max_candidates
@@ -3520,8 +3518,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                    bool enable_typos_for_alpha_numerical_tokens, const size_t& max_filter_by_candidates,
                    bool rerank_hybrid_matches, const bool& validate_field_names, bool is_group_by_first_pass,
                    std::set<uint32_t>& group_by_missing_value_ids, Collection const *const collection,
-                   const std::vector<std::string>& synonym_sets, bool populate_union_result_seq_ids,
-                   std::vector<uint32_t>& union_result_seq_ids,
+                   const std::vector<std::string>& synonym_sets, id_list_t* union_result_seq_ids,
                    const diversity_t& diversity, const size_t group_max_candidates) const {
     std::shared_lock lock(mutex);
 
@@ -3635,7 +3632,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
             vector_query.field_name.empty() && sort_fields_std.size() == 1 &&
             sort_fields_std[0].name == sort_field_const::seq_id && sort_fields_std[0].order == sort_field_const::desc) {
             // optimize for this path specifically
-            std::vector<uint32_t> result_ids;
+            size_t result_ids_size = 0;
             auto it = seq_ids->new_rev_iterator();
 
             std::vector<group_by_field_it_t> group_by_field_it_vec;
@@ -3662,7 +3659,10 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                 scores[0] = seq_id;
                 int64_t match_score_index = -1;
 
-                result_ids.push_back(seq_id);
+                result_ids_size++;
+                if(union_result_seq_ids != nullptr) {
+                    union_result_seq_ids->upsert(seq_id);
+                }
                 KV kv(searched_query_tokens.size(), seq_id, distinct_id, match_score_index, scores);
                 int ret = topster->add(&kv);
 
@@ -3671,16 +3671,13 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                 }
 
                 const auto comp_size = diversity.similarity_equation.empty() ? fetch_size : topster->MAX_SIZE;
-                if (result_ids.size() == comp_size && group_limit == 0) {
+                if (union_result_seq_ids == nullptr && result_ids_size == comp_size && group_limit == 0) {
                     break;
                 }
 
                 it.previous();
             }
 
-            if(populate_union_result_seq_ids) {
-                all_result_ids = seq_ids->uncompress();
-            }
             all_result_ids_len = seq_ids->num_ids();
             goto process_search_results;
         }
@@ -4552,20 +4549,16 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                   facet_index_types, is_group_by_first_pass, group_by_missing_value_ids, collection, &reference_facet_ids);
     }
 
-    if(populate_union_result_seq_ids) {
-        union_result_seq_ids.clear();
-        union_result_seq_ids.reserve(all_result_ids_len + curated_topster->size);
-        if(all_result_ids_len != 0) {
-            union_result_seq_ids.insert(union_result_seq_ids.end(), all_result_ids, all_result_ids + all_result_ids_len);
+    if(union_result_seq_ids != nullptr) {
+        if(all_result_ids != nullptr) {
+            for(size_t i = 0; i < all_result_ids_len; i++) {
+                union_result_seq_ids->upsert(all_result_ids[i]);
+            }
         }
+
         for(uint32_t t = 0; t < curated_topster->size; t++) {
-            union_result_seq_ids.push_back(curated_topster->getKV(t)->key);
+            union_result_seq_ids->upsert(curated_topster->getKV(t)->key);
         }
-        std::sort(union_result_seq_ids.begin(), union_result_seq_ids.end());
-        union_result_seq_ids.erase(std::unique(union_result_seq_ids.begin(), union_result_seq_ids.end()),
-                                   union_result_seq_ids.end());
-    } else {
-        union_result_seq_ids.clear();
     }
 
     all_result_ids_len += (is_group_by_first_pass ? 0 : curated_topster->size);

--- a/test/collection_test.cpp
+++ b/test/collection_test.cpp
@@ -602,6 +602,27 @@ TEST_F(CollectionTest, WildcardQuery) {
     ASSERT_EQ(0, results["found"]);
 }
 
+TEST_F(CollectionTest, WildcardSeqIdDescShouldRemainStableAcrossPages) {
+    std::vector<sort_by> seq_id_desc_sort = { sort_by(sort_field_const::seq_id, sort_field_const::desc) };
+
+    auto page1 = collection->search("*", {}, "", {}, seq_id_desc_sort, {0}, 5, 1, FREQUENCY, {false}).get();
+    auto page2 = collection->search("*", {}, "", {}, seq_id_desc_sort, {0}, 5, 2, FREQUENCY, {false}).get();
+
+    ASSERT_EQ(25, page1["found"].get<uint32_t>());
+    ASSERT_EQ(25, page2["found"].get<uint32_t>());
+    ASSERT_EQ(5, page1["hits"].size());
+    ASSERT_EQ(5, page2["hits"].size());
+
+    std::set<std::string> page1_ids;
+    for(const auto& hit : page1["hits"]) {
+        page1_ids.insert(hit["document"]["id"].get<std::string>());
+    }
+
+    for(const auto& hit : page2["hits"]) {
+        ASSERT_EQ(0, page1_ids.count(hit["document"]["id"].get<std::string>()));
+    }
+}
+
 TEST_F(CollectionTest, PrefixSearching) {
     std::vector<std::string> facets;
     nlohmann::json results = collection->search("ex", query_fields, "", facets, sort_fields, {0}, 10, 1, FREQUENCY, {true}).get();

--- a/test/union_test.cpp
+++ b/test/union_test.cpp
@@ -1304,6 +1304,121 @@ TEST_F(UnionTest, CurationIncludesShouldNotCollapseInUnion) {
     ASSERT_EQ("1", json_res["hits"][1]["document"]["id"]);
 }
 
+TEST_F(UnionTest, RemoveDuplicatesShouldDeduplicateAcrossCuratedAndRawUnionHits) {
+    auto schema_json =
+            R"({
+                "name": "Events",
+                "fields": [
+                    {"name": "title", "type": "string"}
+                ]
+            })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto coll = collection_create_op.get();
+
+    ASSERT_TRUE(coll->add(R"({"id":"0","title":"march madness winner"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"1","title":"regular season recap"})").ok());
+
+    auto& curation_manager = CurationIndexManager::get_instance();
+    curation_manager.init_store(store);
+    auto upsert_set = nlohmann::json::array({
+        nlohmann::json{
+            {"id", "march-madness"},
+            {"rule", {{"query", "march madness"}, {"match", curation_t::MATCH_EXACT}}},
+            {"includes", nlohmann::json::array({
+                nlohmann::json{{"id", "0"}, {"position", 1}}
+            })}
+        }
+    });
+    ASSERT_TRUE(curation_manager.upsert_curation_set("events_curations", upsert_set).ok());
+    ASSERT_TRUE(coll->set_curation_sets({"events_curations"}).ok());
+
+    req_params = {{"remove_duplicates", "true"}};
+    embedded_params = std::vector<nlohmann::json>(2, nlohmann::json::object());
+    searches = R"([
+                    {
+                        "collection": "Events",
+                        "q": "march madness",
+                        "query_by": "title"
+                    },
+                    {
+                        "collection": "Events",
+                        "q": "winner",
+                        "query_by": "title"
+                    }
+                ])"_json;
+
+    auto search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    ASSERT_EQ(1, json_res["found"].get<size_t>());
+    ASSERT_EQ(1, json_res["hits"].size());
+    ASSERT_EQ("0", json_res["hits"][0]["document"]["id"]);
+}
+
+TEST_F(UnionTest, RemoveDuplicatesShouldNotLeakCuratedRawDuplicateToLaterPages) {
+    auto schema_json =
+            R"({
+                "name": "Events",
+                "fields": [
+                    {"name": "title", "type": "string"}
+                ]
+            })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto coll = collection_create_op.get();
+
+    ASSERT_TRUE(coll->add(R"({"id":"0","title":"march madness winner"})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"1","title":"april recap"})").ok());
+
+    auto& curation_manager = CurationIndexManager::get_instance();
+    curation_manager.init_store(store);
+    auto upsert_set = nlohmann::json::array({
+        nlohmann::json{
+            {"id", "march-madness"},
+            {"rule", {{"query", "march madness"}, {"match", curation_t::MATCH_EXACT}}},
+            {"includes", nlohmann::json::array({
+                nlohmann::json{{"id", "0"}, {"position", 1}}
+            })}
+        }
+    });
+    ASSERT_TRUE(curation_manager.upsert_curation_set("events_curations", upsert_set).ok());
+    ASSERT_TRUE(coll->set_curation_sets({"events_curations"}).ok());
+
+    req_params = {
+        {"remove_duplicates", "true"},
+        {"per_page", "1"},
+        {"page", "1"}
+    };
+    embedded_params = std::vector<nlohmann::json>(2, nlohmann::json::object());
+    searches = R"([
+                    {
+                        "collection": "Events",
+                        "q": "march madness",
+                        "query_by": "title"
+                    },
+                    {
+                        "collection": "Events",
+                        "q": "winner",
+                        "query_by": "title"
+                    }
+                ])"_json;
+
+    auto search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(1, json_res["found"].get<size_t>());
+    ASSERT_EQ(1, json_res["hits"].size());
+    ASSERT_EQ("0", json_res["hits"][0]["document"]["id"]);
+
+    req_params["page"] = "2";
+    search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(1, json_res["found"].get<size_t>());
+    ASSERT_TRUE(json_res["hits"].empty());
+}
+
 TEST_F(UnionTest, HybridSearchHasVectorDistance) {
     nlohmann::json schema = R"({
         "name": "coll1",
@@ -1518,6 +1633,56 @@ TEST_F(UnionTest, GroupingWithUnions) {
     ASSERT_EQ(400, json_res["code"]);
     ASSERT_EQ(1, json_res.count("error"));
     ASSERT_EQ("Invalid group_by searches count. All searches with union search should be uniform.", json_res["error"]);
+}
+
+TEST_F(UnionTest, UnionRemoveDuplicatesFoundCountShouldBePageInvariant) {
+    auto schema = R"({
+        "name": "coll1",
+        "fields": [
+            {"name": "name", "type": "string"}
+        ]
+    })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto coll1 = collection_create_op.get();
+
+    for(uint32_t i = 0; i < 300; i++) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["name"] = "ghost monster item " + std::to_string(i);
+        auto add_op = coll1->add(doc.dump());
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    auto embedded_params = std::vector<nlohmann::json>(2, nlohmann::json::object());
+    searches = R"([
+                    {
+                        "collection": "coll1",
+                        "q": "ghost",
+                        "query_by": "name"
+                    },
+                    {
+                        "collection": "coll1",
+                        "q": "monster",
+                        "query_by": "name"
+                    }
+                ])"_json;
+
+    req_params = {
+        {"remove_duplicates", "true"},
+        {"per_page", "10"},
+        {"page", "1"}
+    };
+
+    auto search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(300, json_res["found"].get<size_t>());
+
+    req_params["page"] = "2";
+    search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(300, json_res["found"].get<size_t>());
 }
 
 TEST_F(UnionTest, FacetingWithUnion) {


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->

### Union count computation

The union search flow now computes `found` using per-search sequence ID sets collected during search execution:

- `search_args` now carries `populate_union_result_seq_ids`
- union searches enable that flag
- `Index::search` populates `union_result_seq_ids` only when requested
- `Collection::do_union` computes `found` from the unique union of `(collection_id, seq_id)`

This makes `found` stable across pages.

### Curated-vs-raw duplicate handling

The union merge step now gives curated hits precedence when `remove_duplicates=true`:

- curated union keys are collected before merging
- raw hits whose `(collection_id, distinct_key)` already exists in curated hits are skipped during merge

This keeps returned hits consistent with the deduplicated `found` count.

### Wildcard fast path restoration

The wildcard optimized path was adjusted so that full seq-id expansion only happens when union accounting explicitly requests it:

- non-union wildcard `_seq_id:desc` searches keep the cheap path
- union searches still collect the full seq-id set when needed for dedup count computation

## Tests Added

### Union correctness tests

Added regression coverage for:

- curated hit + raw hit resolving to the same document under union dedup
- page 2 staying empty when only one deduplicated result exists
- `found` remaining page-invariant for overlapping union queries

Relevant tests are in:

- `test/union_test.cpp`

### Wildcard path coverage

Added a public-surface wildcard pagination test to keep coverage on the `_seq_id:desc` optimized path:

- `CollectionTest.WildcardSeqIdDescShouldRemainStableAcrossPages`

Relevant test file:

- `test/collection_test.cpp`

## Result

After these changes:

- union `found` is page-invariant
- curated/raw duplicates no longer leak into merged union results
- the wildcard `_seq_id:desc` fast path is no longer penalized for normal searches

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
