### PR TITLE
fix(multi search): exclude_fields parameter handling in conversations

### DIFF
--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -1296,7 +1296,7 @@ bool post_multi_search(const std::shared_ptr<http_req>& req, const std::shared_p
         auto conversation_history = conversation_history_op.get();
 
         std::vector<std::string> exclude_fields;
-        StringUtils::split(req->params["exclude_fields"], exclude_fields, ",");
+        StringUtils::split(orig_req_params["exclude_fields"], exclude_fields, ",");
         bool exclude_conversation_history = std::find(exclude_fields.begin(), exclude_fields.end(), "conversation_history") != exclude_fields.end();
 
         auto new_conversation_op = ConversationManager::get_last_n_messages(conversation_history["conversation"], 2);


### PR DESCRIPTION
## Change Summary
This changes multi-search conversation handling to read exclude_fields from the original request params (`orig_req_params`) instead of the mutable `req->params.`

 With this change, the decision to include or exclude top-level conversation_history now follows the top-level request params consistently, which matches the intended behavior.

Manual testing:

- Ran a dummy OpenAI-compatible HTTP server and configured a conversation model with openai_url pointing to it.
- Sent the multi search request with `conversation=true` and `exclude_fields=conversation_history` only inside the last search object.
- Verified the fixed build still returned top-level `conversation.conversation_history`.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
