### PR TITLE
Temp facet tree

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -1152,7 +1152,7 @@ public:
 
     Option<bool> parse_facet(const std::string& facet_field, std::vector<facet>& facets) const;
 
-    Option<bool> compute_facet_infos_with_lock(const std::vector<facet>& facets, facet_query_t& facet_query,
+    Option<bool> compute_facet_infos_with_lock(std::vector<facet>& facets, facet_query_t& facet_query,
                                        const uint32_t facet_query_num_typos,
                                        uint32_t* all_result_ids, const size_t& all_result_ids_len,
                                        const std::vector<std::string>& group_by_fields,

--- a/include/field.h
+++ b/include/field.h
@@ -785,6 +785,14 @@ struct range_specs_t {
     }
 };
 
+struct facet;
+
+struct nested_facet {
+    std::string collection_name;
+    std::string alias{};
+    std::vector<facet> facets = {};
+};
+
 struct facet {
     std::string field_name;
     spp::sparse_hash_map<uint64_t, facet_count_t> result_map;
@@ -820,9 +828,7 @@ struct facet {
 
     uint32_t orig_index;
 
-    std::string reference_collection_name;
-    std::string reference_collection_alias_name{};
-    std::vector<facet> nested_join_facets = {};
+    std::vector<nested_facet> nested_join_facets = {};
 
     reference_filter_result_t references{};
 
@@ -850,13 +856,10 @@ struct facet {
 
     explicit facet(const std::string& field_name, uint32_t orig_index, bool is_top_k = false, std::map<int64_t, range_specs_t> facet_range = {},
                    bool is_range_q = false, bool sort_by_alpha=false, const std::string& order="",
-                   const std::string& sort_by_field="", const std::string& reference_collection_name = "",
-                   const std::string& reference_collection_alias_name = "")
+                   const std::string& sort_by_field="")
                    : field_name(field_name), facet_range_map(facet_range),
                    is_range_query(is_range_q), is_sort_by_alpha(sort_by_alpha), sort_order(order),
-                   sort_field(sort_by_field), orig_index(orig_index), is_top_k(is_top_k),
-                   reference_collection_name(reference_collection_name),
-                   reference_collection_alias_name(reference_collection_alias_name) {
+                   sort_field(sort_by_field), orig_index(orig_index), is_top_k(is_top_k) {
     }
 };
 

--- a/include/field.h
+++ b/include/field.h
@@ -822,6 +822,7 @@ struct facet {
 
     std::string reference_collection_name;
     std::string reference_collection_alias_name{};
+    std::vector<facet> nested_join_facets = {};
 
     reference_filter_result_t references{};
 

--- a/include/field.h
+++ b/include/field.h
@@ -785,12 +785,49 @@ struct range_specs_t {
     }
 };
 
-struct facet;
-
-struct nested_facet {
+struct reference_facet_t {
     std::string collection_name;
     std::string alias{};
-    std::vector<facet> facets = {};
+    reference_facet_t* nested_reference_facet = nullptr;
+
+    reference_facet_t() = default;
+
+    ~reference_facet_t() {
+        delete nested_reference_facet;
+    }
+
+    reference_facet_t(const reference_facet_t& other)
+        : collection_name(other.collection_name), alias(other.alias),
+          nested_reference_facet(other.nested_reference_facet
+                                ? new reference_facet_t(*other.nested_reference_facet) : nullptr) {}
+
+    reference_facet_t(reference_facet_t&& other) noexcept
+        : collection_name(std::move(other.collection_name)), alias(std::move(other.alias)),
+          nested_reference_facet(other.nested_reference_facet) {
+        other.nested_reference_facet = nullptr;
+    }
+
+    reference_facet_t& operator=(const reference_facet_t& other) {
+        if (this != &other) {
+            collection_name = other.collection_name;
+            alias = other.alias;
+            delete nested_reference_facet;
+            nested_reference_facet = other.nested_reference_facet
+                                     ? new reference_facet_t(*other.nested_reference_facet) : nullptr;
+        }
+        return *this;
+    }
+
+    reference_facet_t& operator=(reference_facet_t&& other) noexcept {
+        if (this != &other) {
+            collection_name = std::move(other.collection_name);
+            alias = std::move(other.alias);
+            delete nested_reference_facet;
+            nested_reference_facet = other.nested_reference_facet;
+            other.nested_reference_facet = nullptr;
+        }
+        return *this;
+    }
 };
 
 struct facet {
@@ -828,7 +865,7 @@ struct facet {
 
     uint32_t orig_index;
 
-    std::vector<nested_facet> nested_join_facets = {};
+    reference_facet_t* reference_facet = nullptr;
 
     reference_filter_result_t references{};
 
@@ -860,6 +897,111 @@ struct facet {
                    : field_name(field_name), facet_range_map(facet_range),
                    is_range_query(is_range_q), is_sort_by_alpha(sort_by_alpha), sort_order(order),
                    sort_field(sort_by_field), orig_index(orig_index), is_top_k(is_top_k) {
+    }
+
+    ~facet() {
+        delete reference_facet;
+    }
+
+    facet(const facet& other)
+        : field_name(other.field_name),
+          result_map(other.result_map),
+          value_result_map(other.value_result_map),
+          fvalue_tokens(other.fvalue_tokens),
+          hash_tokens(other.hash_tokens),
+          hash_groups(other.hash_groups),
+          stats(other.stats),
+          facet_range_map(other.facet_range_map),
+          is_range_query(other.is_range_query),
+          sampled(other.sampled),
+          is_wildcard_match(other.is_wildcard_match),
+          is_dynamic(other.is_dynamic),
+          is_intersected(other.is_intersected),
+          is_sort_by_alpha(other.is_sort_by_alpha),
+          sort_order(other.sort_order),
+          sort_field(other.sort_field),
+          orig_index(other.orig_index),
+          reference_facet(other.reference_facet ? new reference_facet_t(*other.reference_facet) : nullptr),
+          references(other.references),
+          is_top_k(other.is_top_k) {}
+
+    facet(facet&& other) noexcept
+        : field_name(std::move(other.field_name)),
+          result_map(std::move(other.result_map)),
+          value_result_map(std::move(other.value_result_map)),
+          fvalue_tokens(std::move(other.fvalue_tokens)),
+          hash_tokens(std::move(other.hash_tokens)),
+          hash_groups(std::move(other.hash_groups)),
+          stats(std::move(other.stats)),
+          facet_range_map(std::move(other.facet_range_map)),
+          is_range_query(other.is_range_query),
+          sampled(other.sampled),
+          is_wildcard_match(other.is_wildcard_match),
+          is_dynamic(other.is_dynamic),
+          is_intersected(other.is_intersected),
+          is_sort_by_alpha(other.is_sort_by_alpha),
+          sort_order(std::move(other.sort_order)),
+          sort_field(std::move(other.sort_field)),
+          orig_index(other.orig_index),
+          reference_facet(other.reference_facet),
+          references(std::move(other.references)),
+          is_top_k(other.is_top_k) {
+        other.reference_facet = nullptr;
+    }
+
+    facet& operator=(const facet& other) {
+        if (this != &other) {
+            field_name = other.field_name;
+            result_map = other.result_map;
+            value_result_map = other.value_result_map;
+            fvalue_tokens = other.fvalue_tokens;
+            hash_tokens = other.hash_tokens;
+            hash_groups = other.hash_groups;
+            stats = other.stats;
+            facet_range_map = other.facet_range_map;
+            is_range_query = other.is_range_query;
+            sampled = other.sampled;
+            is_wildcard_match = other.is_wildcard_match;
+            is_dynamic = other.is_dynamic;
+            is_intersected = other.is_intersected;
+            is_sort_by_alpha = other.is_sort_by_alpha;
+            sort_order = other.sort_order;
+            sort_field = other.sort_field;
+            orig_index = other.orig_index;
+            delete reference_facet;
+            reference_facet = other.reference_facet ? new reference_facet_t(*other.reference_facet) : nullptr;
+            references = other.references;
+            is_top_k = other.is_top_k;
+        }
+        return *this;
+    }
+
+    facet& operator=(facet&& other) noexcept {
+        if (this != &other) {
+            field_name = std::move(other.field_name);
+            result_map = std::move(other.result_map);
+            value_result_map = std::move(other.value_result_map);
+            fvalue_tokens = std::move(other.fvalue_tokens);
+            hash_tokens = std::move(other.hash_tokens);
+            hash_groups = std::move(other.hash_groups);
+            stats = std::move(other.stats);
+            facet_range_map = std::move(other.facet_range_map);
+            is_range_query = other.is_range_query;
+            sampled = other.sampled;
+            is_wildcard_match = other.is_wildcard_match;
+            is_dynamic = other.is_dynamic;
+            is_intersected = other.is_intersected;
+            is_sort_by_alpha = other.is_sort_by_alpha;
+            sort_order = std::move(other.sort_order);
+            sort_field = std::move(other.sort_field);
+            orig_index = other.orig_index;
+            delete reference_facet;
+            reference_facet = other.reference_facet;
+            other.reference_facet = nullptr;
+            references = std::move(other.references);
+            is_top_k = other.is_top_k;
+        }
+        return *this;
     }
 };
 

--- a/include/index.h
+++ b/include/index.h
@@ -917,7 +917,7 @@ public:
 
     static void remove_matched_tokens(std::vector<std::string>& tokens, const std::set<std::string>& rule_token_set) ;
 
-    Option<bool> compute_facet_infos_with_lock(const std::vector<facet>& facets, facet_query_t& facet_query,
+    Option<bool> compute_facet_infos_with_lock(std::vector<facet>& facets, facet_query_t& facet_query,
                                                const uint32_t facet_query_num_typos,
                                                uint32_t* all_result_ids, const size_t& all_result_ids_len,
                                                const std::vector<std::string>& group_by_fields,
@@ -932,9 +932,9 @@ public:
     void get_reference_facet_ids(const uint32_t* all_result_ids, const size_t& all_result_ids_len,
                                  const std::string& collection_name, Collection const *const ref_collection,
                                  filter_result_iterator_t& filter_result_iterator,
-                                 std::unordered_map<std::string, reference_filter_result_t>& reference_facet_ids) const;
+                                 reference_filter_result_t& reference_facet_result) const;
 
-    Option<bool> compute_facet_infos(const std::vector<facet>& facets, facet_query_t& facet_query,
+    Option<bool> compute_facet_infos(std::vector<facet>& facets, facet_query_t& facet_query,
                                      const uint32_t facet_query_num_typos,
                                      uint32_t* all_result_ids, const size_t& all_result_ids_len,
                                      const std::vector<std::string>& group_by_fields,
@@ -945,8 +945,7 @@ public:
                                      bool is_group_by_first_pass,
                                      std::set<uint32_t>& group_by_missing_value_ids,
                                      Collection const *const collection,
-                                     filter_result_iterator_t& filter_result_iterator,
-                                     std::unordered_map<std::string, reference_filter_result_t>& reference_facet_ids) const;
+                                     filter_result_iterator_t& filter_result_iterator) const;
 
     void resolve_space_as_typos(std::vector<std::string>& qtokens, const std::string& field_name,
                                 std::vector<std::vector<std::string>>& resolved_queries) const;

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -7821,10 +7821,11 @@ Option<bool> Collection::parse_facet(const std::string& facet_field, std::vector
         }
 
         for (auto& ref_facet: ref_facets) {
-            ref_facet.reference_collection_name = ref_collection_name;
-            ref_facet.reference_collection_alias_name = ref_alias_collection_name;
-            ref_facet.orig_index = facets.size();
-            facets.emplace_back(std::move(ref_facet));
+            facet wrapper_facet(ref_facet.field_name, facets.size(), ref_facet.is_top_k, ref_facet.facet_range_map,
+                               ref_facet.is_range_query, ref_facet.is_sort_by_alpha, ref_facet.sort_order,
+                               ref_facet.sort_field, ref_collection_name, ref_alias_collection_name);
+            wrapper_facet.nested_join_facets.emplace_back(std::move(ref_facet));
+            facets.emplace_back(std::move(wrapper_facet));
         }
 
         return Option<bool>(true);
@@ -9267,6 +9268,47 @@ std::string Collection::get_facet_str_val_with_lock(const std::string& field_nam
     return get_facet_str_val(field_name, facet_id);
 }
 
+static void get_nested_facet_collection_chain(const facet& a_facet,
+                                              std::vector<std::pair<std::string, std::string>>& collection_chain) {
+    if (!a_facet.reference_collection_name.empty()) {
+        collection_chain.emplace_back(a_facet.reference_collection_name, a_facet.reference_collection_alias_name);
+    }
+
+    if (!a_facet.nested_join_facets.empty()) {
+        get_nested_facet_collection_chain(a_facet.nested_join_facets[0], collection_chain);
+    }
+}
+
+static std::string get_nested_facet_field_name(const facet& a_facet) {
+    std::vector<std::pair<std::string, std::string>> collection_chain;
+    get_nested_facet_collection_chain(a_facet, collection_chain);
+
+    std::string field_name = a_facet.field_name;
+    for (size_t i = collection_chain.size(); i > 0; i--) {
+        const auto& collection_name = collection_chain[i - 1].second.empty() ?
+                                      collection_chain[i - 1].first :
+                                      collection_chain[i - 1].second;
+        field_name = "$" + collection_name + "(" + field_name + ")";
+    }
+
+    return field_name;
+}
+
+static std::string get_nested_facet_filter_value(const facet& a_facet, const std::string& filter_value) {
+    std::vector<std::pair<std::string, std::string>> collection_chain;
+    get_nested_facet_collection_chain(a_facet, collection_chain);
+
+    std::string field_name = a_facet.field_name + ": " + filter_value;
+    for (size_t i = collection_chain.size(); i > 0; i--) {
+        const auto& collection_name = collection_chain[i - 1].second.empty() ?
+                                      collection_chain[i - 1].first :
+                                      collection_chain[i - 1].second;
+        field_name = "$" + collection_name + "(" + field_name + ")";
+    }
+
+    return field_name;
+}
+
 union_global_params_t::union_global_params_t(const std::map<std::string, std::string> &req_params) {
     for (const auto& pair: param_pairs) {
         const auto& param = pair.first;
@@ -9345,10 +9387,8 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
         facet_result["sampled"] = a_facet.sampled;
         facet_result["counts"] = nlohmann::json::array();
 
-        if (!a_facet.reference_collection_alias_name.empty()) {
-            facet_result["field_name"] = "$" + a_facet.reference_collection_alias_name + "(" + a_facet.field_name + ")";
-        } else if(!a_facet.reference_collection_name.empty()) {
-            facet_result["field_name"] = "$" + a_facet.reference_collection_name + "(" + a_facet.field_name + ")";
+        if(!a_facet.reference_collection_name.empty()) {
+            facet_result["field_name"] = get_nested_facet_field_name(a_facet);
         }
 
         std::vector<facet_value_t> facet_values;
@@ -9379,7 +9419,9 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
             the_field = search_schema_snapshot.at(a_facet.field_name);
         } else {
             auto& cm = CollectionManager::get_instance();
-            ref_collection = cm.get_collection(a_facet.reference_collection_name);
+            std::vector<std::pair<std::string, std::string>> collection_chain;
+            get_nested_facet_collection_chain(a_facet, collection_chain);
+            ref_collection = cm.get_collection(collection_chain.back().first);
             if (ref_collection == nullptr) {
                 continue;
             }
@@ -9396,10 +9438,7 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
                                                  facet_count.count, 0, nlohmann::json(), std::string()};
 
                     if(!a_facet.reference_collection_name.empty()) {
-                        const auto& ref_coll_name = a_facet.reference_collection_alias_name.empty() ?
-                                                    a_facet.reference_collection_name :
-                                                    a_facet.reference_collection_alias_name;
-                        std::string facet_filter = "$" + ref_coll_name + "(" + a_facet.field_name + ": ";
+                        std::string facet_filter;
                         std::string lower_range, upper_range;
                         //lower range
                         if(the_field.is_float()){
@@ -9417,15 +9456,15 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
 
                         if(facet_range_iter->second.lower_range == INT64_MIN) {
                             //format : range_label[ , val]
-                            facet_filter += "<=" + upper_range + ")";
+                            facet_filter = "<=" + upper_range;
                         } else if(facet_range_iter->first == INT64_MAX) {
                             //format : range_label[val, ]
-                            facet_filter += ">=" + lower_range + ")";
+                            facet_filter = ">=" + lower_range;
                         } else {
-                            facet_filter += "[" + lower_range + ".." + upper_range + "])";
+                            facet_filter = "[" + lower_range + ".." + upper_range + "]";
                         }
 
-                        facet_value.facet_filter = facet_filter;
+                        facet_value.facet_filter = get_nested_facet_filter_value(a_facet, facet_filter);
                     }
 
                     facet_values.emplace_back(facet_value);
@@ -9548,19 +9587,15 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
                                              facet_count.sort_field_val, parent, std::string()};
 
                 if(!a_facet.reference_collection_name.empty()) {
-                    const auto& ref_coll_name = a_facet.reference_collection_alias_name.empty() ?
-                                                a_facet.reference_collection_name :
-                                                a_facet.reference_collection_alias_name;
-                    std::string facet_filter = "$" + ref_coll_name + "(" + a_facet.field_name + ": ";
+                    std::string facet_filter;
 
                     if(the_field.is_string()) {
-                        facet_filter += std::string("`") + value + std::string("`");
+                        facet_filter = std::string("`") + value + std::string("`");
                     } else {
-                        facet_filter += value;
+                        facet_filter = value;
                     }
 
-                    facet_filter += std::string(")");
-                    facet_value.facet_filter = facet_filter;
+                    facet_value.facet_filter = get_nested_facet_filter_value(a_facet, facet_filter);
                 }
 
                 facet_values.emplace_back(facet_value);

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -7823,8 +7823,12 @@ Option<bool> Collection::parse_facet(const std::string& facet_field, std::vector
         for (auto& ref_facet: ref_facets) {
             facet wrapper_facet(ref_facet.field_name, facets.size(), ref_facet.is_top_k, ref_facet.facet_range_map,
                                ref_facet.is_range_query, ref_facet.is_sort_by_alpha, ref_facet.sort_order,
-                               ref_facet.sort_field, ref_collection_name, ref_alias_collection_name);
-            wrapper_facet.nested_join_facets.emplace_back(std::move(ref_facet));
+                               ref_facet.sort_field);
+            nested_facet nested_join_facet;
+            nested_join_facet.collection_name = ref_collection_name;
+            nested_join_facet.alias = ref_alias_collection_name;
+            nested_join_facet.facets.emplace_back(std::move(ref_facet));
+            wrapper_facet.nested_join_facets.emplace_back(std::move(nested_join_facet));
             facets.emplace_back(std::move(wrapper_facet));
         }
 
@@ -8159,7 +8163,7 @@ Option<bool> Collection::process_ref_include_fields_sort(const std::string& sort
     return op;
 }
 
-Option<bool> Collection::compute_facet_infos_with_lock(const std::vector<facet>& facets, facet_query_t& facet_query,
+Option<bool> Collection::compute_facet_infos_with_lock(std::vector<facet>& facets, facet_query_t& facet_query,
                                                const uint32_t facet_query_num_typos,
                                                uint32_t* all_result_ids, const size_t& all_result_ids_len,
                                                const std::vector<std::string>& group_by_fields,
@@ -9270,12 +9274,12 @@ std::string Collection::get_facet_str_val_with_lock(const std::string& field_nam
 
 static void get_nested_facet_collection_chain(const facet& a_facet,
                                               std::vector<std::pair<std::string, std::string>>& collection_chain) {
-    if (!a_facet.reference_collection_name.empty()) {
-        collection_chain.emplace_back(a_facet.reference_collection_name, a_facet.reference_collection_alias_name);
-    }
-
     if (!a_facet.nested_join_facets.empty()) {
-        get_nested_facet_collection_chain(a_facet.nested_join_facets[0], collection_chain);
+        const auto& nested_join_facet = a_facet.nested_join_facets[0];
+        collection_chain.emplace_back(nested_join_facet.collection_name, nested_join_facet.alias);
+        if (!nested_join_facet.facets.empty()) {
+            get_nested_facet_collection_chain(nested_join_facet.facets[0], collection_chain);
+        }
     }
 }
 
@@ -9387,7 +9391,7 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
         facet_result["sampled"] = a_facet.sampled;
         facet_result["counts"] = nlohmann::json::array();
 
-        if(!a_facet.reference_collection_name.empty()) {
+        if(!a_facet.nested_join_facets.empty()) {
             facet_result["field_name"] = get_nested_facet_field_name(a_facet);
         }
 
@@ -9415,7 +9419,7 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
 
         field the_field;
         std::shared_ptr<Collection> ref_collection;
-        if (a_facet.reference_collection_name.empty()) {
+        if (a_facet.nested_join_facets.empty()) {
             the_field = search_schema_snapshot.at(a_facet.field_name);
         } else {
             auto& cm = CollectionManager::get_instance();
@@ -9437,7 +9441,7 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
                     facet_value_t facet_value = {facet_range_iter->second.range_label, std::string(),
                                                  facet_count.count, 0, nlohmann::json(), std::string()};
 
-                    if(!a_facet.reference_collection_name.empty()) {
+                    if(!a_facet.nested_join_facets.empty()) {
                         std::string facet_filter;
                         std::string lower_range, upper_range;
                         //lower range
@@ -9586,7 +9590,7 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
                 facet_value_t facet_value = {value, highlighted_text, facet_count.count,
                                              facet_count.sort_field_val, parent, std::string()};
 
-                if(!a_facet.reference_collection_name.empty()) {
+                if(!a_facet.nested_join_facets.empty()) {
                     std::string facet_filter;
 
                     if(the_field.is_string()) {

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -7824,11 +7824,12 @@ Option<bool> Collection::parse_facet(const std::string& facet_field, std::vector
             facet wrapper_facet(ref_facet.field_name, facets.size(), ref_facet.is_top_k, ref_facet.facet_range_map,
                                ref_facet.is_range_query, ref_facet.is_sort_by_alpha, ref_facet.sort_order,
                                ref_facet.sort_field);
-            nested_facet nested_join_facet;
-            nested_join_facet.collection_name = ref_collection_name;
-            nested_join_facet.alias = ref_alias_collection_name;
-            nested_join_facet.facets.emplace_back(std::move(ref_facet));
-            wrapper_facet.nested_join_facets.emplace_back(std::move(nested_join_facet));
+            auto* ref = new reference_facet_t();
+            ref->collection_name = ref_collection_name;
+            ref->alias = ref_alias_collection_name;
+            ref->nested_reference_facet = ref_facet.reference_facet;
+            ref_facet.reference_facet = nullptr;
+            wrapper_facet.reference_facet = ref;
             facets.emplace_back(std::move(wrapper_facet));
         }
 
@@ -9274,12 +9275,10 @@ std::string Collection::get_facet_str_val_with_lock(const std::string& field_nam
 
 static void get_nested_facet_collection_chain(const facet& a_facet,
                                               std::vector<std::pair<std::string, std::string>>& collection_chain) {
-    if (!a_facet.nested_join_facets.empty()) {
-        const auto& nested_join_facet = a_facet.nested_join_facets[0];
-        collection_chain.emplace_back(nested_join_facet.collection_name, nested_join_facet.alias);
-        if (!nested_join_facet.facets.empty()) {
-            get_nested_facet_collection_chain(nested_join_facet.facets[0], collection_chain);
-        }
+    auto* ref = a_facet.reference_facet;
+    while (ref != nullptr) {
+        collection_chain.emplace_back(ref->collection_name, ref->alias);
+        ref = ref->nested_reference_facet;
     }
 }
 
@@ -9391,7 +9390,7 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
         facet_result["sampled"] = a_facet.sampled;
         facet_result["counts"] = nlohmann::json::array();
 
-        if(!a_facet.nested_join_facets.empty()) {
+        if(a_facet.reference_facet != nullptr) {
             facet_result["field_name"] = get_nested_facet_field_name(a_facet);
         }
 
@@ -9419,7 +9418,7 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
 
         field the_field;
         std::shared_ptr<Collection> ref_collection;
-        if (a_facet.nested_join_facets.empty()) {
+        if (a_facet.reference_facet == nullptr) {
             the_field = search_schema_snapshot.at(a_facet.field_name);
         } else {
             auto& cm = CollectionManager::get_instance();
@@ -9441,7 +9440,7 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
                     facet_value_t facet_value = {facet_range_iter->second.range_label, std::string(),
                                                  facet_count.count, 0, nlohmann::json(), std::string()};
 
-                    if(!a_facet.nested_join_facets.empty()) {
+                    if(a_facet.reference_facet != nullptr) {
                         std::string facet_filter;
                         std::string lower_range, upper_range;
                         //lower range
@@ -9590,7 +9589,7 @@ Option<bool> Collection::populate_facets(std::vector<facet> facets, size_t max_f
                 facet_value_t facet_value = {value, highlighted_text, facet_count.count,
                                              facet_count.sort_field_val, parent, std::string()};
 
-                if(!a_facet.nested_join_facets.empty()) {
+                if(a_facet.reference_facet != nullptr) {
                     std::string facet_filter;
 
                     if(the_field.is_string()) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1527,17 +1527,16 @@ static void append_reference_result(const reference_filter_result_t& ref_result,
 }
 
 static std::string get_reference_facet_cache_key(const facet& a_facet) {
-    if (a_facet.nested_join_facets.empty()) {
+    if (a_facet.reference_facet == nullptr) {
         return "";
     }
 
-    const auto& nested_join_facet = a_facet.nested_join_facets[0];
-    auto cache_key = !nested_join_facet.alias.empty() ? nested_join_facet.alias : nested_join_facet.collection_name;
-    if (!nested_join_facet.facets.empty()) {
-        auto nested_cache_key = get_reference_facet_cache_key(nested_join_facet.facets[0]);
-        if (!nested_cache_key.empty()) {
-            cache_key += ">" + nested_cache_key;
-        }
+    std::string cache_key;
+    auto* ref = a_facet.reference_facet;
+    while (ref != nullptr) {
+        if (!cache_key.empty()) cache_key += ">";
+        cache_key += !ref->alias.empty() ? ref->alias : ref->collection_name;
+        ref = ref->nested_reference_facet;
     }
 
     return cache_key;
@@ -1548,7 +1547,7 @@ static void project_nested_reference_result(const reference_filter_result_t& ref
                                             reference_filter_result_t& projected_result) {
     std::vector<uint32_t> ref_doc_ids;
     std::unordered_map<uint32_t, std::map<std::string, reference_filter_result_t>> ref_doc_id_to_references;
-    const auto& ref_collection_name = a_facet.nested_join_facets[0].collection_name;
+    const auto& ref_collection_name = a_facet.reference_facet->collection_name;
 
     if (reference_result.coll_to_references != nullptr) {
         for (uint32_t i = 0; i < reference_result.count; i++) {
@@ -1630,9 +1629,8 @@ Option<bool> Index::do_facets(std::vector<facet>& facets, facet_query_t & facet_
     // assumed that facet fields have already been validated upstream
     for(auto& a_facet : facets) {
         auto findex = a_facet.orig_index;
-        if (!a_facet.nested_join_facets.empty()) {
-            auto const& nested_join_facet = a_facet.nested_join_facets[0];
-            auto const& ref_collection_name = nested_join_facet.collection_name;
+        if (a_facet.reference_facet != nullptr) {
+            auto const& ref_collection_name = a_facet.reference_facet->collection_name;
 
             auto& cm = CollectionManager::get_instance();
             auto ref_collection = cm.get_collection(ref_collection_name);
@@ -1640,16 +1638,20 @@ Option<bool> Index::do_facets(std::vector<facet>& facets, facet_query_t & facet_
                 return Option<bool>(400, "Referenced collection `" + ref_collection_name + "` in `facet_by` not found.");
             }
 
-            if (a_facet.references.count == 0 || a_facet.nested_join_facets.empty()) {
+            if (a_facet.references.count == 0) {
                 continue;
             }
 
             auto const& ref_facet_result = a_facet.references;
-            std::vector<facet> ref_facets = nested_join_facet.facets;
-            for (auto& ref_facet: ref_facets) {
-                ref_facet.orig_index = 0;
-                ref_facet.references = ref_facet_result;
+            std::vector<facet> ref_facets;
+            facet ref_facet_copy(a_facet.field_name, 0, a_facet.is_top_k, a_facet.facet_range_map,
+                                 a_facet.is_range_query, a_facet.is_sort_by_alpha, a_facet.sort_order,
+                                 a_facet.sort_field);
+            if (a_facet.reference_facet->nested_reference_facet != nullptr) {
+                ref_facet_copy.reference_facet = new reference_facet_t(*a_facet.reference_facet->nested_reference_facet);
             }
+            ref_facet_copy.references = ref_facet_result;
+            ref_facets.emplace_back(std::move(ref_facet_copy));
             std::vector<facet_index_type_t> ref_facet_index_types = {facet_index_types[findex]};
 
             ref_collection->do_facets_with_lock(ref_facets, facet_query, estimate_facets, facet_sample_percent,
@@ -1658,7 +1660,6 @@ Option<bool> Index::do_facets(std::vector<facet>& facets, facet_query_t & facet_
                                                 is_wildcard_no_filter_query, ref_facet_index_types,
                                                 is_group_by_first_pass, group_by_missing_value_ids);
             if (ref_facets.empty()) {
-                // Shouldn't happen, still adding safeguard to prevent crash.
                 LOG(ERROR) << "Reference faceting on `" << ref_collection_name << "." << a_facet.field_name << "` unsuccessful.";
                 continue;
             }
@@ -4440,30 +4441,32 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
 
         for(size_t i = 0; i < facets.size(); i++) {
             const auto& this_facet = facets[i];
-            //process facets separately which has top_k set to true
             if(this_facet.is_top_k) {
-                if(!this_facet.nested_join_facets.empty()) {
+                if(this_facet.reference_facet != nullptr) {
                     top_k_reference_facets.emplace_back(this_facet);
                     continue;
                 }
                 top_k_facets.emplace_back(this_facet.field_name, this_facet.orig_index, this_facet.is_top_k, this_facet.facet_range_map,
                                           this_facet.is_range_query, this_facet.is_sort_by_alpha, this_facet.sort_order, this_facet.sort_field);
-                top_k_facets.back().nested_join_facets = this_facet.nested_join_facets;
+                if (this_facet.reference_facet != nullptr) {
+                    top_k_facets.back().reference_facet = new reference_facet_t(*this_facet.reference_facet);
+                }
                 continue;
             }
 
-            if(!this_facet.nested_join_facets.empty()) {
+            if(this_facet.reference_facet != nullptr) {
                 reference_facets.emplace_back(this_facet);
                 continue;
             }
 
             if(facet_infos[i].use_value_index) {
-                // value based faceting on a single thread
                 value_facets[num_value_facets % num_threads].emplace_back(this_facet.field_name, this_facet.orig_index,
                                           this_facet.is_top_k, this_facet.facet_range_map,
                                           this_facet.is_range_query, this_facet.is_sort_by_alpha,
                                           this_facet.sort_order, this_facet.sort_field);
-                value_facets[num_value_facets % num_threads].back().nested_join_facets = this_facet.nested_join_facets;
+                if (this_facet.reference_facet != nullptr) {
+                    value_facets[num_value_facets % num_threads].back().reference_facet = new reference_facet_t(*this_facet.reference_facet);
+                }
                 num_value_facets++;
                 continue;
             }
@@ -4472,7 +4475,9 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                 facet_batches[j].emplace_back(this_facet.field_name, this_facet.orig_index, this_facet.is_top_k,
                                               this_facet.facet_range_map, this_facet.is_range_query,
                                               this_facet.is_sort_by_alpha, this_facet.sort_order, this_facet.sort_field);
-                facet_batches[j].back().nested_join_facets = this_facet.nested_join_facets;
+                if (this_facet.reference_facet != nullptr) {
+                    facet_batches[j].back().reference_facet = new reference_facet_t(*this_facet.reference_facet);
+                }
             }
         }
 
@@ -6478,9 +6483,8 @@ Option<bool> Index::compute_facet_infos(std::vector<facet>& facets, facet_query_
     for(size_t findex=0; findex < facets.size(); findex++) {
         auto& a_facet = facets[findex];
 
-        if (!a_facet.nested_join_facets.empty()) {
-            auto const& nested_join_facet = a_facet.nested_join_facets[0];
-            auto const& ref_collection_name = nested_join_facet.collection_name;
+        if (a_facet.reference_facet != nullptr) {
+            auto const& ref_collection_name = a_facet.reference_facet->collection_name;
 
             auto& cm = CollectionManager::get_instance();
             auto ref_collection = cm.get_collection(ref_collection_name);
@@ -6505,11 +6509,15 @@ Option<bool> Index::compute_facet_infos(std::vector<facet>& facets, facet_query_
                 continue;
             }
 
-            std::vector<facet> ref_facets = nested_join_facet.facets;
-            for (auto& ref_facet: ref_facets) {
-                ref_facet.orig_index = 0;
-                ref_facet.references = a_facet.references;
+            std::vector<facet> ref_facets;
+            facet ref_facet_copy(a_facet.field_name, 0, a_facet.is_top_k, a_facet.facet_range_map,
+                                 a_facet.is_range_query, a_facet.is_sort_by_alpha, a_facet.sort_order,
+                                 a_facet.sort_field);
+            if (a_facet.reference_facet->nested_reference_facet != nullptr) {
+                ref_facet_copy.reference_facet = new reference_facet_t(*a_facet.reference_facet->nested_reference_facet);
             }
+            ref_facet_copy.references = a_facet.references;
+            ref_facets.emplace_back(std::move(ref_facet_copy));
             auto const& reference_doc_ids = a_facet.references.docs;
             auto const& reference_doc_ids_len = a_facet.references.count;
             std::vector<facet_info_t> ref_facet_infos(1);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1492,9 +1492,103 @@ Option<bool> Index::do_facets_with_lock(std::vector<facet>& facets, facet_query_
                                         std::set<uint32_t>& group_by_missing_value_ids,
                                         Collection const *const collection) const {
     std::shared_lock lock(mutex);
+    std::unordered_map<std::string, reference_filter_result_t> reference_facet_ids;
     return do_facets(facets, facet_query, estimate_facets, facet_sample_percent, facet_infos, group_limit, group_by_fields,
                      group_missing_values, result_ids, results_size, max_facet_count, is_wildcard_query, facet_index_types,
-                     is_group_by_first_pass, group_by_missing_value_ids, collection, nullptr);
+                     is_group_by_first_pass, group_by_missing_value_ids, collection, &reference_facet_ids);
+}
+
+static void merge_reference_maps(std::map<std::string, reference_filter_result_t>& existing_references,
+                                 const std::map<std::string, reference_filter_result_t>& incoming_references) {
+    if (incoming_references.empty()) {
+        return;
+    }
+
+    if (existing_references.empty()) {
+        existing_references.insert(incoming_references.begin(), incoming_references.end());
+        return;
+    }
+
+    std::map<std::string, reference_filter_result_t> merged_references;
+    reference_filter_result_t::or_references(existing_references, incoming_references, merged_references);
+    existing_references = std::move(merged_references);
+}
+
+static void append_reference_result(const reference_filter_result_t& ref_result, std::vector<uint32_t>& ref_doc_ids,
+                                    std::unordered_map<uint32_t, std::map<std::string, reference_filter_result_t>>&
+                                    ref_doc_id_to_references) {
+    for (uint32_t j = 0; j < ref_result.count; j++) {
+        const auto ref_doc_id = ref_result.docs[j];
+        ref_doc_ids.push_back(ref_doc_id);
+
+        if (ref_result.coll_to_references != nullptr) {
+            merge_reference_maps(ref_doc_id_to_references[ref_doc_id], ref_result.coll_to_references[j]);
+        }
+    }
+}
+
+static void project_nested_reference_result(const reference_filter_result_t& reference_result,
+                                            const std::string& ref_collection_name,
+                                            reference_filter_result_t& projected_result) {
+    std::vector<uint32_t> ref_doc_ids;
+    std::unordered_map<uint32_t, std::map<std::string, reference_filter_result_t>> ref_doc_id_to_references;
+
+    if (reference_result.coll_to_references != nullptr) {
+        for (uint32_t i = 0; i < reference_result.count; i++) {
+            auto ref_it = reference_result.coll_to_references[i].find(ref_collection_name);
+            if (ref_it == reference_result.coll_to_references[i].end()) {
+                continue;
+            }
+
+            append_reference_result(ref_it->second, ref_doc_ids, ref_doc_id_to_references);
+        }
+    }
+
+    gfx::timsort(ref_doc_ids.begin(), ref_doc_ids.end());
+    ref_doc_ids.erase(std::unique(ref_doc_ids.begin(), ref_doc_ids.end()), ref_doc_ids.end());
+
+    projected_result.count = ref_doc_ids.size();
+    projected_result.docs = new uint32_t[ref_doc_ids.size()];
+    std::copy(ref_doc_ids.begin(), ref_doc_ids.end(), projected_result.docs);
+
+    if (!ref_doc_id_to_references.empty()) {
+        projected_result.coll_to_references = new std::map<std::string, reference_filter_result_t>[ref_doc_ids.size()] {};
+        for (size_t i = 0; i < ref_doc_ids.size(); i++) {
+            auto ref_doc_references_it = ref_doc_id_to_references.find(ref_doc_ids[i]);
+            if (ref_doc_references_it != ref_doc_id_to_references.end()) {
+                projected_result.coll_to_references[i] = ref_doc_references_it->second;
+            }
+        }
+    }
+}
+
+static void copy_reference_facet_result(const facet& from_facet, facet& to_facet) {
+    to_facet.result_map = from_facet.result_map;
+    to_facet.value_result_map = from_facet.value_result_map;
+    to_facet.fvalue_tokens = from_facet.fvalue_tokens;
+    to_facet.hash_tokens = from_facet.hash_tokens;
+    to_facet.hash_groups = from_facet.hash_groups;
+    to_facet.stats = from_facet.stats;
+    to_facet.sampled = from_facet.sampled;
+    to_facet.is_wildcard_match = from_facet.is_wildcard_match;
+    to_facet.is_dynamic = from_facet.is_dynamic;
+    to_facet.is_intersected = from_facet.is_intersected;
+}
+
+static reference_filter_result_t copy_reference_result_slice(const reference_filter_result_t& reference_result,
+                                                             const uint32_t start_index, const uint32_t length) {
+    auto batch_docs = new uint32_t[length];
+    std::copy(reference_result.docs + start_index, reference_result.docs + start_index + length, batch_docs);
+
+    reference_filter_result_t batch_result(length, batch_docs, reference_result.is_reference_array_field);
+    if (reference_result.coll_to_references != nullptr) {
+        batch_result.coll_to_references = new std::map<std::string, reference_filter_result_t>[length] {};
+        for (uint32_t i = 0; i < length; i++) {
+            batch_result.coll_to_references[i] = reference_result.coll_to_references[start_index + i];
+        }
+    }
+
+    return batch_result;
 }
 
 Option<bool> Index::do_facets(std::vector<facet>& facets, facet_query_t & facet_query,
@@ -1521,10 +1615,6 @@ Option<bool> Index::do_facets(std::vector<facet>& facets, facet_query_t & facet_
         auto findex = a_facet.orig_index;
         if (!a_facet.reference_collection_name.empty()) {
             auto const& ref_collection_name = a_facet.reference_collection_name;
-            if (reference_facet_ids == nullptr || reference_facet_ids->count(ref_collection_name) == 0 ||
-                reference_facet_ids->at(ref_collection_name).count == 0) {
-                continue;
-            }
 
             auto& cm = CollectionManager::get_instance();
             auto ref_collection = cm.get_collection(ref_collection_name);
@@ -1532,12 +1622,33 @@ Option<bool> Index::do_facets(std::vector<facet>& facets, facet_query_t & facet_
                 return Option<bool>(400, "Referenced collection `" + ref_collection_name + "` in `facet_by` not found.");
             }
 
+            if (reference_facet_ids == nullptr) {
+                continue;
+            }
+
+            if (reference_facet_ids->count(ref_collection_name) == 0) {
+                if (a_facet.references.count != 0) {
+                    auto& projected_result = (*reference_facet_ids)[ref_collection_name];
+                    project_nested_reference_result(a_facet.references, ref_collection_name, projected_result);
+                } else {
+                    continue;
+                }
+            }
+
+            if (reference_facet_ids->at(ref_collection_name).count == 0) {
+                continue;
+            }
+
             auto& ref_facet_result = reference_facet_ids->at(ref_collection_name);
-            a_facet.reference_collection_name.clear();
-            auto temp_orig_index = a_facet.orig_index;
-            // Referenced collection only has to process a single facet.
-            a_facet.orig_index = 0;
-            std::vector<facet> ref_facets{a_facet};
+            if (a_facet.nested_join_facets.empty()) {
+                continue;
+            }
+
+            std::vector<facet> ref_facets = a_facet.nested_join_facets;
+            for (auto& ref_facet: ref_facets) {
+                ref_facet.orig_index = 0;
+                ref_facet.references = ref_facet_result;
+            }
 
             ref_collection->do_facets_with_lock(ref_facets, facet_query, estimate_facets, facet_sample_percent,
                                                 {facet_infos[findex]}, group_limit, group_by_fields, group_missing_values,
@@ -1548,9 +1659,7 @@ Option<bool> Index::do_facets(std::vector<facet>& facets, facet_query_t & facet_
                 LOG(ERROR) << "Reference faceting on `" << ref_collection_name << "." << a_facet.field_name << "` unsuccessful.";
                 continue;
             }
-            ref_facets[0].reference_collection_name = ref_collection_name;
-            ref_facets[0].orig_index = temp_orig_index;
-            a_facet = std::move(ref_facets[0]);
+            copy_reference_facet_result(ref_facets[0], a_facet);
             a_facet.references = ref_facet_result;
             continue;
         }
@@ -4332,6 +4441,9 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
             if(this_facet.is_top_k) {
                 top_k_facets.emplace_back(this_facet.field_name, this_facet.orig_index, this_facet.is_top_k, this_facet.facet_range_map,
                                           this_facet.is_range_query, this_facet.is_sort_by_alpha, this_facet.sort_order, this_facet.sort_field);
+                top_k_facets.back().reference_collection_name = this_facet.reference_collection_name;
+                top_k_facets.back().reference_collection_alias_name = this_facet.reference_collection_alias_name;
+                top_k_facets.back().nested_join_facets = this_facet.nested_join_facets;
                 continue;
             }
 
@@ -4343,6 +4455,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                                           this_facet.sort_order, this_facet.sort_field,
                                           this_facet.reference_collection_name,
                                           this_facet.reference_collection_alias_name);
+                value_facets[num_value_facets % num_threads].back().nested_join_facets = this_facet.nested_join_facets;
                 num_value_facets++;
                 continue;
             }
@@ -4353,6 +4466,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                                               this_facet.is_sort_by_alpha, this_facet.sort_order, this_facet.sort_field,
                                               this_facet.reference_collection_name,
                                               this_facet.reference_collection_alias_name);
+                facet_batches[j].back().nested_join_facets = this_facet.nested_join_facets;
             }
         }
 
@@ -4389,14 +4503,10 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                     batch_reference_facet_len = ref_ids_len - reference_facet_index;
                 }
 
-                auto batch_res_ids = new uint32_t[batch_reference_facet_len];
-                // Copying reference ids since they will be required further in `Collection::facet_value_to_string`.
-                std::copy(reference_facet_result.docs + reference_facet_index,
-                          reference_facet_result.docs + reference_facet_index + batch_reference_facet_len,
-                          batch_res_ids);
-
                 std::unordered_map<std::string, reference_filter_result_t> batch_reference_facets;
-                batch_reference_facets[item.first] = reference_filter_result_t(batch_reference_facet_len, batch_res_ids);
+                batch_reference_facets[item.first] = copy_reference_result_slice(reference_facet_result,
+                                                                                 reference_facet_index,
+                                                                                 batch_reference_facet_len);
                 batch_reference_facet_ids.emplace_back(std::move(batch_reference_facets));
 
                 reference_facet_index += batch_reference_facet_len;
@@ -4605,6 +4715,7 @@ void Index::get_reference_facet_ids(const uint32_t* all_result_ids, const size_t
 
     std::vector<uint32_t> ref_doc_ids;
     ref_doc_ids.reserve(all_result_ids_len);
+    std::unordered_map<uint32_t, std::map<std::string, reference_filter_result_t>> ref_doc_id_to_references;
 
     for(uint32_t i = 0; i < all_result_ids_len; ++i) {
         // Only collecting the references of docs in the final result.
@@ -4642,9 +4753,7 @@ void Index::get_reference_facet_ids(const uint32_t* all_result_ids, const size_t
 
         if (has_filter_reference) {
             auto const& ref_result = fit.reference[ref_collection_name];
-            for (uint32_t j = 0; j < ref_result.count; j++) {
-                ref_doc_ids.push_back(ref_result.docs[j]);
-            }
+            append_reference_result(ref_result, ref_doc_ids, ref_doc_id_to_references);
         } else if (doc_has_reference) {
             auto get_reference_field_op = ref_collection->get_referenced_in_field_with_lock(collection_name);
             if (!get_reference_field_op.ok()) {
@@ -4687,6 +4796,15 @@ void Index::get_reference_facet_ids(const uint32_t* all_result_ids, const size_t
     result.count = ref_doc_ids.size();
     result.docs = new uint32_t[ref_doc_ids.size()];
     std::copy(ref_doc_ids.begin(), ref_doc_ids.end(), result.docs);
+    if (!ref_doc_id_to_references.empty()) {
+        result.coll_to_references = new std::map<std::string, reference_filter_result_t>[ref_doc_ids.size()] {};
+        for (size_t i = 0; i < ref_doc_ids.size(); i++) {
+            auto ref_doc_references_it = ref_doc_id_to_references.find(ref_doc_ids[i]);
+            if (ref_doc_references_it != ref_doc_id_to_references.end()) {
+                result.coll_to_references[i] = ref_doc_references_it->second;
+            }
+        }
+    }
 }
 
 void Index::aggregate_facet(const size_t group_limit, facet& this_facet, facet& acc_facet) const {
@@ -6364,17 +6482,28 @@ Option<bool> Index::compute_facet_infos(const std::vector<facet>& facets, facet_
             }
 
             if (reference_facet_ids.count(ref_collection_name) == 0) {
-                get_reference_facet_ids(all_result_ids, all_result_ids_len, collection->get_name(),
-                                        ref_collection.get(), fit, reference_facet_ids);
+                if (a_facet.references.count != 0) {
+                    auto& projected_result = reference_facet_ids[ref_collection_name];
+                    project_nested_reference_result(a_facet.references, ref_collection_name, projected_result);
+                } else {
+                    get_reference_facet_ids(all_result_ids, all_result_ids_len, collection->get_name(),
+                                            ref_collection.get(), fit, reference_facet_ids);
+                }
             }
 
             if (reference_facet_ids.at(ref_collection_name).count == 0) {
                 continue;
             }
 
-            auto ref_facet = a_facet;
-            ref_facet.reference_collection_name.clear();
-            std::vector<facet> ref_facets = {ref_facet};
+            if (a_facet.nested_join_facets.empty()) {
+                continue;
+            }
+
+            std::vector<facet> ref_facets = a_facet.nested_join_facets;
+            for (auto& ref_facet: ref_facets) {
+                ref_facet.orig_index = 0;
+                ref_facet.references = reference_facet_ids.at(ref_collection_name);
+            }
             auto const& reference_doc_ids = reference_facet_ids.at(ref_collection_name).docs;
             auto const& reference_doc_ids_len = reference_facet_ids.at(ref_collection_name).count;
             std::vector<facet_info_t> ref_facet_infos(1);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1492,10 +1492,9 @@ Option<bool> Index::do_facets_with_lock(std::vector<facet>& facets, facet_query_
                                         std::set<uint32_t>& group_by_missing_value_ids,
                                         Collection const *const collection) const {
     std::shared_lock lock(mutex);
-    std::unordered_map<std::string, reference_filter_result_t> reference_facet_ids;
     return do_facets(facets, facet_query, estimate_facets, facet_sample_percent, facet_infos, group_limit, group_by_fields,
                      group_missing_values, result_ids, results_size, max_facet_count, is_wildcard_query, facet_index_types,
-                     is_group_by_first_pass, group_by_missing_value_ids, collection, &reference_facet_ids);
+                     is_group_by_first_pass, group_by_missing_value_ids, collection, nullptr);
 }
 
 static void merge_reference_maps(std::map<std::string, reference_filter_result_t>& existing_references,
@@ -1527,11 +1526,29 @@ static void append_reference_result(const reference_filter_result_t& ref_result,
     }
 }
 
+static std::string get_reference_facet_cache_key(const facet& a_facet) {
+    if (a_facet.nested_join_facets.empty()) {
+        return "";
+    }
+
+    const auto& nested_join_facet = a_facet.nested_join_facets[0];
+    auto cache_key = !nested_join_facet.alias.empty() ? nested_join_facet.alias : nested_join_facet.collection_name;
+    if (!nested_join_facet.facets.empty()) {
+        auto nested_cache_key = get_reference_facet_cache_key(nested_join_facet.facets[0]);
+        if (!nested_cache_key.empty()) {
+            cache_key += ">" + nested_cache_key;
+        }
+    }
+
+    return cache_key;
+}
+
 static void project_nested_reference_result(const reference_filter_result_t& reference_result,
-                                            const std::string& ref_collection_name,
+                                            const facet& a_facet,
                                             reference_filter_result_t& projected_result) {
     std::vector<uint32_t> ref_doc_ids;
     std::unordered_map<uint32_t, std::map<std::string, reference_filter_result_t>> ref_doc_id_to_references;
+    const auto& ref_collection_name = a_facet.nested_join_facets[0].collection_name;
 
     if (reference_result.coll_to_references != nullptr) {
         for (uint32_t i = 0; i < reference_result.count; i++) {
@@ -1613,8 +1630,9 @@ Option<bool> Index::do_facets(std::vector<facet>& facets, facet_query_t & facet_
     // assumed that facet fields have already been validated upstream
     for(auto& a_facet : facets) {
         auto findex = a_facet.orig_index;
-        if (!a_facet.reference_collection_name.empty()) {
-            auto const& ref_collection_name = a_facet.reference_collection_name;
+        if (!a_facet.nested_join_facets.empty()) {
+            auto const& nested_join_facet = a_facet.nested_join_facets[0];
+            auto const& ref_collection_name = nested_join_facet.collection_name;
 
             auto& cm = CollectionManager::get_instance();
             auto ref_collection = cm.get_collection(ref_collection_name);
@@ -1622,38 +1640,23 @@ Option<bool> Index::do_facets(std::vector<facet>& facets, facet_query_t & facet_
                 return Option<bool>(400, "Referenced collection `" + ref_collection_name + "` in `facet_by` not found.");
             }
 
-            if (reference_facet_ids == nullptr) {
+            if (a_facet.references.count == 0 || a_facet.nested_join_facets.empty()) {
                 continue;
             }
 
-            if (reference_facet_ids->count(ref_collection_name) == 0) {
-                if (a_facet.references.count != 0) {
-                    auto& projected_result = (*reference_facet_ids)[ref_collection_name];
-                    project_nested_reference_result(a_facet.references, ref_collection_name, projected_result);
-                } else {
-                    continue;
-                }
-            }
-
-            if (reference_facet_ids->at(ref_collection_name).count == 0) {
-                continue;
-            }
-
-            auto& ref_facet_result = reference_facet_ids->at(ref_collection_name);
-            if (a_facet.nested_join_facets.empty()) {
-                continue;
-            }
-
-            std::vector<facet> ref_facets = a_facet.nested_join_facets;
+            auto const& ref_facet_result = a_facet.references;
+            std::vector<facet> ref_facets = nested_join_facet.facets;
             for (auto& ref_facet: ref_facets) {
                 ref_facet.orig_index = 0;
                 ref_facet.references = ref_facet_result;
             }
+            std::vector<facet_index_type_t> ref_facet_index_types = {facet_index_types[findex]};
 
             ref_collection->do_facets_with_lock(ref_facets, facet_query, estimate_facets, facet_sample_percent,
                                                 {facet_infos[findex]}, group_limit, group_by_fields, group_missing_values,
                                                 ref_facet_result.docs, ref_facet_result.count, max_facet_count,
-                                                is_wildcard_no_filter_query, facet_index_types, is_group_by_first_pass, group_by_missing_value_ids);
+                                                is_wildcard_no_filter_query, ref_facet_index_types,
+                                                is_group_by_first_pass, group_by_missing_value_ids);
             if (ref_facets.empty()) {
                 // Shouldn't happen, still adding safeguard to prevent crash.
                 LOG(ERROR) << "Reference faceting on `" << ref_collection_name << "." << a_facet.field_name << "` unsuccessful.";
@@ -4423,15 +4426,15 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
         std::condition_variable cv_process;
 
         std::vector<facet_info_t> facet_infos(facets.size());
-        std::unordered_map<std::string, reference_filter_result_t> reference_facet_ids;
         compute_facet_infos(facets, facet_query, facet_query_num_typos, all_result_ids, all_result_ids_len,
                             group_by_fields, group_limit, is_wildcard_no_filter_query,
                             max_candidates, facet_infos, facet_index_types, is_group_by_first_pass,
-                            group_by_missing_value_ids, collection, *filter_result_iterator, reference_facet_ids);
+                            group_by_missing_value_ids, collection, *filter_result_iterator);
 
         std::vector<std::vector<facet>> facet_batches(num_threads);
         std::vector<std::vector<facet>> value_facets(concurrency);
-        std::vector<std::unordered_map<std::string, reference_filter_result_t>> batch_reference_facet_ids;
+        std::vector<facet> reference_facets;
+        std::vector<facet> top_k_reference_facets;
 
         size_t num_value_facets = 0;
 
@@ -4439,11 +4442,18 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
             const auto& this_facet = facets[i];
             //process facets separately which has top_k set to true
             if(this_facet.is_top_k) {
+                if(!this_facet.nested_join_facets.empty()) {
+                    top_k_reference_facets.emplace_back(this_facet);
+                    continue;
+                }
                 top_k_facets.emplace_back(this_facet.field_name, this_facet.orig_index, this_facet.is_top_k, this_facet.facet_range_map,
                                           this_facet.is_range_query, this_facet.is_sort_by_alpha, this_facet.sort_order, this_facet.sort_field);
-                top_k_facets.back().reference_collection_name = this_facet.reference_collection_name;
-                top_k_facets.back().reference_collection_alias_name = this_facet.reference_collection_alias_name;
                 top_k_facets.back().nested_join_facets = this_facet.nested_join_facets;
+                continue;
+            }
+
+            if(!this_facet.nested_join_facets.empty()) {
+                reference_facets.emplace_back(this_facet);
                 continue;
             }
 
@@ -4452,9 +4462,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                 value_facets[num_value_facets % num_threads].emplace_back(this_facet.field_name, this_facet.orig_index,
                                           this_facet.is_top_k, this_facet.facet_range_map,
                                           this_facet.is_range_query, this_facet.is_sort_by_alpha,
-                                          this_facet.sort_order, this_facet.sort_field,
-                                          this_facet.reference_collection_name,
-                                          this_facet.reference_collection_alias_name);
+                                          this_facet.sort_order, this_facet.sort_field);
                 value_facets[num_value_facets % num_threads].back().nested_join_facets = this_facet.nested_join_facets;
                 num_value_facets++;
                 continue;
@@ -4463,9 +4471,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
             for(size_t j = 0; j < num_threads; j++) {
                 facet_batches[j].emplace_back(this_facet.field_name, this_facet.orig_index, this_facet.is_top_k,
                                               this_facet.facet_range_map, this_facet.is_range_query,
-                                              this_facet.is_sort_by_alpha, this_facet.sort_order, this_facet.sort_field,
-                                              this_facet.reference_collection_name,
-                                              this_facet.reference_collection_alias_name);
+                                              this_facet.is_sort_by_alpha, this_facet.sort_order, this_facet.sort_field);
                 facet_batches[j].back().nested_join_facets = this_facet.nested_join_facets;
             }
         }
@@ -4485,38 +4491,32 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
             do_facets(top_k_facets, facet_query, estimate_facets, facet_sample_percent,
                       facet_infos, group_limit, group_by_fields, group_missing_values, top_k_result_ids.data(),
                       top_k_result_ids.size(), max_facet_values, is_wildcard_no_filter_query,
-                      facet_index_types, is_group_by_first_pass, group_by_missing_value_ids, collection, &reference_facet_ids);
+                      facet_index_types, is_group_by_first_pass, group_by_missing_value_ids, collection, nullptr);
         }
 
-        bool is_one_valid = false;
+        if(!top_k_reference_facets.empty()) {
+            if(top_k_result_ids.empty()) {
+                get_top_k_result_ids(raw_result_kvs, top_k_result_ids);
+            }
 
-        for (auto& item: reference_facet_ids) {
-            auto& reference_facet_result = item.second;
-            const auto& ref_ids_len = reference_facet_result.count;
-            const auto max_ids_len = std::max((size_t)ref_ids_len, all_result_ids_len);
+            std::vector<facet_info_t> top_k_reference_facet_infos(top_k_reference_facets.size());
+            auto fq = facet_query;
+            compute_facet_infos(top_k_reference_facets, fq, facet_query_num_typos, top_k_result_ids.data(),
+                                top_k_result_ids.size(), group_by_fields, group_limit, is_wildcard_no_filter_query,
+                                max_candidates, top_k_reference_facet_infos, facet_index_types, is_group_by_first_pass,
+                                group_by_missing_value_ids, collection, *filter_result_iterator);
+            do_facets(top_k_reference_facets, fq, estimate_facets, facet_sample_percent,
+                      top_k_reference_facet_infos, group_limit, group_by_fields, group_missing_values,
+                      top_k_result_ids.data(), top_k_result_ids.size(), max_facet_values, is_wildcard_no_filter_query,
+                      facet_index_types, is_group_by_first_pass, group_by_missing_value_ids, collection, nullptr);
 
-            const size_t ref_window_size = (num_threads == 0) ? 0 :
-                                           (max_ids_len + num_threads - 1) / num_threads;
-            uint32_t batch_reference_facet_len = ref_window_size;
-            for(size_t reference_facet_index = 0; reference_facet_index < ref_ids_len; ) {
-                if (reference_facet_index + ref_window_size > ref_ids_len) {
-                    batch_reference_facet_len = ref_ids_len - reference_facet_index;
-                }
-
-                std::unordered_map<std::string, reference_filter_result_t> batch_reference_facets;
-                batch_reference_facets[item.first] = copy_reference_result_slice(reference_facet_result,
-                                                                                 reference_facet_index,
-                                                                                 batch_reference_facet_len);
-                batch_reference_facet_ids.emplace_back(std::move(batch_reference_facets));
-
-                reference_facet_index += batch_reference_facet_len;
-                if (reference_facet_index < reference_facet_result.count) {
-                    is_one_valid = true;
-                }
+            for(auto& this_facet : top_k_reference_facets) {
+                auto& acc_facet = facets[this_facet.orig_index];
+                aggregate_facet(group_limit, this_facet, acc_facet);
             }
         }
 
-        for(size_t thread_id = 0; thread_id < num_threads && (result_index < all_result_ids_len || is_one_valid); thread_id++) {
+        for(size_t thread_id = 0; thread_id < num_threads && result_index < all_result_ids_len; thread_id++) {
             size_t batch_res_len = window_size;
 
             if(result_index + window_size > all_result_ids_len) {
@@ -4536,8 +4536,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                                          facet_sample_percent, group_missing_values,
                                          &parent_search_begin, &parent_search_stop_ms, &parent_search_cutoff,
                                          &num_processed, &m_process, &cv_process, &facet_index_types,
-                                         &is_group_by_first_pass, &group_by_missing_value_ids, &collection,
-                                         &batch_reference_facet_ids]() {
+                                         &is_group_by_first_pass, &group_by_missing_value_ids, &collection]() {
 
 
                 search_begin_us = parent_search_begin;
@@ -4549,8 +4548,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                           facet_infos, group_limit, group_by_fields, group_missing_values,
                           batch_result_ids, batch_res_len, max_facet_values,
                           is_wildcard_no_filter_query, facet_index_types,
-                          is_group_by_first_pass, group_by_missing_value_ids, collection,
-                          batch_reference_facet_ids.size() > thread_id ? &batch_reference_facet_ids[thread_id] : nullptr);
+                          is_group_by_first_pass, group_by_missing_value_ids, collection, nullptr);
 
                 std::unique_lock<std::mutex> lock(m_process);
 
@@ -4582,8 +4580,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                                          facet_sample_percent, group_missing_values,
                                          &parent_search_begin, &parent_search_stop_ms, &parent_search_cutoff,
                                          &num_processed, &m_process, &cv_process, facet_index_types,
-                                         &is_group_by_first_pass, &group_by_missing_value_ids, &collection,
-                                         &reference_facet_ids]() {
+                                         &is_group_by_first_pass, &group_by_missing_value_ids, &collection]() {
 
                 search_begin_us = parent_search_begin;
                 search_stop_us = parent_search_stop_ms;
@@ -4595,7 +4592,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                           facet_infos, group_limit, group_by_fields, group_missing_values,
                           all_result_ids, all_result_ids_len, max_facet_values,
                           is_wildcard_no_filter_query, facet_index_types, is_group_by_first_pass,
-                          group_by_missing_value_ids, collection, &reference_facet_ids);
+                          group_by_missing_value_ids, collection, nullptr);
 
                 std::unique_lock<std::mutex> lock(m_process);
 
@@ -4613,6 +4610,19 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
         std::unique_lock<std::mutex> lock_process(m_process);
         cv_process.wait(lock_process, [&](){ return num_processed == num_queued; });
         search_cutoff = parent_search_cutoff;
+
+        if(!reference_facets.empty()) {
+            auto fq = facet_query;
+            do_facets(reference_facets, fq, estimate_facets, facet_sample_percent,
+                      facet_infos, group_limit, group_by_fields, group_missing_values, all_result_ids,
+                      all_result_ids_len, max_facet_values, is_wildcard_no_filter_query, facet_index_types,
+                      is_group_by_first_pass, group_by_missing_value_ids, collection, nullptr);
+
+            for(auto& this_facet : reference_facets) {
+                auto& acc_facet = facets[this_facet.orig_index];
+                aggregate_facet(group_limit, this_facet, acc_facet);
+            }
+        }
 
         for(auto & acc_facet: facets) {
             for(auto& facet_kv: acc_facet.result_map) {
@@ -4638,25 +4648,23 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
     }
 
     std::vector<facet_info_t> facet_infos(facets.size());
-    std::unordered_map<std::string, reference_filter_result_t> reference_facet_ids;
-
     compute_facet_infos(facets, facet_query, facet_query_num_typos,
                         &included_ids_vec[0], included_ids_vec.size(), group_by_fields,
                         group_limit, is_wildcard_no_filter_query,
                         max_candidates, facet_infos, facet_index_types, is_group_by_first_pass,
-                        group_by_missing_value_ids, collection, *filter_result_iterator, reference_facet_ids);
+                        group_by_missing_value_ids, collection, *filter_result_iterator);
 
     do_facets(facets, facet_query, estimate_facets, facet_sample_percent,
               facet_infos, group_limit, group_by_fields, group_missing_values, &included_ids_vec[0], 
               included_ids_vec.size(), max_facet_values, is_wildcard_no_filter_query,
-              facet_index_types, is_group_by_first_pass, group_by_missing_value_ids, collection, &reference_facet_ids);
+              facet_index_types, is_group_by_first_pass, group_by_missing_value_ids, collection, nullptr);
 
     if(top_k_facets.size() >  0) {
         get_top_k_result_ids(curation_result_kvs, top_k_curated_result_ids);
         do_facets(top_k_facets, facet_query, estimate_facets, facet_sample_percent,
                   facet_infos, group_limit, group_by_fields, group_missing_values, top_k_curated_result_ids.data(),
                   top_k_curated_result_ids.size(), max_facet_values, is_wildcard_no_filter_query,
-                  facet_index_types, is_group_by_first_pass, group_by_missing_value_ids, collection, &reference_facet_ids);
+                  facet_index_types, is_group_by_first_pass, group_by_missing_value_ids, collection, nullptr);
     }
 
     if(union_result_seq_ids != nullptr) {
@@ -4708,10 +4716,9 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
 void Index::get_reference_facet_ids(const uint32_t* all_result_ids, const size_t& all_result_ids_len,
                                     const std::string& collection_name, Collection const *const ref_collection,
                                     filter_result_iterator_t& fit,
-                                    std::unordered_map<std::string, reference_filter_result_t>& reference_facet_ids) const {
+                                    reference_filter_result_t& reference_facet_result) const {
 
     auto const& ref_collection_name = ref_collection->get_name();
-    reference_facet_ids[ref_collection_name] = reference_filter_result_t();
 
     std::vector<uint32_t> ref_doc_ids;
     ref_doc_ids.reserve(all_result_ids_len);
@@ -4792,16 +4799,16 @@ void Index::get_reference_facet_ids(const uint32_t* all_result_ids, const size_t
     gfx::timsort(ref_doc_ids.begin(), ref_doc_ids.end());
     ref_doc_ids.erase(unique(ref_doc_ids.begin(), ref_doc_ids.end()), ref_doc_ids.end());
 
-    auto& result = reference_facet_ids[ref_collection_name];
-    result.count = ref_doc_ids.size();
-    result.docs = new uint32_t[ref_doc_ids.size()];
-    std::copy(ref_doc_ids.begin(), ref_doc_ids.end(), result.docs);
+    reference_facet_result.count = ref_doc_ids.size();
+    reference_facet_result.docs = new uint32_t[ref_doc_ids.size()];
+    std::copy(ref_doc_ids.begin(), ref_doc_ids.end(), reference_facet_result.docs);
     if (!ref_doc_id_to_references.empty()) {
-        result.coll_to_references = new std::map<std::string, reference_filter_result_t>[ref_doc_ids.size()] {};
+        reference_facet_result.coll_to_references =
+                new std::map<std::string, reference_filter_result_t>[ref_doc_ids.size()] {};
         for (size_t i = 0; i < ref_doc_ids.size(); i++) {
             auto ref_doc_references_it = ref_doc_id_to_references.find(ref_doc_ids[i]);
             if (ref_doc_references_it != ref_doc_id_to_references.end()) {
-                result.coll_to_references[i] = ref_doc_references_it->second;
+                reference_facet_result.coll_to_references[i] = ref_doc_references_it->second;
             }
         }
     }
@@ -6428,7 +6435,7 @@ void Index::handle_exclusion(const size_t num_search_fields, std::vector<query_t
     }
 }
 
-Option<bool> Index::compute_facet_infos_with_lock(const std::vector<facet>& facets, facet_query_t& facet_query,
+Option<bool> Index::compute_facet_infos_with_lock(std::vector<facet>& facets, facet_query_t& facet_query,
                                         const uint32_t facet_query_num_typos,
                                         uint32_t* all_result_ids, const size_t& all_result_ids_len,
                                         const std::vector<std::string>& group_by_fields,
@@ -6442,14 +6449,13 @@ Option<bool> Index::compute_facet_infos_with_lock(const std::vector<facet>& face
     std::shared_lock lock(mutex);
 
     auto filter_result_iterator = filter_result_iterator_t(nullptr, 0);
-    std::unordered_map<std::string, reference_filter_result_t> reference_facet_ids;
     return compute_facet_infos(facets, facet_query, facet_query_num_typos, all_result_ids, all_result_ids_len,
                                group_by_fields, group_limit, is_wildcard_no_filter_query, max_candidates, facet_infos,
-                               facet_index_types, is_group_by_first_pass, group_by_missing_value_ids, collection, filter_result_iterator,
-                               reference_facet_ids);
+                               facet_index_types, is_group_by_first_pass, group_by_missing_value_ids, collection,
+                               filter_result_iterator);
 }
 
-Option<bool> Index::compute_facet_infos(const std::vector<facet>& facets, facet_query_t& facet_query,
+Option<bool> Index::compute_facet_infos(std::vector<facet>& facets, facet_query_t& facet_query,
                                         const uint32_t facet_query_num_typos,
                                         uint32_t* all_result_ids, const size_t& all_result_ids_len,
                                         const std::vector<std::string>& group_by_fields,
@@ -6460,20 +6466,21 @@ Option<bool> Index::compute_facet_infos(const std::vector<facet>& facets, facet_
                                         bool is_group_by_first_pass,
                                         std::set<uint32_t>& group_by_missing_value_ids,
                                         Collection const *const collection,
-                                        filter_result_iterator_t& fit,
-                                        std::unordered_map<std::string, reference_filter_result_t>& reference_facet_ids) const {
+                                        filter_result_iterator_t& fit) const {
 
     if(all_result_ids_len == 0) {
         return Option<bool>(true);
     }
 
     size_t total_docs = seq_ids->num_ids();
+    std::unordered_map<std::string, reference_filter_result_t> reference_facet_ids;
 
     for(size_t findex=0; findex < facets.size(); findex++) {
-        const auto& a_facet = facets[findex];
+        auto& a_facet = facets[findex];
 
-        if (!a_facet.reference_collection_name.empty()) {
-            auto const& ref_collection_name = a_facet.reference_collection_name;
+        if (!a_facet.nested_join_facets.empty()) {
+            auto const& nested_join_facet = a_facet.nested_join_facets[0];
+            auto const& ref_collection_name = nested_join_facet.collection_name;
 
             auto& cm = CollectionManager::get_instance();
             auto ref_collection = cm.get_collection(ref_collection_name);
@@ -6481,37 +6488,38 @@ Option<bool> Index::compute_facet_infos(const std::vector<facet>& facets, facet_
                 return Option<bool>(400, "Referenced collection `" + ref_collection_name + "` in `facet_by` not found.");
             }
 
-            if (reference_facet_ids.count(ref_collection_name) == 0) {
+            const auto cache_key = get_reference_facet_cache_key(a_facet);
+            if (reference_facet_ids.count(cache_key) == 0) {
                 if (a_facet.references.count != 0) {
-                    auto& projected_result = reference_facet_ids[ref_collection_name];
-                    project_nested_reference_result(a_facet.references, ref_collection_name, projected_result);
+                    auto& projected_result = reference_facet_ids[cache_key];
+                    project_nested_reference_result(a_facet.references, a_facet, projected_result);
                 } else {
+                    auto& direct_result = reference_facet_ids[cache_key];
                     get_reference_facet_ids(all_result_ids, all_result_ids_len, collection->get_name(),
-                                            ref_collection.get(), fit, reference_facet_ids);
+                                            ref_collection.get(), fit, direct_result);
                 }
             }
+            a_facet.references = reference_facet_ids[cache_key];
 
-            if (reference_facet_ids.at(ref_collection_name).count == 0) {
+            if (a_facet.references.count == 0) {
                 continue;
             }
 
-            if (a_facet.nested_join_facets.empty()) {
-                continue;
-            }
-
-            std::vector<facet> ref_facets = a_facet.nested_join_facets;
+            std::vector<facet> ref_facets = nested_join_facet.facets;
             for (auto& ref_facet: ref_facets) {
                 ref_facet.orig_index = 0;
-                ref_facet.references = reference_facet_ids.at(ref_collection_name);
+                ref_facet.references = a_facet.references;
             }
-            auto const& reference_doc_ids = reference_facet_ids.at(ref_collection_name).docs;
-            auto const& reference_doc_ids_len = reference_facet_ids.at(ref_collection_name).count;
+            auto const& reference_doc_ids = a_facet.references.docs;
+            auto const& reference_doc_ids_len = a_facet.references.count;
             std::vector<facet_info_t> ref_facet_infos(1);
+            std::vector<facet_index_type_t> ref_facet_index_types = {facet_index_types[findex]};
             ref_collection->compute_facet_infos_with_lock(ref_facets, facet_query, facet_query_num_typos,
                                                           reference_doc_ids, reference_doc_ids_len,
                                                           {}, group_limit,
                                                           is_wildcard_no_filter_query, max_candidates, ref_facet_infos,
-                                                          facet_index_types, is_group_by_first_pass, group_by_missing_value_ids);
+                                                          ref_facet_index_types, is_group_by_first_pass,
+                                                          group_by_missing_value_ids);
             if (ref_facet_infos.empty()) {
                 continue;
             }

--- a/test/collection_faceting_test.cpp
+++ b/test/collection_faceting_test.cpp
@@ -1407,16 +1407,19 @@ TEST_F(CollectionFacetingTest, FacetParseTest){
         coll1->parse_facet(facet_field, range_facets);
     }
     ASSERT_EQ(2, range_facets.size());
+    auto get_reference_collection_name = [](const facet& a_facet) -> std::string {
+        return a_facet.nested_join_facets.empty() ? "" : a_facet.nested_join_facets[0].collection_name;
+    };
 
     ASSERT_EQ("ref_score", range_facets[0].field_name);
     ASSERT_TRUE(range_facets[0].is_range_query);
     ASSERT_EQ(2, range_facets[0].facet_range_map.size());
-    ASSERT_EQ("ref_coll", range_facets[0].reference_collection_name);
+    ASSERT_EQ("ref_coll", get_reference_collection_name(range_facets[0]));
 
     ASSERT_EQ("ref_grade", range_facets[1].field_name);
     ASSERT_TRUE(range_facets[1].is_range_query);
     ASSERT_EQ(3, range_facets[1].facet_range_map.size());
-    ASSERT_EQ("ref_coll", range_facets[1].reference_collection_name);
+    ASSERT_EQ("ref_coll", get_reference_collection_name(range_facets[1]));
 
     normal_facet_fields = {
             "$ref_coll(ref_score, ref_grade)"
@@ -1428,9 +1431,9 @@ TEST_F(CollectionFacetingTest, FacetParseTest){
     ASSERT_EQ(2, normal_facets.size());
 
     ASSERT_EQ("ref_score", normal_facets[0].field_name);
-    ASSERT_EQ("ref_coll", normal_facets[0].reference_collection_name);
+    ASSERT_EQ("ref_coll", get_reference_collection_name(normal_facets[0]));
     ASSERT_EQ("ref_grade", normal_facets[1].field_name);
-    ASSERT_EQ("ref_coll", normal_facets[1].reference_collection_name);
+    ASSERT_EQ("ref_coll", get_reference_collection_name(normal_facets[1]));
 
     wildcard_facet_fields = {
             "$ref_coll(ref_ran*, ref_sc*)",
@@ -1445,7 +1448,7 @@ TEST_F(CollectionFacetingTest, FacetParseTest){
     expected = {"ref_range", "ref_rank", "ref_score"};
     for (size_t i = 0; i < wildcard_facets.size(); i++) {
         ASSERT_TRUE(expected.count(wildcard_facets[i].field_name) == 1);
-        ASSERT_EQ("ref_coll", wildcard_facets[i].reference_collection_name);
+        ASSERT_EQ("ref_coll", get_reference_collection_name(wildcard_facets[i]));
     }
 
     wildcard_facets.clear();
@@ -1461,7 +1464,7 @@ TEST_F(CollectionFacetingTest, FacetParseTest){
 
     for (size_t i = 0; i < wildcard_facets.size(); i++) {
         ASSERT_TRUE(expected.count(wildcard_facets[i].field_name) == 1);
-        ASSERT_EQ("ref_coll", wildcard_facets[i].reference_collection_name);
+        ASSERT_EQ("ref_coll", get_reference_collection_name(wildcard_facets[i]));
     }
 
     mixed_facet_fields = {
@@ -1484,17 +1487,17 @@ TEST_F(CollectionFacetingTest, FacetParseTest){
     });
 
     ASSERT_EQ("ref_score", mixed_facets_ptr[3]->field_name);
-    ASSERT_EQ("ref_coll", mixed_facets_ptr[3]->reference_collection_name);
+    ASSERT_EQ("ref_coll", get_reference_collection_name(*mixed_facets_ptr[3]));
 
     ASSERT_EQ("ref_grade", mixed_facets_ptr[0]->field_name);
     ASSERT_TRUE(mixed_facets_ptr[0]->is_range_query);
     ASSERT_GT(mixed_facets_ptr[0]->facet_range_map.size(), 0);
-    ASSERT_EQ("ref_coll", mixed_facets_ptr[0]->reference_collection_name);
+    ASSERT_EQ("ref_coll", get_reference_collection_name(*mixed_facets_ptr[0]));
 
     ASSERT_EQ("ref_rank", mixed_facets_ptr[2]->field_name);
-    ASSERT_EQ("ref_coll", mixed_facets_ptr[2]->reference_collection_name);
+    ASSERT_EQ("ref_coll", get_reference_collection_name(*mixed_facets_ptr[2]));
     ASSERT_EQ("ref_range", mixed_facets_ptr[1]->field_name);
-    ASSERT_EQ("ref_coll", mixed_facets_ptr[1]->reference_collection_name);
+    ASSERT_EQ("ref_coll", get_reference_collection_name(*mixed_facets_ptr[1]));
 }
 
 TEST_F(CollectionFacetingTest, RangeFacetTest) {

--- a/test/collection_faceting_test.cpp
+++ b/test/collection_faceting_test.cpp
@@ -1408,7 +1408,7 @@ TEST_F(CollectionFacetingTest, FacetParseTest){
     }
     ASSERT_EQ(2, range_facets.size());
     auto get_reference_collection_name = [](const facet& a_facet) -> std::string {
-        return a_facet.nested_join_facets.empty() ? "" : a_facet.nested_join_facets[0].collection_name;
+        return a_facet.reference_facet == nullptr ? "" : a_facet.reference_facet->collection_name;
     };
 
     ASSERT_EQ("ref_score", range_facets[0].field_name);
@@ -4238,4 +4238,87 @@ TEST_F(CollectionFacetingTest, FacetMinOccurrenceRatioValidation) {
     ASSERT_EQ("Parameter `facet_min_occurrence_ratio` must be between 0.0 and 1.0.", search_op.error());
 
     collectionManager.drop_collection("dynamic_facet_ratio_validation_coll");
+}
+
+TEST_F(CollectionFacetingTest, ParseFacetNestedReferences) {
+    std::vector<field> fields = {
+        field("title", field_types::STRING, false),
+        field("points", field_types::INT32, false),
+    };
+    auto base_coll = collectionManager.create_collection("base_coll", 1, fields, "points").get();
+
+    fields = {
+        field("variant_name", field_types::STRING, false),
+    };
+    auto variants_coll = collectionManager.create_collection("variants", 1, fields).get();
+
+    fields = {
+        field("rating", field_types::INT32, true),
+        field("inStock", field_types::BOOL, true),
+    };
+    auto stock_coll = collectionManager.create_collection("stock", 1, fields).get();
+
+    auto symlink_op = collectionManager.upsert_symlink("variantsalias", "variants");
+    ASSERT_TRUE(symlink_op.ok());
+    symlink_op = collectionManager.upsert_symlink("stockalias", "stock");
+    ASSERT_TRUE(symlink_op.ok());
+
+    std::string facet_expr = "$variantsalias($stockalias(rating(Average:[0, 3], Good:[3, 4], Great:[4, 5])))";
+    std::vector<facet> facets;
+    auto res = base_coll->parse_facet(facet_expr, facets);
+    ASSERT_TRUE(res.ok()) << res.error();
+    ASSERT_EQ(1, facets.size());
+
+    auto& f = facets[0];
+    ASSERT_EQ("rating", f.field_name);
+    ASSERT_TRUE(f.is_range_query);
+    ASSERT_EQ(3, f.facet_range_map.size());
+
+    ASSERT_NE(nullptr, f.reference_facet);
+    ASSERT_EQ("variants", f.reference_facet->collection_name);
+    ASSERT_EQ("variantsalias", f.reference_facet->alias);
+
+    ASSERT_NE(nullptr, f.reference_facet->nested_reference_facet);
+    ASSERT_EQ("stock", f.reference_facet->nested_reference_facet->collection_name);
+    ASSERT_EQ("stockalias", f.reference_facet->nested_reference_facet->alias);
+
+    ASSERT_EQ(nullptr, f.reference_facet->nested_reference_facet->nested_reference_facet);
+
+    // nested reference with multiple facet fields
+    facet_expr = "$variantsalias($stockalias(rating(Average:[0, 3], Good:[3, 4], Great:[4, 5]), inStock))";
+    facets.clear();
+    res = base_coll->parse_facet(facet_expr, facets);
+    ASSERT_TRUE(res.ok()) << res.error();
+    ASSERT_EQ(2, facets.size());
+
+    auto& f_rating = facets[0];
+    ASSERT_EQ("rating", f_rating.field_name);
+    ASSERT_TRUE(f_rating.is_range_query);
+    ASSERT_EQ(3, f_rating.facet_range_map.size());
+
+    ASSERT_NE(nullptr, f_rating.reference_facet);
+    ASSERT_EQ("variants", f_rating.reference_facet->collection_name);
+    ASSERT_EQ("variantsalias", f_rating.reference_facet->alias);
+
+    ASSERT_NE(nullptr, f_rating.reference_facet->nested_reference_facet);
+    ASSERT_EQ("stock", f_rating.reference_facet->nested_reference_facet->collection_name);
+    ASSERT_EQ("stockalias", f_rating.reference_facet->nested_reference_facet->alias);
+    ASSERT_EQ(nullptr, f_rating.reference_facet->nested_reference_facet->nested_reference_facet);
+
+    auto& f_inStock = facets[1];
+    ASSERT_EQ("inStock", f_inStock.field_name);
+    ASSERT_FALSE(f_inStock.is_range_query);
+
+    ASSERT_NE(nullptr, f_inStock.reference_facet);
+    ASSERT_EQ("variants", f_inStock.reference_facet->collection_name);
+    ASSERT_EQ("variantsalias", f_inStock.reference_facet->alias);
+
+    ASSERT_NE(nullptr, f_inStock.reference_facet->nested_reference_facet);
+    ASSERT_EQ("stock", f_inStock.reference_facet->nested_reference_facet->collection_name);
+    ASSERT_EQ("stockalias", f_inStock.reference_facet->nested_reference_facet->alias);
+    ASSERT_EQ(nullptr, f_inStock.reference_facet->nested_reference_facet->nested_reference_facet);
+
+    collectionManager.drop_collection("stock");
+    collectionManager.drop_collection("variants");
+    collectionManager.drop_collection("base_coll");
 }

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -11200,6 +11200,130 @@ TEST_F(CollectionJoinTest, FacetByReferenceExtended) {
     ASSERT_EQ("$Subjects(electives.grade: 87)", res_obj["facet_counts"][0]["counts"][2]["facet_filter"].get<std::string>());
 }
 
+TEST_F(CollectionJoinTest, FacetByNestedReference) {
+    auto schema_json =
+            R"({
+            "name": "Products",
+            "fields": [
+                {"name": "name", "type": "string"},
+                {"name": "brand", "type": "string", "facet": true}
+            ]
+        })"_json;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+
+    std::vector<nlohmann::json> documents = {
+            R"({"id":"p-1","name":"Product 1","brand":"A"})"_json,
+            R"({"id":"p-2","name":"Product 2","brand":"A"})"_json,
+            R"({"id":"p-3","name":"Product 3","brand":"B"})"_json,
+            R"({"id":"p-4","name":"Product 4","brand":"C"})"_json
+    };
+    for (const auto& document: documents) {
+        auto add_op = collection_create_op.get()->add(document.dump());
+        ASSERT_TRUE(add_op.ok()) << add_op.error();
+    }
+
+    auto symlink_op = collectionManager.upsert_symlink("ProductsAlias", "Products");
+    ASSERT_TRUE(symlink_op.ok());
+
+    schema_json =
+            R"({
+            "name": "Variants",
+            "fields": [
+                {"name": "product_id", "type": "string", "reference": "ProductsAlias.id", "async_reference": true, "facet": true},
+                {"name": "color", "type": "string", "facet": true}
+            ]
+        })"_json;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+
+    documents = {
+            R"({"id":"p-1-v-1","product_id":"p-1","color":"Red"})"_json,
+            R"({"id":"p-1-v-2","product_id":"p-1","color":"Green"})"_json,
+            R"({"id":"p-1-v-3","product_id":"p-1","color":"Blue"})"_json,
+            R"({"id":"p-2-v-1","product_id":"p-2","color":"Pink"})"_json,
+            R"({"id":"p-2-v-2","product_id":"p-2","color":"Red"})"_json,
+            R"({"id":"p-3-v-1","product_id":"p-3","color":"Red"})"_json,
+            R"({"id":"p-3-v-2","product_id":"p-3","color":"Blue"})"_json,
+            R"({"id":"p-4-v-1","product_id":"p-4","color":"Red"})"_json
+    };
+    for (const auto& document: documents) {
+        auto add_op = collection_create_op.get()->add(document.dump());
+        ASSERT_TRUE(add_op.ok()) << add_op.error();
+    }
+
+    symlink_op = collectionManager.upsert_symlink("VariantsAlias", "Variants");
+    ASSERT_TRUE(symlink_op.ok());
+
+    schema_json =
+            R"({
+            "name": "Stock",
+            "fields": [
+                {"name": "variant_id", "type": "string", "reference": "VariantsAlias.id"},
+                {"name": "inStock", "type": "bool", "facet": true},
+                {"name": "warehouse", "type": "string", "facet": true}
+            ]
+        })"_json;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+
+    documents = {
+            R"({"id":"p-1-v-1-s-1","variant_id":"p-1-v-1","inStock":true,"warehouse":"A"})"_json,
+            R"({"id":"p-1-v-2-s-2","variant_id":"p-1-v-2","inStock":false,"warehouse":"B"})"_json,
+            R"({"id":"p-4-v-1-s-1","variant_id":"p-4-v-1","inStock":true,"warehouse":"A"})"_json
+    };
+    for (const auto& document: documents) {
+        auto add_op = collection_create_op.get()->add(document.dump());
+        ASSERT_TRUE(add_op.ok()) << add_op.error();
+    }
+
+    symlink_op = collectionManager.upsert_symlink("StockAlias", "Stock");
+    ASSERT_TRUE(symlink_op.ok());
+
+    std::map<std::string, std::string> req_params = {
+            {"collection", "ProductsAlias"},
+            {"q", "*"},
+            {"filter_by", "id:* || $VariantsAlias(id:*) || $VariantsAlias($StockAlias(id:*))"},
+            {"facet_by", "brand, $VariantsAlias(color, $StockAlias(inStock, warehouse))"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok()) << search_op.error();
+
+    auto res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(4, res_obj["found"]);
+    ASSERT_EQ(4, res_obj["facet_counts"].size());
+
+    ASSERT_EQ("brand", res_obj["facet_counts"][0]["field_name"].get<std::string>());
+    ASSERT_EQ("$VariantsAlias(color)", res_obj["facet_counts"][1]["field_name"].get<std::string>());
+    ASSERT_EQ("$VariantsAlias($StockAlias(inStock))", res_obj["facet_counts"][2]["field_name"].get<std::string>());
+    ASSERT_EQ("$VariantsAlias($StockAlias(warehouse))", res_obj["facet_counts"][3]["field_name"].get<std::string>());
+
+    ASSERT_EQ(2, res_obj["facet_counts"][2]["counts"].size());
+    ASSERT_EQ("true", res_obj["facet_counts"][2]["counts"][0]["value"].get<std::string>());
+    ASSERT_EQ(2, (int) res_obj["facet_counts"][2]["counts"][0]["count"]);
+    ASSERT_EQ("$VariantsAlias($StockAlias(inStock: true))",
+              res_obj["facet_counts"][2]["counts"][0]["facet_filter"].get<std::string>());
+    ASSERT_EQ("false", res_obj["facet_counts"][2]["counts"][1]["value"].get<std::string>());
+    ASSERT_EQ(1, (int) res_obj["facet_counts"][2]["counts"][1]["count"]);
+    ASSERT_EQ("$VariantsAlias($StockAlias(inStock: false))",
+              res_obj["facet_counts"][2]["counts"][1]["facet_filter"].get<std::string>());
+
+    ASSERT_EQ(2, res_obj["facet_counts"][3]["counts"].size());
+    ASSERT_EQ("A", res_obj["facet_counts"][3]["counts"][0]["value"].get<std::string>());
+    ASSERT_EQ(2, (int) res_obj["facet_counts"][3]["counts"][0]["count"]);
+    ASSERT_EQ("$VariantsAlias($StockAlias(warehouse: `A`))",
+              res_obj["facet_counts"][3]["counts"][0]["facet_filter"].get<std::string>());
+    ASSERT_EQ("B", res_obj["facet_counts"][3]["counts"][1]["value"].get<std::string>());
+    ASSERT_EQ(1, (int) res_obj["facet_counts"][3]["counts"][1]["count"]);
+    ASSERT_EQ("$VariantsAlias($StockAlias(warehouse: `B`))",
+              res_obj["facet_counts"][3]["counts"][1]["facet_filter"].get<std::string>());
+}
+
 TEST_F(CollectionJoinTest, AlterReferenceField) {
     auto schema_json =
             R"({


### PR DESCRIPTION
## Change Summary
- fix nested reference facet_by parsing so nested facets are preserved recursively instead of being flattened to the terminal collection
  - store nested facet wrapper metadata in facet, closer to nested include_fields / ref_include_exclude_fields
- add regression tests for products -> variants -> stock nested faceting like in #2863 


## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
