### PR TITLE
fix: skip conversation model call when all searches fail in multi-search

### DIFF
--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -1218,6 +1218,28 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
             }
         }
 
+        // If all searches failed, skip the model call entirely
+        bool has_docs = false;
+        for(const auto& docs : result_docs_arr) {
+            if(!docs.empty()) {
+                has_docs = true;
+                break;
+            }
+        }
+
+        if(!has_docs) {
+            // No successful search results — skip conversation model call
+            // and return the response with just the error results
+            std::string response_str = response.dump();
+            if(res->content_type_header.find("event-stream") != std::string::npos) {
+                response_str = "data: " + response_str + "\n\n";
+            }
+            res->set_200(response_str);
+            res->final = true;
+            stream_response(req, res);
+            return true;
+        }
+
         const std::string& conversation_model_id = orig_req_params["conversation_model_id"];
         auto conversation_model = ConversationModelManager::get_model(conversation_model_id).get();
         auto min_required_bytes_op = ConversationModel::get_minimum_required_bytes(conversation_model);

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -1218,16 +1218,9 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
             }
         }
 
-        // If all searches failed, skip the model call entirely
-        bool has_docs = false;
-        for(const auto& docs : result_docs_arr) {
-            if(!docs.empty()) {
-                has_docs = true;
-                break;
-            }
-        }
-
-        if(!has_docs) {
+        // If all searches failed (no successful search results), skip the model call entirely.
+        // Successful searches with zero hits should still follow the normal conversation path.
+        if(result_docs_arr.empty()) {
             // No successful search results — skip conversation model call
             // and return the response with just the error results
             std::string response_str = response.dump();

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -665,6 +665,55 @@ TEST_F(CoreAPIUtilsTest, GetSearchConversationUnderlyingSearchErrorShouldNotThro
               response["message"].get<std::string>());
 }
 
+TEST_F(CoreAPIUtilsTest, MultiSearchConversationAllSearchesFailedSkipsModelCall) {
+    nlohmann::json schema = R"({
+        "name": "conversation_all_fail_docs",
+        "fields": [
+          {"name": "title", "type": "string" }
+        ]
+    })"_json;
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+
+    const std::string model_id = "conversation-all-fail-model-" + StringUtils::randstring(8);
+    nlohmann::json model = {
+        {"id", model_id},
+        {"model_name", "azure/test-model"},
+        {"api_key", "dummy"},
+        {"url", "http://127.0.0.1:1"},
+        {"history_collection", "conversation_store"},
+        {"max_bytes", 100000}
+    };
+    ConversationModelManager::insert_model_for_testing(model_id, model);
+
+    auto req = std::make_shared<http_req>();
+    auto res = std::make_shared<http_res>(nullptr);
+    req->params["conversation"] = "true";
+    req->params["conversation_model_id"] = model_id;
+    req->params["q"] = "duck";
+    req->embedded_params_vec.push_back(nlohmann::json::object());
+
+    nlohmann::json body;
+    body["searches"] = nlohmann::json::array();
+    body["searches"].push_back({
+        {"collection", "conversation_all_fail_docs"},
+        {"query_by", "missing_field"}
+    });
+    req->body = body.dump();
+
+    bool handled = post_multi_search(req, res);
+    EXPECT_TRUE(handled);
+    EXPECT_EQ(200, res->status_code);
+
+    auto response = nlohmann::json::parse(res->body);
+    // The error result should be present
+    ASSERT_TRUE(response.contains("results"));
+    ASSERT_EQ(1, response["results"].size());
+    ASSERT_TRUE(response["results"][0].contains("code"));
+    // The conversation block should NOT be present since model call was skipped
+    ASSERT_FALSE(response.contains("conversation"));
+}
+
 TEST_F(CoreAPIUtilsTest, MultiSearchConversationZeroHitTrimmingShouldNotHang) {
     nlohmann::json schema = R"({
         "name": "conversation_zero_hits_docs",


### PR DESCRIPTION
## Change Summary

Multi search with conversation enabled is calling the conversation model even when all searches failed. Error results are skipped during document collection, but if every search errored, the handler still called  with an empty `[]` context. The response returned  with an answer generated from no data.

The fix checks whether any documents were collected after processing search results. If all searches failed (no documents), it skips the model call entirely and returns the response with just the error results and no `conversation` block.

## Test Plan

- **Regression test**: The unit test fails without the fix passes after the test
- **Manual test**: Started a dummy model server, confirmed no request is sent to the model when all searches fail


## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
