### PR TITLE
fix(joins): allow null optional nested references in object arrays on update

### DIFF
--- a/src/join.cpp
+++ b/src/join.cpp
@@ -156,15 +156,23 @@ Option<bool> Join::populate_reference_helper_fields(nlohmann::json& document,
                 auto const& object_array = document[keys[0]];
 
                 for (uint32_t i = 0; i < object_array.size(); i++) {
-                    if (optional && object_array[i].count(keys[1]) == 0) {
-                        continue;
-                    } else if (object_array[i].count(keys[1]) == 0) {
+                    if (object_array[i].count(keys[1]) == 0) {
+                        if (optional) {
+                            continue;
+                        }
                         return Option<bool>(400, "Object at index `" + std::to_string(i) + "` is missing `" + field_name + "`.");
-                    } else if (!object_array[i].at(keys[1]).is_string()) {
+                    }
+
+                    auto const& child_value = object_array[i].at(keys[1]);
+                    if (optional && child_value.is_null()) {
+                        continue;
+                    }
+
+                    if (!child_value.is_string()) {
                         return id_field_type_error_op;
                     }
 
-                    auto id = object_array[i].at(keys[1]).get<std::string>();
+                    auto id = child_value.get<std::string>();
                     auto ref_doc_id_op = CollectionManager::doc_id_to_seq_id(reference_collection_name, id);
                     if (!ref_doc_id_op.ok() && is_async_reference) {
                         auto const& value = nlohmann::json::array({i, Join::reference_helper_sentinel_value});
@@ -267,6 +275,8 @@ Option<bool> Join::populate_reference_helper_fields(nlohmann::json& document,
                     continue;
                 } else if (object_array[i].count(keys[1]) == 0) {
                     return Option<bool>(400, "Object at index `" + std::to_string(i) + "` is missing `" + field_name + "`.");
+                } else if (optional && object_array[i].at(keys[1]).is_null()) {
+                    continue;
                 }
 
                 temp_doc[field_name] = object_array[i].at(keys[1]);

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -1,6 +1,17 @@
 #include "validator.h"
 #include "field.h"
 
+namespace {
+bool is_valid_uint32_json_integer(const nlohmann::json& value) {
+    if (!value.is_number_integer() && !value.is_number_unsigned()) {
+        return false;
+    }
+
+    const auto signed_value = value.get<int64_t>();
+    return signed_value >= 0 && static_cast<uint64_t>(signed_value) <= UINT32_MAX;
+}
+}
+
 Option<uint32_t> validator_t::coerce_element(const field& a_field, nlohmann::json& document,
                                        nlohmann::json& doc_ele,
                                        const std::string& fallback_field_type,
@@ -340,7 +351,8 @@ Option<uint32_t> validator_t::coerce_int64_t(const DIRTY_VALUES& dirty_values, c
     // Object array reference helper field. It's not provided by the user.
     if(is_array && a_field.nested && a_field.is_reference_helper) {
         // It's an array of two uint32_t values indicating the object index and referenced doc id respectively.
-        if(item.size() != 2 || !item.at(0).is_number_unsigned() || !item.at(1).is_number_unsigned()) {
+        if(item.size() != 2 || !is_valid_uint32_json_integer(item.at(0)) ||
+           !is_valid_uint32_json_integer(item.at(1))) {
             return Option<>(400, "`" + field_name + "` object array reference helper field has wrong value `"
                                  + item.dump() + "`.");
         }

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -1117,6 +1117,79 @@ TEST_F(CollectionJoinTest, IndexDocumentHavingReferenceField) {
     ASSERT_EQ("Cannot add a reference to `coll1.object_array_field` of type `object[]`.", add_doc_op.error());
 }
 
+TEST_F(CollectionJoinTest, UpdateOptionalNestedReferenceInObjectArrayViaPatchPath) {
+    auto objects_schema_json =
+            R"({
+                "name": "objects_patch",
+                "fields": [
+                    {"name": "title", "type": "string" },
+                    {"name": "code", "type": "string" }
+                ]
+            })"_json;
+
+    auto objects_collection_op = collectionManager.create_collection(objects_schema_json);
+    ASSERT_TRUE(objects_collection_op.ok());
+    auto objects_collection = objects_collection_op.get();
+
+    ASSERT_TRUE(objects_collection->add(R"({"id":"obj-123","title":"Sample Object","code":"OBJ001"})").ok());
+
+    auto items_schema_json =
+            R"({
+                "name": "items_patch",
+                "enable_nested_fields": true,
+                "fields": [
+                    {"name": "recordidentifier", "type": "string" },
+                    {"name": "title", "type": "string" },
+                    {"name": "relatedassetsdata", "type": "object[]", "optional": true },
+                    {"name": "relatedassetsdata.id", "type": "int32[]", "optional": true },
+                    {"name": "relatedassetsdata.relationtype", "type": "string[]", "optional": true },
+                    {"name": "relatedassetsdata.childobjectid", "type": "string[]", "reference": "objects_patch.id", "optional": true }
+                ]
+            })"_json;
+
+    auto items_collection_op = collectionManager.create_collection(items_schema_json);
+    ASSERT_TRUE(items_collection_op.ok());
+    auto items_collection = items_collection_op.get();
+
+    nlohmann::json create_doc = R"({
+        "id": "item-001",
+        "recordidentifier": "REC001",
+        "title": "Test Item with Null Reference",
+        "relatedassetsdata": [
+            {
+                "id": 1,
+                "relationtype": "Related",
+                "childobjectid": null
+            }
+        ]
+    })"_json;
+    auto add_op = items_collection->add(create_doc.dump(), CREATE);
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    nlohmann::json update_doc = R"({
+        "title": "Updated Test Item - Reference Still Null",
+        "relatedassetsdata": [
+            {
+                "id": 1,
+                "relationtype": "Related",
+                "childobjectid": null
+            }
+        ]
+    })"_json;
+    std::string dirty_values;
+    auto update_op = items_collection->update_matching_filter("id:=item-001", update_doc.dump(), dirty_values);
+    ASSERT_TRUE(update_op.ok()) << update_op.error();
+    ASSERT_EQ(1, update_op.get()["num_updated"]);
+
+    auto get_op = items_collection->get("item-001");
+    ASSERT_TRUE(get_op.ok());
+    auto doc = get_op.get();
+    ASSERT_EQ("Updated Test Item - Reference Still Null", doc["title"]);
+    ASSERT_EQ(1, doc.count("relatedassetsdata"));
+    ASSERT_EQ(1, doc["relatedassetsdata"].size());
+    ASSERT_EQ(0, doc["relatedassetsdata"][0].count("childobjectid"));
+}
+
 TEST_F(CollectionJoinTest, IndexDocumentHavingAsyncReferenceField) {
     auto schema_json =
             R"({

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -1190,6 +1190,172 @@ TEST_F(CollectionJoinTest, UpdateOptionalNestedReferenceInObjectArrayViaPatchPat
     ASSERT_EQ(0, doc["relatedassetsdata"][0].count("childobjectid"));
 }
 
+TEST_F(CollectionJoinTest, UpdateOptionalNestedReferenceInObjectArrayViaPatchPathOnCodeField) {
+    auto objects_schema_json =
+            R"({
+                "name": "objects_patch_code",
+                "fields": [
+                    {"name": "title", "type": "string"},
+                    {"name": "code", "type": "string"}
+                ]
+            })"_json;
+
+    auto objects_collection_op = collectionManager.create_collection(objects_schema_json);
+    ASSERT_TRUE(objects_collection_op.ok());
+    auto objects_collection = objects_collection_op.get();
+
+    ASSERT_TRUE(objects_collection->add(R"({
+        "id": "obj-123",
+        "title": "Sample Object",
+        "code": "OBJ001"
+    })").ok());
+
+    auto items_schema_json =
+            R"({
+                "name": "items_patch_code",
+                "enable_nested_fields": true,
+                "fields": [
+                    {"name": "recordidentifier", "type": "string"},
+                    {"name": "title", "type": "string"},
+                    {"name": "relatedassetsdata", "type": "object[]", "optional": true},
+                    {"name": "relatedassetsdata.id", "type": "int32[]", "optional": true},
+                    {"name": "relatedassetsdata.relationtype", "type": "string[]", "optional": true},
+                    {"name": "relatedassetsdata.childobjectcode", "type": "string[]", "reference": "objects_patch_code.code", "optional": true}
+                ]
+            })"_json;
+
+    auto items_collection_op = collectionManager.create_collection(items_schema_json);
+    ASSERT_TRUE(items_collection_op.ok());
+    auto items_collection = items_collection_op.get();
+
+    ASSERT_TRUE(items_collection->add(R"({
+        "id": "item-001",
+        "recordidentifier": "REC001",
+        "title": "Test Item with Null Reference",
+        "relatedassetsdata": [
+            {
+                "id": 1,
+                "relationtype": "Related",
+                "childobjectcode": null
+            }
+        ]
+    })", CREATE).ok());
+
+    std::string dirty_values;
+    auto update_op = items_collection->update_matching_filter("id:=item-001", R"({
+        "title": "Updated Test Item - Reference Still Null",
+        "relatedassetsdata": [
+            {
+                "id": 1,
+                "relationtype": "Related",
+                "childobjectcode": null
+            }
+        ]
+    })", dirty_values);
+    ASSERT_TRUE(update_op.ok()) << update_op.error();
+    ASSERT_EQ(1, update_op.get()["num_updated"]);
+
+    auto get_op = items_collection->get("item-001");
+    ASSERT_TRUE(get_op.ok());
+    auto doc = get_op.get();
+    ASSERT_EQ("Updated Test Item - Reference Still Null", doc["title"]);
+    ASSERT_EQ(1, doc.count("relatedassetsdata"));
+    ASSERT_EQ(1, doc["relatedassetsdata"].size());
+    ASSERT_EQ(0, doc["relatedassetsdata"][0].count("childobjectcode"));
+}
+
+TEST_F(CollectionJoinTest, AsyncOptionalNestedReferenceInObjectArraySkipsNullSlots) {
+    auto objects_schema_json =
+            R"({
+                "name": "objects_async_patch",
+                "fields": [
+                    {"name": "title", "type": "string"},
+                    {"name": "code", "type": "string"}
+                ]
+            })"_json;
+
+    auto objects_collection_op = collectionManager.create_collection(objects_schema_json);
+    ASSERT_TRUE(objects_collection_op.ok());
+    auto objects_collection = objects_collection_op.get();
+    ASSERT_TRUE(objects_collection->add(R"({
+        "id": "obj-123",
+        "title": "Sample Object",
+        "code": "OBJ001"
+    })").ok());
+
+    auto items_schema_json =
+            R"({
+                "name": "items_async_patch",
+                "enable_nested_fields": true,
+                "fields": [
+                    {"name": "recordidentifier", "type": "string"},
+                    {"name": "title", "type": "string"},
+                    {"name": "relatedassetsdata", "type": "object[]", "optional": true},
+                    {"name": "relatedassetsdata.id", "type": "int32[]", "optional": true},
+                    {"name": "relatedassetsdata.relationtype", "type": "string[]", "optional": true},
+                    {"name": "relatedassetsdata.childobjectcode", "type": "string[]", "reference": "objects_async_patch.code", "optional": true, "async_reference": true}
+                ]
+            })"_json;
+
+    auto items_collection_op = collectionManager.create_collection(items_schema_json);
+    ASSERT_TRUE(items_collection_op.ok());
+    auto items_collection = items_collection_op.get();
+
+    ASSERT_TRUE(items_collection->add(R"({
+        "id": "item-async-001",
+        "recordidentifier": "RECASYNC001",
+        "title": "Async Item with Mixed Nested References",
+        "relatedassetsdata": [
+            {
+                "id": 1,
+                "relationtype": "Related",
+                "childobjectcode": null
+            },
+            {
+                "id": 2,
+                "relationtype": "Related",
+                "childobjectcode": null
+            }
+        ]
+    })", CREATE).ok());
+
+    nlohmann::json update_doc = R"({
+        "id": "item-async-001",
+        "title": "Updated Async Item",
+        "relatedassetsdata": [
+            {
+                "id": 1,
+                "relationtype": "Related",
+                "childobjectcode": null
+            },
+            {
+                "id": 2,
+                "relationtype": "Related",
+                "childobjectcode": "missing-code"
+            }
+        ]
+    })"_json;
+    auto update_op = items_collection->add(update_doc.dump(), UPDATE);
+    ASSERT_TRUE(update_op.ok()) << update_op.error();
+
+    auto get_op = items_collection->get("item-async-001");
+    ASSERT_TRUE(get_op.ok());
+    auto doc = get_op.get();
+    ASSERT_EQ("Updated Async Item", doc["title"]);
+    ASSERT_EQ(1, doc.count(".ref"));
+    ASSERT_EQ(1, doc[".ref"].size());
+    ASSERT_EQ("relatedassetsdata.childobjectcode_sequence_id", doc[".ref"][0]);
+    ASSERT_EQ(1, doc.count("relatedassetsdata.childobjectcode_sequence_id"));
+    ASSERT_EQ(1, doc["relatedassetsdata.childobjectcode_sequence_id"].size());
+    ASSERT_EQ(2, doc["relatedassetsdata.childobjectcode_sequence_id"][0].size());
+    ASSERT_EQ(1, doc["relatedassetsdata.childobjectcode_sequence_id"][0][0]);
+    ASSERT_EQ(Join::reference_helper_sentinel_value, doc["relatedassetsdata.childobjectcode_sequence_id"][0][1]);
+    ASSERT_EQ(2, doc["relatedassetsdata"].size());
+    ASSERT_EQ(0, doc["relatedassetsdata"][0].count("childobjectcode"));
+    ASSERT_EQ(1, doc["relatedassetsdata"][1].count("childobjectcode"));
+    ASSERT_EQ("missing-code", doc["relatedassetsdata"][1]["childobjectcode"]);
+}
+
 TEST_F(CollectionJoinTest, IndexDocumentHavingAsyncReferenceField) {
     auto schema_json =
             R"({


### PR DESCRIPTION
## Change Summary
  - allow optional nested reference fields in object arrays to skip null values during  update and async reference handling
  - accept signed and unsigned json integers within the uint32 range for nested reference
    helper arrays
  - add tests for nested reference updates, code-based references and mixed null/unresolved async cases


## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
