### PR TITLE
fix: skip response cache for conversation searches

### DIFF
--- a/include/core_api.h
+++ b/include/core_api.h
@@ -226,6 +226,8 @@ Option<std::pair<std::string,std::string>> get_api_key_and_ip(const std::string&
 
 void init_api(uint32_t cache_num_entries);
 
+bool use_response_cache(const std::map<std::string, std::string>& params);
+
 
 bool post_proxy(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res);
 

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -71,6 +71,19 @@ void init_api(uint32_t cache_num_entries) {
     res_cache.capacity(cache_num_entries);
 }
 
+bool use_response_cache(const std::map<std::string, std::string>& params) {
+    const auto use_cache_it = params.find("use_cache");
+    bool use_cache = (use_cache_it != params.end()) &&
+                     (use_cache_it->second == "1" || use_cache_it->second == "true");
+
+    const auto conversation_it = params.find("conversation");
+    if(conversation_it != params.end() && conversation_it->second == "true") {
+        use_cache = false;
+    }
+
+    return use_cache;
+}
+
 bool get_alter_in_progress(const std::string& collection) {
     std::shared_lock lock(alter_mutex);
     return alters_in_progress.count(collection) != 0;
@@ -599,8 +612,8 @@ uint64_t hash_request(const std::shared_ptr<http_req>& req) {
 }
 
 bool get_search(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
-    const auto use_cache_it = req->params.find("use_cache");
-    bool use_cache = (use_cache_it != req->params.end()) && (use_cache_it->second == "1" || use_cache_it->second == "true");
+    bool use_cache = use_response_cache(req->params);
+
     uint64_t req_hash = 0;
 
     in_flight_req_guard_t in_flight_req_guard(req);
@@ -887,8 +900,8 @@ bool get_search(const std::shared_ptr<http_req>& req, const std::shared_ptr<http
 }
 
 bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
-    const auto use_cache_it = req->params.find("use_cache");
-    bool use_cache = (use_cache_it != req->params.end()) && (use_cache_it->second == "1" || use_cache_it->second == "true");
+    bool use_cache = use_response_cache(req->params);
+
     uint64_t req_hash = 0;
 
     in_flight_req_guard_t in_flight_req_guard(req);

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -566,6 +566,38 @@ TEST_F(CoreAPIUtilsTest, SearchCacheShouldIncludeParamNamesAndIgnoreInternalEmbe
     ASSERT_EQ(hash_request(hash_req_base), hash_request(hash_req_variant));
 }
 
+TEST_F(CoreAPIUtilsTest, ConversationSearchShouldBypassHttpResponseCache) {
+    std::map<std::string, std::string> params = {
+        {"use_cache", "1"},
+        {"conversation", "true"},
+        {"q", "cache conversation"}
+    };
+
+    std::map<std::string, std::string> cacheable_params = {
+        {"use_cache", "1"},
+        {"q", "cache conversation"}
+    };
+
+    ASSERT_TRUE(use_response_cache(cacheable_params));
+    ASSERT_FALSE(use_response_cache(params));
+}
+
+TEST_F(CoreAPIUtilsTest, ConversationMultiSearchShouldBypassHttpResponseCache) {
+    std::map<std::string, std::string> params = {
+        {"use_cache", "true"},
+        {"conversation", "true"},
+        {"q", "cache conversation"}
+    };
+
+    std::map<std::string, std::string> cacheable_params = {
+        {"use_cache", "true"},
+        {"q", "cache conversation"}
+    };
+
+    ASSERT_TRUE(use_response_cache(cacheable_params));
+    ASSERT_FALSE(use_response_cache(params));
+}
+
 TEST_F(CoreAPIUtilsTest, MultiSearchConversationWithEarlierErrorShouldNotReuseFirstSearchCollection) {
     nlohmann::json schema = R"({
         "name": "stale_res_index_docs",


### PR DESCRIPTION
## Change Summary
Fixes conversation searches being cached at the HTTP response level, causing cache hits to return stale conversation responses (same `conversation_id`, same `last_updated`) instead of generating fresh model answers.

* extract cache decision into shared `use_response_cache()` helper used by both `get_search` and `post_multi_search`
* disable response caching when `conversation=true`, ensuring each conversation request gets a fresh model call

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
