### PR TITLE
support facet_return_parent for reference facets

### DIFF
--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -60,7 +60,8 @@ private:
         return "";
     }
 
-    static Option<bool> validate_facet_params(const std::vector<collection_search_args_t>& coll_searches);
+    static Option<bool> validate_facet_params(const std::vector<collection_search_args_t>& coll_searches,
+                                              const std::vector<std::shared_ptr<Collection>>& collections);
 
 public:
     static constexpr const size_t DEFAULT_NUM_MEMORY_SHARDS = 4;

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -4888,17 +4888,31 @@ nlohmann::json Collection::get_parent_object(const nlohmann::json& parent, const
                                  const std::vector<std::string>& field_path, size_t field_index,
                                  const std::string& val) {
     if(field_index == field_path.size()) {
-        std::string str_val;
+        auto json_to_facet_str = [](const nlohmann::json& value) -> std::string {
+            if(value.is_string()) {
+                return value.get<std::string>();
+            }
 
-        if(child.is_string()) {
-            str_val = child.get<std::string>();
-        } else if(child.is_number_integer()) {
-            str_val = std::to_string(child.get<int>());
-        } else if(child.is_number_float()) {
-            str_val = std::to_string(child.get<float>());
-        }  else if(child.is_boolean()) {
-            str_val = std::to_string(child.get<bool>());
-        }
+            if(value.is_number_integer()) {
+                return std::to_string(value.get<int64_t>());
+            }
+
+            if(value.is_number_unsigned()) {
+                return std::to_string(value.get<uint64_t>());
+            }
+
+            if(value.is_number_float()) {
+                return StringUtils::float_to_str(value.get<float>());
+            }
+
+            if(value.is_boolean()) {
+                return value.get<bool>() ? "true" : "false";
+            }
+
+            return "";
+        };
+
+        const auto str_val = json_to_facet_str(child);
 
         if(str_val == val) {
             return parent;
@@ -4906,7 +4920,7 @@ nlohmann::json Collection::get_parent_object(const nlohmann::json& parent, const
 
         if(child.is_array()) {
             for(const auto& ele: child) {
-                if(ele.is_string() && ele == val) {
+                if(json_to_facet_str(ele) == val) {
                     return parent;
                 }
             }
@@ -9519,15 +9533,17 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
                 }
 
                 nlohmann::json parent;
-                if(the_field.nested && should_return_parent) {
+                const bool is_reference_facet = !a_facet.reference_collection_name.empty();
+                if(should_return_parent && (the_field.nested || is_reference_facet)) {
+                    const Collection* parent_collection = is_reference_facet ? ref_collection.get() : this;
                     nlohmann::json document;
-                    const std::string &seq_id_key = get_seq_id_key((uint32_t) facet_count.doc_id);
-                    const Option<bool> &document_op = get_document_from_store(seq_id_key, document);
+                    const std::string& seq_id_key = parent_collection->get_seq_id_key((uint32_t) facet_count.doc_id);
+                    const Option<bool>& document_op = parent_collection->get_document_from_store(seq_id_key, document);
                     if (!document_op.ok()) {
                         LOG(ERROR) << "Facet fetch error. " << document_op.error();
                         continue;
                     }
-                    parent = get_facet_parent(the_field.name, document, value, the_field.is_array());
+                    parent = parent_collection->get_facet_parent(the_field.name, document, value, the_field.is_array());
                 }
 
                 const auto& highlighted_text = highlight.snippets.empty() ? value : highlight.snippets[0];

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -9366,6 +9366,10 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
             facet_result["field_name"] = "$" + a_facet.reference_collection_name + "(" + a_facet.field_name + ")";
         }
 
+        if(is_union && !a_facet.reference_collection_name.empty()) {
+            facet_result["merge_key"] = "$" + a_facet.reference_collection_name + "(" + a_facet.field_name + ")";
+        }
+
         std::vector<facet_value_t> facet_values;
         std::vector<facet_count_t> facet_counts;
 
@@ -9657,23 +9661,23 @@ Option<bool> Collection::merge_facet_results(nlohmann::json& result) {
 
         //first pass : merge all results by field
         for(const auto& facet_count : result["facet_counts"]) {
+            const auto merge_key = facet_count.value("merge_key", facet_count["field_name"]).get<std::string>();
+            const auto field_name = facet_count["field_name"].get<std::string>();
             for(const auto& count : facet_count["counts"]) {
-                const auto& field_name = facet_count["field_name"];
-
-                if(field_to_facet_counts.find(field_name) == field_to_facet_counts.end()) {
-                    field_to_facet_counts[field_name]["counts"] = nlohmann::json::array();
-                    field_to_facet_counts[field_name]["field_name"] = field_name;
-                    field_to_facet_counts[field_name]["sampled"] = facet_count["sampled"];
-                    field_to_facet_counts[field_name]["is_sortby_alpha"] = facet_count["is_sortby_alpha"];
-                    field_to_facet_counts[field_name]["sort_order"] = facet_count["sort_order"];
-                    field_to_facet_counts[field_name]["is_dynamic"] = facet_count.value("is_dynamic", false);
+                if(field_to_facet_counts.find(merge_key) == field_to_facet_counts.end()) {
+                    field_to_facet_counts[merge_key]["counts"] = nlohmann::json::array();
+                    field_to_facet_counts[merge_key]["field_name"] = field_name;
+                    field_to_facet_counts[merge_key]["sampled"] = facet_count["sampled"];
+                    field_to_facet_counts[merge_key]["is_sortby_alpha"] = facet_count["is_sortby_alpha"];
+                    field_to_facet_counts[merge_key]["sort_order"] = facet_count["sort_order"];
+                    field_to_facet_counts[merge_key]["is_dynamic"] = facet_count.value("is_dynamic", false);
                 } else {
-                    field_to_facet_counts[field_name]["is_dynamic"] =
-                        field_to_facet_counts[field_name]["is_dynamic"].get<bool>() &&
+                    field_to_facet_counts[merge_key]["is_dynamic"] =
+                        field_to_facet_counts[merge_key]["is_dynamic"].get<bool>() &&
                         facet_count.value("is_dynamic", false);
                 }
 
-                field_to_facet_counts[field_name]["counts"].push_back(count);
+                field_to_facet_counts[merge_key]["counts"].push_back(count);
             }
         }
 
@@ -9728,10 +9732,11 @@ Option<bool> Collection::merge_facet_results(nlohmann::json& result) {
                                  });
             }
 
-            result["facet_counts"].clear();
-            for (const auto& kv: field_to_facet_counts) {
-                result["facet_counts"].push_back(kv.second);
-            }
+        }
+
+        result["facet_counts"].clear();
+        for (const auto& kv: field_to_facet_counts) {
+            result["facet_counts"].push_back(kv.second);
         }
     }
     return Option<bool>(true);

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1555,9 +1555,10 @@ void remove_global_params(std::map<std::string, std::string>& req_params) {
     }
 }
 
-Option<bool> CollectionManager::validate_facet_params(const std::vector<collection_search_args_t>& coll_searches) {
+Option<bool> CollectionManager::validate_facet_params(const std::vector<collection_search_args_t>& coll_searches,
+                                                      const std::vector<std::shared_ptr<Collection>>& collections) {
     struct facet_field_parent {
-        std::string facet_field;
+        std::string facet_signature;
         bool should_return_parent;
     };
 
@@ -1566,8 +1567,27 @@ Option<bool> CollectionManager::validate_facet_params(const std::vector<collecti
     const auto& facet_min_occurrence_ratio = coll_searches[0].facet_min_occurrence_ratio;
     spp::sparse_hash_map<std::string, facet_field_parent> field_to_facet_field_map;
     std::string generic_error = " should be uniform across searches for faceting with union search.";
+    auto facet_signature = [](const facet& a_facet) {
+        std::stringstream ss;
+        ss << a_facet.field_name
+           << "|ref:" << a_facet.reference_collection_name
+           << "|range:" << a_facet.is_range_query
+           << "|alpha:" << a_facet.is_sort_by_alpha
+           << "|order:" << a_facet.sort_order
+           << "|sort:" << a_facet.sort_field
+           << "|topk:" << a_facet.is_top_k;
 
-    for(const auto& args : coll_searches) {
+        if(a_facet.is_range_query) {
+            for(const auto& kv : a_facet.facet_range_map) {
+                ss << "|bucket:" << kv.first << ":" << kv.second.lower_range << ":" << kv.second.range_label;
+            }
+        }
+
+        return ss.str();
+    };
+
+    for(size_t search_index = 0; search_index < coll_searches.size(); search_index++) {
+        const auto& args = coll_searches[search_index];
         if(args.facet_fields.empty()) {
             continue;
         }
@@ -1584,30 +1604,37 @@ Option<bool> CollectionManager::validate_facet_params(const std::vector<collecti
             return Option<bool>(400, "`facet_min_occurrence_ratio`" + generic_error);
         }
 
+        auto collection = collections[search_index];
+        if(collection == nullptr) {
+            return Option<bool>(404, "Collection not found while validating union facet params.");
+        }
+
         for(const auto& field : args.facet_fields) {
-            std::string field_name = field;
-
-            auto pos = field_name.find("(");
-            field_name = field_name.substr(0, pos);
-
-            auto should_return_parent = false;
-            for(const auto& val : args.facet_return_parent) {
-                if(val == "*" || val == field_name) {
-                    should_return_parent = true;
-                    break;
-                }
+            std::vector<facet> parsed_facets;
+            auto parse_op = collection->parse_facet_with_lock(field, parsed_facets);
+            if(!parse_op.ok()) {
+                return parse_op;
             }
 
-            auto it1 = field_to_facet_field_map.find(field_name);
+            for(const auto& a_facet : parsed_facets) {
+                const auto& field_name = a_facet.field_name;
+                const auto signature = facet_signature(a_facet);
+                const auto should_return_parent =
+                    args.facet_return_parent.size() == 1 && args.facet_return_parent[0] == "*" ||
+                    std::find(args.facet_return_parent.begin(), args.facet_return_parent.end(), field_name) !=
+                        args.facet_return_parent.end();
 
-            if (it1 != field_to_facet_field_map.end()) {
-                if(field != it1->second.facet_field) {
-                    return Option<bool>(400, "facet fields" + generic_error);
-                } else if(it1->second.should_return_parent != should_return_parent) {
-                    return Option<bool>(400, "`facet_return_parent`" + generic_error);
+                auto it1 = field_to_facet_field_map.find(field_name);
+
+                if (it1 != field_to_facet_field_map.end()) {
+                    if(signature != it1->second.facet_signature) {
+                        return Option<bool>(400, "facet fields" + generic_error);
+                    } else if(it1->second.should_return_parent != should_return_parent) {
+                        return Option<bool>(400, "`facet_return_parent`" + generic_error);
+                    }
+                } else {
+                    field_to_facet_field_map[field_name] = facet_field_parent{signature, should_return_parent};
                 }
-            } else {
-                field_to_facet_field_map[field_name] = facet_field_parent{field, should_return_parent};
             }
         }
     }
@@ -1630,6 +1657,7 @@ Option<bool> CollectionManager::do_union(std::map<std::string, std::string>& req
     auto const orig_req_params = req_params;
     std::vector<collection_search_args_t> coll_searches;
     std::vector<uint32_t> collection_ids;
+    std::vector<std::shared_ptr<Collection>> union_collections;
     auto result_op = Option<bool>(true);
     auto group_by_args_count = 0;
 
@@ -1693,6 +1721,7 @@ Option<bool> CollectionManager::do_union(std::map<std::string, std::string>& req
         args.curation_union_global_params(union_params);
         coll_searches.emplace_back(std::move(args));
         collection_ids.emplace_back(collection->get_collection_id());
+        union_collections.emplace_back(collection);
     }
 
     if(result_op.ok() && group_by_args_count > 0 && group_by_args_count != searches.size()) {
@@ -1700,7 +1729,7 @@ Option<bool> CollectionManager::do_union(std::map<std::string, std::string>& req
     }
 
     if (result_op.ok()) {
-        result_op = validate_facet_params(coll_searches);
+        result_op = validate_facet_params(coll_searches, union_collections);
     }
 
     if (!result_op.ok()) {

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1572,8 +1572,11 @@ Option<bool> CollectionManager::validate_facet_params(const std::vector<collecti
     const auto& facet_strategy = coll_searches[0].facet_strategy;
     const auto& simple_facet_query = coll_searches[0].simple_facet_query;
     const auto& facet_min_occurrence_ratio = coll_searches[0].facet_min_occurrence_ratio;
-    spp::sparse_hash_map<std::string, facet_field_parent> field_to_facet_field_map;
+    spp::sparse_hash_map<std::string, facet_field_parent> facet_identity_to_facet_field_map;
     std::string generic_error = " should be uniform across searches for faceting with union search.";
+    auto facet_identity = [](const facet& a_facet) {
+        return a_facet.field_name + "|ref:" + a_facet.reference_collection_name;
+    };
     auto facet_signature = [](const facet& a_facet) {
         std::stringstream ss;
         ss << a_facet.field_name
@@ -1616,6 +1619,14 @@ Option<bool> CollectionManager::validate_facet_params(const std::vector<collecti
             return Option<bool>(404, "Collection not found while validating union facet params.");
         }
 
+        auto normalized_facet_return_parent = args.facet_return_parent;
+        if(!normalized_facet_return_parent.empty()) {
+            auto facet_return_parent_op = collection->process_facet_return_parent(normalized_facet_return_parent);
+            if(!facet_return_parent_op.ok()) {
+                return facet_return_parent_op;
+            }
+        }
+
         for(const auto& field : args.facet_fields) {
             std::vector<facet> parsed_facets;
             auto parse_op = collection->parse_facet_with_lock(field, parsed_facets);
@@ -1624,23 +1635,24 @@ Option<bool> CollectionManager::validate_facet_params(const std::vector<collecti
             }
 
             for(const auto& a_facet : parsed_facets) {
-                const auto& field_name = a_facet.field_name;
+                const auto field_identity = facet_identity(a_facet);
                 const auto signature = facet_signature(a_facet);
                 const auto should_return_parent =
-                    args.facet_return_parent.size() == 1 && args.facet_return_parent[0] == "*" ||
-                    std::find(args.facet_return_parent.begin(), args.facet_return_parent.end(), field_name) !=
-                        args.facet_return_parent.end();
+                    normalized_facet_return_parent.size() == 1 && normalized_facet_return_parent[0] == "*" ||
+                    std::find(normalized_facet_return_parent.begin(), normalized_facet_return_parent.end(),
+                              a_facet.field_name) != normalized_facet_return_parent.end();
 
-                auto it1 = field_to_facet_field_map.find(field_name);
+                auto it1 = facet_identity_to_facet_field_map.find(field_identity);
 
-                if (it1 != field_to_facet_field_map.end()) {
+                if (it1 != facet_identity_to_facet_field_map.end()) {
                     if(signature != it1->second.facet_signature) {
                         return Option<bool>(400, "facet fields" + generic_error);
                     } else if(it1->second.should_return_parent != should_return_parent) {
                         return Option<bool>(400, "`facet_return_parent`" + generic_error);
                     }
                 } else {
-                    field_to_facet_field_map[field_name] = facet_field_parent{signature, should_return_parent};
+                    facet_identity_to_facet_field_map[field_identity] =
+                        facet_field_parent{signature, should_return_parent};
                 }
             }
         }

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -10389,6 +10389,61 @@ TEST_F(CollectionJoinTest, FacetByReference) {
             {"collection", "Products"},
             {"q", "*"},
             {"filter_by", "$Customers(customer_id: customer_a)"},
+            {"facet_by", "$Customers(product_price)"},
+            {"facet_return_parent", "*"}
+    };
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, res_obj["facet_counts"][0]["counts"].size());
+    ASSERT_EQ("143", res_obj["facet_counts"][0]["counts"][0]["value"].get<std::string>());
+    ASSERT_EQ("customer_a", res_obj["facet_counts"][0]["counts"][0]["parent"]["customer_id"]);
+    ASSERT_EQ("Joe", res_obj["facet_counts"][0]["counts"][0]["parent"]["customer_name"]);
+    ASSERT_EQ(143, res_obj["facet_counts"][0]["counts"][0]["parent"]["product_price"]);
+    ASSERT_EQ("product_a", res_obj["facet_counts"][0]["counts"][0]["parent"]["product_id"]);
+    ASSERT_EQ("73.5", res_obj["facet_counts"][0]["counts"][1]["value"].get<std::string>());
+    ASSERT_EQ("customer_a", res_obj["facet_counts"][0]["counts"][1]["parent"]["customer_id"]);
+    ASSERT_EQ("Joe", res_obj["facet_counts"][0]["counts"][1]["parent"]["customer_name"]);
+    ASSERT_EQ(73.5, res_obj["facet_counts"][0]["counts"][1]["parent"]["product_price"]);
+    ASSERT_EQ("product_b", res_obj["facet_counts"][0]["counts"][1]["parent"]["product_id"]);
+
+    req_params = {
+            {"collection", "Products"},
+            {"q", "*"},
+            {"filter_by", "$Customers(customer_id: customer_a)"},
+            {"facet_by", "$Customers(product_price)"},
+            {"facet_return_parent", "product_price"}
+    };
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, res_obj["facet_counts"][0]["counts"].size());
+    ASSERT_EQ(143, res_obj["facet_counts"][0]["counts"][0]["parent"]["product_price"]);
+    ASSERT_EQ("product_a", res_obj["facet_counts"][0]["counts"][0]["parent"]["product_id"]);
+    ASSERT_EQ(73.5, res_obj["facet_counts"][0]["counts"][1]["parent"]["product_price"]);
+    ASSERT_EQ("product_b", res_obj["facet_counts"][0]["counts"][1]["parent"]["product_id"]);
+
+    req_params = {
+            {"collection", "Products"},
+            {"q", "*"},
+            {"filter_by", "$Customers(customer_id: customer_a)"},
+            {"facet_by", "$Customers(product_price)"},
+            {"facet_return_parent", "customer_name"}
+    };
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, res_obj["facet_counts"][0]["counts"].size());
+    ASSERT_EQ(0, res_obj["facet_counts"][0]["counts"][0].count("parent"));
+    ASSERT_EQ(0, res_obj["facet_counts"][0]["counts"][1].count("parent"));
+
+    req_params = {
+            {"collection", "Products"},
+            {"q", "*"},
+            {"filter_by", "$Customers(customer_id: customer_a)"},
             {"facet_by", "rating, $Customers(product_price)"}
     };
 

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -11,6 +11,7 @@
 #include <conversation_model.h>
 #include <core_api.h>
 #include <gtest/gtest.h>
+#include <map>
 #include <unistd.h>
 #include <vector>
 
@@ -1303,6 +1304,86 @@ TEST_F(CoreAPIUtilsTest, SearchPagination) {
     ASSERT_EQ(2, results["page"].get<size_t>());
     ASSERT_EQ(0, results.count("offset"));
 
+}
+
+TEST_F(CoreAPIUtilsTest, MultiSearchFacetReturnParentOnJoinedFacet) {
+    auto attribute_types_schema = R"({
+        "name": "AttributeTypes",
+        "fields": [
+            {"name": "name", "type": "string"},
+            {"name": "label", "type": "string"},
+            {"name": "sort", "type": "int32"}
+        ],
+        "default_sorting_field": "sort"
+    })"_json;
+
+    auto attribute_values_schema = R"({
+        "name": "AttributeValues",
+        "fields": [
+            {"name": "value", "type": "string", "facet": true},
+            {"name": "type_id", "type": "string", "reference": "AttributeTypes.id"},
+            {"name": "sort", "type": "int32"}
+        ],
+        "default_sorting_field": "sort"
+    })"_json;
+
+    auto attribute_types_op = collectionManager.create_collection(attribute_types_schema);
+    ASSERT_TRUE(attribute_types_op.ok());
+
+    auto attribute_values_op = collectionManager.create_collection(attribute_values_schema);
+    ASSERT_TRUE(attribute_values_op.ok());
+
+    auto attribute_types = attribute_types_op.get();
+    auto attribute_values = attribute_values_op.get();
+
+    ASSERT_TRUE(attribute_types->add(R"({"id":"1","name":"Color","label":"Color","sort":1})").ok());
+    ASSERT_TRUE(attribute_types->add(R"({"id":"2","name":"Size","label":"Size","sort":2})").ok());
+    ASSERT_TRUE(attribute_values->add(R"({"id":"1","value":"Red","type_id":"1","sort":1})").ok());
+    ASSERT_TRUE(attribute_values->add(R"({"id":"2","value":"Large","type_id":"2","sort":2})").ok());
+
+    std::shared_ptr<http_req> req = std::make_shared<http_req>();
+    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
+
+    nlohmann::json body;
+    body["searches"] = nlohmann::json::array();
+    nlohmann::json search;
+    search["collection"] = "AttributeTypes";
+    search["q"] = "*";
+    search["filter_by"] = "$AttributeValues(id: *)";
+    search["facet_by"] = "$AttributeValues(value)";
+    search["facet_return_parent"] = "*";
+    body["searches"].push_back(search);
+    req->body = body.dump();
+
+    nlohmann::json embedded_params;
+    req->embedded_params_vec.push_back(embedded_params);
+
+    post_multi_search(req, res);
+
+    auto response = nlohmann::json::parse(res->body);
+    ASSERT_EQ(0, response.count("code")) << response.dump();
+    ASSERT_EQ(1, response["results"].size()) << response.dump();
+    ASSERT_EQ(1, response["results"][0]["facet_counts"].size()) << response.dump();
+    ASSERT_EQ("$AttributeValues(value)", response["results"][0]["facet_counts"][0]["field_name"]);
+    ASSERT_EQ(2, response["results"][0]["facet_counts"][0]["counts"].size()) << response.dump();
+
+    std::map<std::string, nlohmann::json> parents_by_value;
+    for(const auto& count: response["results"][0]["facet_counts"][0]["counts"]) {
+        parents_by_value[count["value"].get<std::string>()] = count["parent"];
+    }
+
+    ASSERT_EQ(1, parents_by_value.count("Red")) << response.dump();
+    ASSERT_EQ(1, parents_by_value.count("Large")) << response.dump();
+
+    ASSERT_EQ("1", parents_by_value["Red"]["id"]);
+    ASSERT_EQ("Red", parents_by_value["Red"]["value"]);
+    ASSERT_EQ("1", parents_by_value["Red"]["type_id"]);
+    ASSERT_EQ(1, parents_by_value["Red"]["sort"]);
+
+    ASSERT_EQ("2", parents_by_value["Large"]["id"]);
+    ASSERT_EQ("Large", parents_by_value["Large"]["value"]);
+    ASSERT_EQ("2", parents_by_value["Large"]["type_id"]);
+    ASSERT_EQ(2, parents_by_value["Large"]["sort"]);
 }
 
 TEST_F(CoreAPIUtilsTest, Union) {

--- a/test/union_test.cpp
+++ b/test/union_test.cpp
@@ -2084,6 +2084,47 @@ TEST_F(UnionTest, FacetingWithUnion) {
     ASSERT_EQ(1, json_res["facet_counts"][0]["counts"][4]["count"].get<size_t>());
     ASSERT_EQ("England", json_res["facet_counts"][0]["counts"][5]["value"]);
     ASSERT_EQ(1, json_res["facet_counts"][0]["counts"][5]["count"].get<size_t>());
+
+    auto symlink_op = collectionManager.upsert_symlink("Countries_alias", "Countries");
+    ASSERT_TRUE(symlink_op.ok());
+
+    // joined facets using an alias and the canonical collection name should merge into one runtime facet
+    req_params.clear();
+    json_res.clear();
+    searches = R"OVR([
+                    {
+                        "collection": "Cars",
+                        "q": "*",
+                        "filter_by": "$Countries(id:*)",
+                        "facet_by": "$Countries(country_name)"
+                    },
+                    {
+                        "collection": "Watches",
+                        "q": "*",
+                        "filter_by": "$Countries_alias(id:*)",
+                        "facet_by": "$Countries_alias(country_name)"
+                    }
+                ])OVR"_json;
+
+    search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(1, json_res["facet_counts"].size()) << json_res.dump();
+    ASSERT_EQ("$Countries(country_name)", json_res["facet_counts"][0]["field_name"]);
+    ASSERT_EQ(6, json_res["facet_counts"][0]["counts"].size());
+    ASSERT_EQ(6, json_res["facet_counts"][0]["stats"]["total_values"]);
+
+    ASSERT_EQ("Italy", json_res["facet_counts"][0]["counts"][0]["value"]);
+    ASSERT_EQ(2, json_res["facet_counts"][0]["counts"][0]["count"].get<size_t>());
+    ASSERT_EQ("Germany", json_res["facet_counts"][0]["counts"][1]["value"]);
+    ASSERT_EQ(2, json_res["facet_counts"][0]["counts"][1]["count"].get<size_t>());
+    ASSERT_EQ("United States", json_res["facet_counts"][0]["counts"][2]["value"]);
+    ASSERT_EQ(1, json_res["facet_counts"][0]["counts"][2]["count"].get<size_t>());
+    ASSERT_EQ("Switzerland", json_res["facet_counts"][0]["counts"][3]["value"]);
+    ASSERT_EQ(1, json_res["facet_counts"][0]["counts"][3]["count"].get<size_t>());
+    ASSERT_EQ("France", json_res["facet_counts"][0]["counts"][4]["value"]);
+    ASSERT_EQ(1, json_res["facet_counts"][0]["counts"][4]["count"].get<size_t>());
+    ASSERT_EQ("England", json_res["facet_counts"][0]["counts"][5]["value"]);
+    ASSERT_EQ(1, json_res["facet_counts"][0]["counts"][5]["count"].get<size_t>());
 }
 
 TEST_F(UnionTest, FacetingWithUnionsValidation) {
@@ -2091,7 +2132,7 @@ TEST_F(UnionTest, FacetingWithUnionsValidation) {
             R"({
                 "name": "Cars",
                 "fields": [
-                    {"name": "name", "type": "string"},
+                    {"name": "name", "type": "string", "facet": true},
                     {"name": "country", "type": "string", "facet": true},
                     {"name": "rating", "type": "float", "facet": true},
                     {"name" : "country_id", "type": "string", "reference": "Countries.country_id"},
@@ -2103,7 +2144,7 @@ TEST_F(UnionTest, FacetingWithUnionsValidation) {
             R"({
                 "name": "Watches",
                 "fields": [
-                    {"name": "name", "type": "string"},
+                    {"name": "name", "type": "string", "facet": true},
                     {"name": "country", "type": "string", "facet": true},
                     {"name": "rating", "type": "float", "facet":true},
                     {"name" : "country_id", "type": "string", "reference": "Countries.country_id"}
@@ -2267,6 +2308,31 @@ TEST_F(UnionTest, FacetingWithUnionsValidation) {
     ASSERT_EQ(1, json_res.count("error"));
     ASSERT_EQ("`facet_return_parent` should be uniform across searches for faceting with union search.", json_res["error"]);
 
+    // facet_return_parent should be validated after wildcard normalization
+    req_params.clear();
+    json_res.clear();
+    searches = R"OVR([
+                    {
+                        "collection": "Cars",
+                        "q": "*",
+                        "facet_by": "country",
+                        "facet_strategy": "top_values",
+                        "facet_return_parent": "cou*"
+                    },
+                    {
+                        "collection": "Watches",
+                        "q": "*",
+                        "facet_by": "country",
+                        "facet_strategy": "top_values",
+                        "facet_return_parent": "country"
+                    }
+                ])OVR"_json;
+
+    search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(0, json_res.count("code")) << json_res.dump();
+    ASSERT_EQ(0, json_res.count("error")) << json_res.dump();
+
     // canonical and alias-based joined facets should be treated as the same facet shape
     req_params.clear();
     json_res.clear();
@@ -2349,6 +2415,31 @@ TEST_F(UnionTest, FacetingWithUnionsValidation) {
     ASSERT_EQ(1, json_res.count("error"));
     ASSERT_EQ("`facet_return_parent` should be uniform across searches for faceting with union search.", json_res["error"]);
 
+    // a local facet and a joined facet with the same field name should still be treated as distinct facets
+    req_params.clear();
+    json_res.clear();
+    searches = R"OVR([
+                    {
+                        "collection": "Cars",
+                        "q": "*",
+                        "filter_by": "$Countries(id:*)",
+                        "facet_by": "name, $Countries(name)",
+                        "facet_strategy": "top_values"
+                    },
+                    {
+                        "collection": "Watches",
+                        "q": "*",
+                        "filter_by": "$Countries(id:*)",
+                        "facet_by": "name, $Countries(name)",
+                        "facet_strategy": "top_values"
+                    }
+                ])OVR"_json;
+
+    search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(0, json_res.count("code")) << json_res.dump();
+    ASSERT_EQ(0, json_res.count("error")) << json_res.dump();
+
     // if facet fields are different then it's alright
     req_params.clear();
     json_res.clear();
@@ -2415,6 +2506,160 @@ TEST_F(UnionTest, FacetingWithUnionsValidation) {
     ASSERT_TRUE(search_op.ok());
     ASSERT_EQ(1, json_res.count("code"));
     ASSERT_EQ(1, json_res.count("error"));
+}
+
+TEST_F(UnionTest, FacetingWithUnionsShouldMergeAliasAndCanonicalJoinedFacetResults) {
+    auto cars_schema = R"({
+        "name": "Cars",
+        "fields": [
+            {"name": "name", "type": "string"},
+            {"name": "country_id", "type": "string", "reference": "Countries.country_id"}
+        ]
+    })"_json;
+
+    auto watches_schema = R"({
+        "name": "Watches",
+        "fields": [
+            {"name": "name", "type": "string"},
+            {"name": "country_id", "type": "string", "reference": "Countries.country_id"}
+        ]
+    })"_json;
+
+    auto countries_schema = R"({
+        "name": "Countries",
+        "fields": [
+            {"name": "country_id", "type": "string"},
+            {"name": "name", "type": "string", "facet": true}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(cars_schema);
+    ASSERT_TRUE(create_op.ok());
+    auto cars = create_op.get();
+
+    create_op = collectionManager.create_collection(watches_schema);
+    ASSERT_TRUE(create_op.ok());
+    auto watches = create_op.get();
+
+    create_op = collectionManager.create_collection(countries_schema);
+    ASSERT_TRUE(create_op.ok());
+    auto countries = create_op.get();
+
+    auto symlink_op = collectionManager.upsert_symlink("Countries_alias", "Countries");
+    ASSERT_TRUE(symlink_op.ok());
+
+    ASSERT_TRUE(countries->add(R"({"id":"country_1_doc","country_id":"country_1","name":"USA"})").ok());
+    ASSERT_TRUE(countries->add(R"({"id":"country_2_doc","country_id":"country_2","name":"Japan"})").ok());
+
+    ASSERT_TRUE(cars->add(R"({"id":"car_1","name":"Sedan","country_id":"country_1"})").ok());
+    ASSERT_TRUE(cars->add(R"({"id":"car_2","name":"Coupe","country_id":"country_2"})").ok());
+    ASSERT_TRUE(watches->add(R"({"id":"watch_1","name":"Field","country_id":"country_1"})").ok());
+
+    req_params.clear();
+    json_res.clear();
+    embedded_params = std::vector<nlohmann::json>(2, nlohmann::json::object());
+    searches = R"OVR([
+                    {
+                        "collection": "Cars",
+                        "q": "*",
+                        "filter_by": "$Countries(id:*)",
+                        "facet_by": "$Countries(name)"
+                    },
+                    {
+                        "collection": "Watches",
+                        "q": "*",
+                        "filter_by": "$Countries_alias(id:*)",
+                        "facet_by": "$Countries_alias(name)"
+                    }
+                ])OVR"_json;
+
+    auto search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(0, json_res.count("code")) << json_res.dump();
+    ASSERT_EQ(0, json_res.count("error")) << json_res.dump();
+    ASSERT_EQ(3, json_res["found"].get<size_t>());
+    ASSERT_EQ(1, json_res["facet_counts"].size()) << json_res.dump();
+    ASSERT_EQ("$Countries(name)", json_res["facet_counts"][0]["field_name"]);
+    ASSERT_EQ(2, json_res["facet_counts"][0]["counts"].size());
+    ASSERT_EQ(2, json_res["facet_counts"][0]["stats"]["total_values"]);
+
+    ASSERT_EQ("USA", json_res["facet_counts"][0]["counts"][0]["value"]);
+    ASSERT_EQ(2, json_res["facet_counts"][0]["counts"][0]["count"].get<size_t>());
+    ASSERT_EQ("Japan", json_res["facet_counts"][0]["counts"][1]["value"]);
+    ASSERT_EQ(1, json_res["facet_counts"][0]["counts"][1]["count"].get<size_t>());
+}
+
+TEST_F(UnionTest, FacetingWithUnionsShouldNormalizeFacetReturnParentPrefixes) {
+    auto paints_schema_a = R"({
+        "name": "PaintsA",
+        "enable_nested_fields": true,
+        "fields": [
+            {"name": "value.color", "type": "string", "facet": true},
+            {"name": "value.r", "type": "int32", "facet": true},
+            {"name": "value.g", "type": "int32", "facet": true},
+            {"name": "value.b", "type": "int32", "facet": true}
+        ]
+    })"_json;
+
+    auto paints_schema_b = paints_schema_a;
+    paints_schema_b["name"] = "PaintsB";
+
+    auto create_op = collectionManager.create_collection(paints_schema_a);
+    ASSERT_TRUE(create_op.ok());
+    auto paints_a = create_op.get();
+
+    create_op = collectionManager.create_collection(paints_schema_b);
+    ASSERT_TRUE(create_op.ok());
+    auto paints_b = create_op.get();
+
+    ASSERT_TRUE(paints_a->add(R"({
+        "id": "paint_a_red",
+        "value": {"color": "red", "r": 255, "g": 0, "b": 0}
+    })").ok());
+    ASSERT_TRUE(paints_a->add(R"({
+        "id": "paint_a_blue",
+        "value": {"color": "blue", "r": 0, "g": 0, "b": 255}
+    })").ok());
+    ASSERT_TRUE(paints_b->add(R"({
+        "id": "paint_b_red",
+        "value": {"color": "red", "r": 255, "g": 0, "b": 0}
+    })").ok());
+
+    req_params.clear();
+    json_res.clear();
+    embedded_params = std::vector<nlohmann::json>(2, nlohmann::json::object());
+    searches = R"OVR([
+                    {
+                        "collection": "PaintsA",
+                        "q": "*",
+                        "facet_by": "value.color",
+                        "facet_return_parent": "value.*"
+                    },
+                    {
+                        "collection": "PaintsB",
+                        "q": "*",
+                        "facet_by": "value.color",
+                        "facet_return_parent": "value.color"
+                    }
+                ])OVR"_json;
+
+    auto search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(0, json_res.count("code")) << json_res.dump();
+    ASSERT_EQ(0, json_res.count("error")) << json_res.dump();
+    ASSERT_EQ(3, json_res["found"].get<size_t>());
+    ASSERT_EQ(1, json_res["facet_counts"].size()) << json_res.dump();
+    ASSERT_EQ("value.color", json_res["facet_counts"][0]["field_name"]);
+    ASSERT_EQ(2, json_res["facet_counts"][0]["counts"].size());
+
+    ASSERT_EQ("red", json_res["facet_counts"][0]["counts"][0]["value"]);
+    ASSERT_EQ(2, json_res["facet_counts"][0]["counts"][0]["count"].get<size_t>());
+    ASSERT_EQ("{\"b\":0,\"color\":\"red\",\"g\":0,\"r\":255}",
+              json_res["facet_counts"][0]["counts"][0]["parent"].dump());
+    ASSERT_EQ("blue", json_res["facet_counts"][0]["counts"][1]["value"]);
+    ASSERT_EQ(1, json_res["facet_counts"][0]["counts"][1]["count"].get<size_t>());
+    ASSERT_EQ("{\"b\":255,\"color\":\"blue\",\"g\":0,\"r\":0}",
+              json_res["facet_counts"][0]["counts"][1]["parent"].dump());
 }
 
 TEST_F(UnionTest, UnionHighlightingUAFRaceASAN) {

--- a/test/union_test.cpp
+++ b/test/union_test.cpp
@@ -1975,6 +1975,9 @@ TEST_F(UnionTest, FacetingWithUnionsValidation) {
     collection_create_op = collectionManager.create_collection(schema_json4);
     ASSERT_TRUE(collection_create_op.ok());
 
+    auto symlink_op = collectionManager.upsert_symlink("Countries_alias", "Countries");
+    ASSERT_TRUE(symlink_op.ok());
+
     embedded_params = std::vector<nlohmann::json>(2, nlohmann::json::object());
     //facet query should be uniform across all faceted searches
     searches = R"OVR([
@@ -2089,6 +2092,88 @@ TEST_F(UnionTest, FacetingWithUnionsValidation) {
                         "facet_by": "rating, country",
                         "facet_strategy": "top_values",
                         "facet_return_parent": "country, rating"
+                    }
+                ])OVR"_json;
+
+    search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(1, json_res.count("code"));
+    ASSERT_EQ(400, json_res["code"]);
+    ASSERT_EQ(1, json_res.count("error"));
+    ASSERT_EQ("`facet_return_parent` should be uniform across searches for faceting with union search.", json_res["error"]);
+
+    // canonical and alias-based joined facets should be treated as the same facet shape
+    req_params.clear();
+    json_res.clear();
+    searches = R"OVR([
+                    {
+                        "collection": "Cars",
+                        "q": "*",
+                        "filter_by": "$Countries(id:*)",
+                        "facet_by": "$Countries(name)",
+                        "facet_strategy": "top_values",
+                        "facet_return_parent": "name"
+                    },
+                    {
+                        "collection": "Watches",
+                        "q": "*",
+                        "filter_by": "$Countries_alias(id:*)",
+                        "facet_by": "$Countries_alias(name)",
+                        "facet_strategy": "top_values",
+                        "facet_return_parent": "name"
+                    }
+                ])OVR"_json;
+
+    search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(0, json_res.count("code"));
+    ASSERT_EQ(0, json_res.count("error"));
+
+    // joined reference facets should use the referenced field name for parent-return validation
+    req_params.clear();
+    json_res.clear();
+    searches = R"OVR([
+                    {
+                        "collection": "Cars",
+                        "q": "*",
+                        "filter_by": "$Countries(id:*)",
+                        "facet_by": "$Countries(name)",
+                        "facet_strategy": "top_values",
+                        "facet_return_parent": "name"
+                    },
+                    {
+                        "collection": "Watches",
+                        "q": "*",
+                        "filter_by": "$Countries(id:*)",
+                        "facet_by": "$Countries(name)",
+                        "facet_strategy": "top_values",
+                        "facet_return_parent": "name"
+                    }
+                ])OVR"_json;
+
+    search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(0, json_res.count("code"));
+    ASSERT_EQ(0, json_res.count("error"));
+
+    // joined reference facet mismatch should still fail the uniformity check
+    req_params.clear();
+    json_res.clear();
+    searches = R"OVR([
+                    {
+                        "collection": "Cars",
+                        "q": "*",
+                        "filter_by": "$Countries(id:*)",
+                        "facet_by": "$Countries(name)",
+                        "facet_strategy": "top_values",
+                        "facet_return_parent": "name"
+                    },
+                    {
+                        "collection": "Watches",
+                        "q": "*",
+                        "filter_by": "$Countries(id:*)",
+                        "facet_by": "$Countries(name)",
+                        "facet_strategy": "top_values"
                     }
                 ])OVR"_json;
 


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
This change fixes `facet_return_parent` for joined reference facets and aligns union-search validation with the runtime behavior already used for faceting.

