### PR TITLE
fix: strip vector fields, hit metadata and handle grouped_hits in conversation mode

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -992,6 +992,8 @@ public:
 
     Option<nlohmann::json> search(collection_search_args_t& coll_args);
 
+    nlohmann::json preprocess_result_docs_for_conversation(const nlohmann::json& result_hits) const;
+
     // Only for tests.
     Option<nlohmann::json> search(std::string query, const std::vector<std::string> & search_fields,
                                   const std::string & filter_query, const std::vector<std::string> & facet_fields,

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -3461,6 +3461,37 @@ Option<nlohmann::json> Collection::search(collection_search_args_t& coll_args) {
     return Option<nlohmann::json>(result);
 }
 
+nlohmann::json Collection::preprocess_result_docs_for_conversation(const nlohmann::json& result_hits) const {
+    nlohmann::json result_docs = nlohmann::json::array();
+    if(!result_hits.is_array()) {
+        return result_docs;
+    }
+
+    std::shared_lock lock(mutex);
+    std::vector<std::string> vector_fields;
+
+    for(const auto& schema_field : search_schema) {
+        if(schema_field.type == field_types::FLOAT_ARRAY) {
+            vector_fields.push_back(schema_field.name);
+        }
+    }
+    for(const auto& hit : result_hits) {
+        if(!hit.is_object() || !hit.contains("document")) {
+            continue;
+        }
+
+        auto doc = hit["document"];
+        for(const auto& vector_field : vector_fields) {
+            if(doc.contains(vector_field)) {
+                doc.erase(vector_field);
+            }
+        }
+        result_docs.push_back(std::move(doc));
+    }
+
+    return result_docs;
+}
+
 void Collection::do_highlighting(const tsl::htrie_map<char, field>& search_schema, const bool& enable_nested_fields,
                                  const std::vector<char>& symbols_to_index, const std::vector<char>& token_separators,
                                  const string& query, const std::vector<std::string>& raw_search_fields,

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -76,39 +76,6 @@ bool get_alter_in_progress(const std::string& collection) {
     return alters_in_progress.count(collection) != 0;
 }
 
-std::vector<std::string> get_vector_fields(const std::shared_ptr<Collection>& collection) {
-    std::vector<std::string> vector_fields;
-    if(collection == nullptr) {
-        return vector_fields;
-    }
-
-    auto search_schema = collection->get_schema();
-    for(const auto& field : search_schema) {
-        if(field.type == field_types::FLOAT_ARRAY) {
-            vector_fields.push_back(field.name);
-        }
-    }
-
-    return vector_fields;
-}
-
-nlohmann::json get_result_docs_without_vector_fields(const nlohmann::json& hits,
-                                                            const std::vector<std::string>& vector_fields) {
-    nlohmann::json result_docs = nlohmann::json::array();
-
-    for(const auto& hit : hits) {
-        auto doc = hit["document"];
-        for(const auto& vector_field : vector_fields) {
-            if(doc.contains(vector_field)) {
-                doc.erase(vector_field);
-            }
-        }
-        result_docs.push_back(doc);
-    }
-
-    return result_docs;
-}
-
 bool handle_authentication(std::map<std::string, std::string>& req_params,
                            std::vector<nlohmann::json>& embedded_params_vec,
                            const std::string& body,
@@ -776,15 +743,16 @@ bool get_search(const std::shared_ptr<http_req>& req, const std::shared_ptr<http
         results_json["conversation"]["query"] = query;
 
         auto collection = CollectionManager::get_instance().get_collection(req->params["collection"]);
-        auto vector_fields = get_vector_fields(collection);
         nlohmann::json docs_array = nlohmann::json::array();
-        if(results_json.contains("grouped_hits")) {
-            for(const auto& grouped_hit : results_json["grouped_hits"]) {
-                auto group_docs = get_result_docs_without_vector_fields(grouped_hit["hits"], vector_fields);
-                docs_array.insert(docs_array.end(), group_docs.begin(), group_docs.end());
+        if(collection != nullptr) {
+            if(results_json.contains("grouped_hits")) {
+                for(const auto& grouped_hit : results_json["grouped_hits"]) {
+                    auto group_docs = collection->preprocess_result_docs_for_conversation(grouped_hit["hits"]);
+                    docs_array.insert(docs_array.end(), group_docs.begin(), group_docs.end());
+                }
+            } else {
+                docs_array = collection->preprocess_result_docs_for_conversation(results_json["hits"]);
             }
-        } else {
-            docs_array = get_result_docs_without_vector_fields(results_json["hits"], vector_fields);
         }
 
         auto conversation_model = ConversationModelManager::get_model(conversation_model_id).get();
@@ -1216,15 +1184,18 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
                 auto collection = collection_name_it == result["request_params"].end() || !collection_name_it->is_string()
                                   ? nullptr
                                   : CollectionManager::get_instance().get_collection(collection_name_it->get<std::string>());
-                auto vector_fields = get_vector_fields(collection);
+                if(collection == nullptr) {
+                    continue;
+                }
+
                 nlohmann::json result_docs = nlohmann::json::array();
                 if(result.contains("grouped_hits")) {
                     for(const auto& grouped_hit : result["grouped_hits"]) {
-                        auto group_docs = get_result_docs_without_vector_fields(grouped_hit["hits"], vector_fields);
+                        auto group_docs = collection->preprocess_result_docs_for_conversation(grouped_hit["hits"]);
                         result_docs.insert(result_docs.end(), group_docs.begin(), group_docs.end());
                     }
                 } else {
-                    result_docs = get_result_docs_without_vector_fields(result["hits"], vector_fields);
+                    result_docs = collection->preprocess_result_docs_for_conversation(result["hits"]);
                 }
 
                 result_docs_arr.push_back(result_docs);
@@ -1333,7 +1304,6 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
             response["conversation"]["conversation_history"] = conversation_history;
         }
         response["conversation"]["conversation_id"] = add_conversation_op.get();
-
     }
 
     std::string response_str = response.dump();

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -76,6 +76,39 @@ bool get_alter_in_progress(const std::string& collection) {
     return alters_in_progress.count(collection) != 0;
 }
 
+static std::vector<std::string> get_vector_fields(const std::shared_ptr<Collection>& collection) {
+    std::vector<std::string> vector_fields;
+    if(collection == nullptr) {
+        return vector_fields;
+    }
+
+    auto search_schema = collection->get_schema();
+    for(const auto& field : search_schema) {
+        if(field.type == field_types::FLOAT_ARRAY) {
+            vector_fields.push_back(field.name);
+        }
+    }
+
+    return vector_fields;
+}
+
+static nlohmann::json get_result_docs_without_vector_fields(const nlohmann::json& hits,
+                                                            const std::vector<std::string>& vector_fields) {
+    nlohmann::json result_docs = nlohmann::json::array();
+
+    for(const auto& hit : hits) {
+        auto doc = hit["document"];
+        for(const auto& vector_field : vector_fields) {
+            if(doc.contains(vector_field)) {
+                doc.erase(vector_field);
+            }
+        }
+        result_docs.push_back(doc);
+    }
+
+    return result_docs;
+}
+
 bool handle_authentication(std::map<std::string, std::string>& req_params,
                            std::vector<nlohmann::json>& embedded_params_vec,
                            const std::string& body,
@@ -742,42 +775,16 @@ bool get_search(const std::shared_ptr<http_req>& req, const std::shared_ptr<http
         results_json["conversation"] = nlohmann::json::object();
         results_json["conversation"]["query"] = query;
 
-        nlohmann::json docs_array = nlohmann::json::array();
-
-        // Collect vector fields to strip from documents
-        std::vector<std::string> vector_fields;
         auto collection = CollectionManager::get_instance().get_collection(req->params["collection"]);
-        if(collection != nullptr) {
-            auto search_schema = collection->get_schema();
-            for(const auto& field : search_schema) {
-                if(field.type == field_types::FLOAT_ARRAY) {
-                    vector_fields.push_back(field.name);
-                }
-            }
-        }
-
+        auto vector_fields = get_vector_fields(collection);
+        nlohmann::json docs_array = nlohmann::json::array();
         if(results_json.contains("grouped_hits")) {
             for(const auto& grouped_hit : results_json["grouped_hits"]) {
-                for(const auto& hit : grouped_hit["hits"]) {
-                    auto doc = hit["document"];
-                    for(const auto& vector_field : vector_fields) {
-                        if(doc.contains(vector_field)) {
-                            doc.erase(vector_field);
-                        }
-                    }
-                    docs_array.push_back(doc);
-                }
+                auto group_docs = get_result_docs_without_vector_fields(grouped_hit["hits"], vector_fields);
+                docs_array.insert(docs_array.end(), group_docs.begin(), group_docs.end());
             }
         } else {
-            for(const auto& hit : results_json["hits"]) {
-                auto doc = hit["document"];
-                for(const auto& vector_field : vector_fields) {
-                    if(doc.contains(vector_field)) {
-                        doc.erase(vector_field);
-                    }
-                }
-                docs_array.push_back(doc);
-            }
+            docs_array = get_result_docs_without_vector_fields(results_json["hits"], vector_fields);
         }
 
         auto conversation_model = ConversationModelManager::get_model(conversation_model_id).get();
@@ -1205,45 +1212,19 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
                     continue;
                 }
 
-                nlohmann::json result_docs = nlohmann::json::array();
-                std::vector<std::string> vector_fields;
-
                 auto collection_name_it = result["request_params"].find("collection_name");
                 auto collection = collection_name_it == result["request_params"].end() || !collection_name_it->is_string()
                                   ? nullptr
                                   : CollectionManager::get_instance().get_collection(collection_name_it->get<std::string>());
-                if(collection != nullptr) {
-                    auto search_schema = collection->get_schema();
-                    for(const auto& field : search_schema) {
-                        if(field.type == field_types::FLOAT_ARRAY) {
-                            vector_fields.push_back(field.name);
-                        }
-                    }
-                }
-
+                auto vector_fields = get_vector_fields(collection);
+                nlohmann::json result_docs = nlohmann::json::array();
                 if(result.contains("grouped_hits")) {
                     for(const auto& grouped_hit : result["grouped_hits"]) {
-                        for(const auto& hit : grouped_hit["hits"]) {
-                            auto doc = hit["document"];
-                            for(const auto& vector_field : vector_fields) {
-                                if(doc.contains(vector_field)) {
-                                    doc.erase(vector_field);
-                                }
-                            }
-                            result_docs.push_back(doc);
-                        }
+                        auto group_docs = get_result_docs_without_vector_fields(grouped_hit["hits"], vector_fields);
+                        result_docs.insert(result_docs.end(), group_docs.begin(), group_docs.end());
                     }
-                }
-                else {
-                    for(const auto& hit : result["hits"]) {
-                        auto doc = hit["document"];
-                        for(const auto& vector_field : vector_fields) {
-                            if(doc.contains(vector_field)) {
-                                doc.erase(vector_field);
-                            }
-                        }
-                        result_docs.push_back(doc);
-                    }
+                } else {
+                    result_docs = get_result_docs_without_vector_fields(result["hits"], vector_fields);
                 }
 
                 result_docs_arr.push_back(result_docs);

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -744,8 +744,40 @@ bool get_search(const std::shared_ptr<http_req>& req, const std::shared_ptr<http
 
         nlohmann::json docs_array = nlohmann::json::array();
 
-        if(results_json.count("hits") != 0 && results_json["hits"].is_array()) {
-            docs_array = results_json["hits"];
+        // Collect vector fields to strip from documents
+        std::vector<std::string> vector_fields;
+        auto collection = CollectionManager::get_instance().get_collection(req->params["collection"]);
+        if(collection != nullptr) {
+            auto search_schema = collection->get_schema();
+            for(const auto& field : search_schema) {
+                if(field.type == field_types::FLOAT_ARRAY) {
+                    vector_fields.push_back(field.name);
+                }
+            }
+        }
+
+        if(results_json.contains("grouped_hits")) {
+            for(const auto& grouped_hit : results_json["grouped_hits"]) {
+                for(const auto& hit : grouped_hit["hits"]) {
+                    auto doc = hit["document"];
+                    for(const auto& vector_field : vector_fields) {
+                        if(doc.contains(vector_field)) {
+                            doc.erase(vector_field);
+                        }
+                    }
+                    docs_array.push_back(doc);
+                }
+            }
+        } else {
+            for(const auto& hit : results_json["hits"]) {
+                auto doc = hit["document"];
+                for(const auto& vector_field : vector_fields) {
+                    if(doc.contains(vector_field)) {
+                        doc.erase(vector_field);
+                    }
+                }
+                docs_array.push_back(doc);
+            }
         }
 
         auto conversation_model = ConversationModelManager::get_model(conversation_model_id).get();

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -76,7 +76,7 @@ bool get_alter_in_progress(const std::string& collection) {
     return alters_in_progress.count(collection) != 0;
 }
 
-static std::vector<std::string> get_vector_fields(const std::shared_ptr<Collection>& collection) {
+std::vector<std::string> get_vector_fields(const std::shared_ptr<Collection>& collection) {
     std::vector<std::string> vector_fields;
     if(collection == nullptr) {
         return vector_fields;
@@ -92,7 +92,7 @@ static std::vector<std::string> get_vector_fields(const std::shared_ptr<Collecti
     return vector_fields;
 }
 
-static nlohmann::json get_result_docs_without_vector_fields(const nlohmann::json& hits,
+nlohmann::json get_result_docs_without_vector_fields(const nlohmann::json& hits,
                                                             const std::vector<std::string>& vector_fields) {
     nlohmann::json result_docs = nlohmann::json::array();
 

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -777,6 +777,76 @@ TEST_F(CollectionManagerTest, QuerySuggestionsShouldBeTrimmed) {
     collectionManager.drop_collection("coll1");
 }
 
+TEST_F(CollectionManagerTest, CollectionPreprocessesConversationResultDocs) {
+    nlohmann::json conversation_schema = R"({
+        "name": "conversation_docs",
+        "fields": [
+            {"name": "title", "type": "string"},
+            {"name": "brand", "type": "string", "facet": true},
+            {"name": "points", "type": "int32"},
+            {"name": "embedding", "type": "float[]", "num_dim": 2}
+        ],
+        "default_sorting_field": "points"
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(conversation_schema);
+    ASSERT_TRUE(create_op.ok());
+    auto conversation_coll = create_op.get();
+
+    ASSERT_TRUE(conversation_coll->add(R"({
+        "id": "1",
+        "title": "duck story",
+        "brand": "acme",
+        "points": 30,
+        "embedding": [0.1, 0.2]
+    })").ok());
+    ASSERT_TRUE(conversation_coll->add(R"({
+        "id": "2",
+        "title": "duck facts",
+        "brand": "acme",
+        "points": 20,
+        "embedding": [0.2, 0.3]
+    })").ok());
+    ASSERT_TRUE(conversation_coll->add(R"({
+        "id": "3",
+        "title": "duck recipes",
+        "brand": "beta",
+        "points": 10,
+        "embedding": [0.3, 0.4]
+    })").ok());
+
+    std::map<std::string, std::string> req_params = {
+        {"collection", "conversation_docs"},
+        {"q", "duck"},
+        {"query_by", "title"},
+        {"group_by", "brand"},
+        {"group_limit", "2"}
+    };
+    nlohmann::json embedded_params = nlohmann::json::object();
+    std::string json_res;
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, 0);
+    ASSERT_TRUE(search_op.ok());
+
+    auto results = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, results["grouped_hits"].size());
+    ASSERT_TRUE(results["grouped_hits"][0]["hits"][0]["document"].contains("embedding"));
+
+    nlohmann::json conversation_result_docs = nlohmann::json::array();
+    for(const auto& grouped_hit : results["grouped_hits"]) {
+        auto group_docs = conversation_coll->preprocess_result_docs_for_conversation(grouped_hit["hits"]);
+        conversation_result_docs.insert(conversation_result_docs.end(), group_docs.begin(), group_docs.end());
+    }
+
+    ASSERT_EQ(3, conversation_result_docs.size());
+    ASSERT_EQ("1", conversation_result_docs[0]["id"]);
+    ASSERT_EQ("2", conversation_result_docs[1]["id"]);
+    ASSERT_EQ("3", conversation_result_docs[2]["id"]);
+    ASSERT_FALSE(conversation_result_docs[0].contains("embedding"));
+    ASSERT_FALSE(conversation_result_docs[1].contains("embedding"));
+    ASSERT_FALSE(conversation_result_docs[2].contains("embedding"));
+}
+
 TEST_F(CollectionManagerTest, NoHitsQueryAggregation) {
     std::vector<field> fields = {field("title", field_types::STRING, false, false, true, "", -1, 1),
                                  field("year", field_types::INT32, false),


### PR DESCRIPTION
## Change Summary

The `GET /documents/search` conversation branch was sending raw hit objects to the conversation model, unlike the `POST /multi_search` path which extracts only document bodies and strips vector fields. This caused two issues:

1. **Vector fields and hit metadata sent to model**: The conversation prompt included `FLOAT_ARRAY` embedding vectors, `highlight`, `highlights`, `text_match`, and `text_match_info`, polluting the prompt with irrelevant data.

2. **Grouped search results invisible to model**: When `group_by` is used, results are returned under `grouped_hits` instead of `hits`. The conversation branch only read `hits`, so the model received an empty `[]` even though the search found results.

Both fixes align the `GET /documents/search` conversation path with the existing `POST /multi_search` conversation path.
## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
