### PR TITLE
fix: handle union response in post_multi_search for conversations

### DIFF
--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -227,6 +227,8 @@ public:
                                        filter_result_t& filter_result,
                                        const bool& should_timeout = true, const bool& validate_field_names = true);
 
+    static nlohmann::json preprocess_union_hits_for_conversation(const nlohmann::json& hits);
+
     bool is_referenced_in_any(const std::string& referenced_coll_name) const;
 
     Option<reference_info_t> is_referenced_in(const std::string& referenced_coll_name,

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -2875,3 +2875,37 @@ void CollectionManager::lock_nested_referencing_collections(const std::string& c
     std::set<std::string> referencing_collections{coll_name};
     lock_nested_referencing_collections_helper(coll_name, cascade_tree, referencing_collections);
 }
+
+nlohmann::json CollectionManager::preprocess_union_hits_for_conversation(const nlohmann::json& hits) {
+    nlohmann::json result_docs = nlohmann::json::array();
+    if(!hits.is_array()) {
+        return result_docs;
+    }
+
+    std::unordered_map<std::string, nlohmann::json> collection_to_hits;
+    for(const auto& hit : hits) {
+        if(!hit.is_object() || !hit.contains("document")) {
+            continue;
+        }
+
+        auto collection_name_it = hit.find("collection");
+        if(collection_name_it == hit.end() || !collection_name_it->is_string()) {
+            result_docs.push_back(hit["document"]);
+            continue;
+        }
+
+        collection_to_hits[collection_name_it->get<std::string>()].push_back(hit);
+    }
+
+    for(const auto& [collection_name, coll_hits] : collection_to_hits) {
+        auto collection = CollectionManager::get_instance().get_collection(collection_name);
+        if(collection == nullptr) {
+            continue;
+        }
+
+        auto group_docs = collection->preprocess_result_docs_for_conversation(coll_hits);
+        result_docs.insert(result_docs.end(), group_docs.begin(), group_docs.end());
+    }
+
+    return result_docs;
+}

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -1188,33 +1188,36 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
     if(conversation) {
         nlohmann::json result_docs_arr = nlohmann::json::array();
         if(is_union && response.contains("hits") && response["hits"].is_array()) {
-            // Union response has top-level hits, not a results[] array.
-            // Gather vector fields from all collections involved in the union.
-            std::vector<std::string> vector_fields;
-            for(const auto& search : searches) {
-                if(search.contains("collection") && search["collection"].is_string()) {
-                    auto coll = CollectionManager::get_instance().get_collection(search["collection"].get<std::string>());
-                    if(coll != nullptr) {
-                        for(const auto& field : coll->get_schema()) {
-                            if(field.type == field_types::FLOAT_ARRAY) {
-                                vector_fields.push_back(field.name);
-                            }
-                        }
-                    }
+            nlohmann::json result_docs = nlohmann::json::array();
+            std::unordered_map<std::string, nlohmann::json> collection_to_hits;
+            nlohmann::json current_group_hits = nlohmann::json::array();
+            for(const auto& hit : response["hits"]) {
+                if(!hit.is_object() || !hit.contains("document")) {
+                    continue;
                 }
+
+                auto collection_name_it = hit.find("collection");
+                if(collection_name_it == hit.end() || !collection_name_it->is_string()) {
+                    // if collection not found, directly insert the hit to the result_docs
+                    auto doc = hit["document"];
+                    result_docs.push_back(doc);
+                }
+
+                const auto hit_collection_name = collection_name_it->get<std::string>();
+                collection_to_hits[hit_collection_name].push_back(hit);
+            }
+            for(const auto& [collection_name, hits] : collection_to_hits) {
+                auto collection = CollectionManager::get_instance().get_collection(collection_name);
+                if(collection == nullptr) {
+                    continue;
+                }
+
+                auto group_docs = collection->preprocess_result_docs_for_conversation(hits);
+                result_docs.insert(result_docs.end(), group_docs.begin(), group_docs.end());
             }
 
-            nlohmann::json result_docs = nlohmann::json::array();
-            for(const auto& hit : response["hits"]) {
-                auto doc = hit["document"];
-                for(const auto& vector_field : vector_fields) {
-                    if(doc.contains(vector_field)) {
-                        doc.erase(vector_field);
-                    }
-                }
-                result_docs.push_back(doc);
-            }
             result_docs_arr.push_back(result_docs);
+
         } else if(response.contains("results") && response["results"].is_array()) {
             for(const auto& result : response["results"]) {
                 if(result.count("code") != 0) {

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -1187,33 +1187,20 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
 
     if(conversation) {
         nlohmann::json result_docs_arr = nlohmann::json::array();
-        if(is_union && response.contains("hits") && response["hits"].is_array()) {
+        if(is_union && ((response.contains("hits") && response["hits"].is_array()) ||
+                        (response.contains("grouped_hits") && response["grouped_hits"].is_array()))) {
             nlohmann::json result_docs = nlohmann::json::array();
-            std::unordered_map<std::string, nlohmann::json> collection_to_hits;
-            for(const auto& hit : response["hits"]) {
-                if(!hit.is_object() || !hit.contains("document")) {
-                    continue;
-                }
+            if(response.contains("grouped_hits") && response["grouped_hits"].is_array()) {
+                for(const auto& grouped_hit : response["grouped_hits"]) {
+                    if(!grouped_hit.is_object() || !grouped_hit.contains("hits") || !grouped_hit["hits"].is_array()) {
+                        continue;
+                    }
 
-                auto collection_name_it = hit.find("collection");
-                if(collection_name_it == hit.end() || !collection_name_it->is_string()) {
-                    // if collection not found, directly insert the hit to the result_docs
-                    auto doc = hit["document"];
-                    result_docs.push_back(doc);
-                    continue;
+                    auto group_docs = CollectionManager::preprocess_union_hits_for_conversation(grouped_hit["hits"]);
+                    result_docs.insert(result_docs.end(), group_docs.begin(), group_docs.end());
                 }
-
-                const auto hit_collection_name = collection_name_it->get<std::string>();
-                collection_to_hits[hit_collection_name].push_back(hit);
-            }
-            for(const auto& [collection_name, hits] : collection_to_hits) {
-                auto collection = CollectionManager::get_instance().get_collection(collection_name);
-                if(collection == nullptr) {
-                    continue;
-                }
-
-                auto group_docs = collection->preprocess_result_docs_for_conversation(hits);
-                result_docs.insert(result_docs.end(), group_docs.begin(), group_docs.end());
+            } else {
+                result_docs = CollectionManager::preprocess_union_hits_for_conversation(response["hits"]);
             }
 
             result_docs_arr.push_back(result_docs);

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -1187,63 +1187,62 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
 
     if(conversation) {
         nlohmann::json result_docs_arr = nlohmann::json::array();
-        if(response.contains("hits") && response["hits"].is_array()) {
-            if(is_union) {
+        if(is_union && response.contains("hits") && response["hits"].is_array()) {
+            nlohmann::json result_docs = nlohmann::json::array();
+            std::unordered_map<std::string, nlohmann::json> collection_to_hits;
+            for(const auto& hit : response["hits"]) {
+                if(!hit.is_object() || !hit.contains("document")) {
+                    continue;
+                }
+
+                auto collection_name_it = hit.find("collection");
+                if(collection_name_it == hit.end() || !collection_name_it->is_string()) {
+                    // if collection not found, directly insert the hit to the result_docs
+                    auto doc = hit["document"];
+                    result_docs.push_back(doc);
+                    continue;
+                }
+
+                const auto hit_collection_name = collection_name_it->get<std::string>();
+                collection_to_hits[hit_collection_name].push_back(hit);
+            }
+            for(const auto& [collection_name, hits] : collection_to_hits) {
+                auto collection = CollectionManager::get_instance().get_collection(collection_name);
+                if(collection == nullptr) {
+                    continue;
+                }
+
+                auto group_docs = collection->preprocess_result_docs_for_conversation(hits);
+                result_docs.insert(result_docs.end(), group_docs.begin(), group_docs.end());
+            }
+
+            result_docs_arr.push_back(result_docs);
+
+        } else if(!is_union && response.contains("results") && response["results"].is_array()) {
+            for(const auto& result : response["results"]) {
+                if(result.count("code") != 0) {
+                    continue;
+                }
+
+                auto collection_name_it = result["request_params"].find("collection_name");
+                auto collection = (collection_name_it == result["request_params"].end() || !collection_name_it->is_string())
+                                  ? nullptr
+                                  : CollectionManager::get_instance().get_collection(collection_name_it->get<std::string>());
+                if(collection == nullptr) {
+                    continue;
+                }
+
                 nlohmann::json result_docs = nlohmann::json::array();
-                std::unordered_map<std::string, nlohmann::json> collection_to_hits;
-                for(const auto& hit : response["hits"]) {
-                    if(!hit.is_object() || !hit.contains("document")) {
-                        continue;
+                if(result.contains("grouped_hits")) {
+                    for(const auto& grouped_hit : result["grouped_hits"]) {
+                        auto group_docs = collection->preprocess_result_docs_for_conversation(grouped_hit["hits"]);
+                        result_docs.insert(result_docs.end(), group_docs.begin(), group_docs.end());
                     }
-    
-                    auto collection_name_it = hit.find("collection");
-                    if(collection_name_it == hit.end() || !collection_name_it->is_string()) {
-                        // if collection not found, directly insert the hit to the result_docs
-                        auto doc = hit["document"];
-                        result_docs.push_back(doc);
-                    }
-    
-                    const auto hit_collection_name = collection_name_it->get<std::string>();
-                    collection_to_hits[hit_collection_name].push_back(hit);
+                } else {
+                    result_docs = collection->preprocess_result_docs_for_conversation(result["hits"]);
                 }
-                for(const auto& [collection_name, hits] : collection_to_hits) {
-                    auto collection = CollectionManager::get_instance().get_collection(collection_name);
-                    if(collection == nullptr) {
-                        continue;
-                    }
-    
-                    auto group_docs = collection->preprocess_result_docs_for_conversation(hits);
-                    result_docs.insert(result_docs.end(), group_docs.begin(), group_docs.end());
-                }
-    
+
                 result_docs_arr.push_back(result_docs);
-    
-            } else {
-                for(const auto& result : response["results"]) {
-                    if(result.count("code") != 0) {
-                        continue;
-                    }
-    
-                    auto collection_name_it = result["request_params"].find("collection_name");
-                    auto collection = collection_name_it == result["request_params"].end() || !collection_name_it->is_string()
-                                      ? nullptr
-                                      : CollectionManager::get_instance().get_collection(collection_name_it->get<std::string>());
-                    if(collection == nullptr) {
-                        continue;
-                    }
-    
-                    nlohmann::json result_docs = nlohmann::json::array();
-                    if(result.contains("grouped_hits")) {
-                        for(const auto& grouped_hit : result["grouped_hits"]) {
-                            auto group_docs = collection->preprocess_result_docs_for_conversation(grouped_hit["hits"]);
-                            result_docs.insert(result_docs.end(), group_docs.begin(), group_docs.end());
-                        }
-                    } else {
-                        result_docs = collection->preprocess_result_docs_for_conversation(result["hits"]);
-                    }
-    
-                    result_docs_arr.push_back(result_docs);
-                }
             }
         }
 

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -1190,7 +1190,6 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
         if(is_union && response.contains("hits") && response["hits"].is_array()) {
             nlohmann::json result_docs = nlohmann::json::array();
             std::unordered_map<std::string, nlohmann::json> collection_to_hits;
-            nlohmann::json current_group_hits = nlohmann::json::array();
             for(const auto& hit : response["hits"]) {
                 if(!hit.is_object() || !hit.contains("document")) {
                     continue;

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -1187,61 +1187,63 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
 
     if(conversation) {
         nlohmann::json result_docs_arr = nlohmann::json::array();
-        if(is_union && response.contains("hits") && response["hits"].is_array()) {
-            nlohmann::json result_docs = nlohmann::json::array();
-            std::unordered_map<std::string, nlohmann::json> collection_to_hits;
-            for(const auto& hit : response["hits"]) {
-                if(!hit.is_object() || !hit.contains("document")) {
-                    continue;
-                }
-
-                auto collection_name_it = hit.find("collection");
-                if(collection_name_it == hit.end() || !collection_name_it->is_string()) {
-                    // if collection not found, directly insert the hit to the result_docs
-                    auto doc = hit["document"];
-                    result_docs.push_back(doc);
-                }
-
-                const auto hit_collection_name = collection_name_it->get<std::string>();
-                collection_to_hits[hit_collection_name].push_back(hit);
-            }
-            for(const auto& [collection_name, hits] : collection_to_hits) {
-                auto collection = CollectionManager::get_instance().get_collection(collection_name);
-                if(collection == nullptr) {
-                    continue;
-                }
-
-                auto group_docs = collection->preprocess_result_docs_for_conversation(hits);
-                result_docs.insert(result_docs.end(), group_docs.begin(), group_docs.end());
-            }
-
-            result_docs_arr.push_back(result_docs);
-
-        } else if(response.contains("results") && response["results"].is_array()) {
-            for(const auto& result : response["results"]) {
-                if(result.count("code") != 0) {
-                    continue;
-                }
-
-                auto collection_name_it = result["request_params"].find("collection_name");
-                auto collection = collection_name_it == result["request_params"].end() || !collection_name_it->is_string()
-                                  ? nullptr
-                                  : CollectionManager::get_instance().get_collection(collection_name_it->get<std::string>());
-                if(collection == nullptr) {
-                    continue;
-                }
-
+        if(response.contains("hits") && response["hits"].is_array()) {
+            if(is_union) {
                 nlohmann::json result_docs = nlohmann::json::array();
-                if(result.contains("grouped_hits")) {
-                    for(const auto& grouped_hit : result["grouped_hits"]) {
-                        auto group_docs = collection->preprocess_result_docs_for_conversation(grouped_hit["hits"]);
-                        result_docs.insert(result_docs.end(), group_docs.begin(), group_docs.end());
+                std::unordered_map<std::string, nlohmann::json> collection_to_hits;
+                for(const auto& hit : response["hits"]) {
+                    if(!hit.is_object() || !hit.contains("document")) {
+                        continue;
                     }
-                } else {
-                    result_docs = collection->preprocess_result_docs_for_conversation(result["hits"]);
+    
+                    auto collection_name_it = hit.find("collection");
+                    if(collection_name_it == hit.end() || !collection_name_it->is_string()) {
+                        // if collection not found, directly insert the hit to the result_docs
+                        auto doc = hit["document"];
+                        result_docs.push_back(doc);
+                    }
+    
+                    const auto hit_collection_name = collection_name_it->get<std::string>();
+                    collection_to_hits[hit_collection_name].push_back(hit);
                 }
-
+                for(const auto& [collection_name, hits] : collection_to_hits) {
+                    auto collection = CollectionManager::get_instance().get_collection(collection_name);
+                    if(collection == nullptr) {
+                        continue;
+                    }
+    
+                    auto group_docs = collection->preprocess_result_docs_for_conversation(hits);
+                    result_docs.insert(result_docs.end(), group_docs.begin(), group_docs.end());
+                }
+    
                 result_docs_arr.push_back(result_docs);
+    
+            } else {
+                for(const auto& result : response["results"]) {
+                    if(result.count("code") != 0) {
+                        continue;
+                    }
+    
+                    auto collection_name_it = result["request_params"].find("collection_name");
+                    auto collection = collection_name_it == result["request_params"].end() || !collection_name_it->is_string()
+                                      ? nullptr
+                                      : CollectionManager::get_instance().get_collection(collection_name_it->get<std::string>());
+                    if(collection == nullptr) {
+                        continue;
+                    }
+    
+                    nlohmann::json result_docs = nlohmann::json::array();
+                    if(result.contains("grouped_hits")) {
+                        for(const auto& grouped_hit : result["grouped_hits"]) {
+                            auto group_docs = collection->preprocess_result_docs_for_conversation(grouped_hit["hits"]);
+                            result_docs.insert(result_docs.end(), group_docs.begin(), group_docs.end());
+                        }
+                    } else {
+                        result_docs = collection->preprocess_result_docs_for_conversation(result["hits"]);
+                    }
+    
+                    result_docs_arr.push_back(result_docs);
+                }
             }
         }
 

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -1167,7 +1167,35 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
 
     if(conversation) {
         nlohmann::json result_docs_arr = nlohmann::json::array();
-        if(response.contains("results") && response["results"].is_array()) {
+        if(is_union && response.contains("hits") && response["hits"].is_array()) {
+            // Union response has top-level hits, not a results[] array.
+            // Gather vector fields from all collections involved in the union.
+            std::vector<std::string> vector_fields;
+            for(const auto& search : searches) {
+                if(search.contains("collection") && search["collection"].is_string()) {
+                    auto coll = CollectionManager::get_instance().get_collection(search["collection"].get<std::string>());
+                    if(coll != nullptr) {
+                        for(const auto& field : coll->get_schema()) {
+                            if(field.type == field_types::FLOAT_ARRAY) {
+                                vector_fields.push_back(field.name);
+                            }
+                        }
+                    }
+                }
+            }
+
+            nlohmann::json result_docs = nlohmann::json::array();
+            for(const auto& hit : response["hits"]) {
+                auto doc = hit["document"];
+                for(const auto& vector_field : vector_fields) {
+                    if(doc.contains(vector_field)) {
+                        doc.erase(vector_field);
+                    }
+                }
+                result_docs.push_back(doc);
+            }
+            result_docs_arr.push_back(result_docs);
+        } else if(response.contains("results") && response["results"].is_array()) {
             for(const auto& result : response["results"]) {
                 if(result.count("code") != 0) {
                     continue;

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -858,6 +858,80 @@ TEST_F(CollectionManagerTest, CollectionPreprocessesConversationResultDocs) {
     ASSERT_FALSE(conversation_result_docs[2].contains("embedding"));
 }
 
+TEST_F(CollectionManagerTest, PreprocessUnionHitsForConversation) {
+    nlohmann::json schema_a = R"({
+        "name": "union_docs_a",
+        "fields": [
+            {"name": "title", "type": "string"},
+            {"name": "points", "type": "int32"},
+            {"name": "embedding", "type": "float[]", "num_dim": 2}
+        ],
+        "default_sorting_field": "points"
+    })"_json;
+
+    nlohmann::json schema_b = R"({
+        "name": "union_docs_b",
+        "fields": [
+            {"name": "title", "type": "string"},
+            {"name": "points", "type": "int32"},
+            {"name": "embedding", "type": "float[]", "num_dim": 2}
+        ],
+        "default_sorting_field": "points"
+    })"_json;
+
+    auto coll_a = collectionManager.create_collection(schema_a).get();
+    auto coll_b = collectionManager.create_collection(schema_b).get();
+
+    ASSERT_TRUE(coll_a->add(R"({
+        "id": "a1", "title": "duck story", "points": 30, "embedding": [0.1, 0.2]
+    })").ok());
+    ASSERT_TRUE(coll_b->add(R"({
+        "id": "b1", "title": "duck facts", "points": 20, "embedding": [0.2, 0.3]
+    })").ok());
+
+    // hits from a grouped_hits entry: each hit carries its source collection
+    nlohmann::json union_hits = nlohmann::json::array();
+    union_hits.push_back(nlohmann::json{
+        {"collection", "union_docs_a"},
+        {"document", {{"id", "a1"}, {"title", "duck story"}, {"points", 30}, {"embedding", {0.1, 0.2}}}}
+    });
+    union_hits.push_back(nlohmann::json{
+        {"collection", "union_docs_b"},
+        {"document", {{"id", "b1"}, {"title", "duck facts"}, {"points", 20}, {"embedding", {0.2, 0.3}}}}
+    });
+    // hit without a collection field should be kept as-is (the raw document)
+    union_hits.push_back(nlohmann::json{
+        {"document", {{"id", "x1"}, {"title", "orphan"}}}
+    });
+    // hit whose collection does not exist should be dropped
+    union_hits.push_back(nlohmann::json{
+        {"collection", "missing_coll"},
+        {"document", {{"id", "m1"}, {"title", "missing"}}}
+    });
+
+    auto result_docs = CollectionManager::preprocess_union_hits_for_conversation(union_hits);
+
+    ASSERT_EQ(3, result_docs.size());
+
+    std::map<std::string, nlohmann::json> docs_by_id;
+    for(const auto& doc : result_docs) {
+        docs_by_id[doc["id"].get<std::string>()] = doc;
+    }
+    ASSERT_EQ(1, docs_by_id.count("a1"));
+    ASSERT_EQ(1, docs_by_id.count("b1"));
+    ASSERT_EQ(1, docs_by_id.count("x1"));
+    ASSERT_EQ(0, docs_by_id.count("m1"));
+
+    // embedding is stripped for hits routed through a known collection
+    ASSERT_FALSE(docs_by_id["a1"].contains("embedding"));
+    ASSERT_FALSE(docs_by_id["b1"].contains("embedding"));
+
+    // non-array input returns empty array
+    auto empty_result = CollectionManager::preprocess_union_hits_for_conversation(nlohmann::json::object());
+    ASSERT_TRUE(empty_result.is_array());
+    ASSERT_EQ(0, empty_result.size());
+}
+
 TEST_F(CollectionManagerTest, NoHitsQueryAggregation) {
     std::vector<field> fields = {field("title", field_types::STRING, false, false, true, "", -1, 1),
                                  field("year", field_types::INT32, false),


### PR DESCRIPTION
## Change Summary

`POST /multi_search` with `union=true&conversation=true` was sending empty data to the conversation model. `CollectionManager::do_union()` writes results as top-level `hits`, not a `results[]` array. The conversation post-processing only iterated `response["results"]`, which doesn't exist in union responses, so the model always received `[]`.

The fix adds a dedicated branch for the union case that reads documents from the top-level `hits` array and gathers vector fields from all collections involved in the union.

## Test Plan

- Started a dummy model server (`test/dummy_model_server.py`) that logs the full request body received from Typesense
- **Without fix**: `POST /multi_search?conversation=true&union=true` with two searches against `hnstories`, the model received `[]` (empty data) even though the union search found hits. The response also contained `"results": null`
- **With fix**: The model receives the hits correctly for the same request

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X]  I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