### What changed

For facet serialization:
- parent return is no longer limited to nested local facets only
- parent return now also works for joined reference facets

For joined reference facets:
- the representative document is fetched from the referenced collection
- the sequence key is resolved from the referenced collection
- parent extraction is executed against the referenced collection

### Parent Matching Fix

The parent lookup helper now normalizes JSON values using facet-compatible string conversion for:
- strings
- signed integers
- unsigned integers
- floats
- booleans
- arrays of those values

This matters because joined facet values such as `product_price` are serialized as strings like `143` or `73.5`, and the parent finder must compare against the same representation.

Without this normalization, joined numeric facets can fail to locate the correct parent object even after the referenced collection lookup is fixed.

### Union Validation Fix
Union validation now:
- parses each `facet_by` entry using the actual collection for that search
- uses the parsed facet field name for `facet_return_parent` consistency checks
- compares parsed facet shape instead of raw `facet_by` text when checking facet uniformity

The parsed facet signature includes:
- leaf field name
- referenced collection name
- range configuration
- alpha sorting flag
- sort order
- sort field
- top-k flag

This keeps validation aligned with the runtime logic while remaining narrow in scope.

### Alias vs Canonical Joined Facets

Union validation now treats these as the same underlying joined facet shape when they resolve to the same referenced collection:
- `$Countries(name)`
- `$Countries_alias(name)`

This is handled by comparing parsed facet signature rather than raw `facet_by` text.

## Known Limitation

A known limitation remains:
- distinct facets that share the same leaf field name are still ambiguous under current runtime semantics

Examples:
- local `name` and `$Countries(name)`
- `$Countries(name)` and `$Brands(name)`

This PR does not attempt to solve that because doing so would require a broader selector/identity design change. The current implementation keeps runtime and validation aligned without expanding the API surface.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
