### PR TITLE
Fix grouped vector search stale facets and counts

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -925,6 +925,19 @@ public:
                                  const bool& is_group_by_first_pass,
                                  std::set<uint32_t>& group_by_missing_value_ids) const;
 
+    void process_grouped_vector_results_hnsw(filter_result_iterator_t* filter_result_iterator_no_groups,
+                                             const vector_query_t& vector_query,
+                                             hnsw_index_t* field_vector_index,
+                                             VectorFilterFunctor& filter_functor,
+                                             size_t initial_k,
+                                             size_t fetch_size,
+                                             size_t group_limit,
+                                             const std::vector<std::string>& group_by_fields,
+                                             bool group_missing_values,
+                                             bool is_group_by_first_pass,
+                                             bool is_wildcard_non_phrase_query,
+                                             std::vector<std::pair<float, single_filter_result_t>>& dist_results) const;
+
     Option<bool> search_infix(const std::string& query, const std::string& field_name, std::vector<uint32_t>& ids,
                               size_t max_extra_prefix, size_t max_extra_suffix) const;
 

--- a/include/index.h
+++ b/include/index.h
@@ -406,6 +406,35 @@ struct group_by_field_it_t {
 
 class Index {
 private:
+    struct grouped_search_pass_state_t {
+        // The first grouped pass only discovers candidate groups, so it does not need facet state.
+        std::vector<facet> facets;
+        spp::sparse_hash_map<uint64_t, uint32_t> groups_processed;
+        std::vector<std::vector<std::string>> searched_query_tokens;
+        tsl::htrie_map<char, token_leaf> qtoken_set;
+        Topster<KV>* topster = nullptr;
+        Topster<KV>* curated_topster = nullptr;
+        std::unique_ptr<Topster<KV>> topster_guard;
+        std::unique_ptr<Topster<KV>> curated_topster_guard;
+        std::vector<std::vector<KV*>> raw_result_kvs;
+        std::vector<std::vector<KV*>> curation_result_kvs;
+        size_t all_result_ids_len = 0;
+
+        void take_ownership() {
+            topster_guard.reset(topster);
+            curated_topster_guard.reset(curated_topster);
+        }
+
+        bool empty() const {
+            return raw_result_kvs.empty() && curation_result_kvs.empty();
+        }
+
+        size_t groups_count() const {
+            return (topster != nullptr ? topster->getGroupsCount() : 0) +
+                   (curated_topster != nullptr ? curated_topster->getGroupsCount() : 0);
+        }
+    };
+
     mutable std::shared_mutex mutex;
 
     std::string name;

--- a/include/index.h
+++ b/include/index.h
@@ -931,6 +931,7 @@ public:
                                              VectorFilterFunctor& filter_functor,
                                              size_t initial_k,
                                              size_t fetch_size,
+                                             size_t group_max_candidates,
                                              size_t group_limit,
                                              const std::vector<std::string>& group_by_fields,
                                              bool group_missing_values,

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3524,7 +3524,27 @@ void Index::process_grouped_vector_results_hnsw(
         return;
     }
 
-    auto count_distinct_groups = [&](const std::vector<std::pair<float, single_filter_result_t>>& results) {
+    // Group discovery only needs enough distinct groups for the current page.
+    const size_t target_group_count = fetch_size;
+    struct group_discovery_stats_t {
+        size_t docs_seen = 0;
+        size_t groups_seen = 0;
+    };
+    std::unordered_map<uint32_t, uint64_t> distinct_id_cache;
+    distinct_id_cache.reserve(initial_k);
+    auto compute_distinct_id_for_seq_id = [&](uint32_t seq_id) {
+        std::set<uint32_t> missing_value_ids;
+        uint64_t distinct_id = 1;
+        auto group_by_field_it_vec = get_group_by_field_iterators(group_by_fields);
+        for (auto& kv : group_by_field_it_vec) {
+            get_distinct_id(kv.it, seq_id, kv.is_array, group_missing_values, distinct_id,
+                            is_group_by_first_pass, missing_value_ids);
+        }
+        distinct_id_cache.emplace(seq_id, distinct_id);
+        return distinct_id;
+    };
+
+    auto analyze_group_discovery = [&](const std::vector<std::pair<float, single_filter_result_t>>& results) {
         std::vector<uint32_t> candidate_seq_ids;
         candidate_seq_ids.reserve(results.size());
 
@@ -3545,30 +3565,27 @@ void Index::process_grouped_vector_results_hnsw(
         }
 
         if (candidate_seq_ids.empty()) {
-            return size_t(0);
+            return group_discovery_stats_t{};
         }
 
         std::sort(candidate_seq_ids.begin(), candidate_seq_ids.end());
         candidate_seq_ids.erase(std::unique(candidate_seq_ids.begin(), candidate_seq_ids.end()),
                                 candidate_seq_ids.end());
 
-        auto group_by_field_it_vec = get_group_by_field_iterators(group_by_fields);
-        std::set<uint64_t> distinct_groups;
-        std::set<uint32_t> missing_value_ids;
+        std::unordered_set<uint64_t> distinct_groups;
+        distinct_groups.reserve(candidate_seq_ids.size());
 
         for (const auto seq_id : candidate_seq_ids) {
-            uint64_t distinct_id = 1;
-            for (auto& kv : group_by_field_it_vec) {
-                get_distinct_id(kv.it, seq_id, kv.is_array, group_missing_values, distinct_id,
-                                is_group_by_first_pass, missing_value_ids);
+            auto distinct_id_it = distinct_id_cache.find(seq_id);
+            if (distinct_id_it != distinct_id_cache.end()) {
+                distinct_groups.insert(distinct_id_it->second);
+                continue;
             }
-            distinct_groups.insert(distinct_id);
-            if (distinct_groups.size() >= fetch_size) {
-                break;
-            }
+
+            distinct_groups.insert(compute_distinct_id_for_seq_id(seq_id));
         }
 
-        return distinct_groups.size();
+        return group_discovery_stats_t{candidate_seq_ids.size(), distinct_groups.size()};
     };
 
     size_t current_k = initial_k;
@@ -3578,13 +3595,23 @@ void Index::process_grouped_vector_results_hnsw(
 
     while (true) {
         run_hnsw(current_k);
+        auto group_discovery = analyze_group_discovery(dist_results);
 
-        if (count_distinct_groups(dist_results) >= fetch_size ||
+        if (group_discovery.docs_seen == 0 ||
+            group_discovery.groups_seen >= target_group_count ||
             dist_results.size() < current_k || current_k >= max_k) {
             return;
         }
 
-        current_k = std::min(max_k, std::max(current_k + 1, current_k * 2));
+        size_t next_k = std::max(current_k + 1, current_k * 2);
+        if (group_discovery.groups_seen > 0) {
+            const double duplication_ratio =
+                static_cast<double>(group_discovery.docs_seen) / static_cast<double>(group_discovery.groups_seen);
+            const auto estimated_k = static_cast<size_t>(std::ceil(duplication_ratio * target_group_count));
+            next_k = std::max(current_k + 1, estimated_k);
+        }
+
+        current_k = std::min(max_k, next_k);
     }
 }
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2522,26 +2522,32 @@ Option<bool> Index::run_search(search_args* search_params) {
     }
 #endif
 
+    size_t first_pass_found_count = 0;
+    size_t first_pass_found_docs = 0;
+    const bool is_vector_group_query = search_params->group_limit && !search_params->vector_query.field_name.empty();
+
     if (search_params->group_limit) {
         if (!search_params->diversity.similarity_equation.empty()) {
             return Option<bool>(400, "Diversity is not supported along with group_by.");
         }
+        grouped_search_pass_state_t first_pass;
+
         auto res = search(search_params->field_query_tokens,
                           search_params->search_fields,
                           search_params->match_type,
                           filter_result_iterator, filter_result_iterator_no_groups,
-                          search_params->facets, search_params->facet_query,
+                          first_pass.facets, search_params->facet_query,
                           search_params->max_facet_values,
                           search_params->included_ids, search_params->excluded_ids,
                           search_params->sort_fields_std, search_params->num_typos,
-                          search_params->topster, search_params->curated_topster,
+                          first_pass.topster, first_pass.curated_topster,
                           search_params->fetch_size,
                           search_params->per_page, search_params->offset, search_params->token_order,
                           search_params->prefixes, search_params->drop_tokens_threshold,
-                          search_params->all_result_ids_len, search_params->groups_processed,
-                          search_params->searched_query_tokens,
-                          search_params->qtoken_set,
-                          search_params->raw_result_kvs, search_params->curation_result_kvs,
+                          first_pass.all_result_ids_len, first_pass.groups_processed,
+                          first_pass.searched_query_tokens,
+                          first_pass.qtoken_set,
+                          first_pass.raw_result_kvs, first_pass.curation_result_kvs,
                           search_params->typo_tokens_threshold,
                           search_params->group_limit,
                           search_params->group_by_fields,
@@ -2583,6 +2589,7 @@ Option<bool> Index::run_search(search_args* search_params) {
                           search_params->synonym_sets,
                           search_params->union_result_seq_ids,
                           search_params->diversity, search_params->group_max_candidates);
+        first_pass.take_ownership();
 
         // The filter iterator can be updated in places like `Index::do_phrase_search`.
         filter_iterator_guard.release();
@@ -2591,8 +2598,12 @@ Option<bool> Index::run_search(search_args* search_params) {
         if (!res.ok()) {
             return res;
         }
-        if (search_params->raw_result_kvs.empty() && search_params->curation_result_kvs.empty()) {
+        if (first_pass.empty()) {
             return Option<bool>(true);
+        }
+        if (!is_vector_group_query) {
+            first_pass_found_count = first_pass.groups_count();
+            first_pass_found_docs = first_pass.all_result_ids_len;
         }
 
         std::shared_lock lock(mutex);
@@ -2612,7 +2623,7 @@ Option<bool> Index::run_search(search_args* search_params) {
         }
 
         std::vector<std::set<std::string>> group_by_values_list(group_by_fields.size());
-        get_group_by_values(search_params->raw_result_kvs, search_params->curation_result_kvs, group_by_fields,
+        get_group_by_values(first_pass.raw_result_kvs, first_pass.curation_result_kvs, group_by_fields,
                             group_by_values_list);
 
         std::string filter_by;
@@ -2701,20 +2712,7 @@ Option<bool> Index::run_search(search_args* search_params) {
             filter_iterator_guard.reset(filter_result_iterator);
         }
 
-        // for grouping found_count reflects how many groups were found for the query.
-        search_params->found_count = search_params->topster->getGroupsCount() + search_params->curated_topster->getGroupsCount();
-        search_params->found_docs = search_params->all_result_ids_len;
-
         filter_result_iterator_no_groups->reset();
-
-        delete search_params->topster;
-        delete search_params->curated_topster;
-
-        search_params->topster = nullptr;
-        search_params->curated_topster = nullptr;
-
-        search_params->groups_processed.clear();
-        search_params->all_result_ids_len = 0;
         group_by_missing_value_ids.clear();
     }
 
@@ -2784,15 +2782,20 @@ Option<bool> Index::run_search(search_args* search_params) {
     filter_iterator_guard.reset(filter_result_iterator);
 
     if (search_params->group_limit) {
+        search_params->found_docs = is_vector_group_query ? search_params->all_result_ids_len : first_pass_found_docs;
+
         if (search_params->group_max_candidates != DEFAULT_TOPSTER_SIZE) {
             // User has set an appropriate upper limit of the expected group count. Assuming all the groups have been
             // processed, no need to rely on approximate count.
             search_params->found_count = search_params->raw_result_kvs.size() + search_params->curation_result_kvs.size();
         } else {
-            // Doing std::max since in case of group_by, loglog_counter returns an approximate count of the number of distinct
-            // group_by values in the first pass and sometimes the count can be less than the size of returned result.
-            search_params->found_count = std::max(search_params->found_count,
-                                                  search_params->raw_result_kvs.size() + search_params->curation_result_kvs.size());
+            const auto grouped_result_count = search_params->raw_result_kvs.size() + search_params->curation_result_kvs.size();
+            const auto approx_group_count = is_vector_group_query
+                ? (search_params->topster->getGroupsCount() + search_params->curated_topster->getGroupsCount())
+                : first_pass_found_count;
+            // For vector-grouped queries, use only final-pass counts because first-pass counts are not final-qualified.
+            // For non-vector grouping, preserve the historical first-pass approximate count semantics.
+            search_params->found_count = std::max(approx_group_count, grouped_result_count);
         }
     } else {
         search_params->found_count = search_params->all_result_ids_len;
@@ -3682,7 +3685,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
             goto process_search_results;
         }
 
-        if (!vector_query.field_name.empty() && !is_group_by_first_pass) {
+        if (!vector_query.field_name.empty()) {
             auto k = vector_query.k == 0 ? std::max<size_t>(vector_query.k, fetch_size) : vector_query.k;
 
             VectorFilterFunctor filterFunctor(filter_result_iterator_no_groups, excluded_result_ids, excluded_result_ids_size);
@@ -4079,7 +4082,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
         filter_result_iterator->reset();
         search_cutoff = search_cutoff || filter_result_iterator->validity == filter_result_iterator_t::timed_out;
 
-        if(!vector_query.field_name.empty() && !is_group_by_first_pass) {
+        if(!vector_query.field_name.empty()) {
             // check at least one of sort fields is text match
             bool has_text_match = false;
             for(auto& sort_field : sort_fields_std) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3499,6 +3499,95 @@ void process_results_hnsw_index(filter_result_iterator_t* filter_result_iterator
     }
 }
 
+void Index::process_grouped_vector_results_hnsw(
+    filter_result_iterator_t* filter_result_iterator_no_groups,
+    const vector_query_t& vector_query,
+    hnsw_index_t* field_vector_index,
+    VectorFilterFunctor& filter_functor,
+    size_t initial_k,
+    size_t fetch_size,
+    size_t group_limit,
+    const std::vector<std::string>& group_by_fields,
+    bool group_missing_values,
+    bool is_group_by_first_pass,
+    bool is_wildcard_non_phrase_query,
+    std::vector<std::pair<float, single_filter_result_t>>& dist_results) const {
+
+    auto run_hnsw = [&](size_t current_k) {
+        dist_results.clear();
+        process_results_hnsw_index(filter_result_iterator_no_groups, vector_query, field_vector_index,
+                                   filter_functor, current_k, dist_results, is_wildcard_non_phrase_query);
+    };
+
+    if (group_limit == 0 || vector_query.k != 0) {
+        run_hnsw(initial_k);
+        return;
+    }
+
+    auto count_distinct_groups = [&](const std::vector<std::pair<float, single_filter_result_t>>& results) {
+        std::vector<uint32_t> candidate_seq_ids;
+        candidate_seq_ids.reserve(results.size());
+
+        for (const auto& dist_result : results) {
+            const auto& seq_id = dist_result.second.seq_id;
+            if (vector_query.query_doc_given && vector_query.seq_id == seq_id) {
+                continue;
+            }
+
+            auto vec_dist_score = (field_vector_index->distance_type == cosine)
+                                  ? std::abs(dist_result.first)
+                                  : dist_result.first;
+            if (vec_dist_score > vector_query.distance_threshold) {
+                continue;
+            }
+
+            candidate_seq_ids.push_back(seq_id);
+        }
+
+        if (candidate_seq_ids.empty()) {
+            return size_t(0);
+        }
+
+        std::sort(candidate_seq_ids.begin(), candidate_seq_ids.end());
+        candidate_seq_ids.erase(std::unique(candidate_seq_ids.begin(), candidate_seq_ids.end()),
+                                candidate_seq_ids.end());
+
+        auto group_by_field_it_vec = get_group_by_field_iterators(group_by_fields);
+        std::set<uint64_t> distinct_groups;
+        std::set<uint32_t> missing_value_ids;
+
+        for (const auto seq_id : candidate_seq_ids) {
+            uint64_t distinct_id = 1;
+            for (auto& kv : group_by_field_it_vec) {
+                get_distinct_id(kv.it, seq_id, kv.is_array, group_missing_values, distinct_id,
+                                is_group_by_first_pass, missing_value_ids);
+            }
+            distinct_groups.insert(distinct_id);
+            if (distinct_groups.size() >= fetch_size) {
+                break;
+            }
+        }
+
+        return distinct_groups.size();
+    };
+
+    size_t current_k = initial_k;
+    const auto no_group_filter_provided = filter_result_iterator_no_groups->is_filter_provided();
+    const auto filter_id_count = filter_result_iterator_no_groups->approx_filter_ids_length;
+    const size_t max_k = no_group_filter_provided ? std::max<size_t>(filter_id_count, current_k) : num_seq_ids();
+
+    while (true) {
+        run_hnsw(current_k);
+
+        if (count_distinct_groups(dist_results) >= fetch_size ||
+            dist_results.size() < current_k || current_k >= max_k) {
+            return;
+        }
+
+        current_k = std::min(max_k, std::max(current_k + 1, current_k * 2));
+    }
+}
+
 #ifdef TEST_BUILD
     bool testing_not_equals_bug = false;
 #endif
@@ -3710,7 +3799,10 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
         }
 
         if (!vector_query.field_name.empty()) {
-            auto k = vector_query.k == 0 ? std::max<size_t>(vector_query.k, fetch_size) : vector_query.k;
+            auto k = vector_query.k;
+            if (k == 0) {
+                k = fetch_size;
+            }
 
             VectorFilterFunctor filterFunctor(filter_result_iterator_no_groups, excluded_result_ids, excluded_result_ids_size);
             auto& field_vector_index = vector_index.at(vector_query.field_name);
@@ -3733,8 +3825,9 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                 process_results_bruteforce(filter_result_iterator_no_groups, vector_query, field_vector_index, dist_results);
             } else if(!no_group_filter_provided ||
                 (filter_id_count >= vector_query.flat_search_cutoff && filter_result_iterator_no_groups->validity == filter_result_iterator_t::valid)) {
-                dist_results.clear();
-                process_results_hnsw_index(filter_result_iterator_no_groups, vector_query, field_vector_index, filterFunctor, k, dist_results, true);
+                process_grouped_vector_results_hnsw(filter_result_iterator_no_groups, vector_query, field_vector_index,
+                                                    filterFunctor, k, fetch_size, group_limit, group_by_fields,
+                                                    group_missing_values, is_group_by_first_pass, true, dist_results);
             }
 
             search_cutoff = search_cutoff || filter_result_iterator_no_groups->validity == filter_result_iterator_t::timed_out;
@@ -4135,10 +4228,14 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                 dist_results.clear();
                 // use k as 100 by default for ensuring results stability in pagination
                 size_t default_k = 100;
-                auto k = vector_query.k == 0 ? std::max<size_t>(fetch_size, default_k)
-                                             : vector_query.k;
+                auto k = vector_query.k;
+                if (k == 0) {
+                    k = std::max<size_t>(fetch_size, default_k);
+                }
 
-                process_results_hnsw_index(filter_result_iterator_no_groups, vector_query, field_vector_index, filterFunctor, k, dist_results);
+                process_grouped_vector_results_hnsw(filter_result_iterator_no_groups, vector_query, field_vector_index,
+                                                    filterFunctor, k, fetch_size, group_limit, group_by_fields,
+                                                    group_missing_values, is_group_by_first_pass, false, dist_results);
             }
 
             filter_result_iterator_no_groups->reset();

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3530,20 +3530,6 @@ void Index::process_grouped_vector_results_hnsw(
         size_t docs_seen = 0;
         size_t groups_seen = 0;
     };
-    std::unordered_map<uint32_t, uint64_t> distinct_id_cache;
-    distinct_id_cache.reserve(initial_k);
-    auto compute_distinct_id_for_seq_id = [&](uint32_t seq_id) {
-        std::set<uint32_t> missing_value_ids;
-        uint64_t distinct_id = 1;
-        auto group_by_field_it_vec = get_group_by_field_iterators(group_by_fields);
-        for (auto& kv : group_by_field_it_vec) {
-            get_distinct_id(kv.it, seq_id, kv.is_array, group_missing_values, distinct_id,
-                            is_group_by_first_pass, missing_value_ids);
-        }
-        distinct_id_cache.emplace(seq_id, distinct_id);
-        return distinct_id;
-    };
-
     auto analyze_group_discovery = [&](const std::vector<std::pair<float, single_filter_result_t>>& results) {
         std::vector<uint32_t> candidate_seq_ids;
         candidate_seq_ids.reserve(results.size());
@@ -3572,17 +3558,17 @@ void Index::process_grouped_vector_results_hnsw(
         candidate_seq_ids.erase(std::unique(candidate_seq_ids.begin(), candidate_seq_ids.end()),
                                 candidate_seq_ids.end());
 
-        std::unordered_set<uint64_t> distinct_groups;
-        distinct_groups.reserve(candidate_seq_ids.size());
+        std::set<uint64_t> distinct_groups;
+        auto group_by_field_it_vec = get_group_by_field_iterators(group_by_fields);
 
         for (const auto seq_id : candidate_seq_ids) {
-            auto distinct_id_it = distinct_id_cache.find(seq_id);
-            if (distinct_id_it != distinct_id_cache.end()) {
-                distinct_groups.insert(distinct_id_it->second);
-                continue;
+            std::set<uint32_t> missing_value_ids;
+            uint64_t distinct_id = 1;
+            for (auto& kv : group_by_field_it_vec) {
+                get_distinct_id(kv.it, seq_id, kv.is_array, group_missing_values, distinct_id,
+                                is_group_by_first_pass, missing_value_ids);
             }
-
-            distinct_groups.insert(compute_distinct_id_for_seq_id(seq_id));
+            distinct_groups.insert(distinct_id);
         }
 
         return group_discovery_stats_t{candidate_seq_ids.size(), distinct_groups.size()};

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3506,6 +3506,7 @@ void Index::process_grouped_vector_results_hnsw(
     VectorFilterFunctor& filter_functor,
     size_t initial_k,
     size_t fetch_size,
+    size_t group_max_candidates,
     size_t group_limit,
     const std::vector<std::string>& group_by_fields,
     bool group_missing_values,
@@ -3524,8 +3525,11 @@ void Index::process_grouped_vector_results_hnsw(
         return;
     }
 
-    // Group discovery only needs enough distinct groups for the current page.
-    const size_t target_group_count = fetch_size;
+    // When the caller explicitly raises `group_max_candidates`, the first pass must discover
+    // that many groups so the later exact-count path remains valid for grouped vector queries.
+    const size_t target_group_count = group_max_candidates != DEFAULT_TOPSTER_SIZE
+                                      ? std::max(fetch_size, group_max_candidates)
+                                      : fetch_size;
     struct group_discovery_stats_t {
         size_t docs_seen = 0;
         size_t groups_seen = 0;
@@ -3839,7 +3843,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
             } else if(!no_group_filter_provided ||
                 (filter_id_count >= vector_query.flat_search_cutoff && filter_result_iterator_no_groups->validity == filter_result_iterator_t::valid)) {
                 process_grouped_vector_results_hnsw(filter_result_iterator_no_groups, vector_query, field_vector_index,
-                                                    filterFunctor, k, fetch_size, group_limit, group_by_fields,
+                                                    filterFunctor, k, fetch_size, group_max_candidates, group_limit, group_by_fields,
                                                     group_missing_values, is_group_by_first_pass, true, dist_results);
             }
 
@@ -4247,7 +4251,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                 }
 
                 process_grouped_vector_results_hnsw(filter_result_iterator_no_groups, vector_query, field_vector_index,
-                                                    filterFunctor, k, fetch_size, group_limit, group_by_fields,
+                                                    filterFunctor, k, fetch_size, group_max_candidates, group_limit, group_by_fields,
                                                     group_missing_values, is_group_by_first_pass, false, dist_results);
             }
 

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -10933,6 +10933,106 @@ TEST_F(CollectionJoinTest, FacetByReference) {
     ASSERT_EQ("73.5", res_obj["facet_counts"][0]["counts"][3]["value"].get<std::string>());
 }
 
+TEST_F(CollectionJoinTest, GroupByWithVectorQueryDoesNotLeakReferenceFacets) {
+    auto schema_json =
+            R"({
+            "name": "Products",
+            "fields": [
+                {"name": "product_id", "type": "string"},
+                {"name": "product_group", "type": "string", "facet": true},
+                {"name": "vec", "type": "float[]", "num_dim": 3}
+            ]
+        })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+
+    std::vector<nlohmann::json> documents = {
+            R"({
+            "product_id": "product_a",
+            "product_group": "group_a",
+            "vec": [0.1, 0.2, 0.3]
+        })"_json,
+            R"({
+            "product_id": "product_b",
+            "product_group": "group_b",
+            "vec": [0.6, 0.7, 0.8]
+        })"_json
+    };
+
+    for (auto const& json : documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    schema_json =
+            R"({
+            "name": "Customers",
+            "fields": [
+                {"name": "customer_id", "type": "string"},
+                {"name": "customer_name", "type": "string", "facet": true},
+                {"name": "product_id", "type": "string", "reference": "Products.product_id"}
+            ]
+        })"_json;
+
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+
+    documents = {
+            R"({
+            "customer_id": "customer_a",
+            "customer_name": "Joe",
+            "product_id": "product_a"
+        })"_json,
+            R"({
+            "customer_id": "customer_a",
+            "customer_name": "Joe",
+            "product_id": "product_b"
+        })"_json
+    };
+
+    for (auto const& json : documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    std::map<std::string, std::string> req_params = {
+            {"collection", "Products"},
+            {"q", "*"},
+            {"filter_by", "$Customers(customer_id:=customer_a)"},
+            {"facet_by", "$Customers(customer_name)"},
+            {"vector_query", "vec:([0.3,0.4,0.5], distance_threshold:0.0)"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    auto res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(0, res_obj["found"]);
+    ASSERT_EQ(0, res_obj["hits"].size());
+    ASSERT_EQ(1, res_obj["facet_counts"].size());
+    ASSERT_EQ("$Customers(customer_name)", res_obj["facet_counts"][0]["field_name"].get<std::string>());
+    ASSERT_EQ(0, res_obj["facet_counts"][0]["counts"].size());
+
+    req_params["group_by"] = "product_group";
+    req_params["group_limit"] = "1";
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(0, res_obj["found"]);
+    ASSERT_EQ(0, res_obj["found_docs"]);
+    ASSERT_EQ(0, res_obj["grouped_hits"].size());
+    ASSERT_EQ(1, res_obj["facet_counts"].size());
+    ASSERT_EQ("$Customers(customer_name)", res_obj["facet_counts"][0]["field_name"].get<std::string>());
+    ASSERT_EQ(0, res_obj["facet_counts"][0]["counts"].size());
+}
+
 TEST_F(CollectionJoinTest, FacetByReferenceExtended) {
     auto schema_json =
             R"({

--- a/test/collection_vector_search_test.cpp
+++ b/test/collection_vector_search_test.cpp
@@ -2328,6 +2328,202 @@ TEST_F(CollectionVectorTest, GroupByWithVectorSearch) {
     ASSERT_EQ(1, res["grouped_hits"][0]["hits"][0].count("vector_distance"));
 }
 
+TEST_F(CollectionVectorTest, GroupByWithVectorSearchFacetsRespectDistanceThreshold) {
+    nlohmann::json schema = R"({
+        "name": "grouped_vector_facets",
+        "fields": [
+            {"name": "group", "type": "string", "facet": true},
+            {"name": "category", "type": "string", "facet": true},
+            {"name": "vec", "type": "float[]", "num_dim": 3}
+        ]
+    })"_json;
+
+    Collection* coll1 = collectionManager.create_collection(schema).get();
+
+    nlohmann::json doc;
+    doc["id"] = "0";
+    doc["group"] = "group-a";
+    doc["category"] = "keep";
+    doc["vec"] = {0.6, 0.7, 0.8};
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    doc["id"] = "1";
+    doc["group"] = "group-b";
+    doc["category"] = "stale";
+    doc["vec"] = {0.1, 0.2, 0.3};
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    const std::string vector_query = "vec:([0.3,0.4,0.5], distance_threshold:0.01)";
+
+    auto ungrouped_res = coll1->search("*", {}, "", {"category"}, {}, {0}, 20, 1, FREQUENCY, {true},
+                                       Index::DROP_TOKENS_THRESHOLD,
+                                       spp::sparse_hash_set<std::string>(),
+                                       spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                       "", 10, {}, {}, {}, 0,
+                                       "<mark>", "</mark>", {}, 1000, true, false, true, "", false,
+                                       6000 * 1000, 4, 7, fallback,
+                                       4, {off}, 32767, 32767, 2,
+                                       false, true, vector_query).get();
+
+    ASSERT_EQ(1, ungrouped_res["found"].get<size_t>());
+    ASSERT_EQ(1, ungrouped_res["hits"].size());
+    ASSERT_EQ(1, ungrouped_res["facet_counts"].size());
+    ASSERT_EQ(1, ungrouped_res["facet_counts"][0]["counts"].size());
+    ASSERT_EQ("keep", ungrouped_res["facet_counts"][0]["counts"][0]["value"].get<std::string>());
+
+    auto grouped_res = coll1->search("*", {}, "", {"category"}, {}, {0}, 20, 1, FREQUENCY, {true},
+                                     Index::DROP_TOKENS_THRESHOLD,
+                                     spp::sparse_hash_set<std::string>(),
+                                     spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                     "", 10, {}, {}, {"group"}, 1,
+                                     "<mark>", "</mark>", {}, 1000, true, false, true, "", false,
+                                     6000 * 1000, 4, 7, fallback,
+                                     4, {off}, 32767, 32767, 2,
+                                     false, true, vector_query).get();
+
+    ASSERT_EQ(1, grouped_res["found"].get<size_t>());
+    ASSERT_EQ(1, grouped_res["found_docs"].get<size_t>());
+    ASSERT_EQ(1, grouped_res["grouped_hits"].size());
+    ASSERT_EQ(1, grouped_res["grouped_hits"][0]["hits"].size());
+    ASSERT_EQ("0", grouped_res["grouped_hits"][0]["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_EQ(1, grouped_res["facet_counts"].size());
+    ASSERT_EQ(1, grouped_res["facet_counts"][0]["counts"].size());
+    ASSERT_EQ("keep", grouped_res["facet_counts"][0]["counts"][0]["value"].get<std::string>());
+}
+
+TEST_F(CollectionVectorTest, GroupByWithVectorSearchEmptyResultsRespectDistanceThreshold) {
+    nlohmann::json schema = R"({
+        "name": "grouped_vector_empty",
+        "fields": [
+            {"name": "group", "type": "string", "facet": true},
+            {"name": "category", "type": "string", "facet": true},
+            {"name": "vec", "type": "float[]", "num_dim": 3}
+        ]
+    })"_json;
+
+    Collection* coll1 = collectionManager.create_collection(schema).get();
+
+    nlohmann::json doc;
+    doc["id"] = "0";
+    doc["group"] = "group-a";
+    doc["category"] = "keep";
+    doc["vec"] = {0.6, 0.7, 0.8};
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    doc["id"] = "1";
+    doc["group"] = "group-b";
+    doc["category"] = "stale";
+    doc["vec"] = {0.1, 0.2, 0.3};
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    const std::string vector_query = "vec:([0.3,0.4,0.5], distance_threshold:0.0)";
+
+    auto ungrouped_res = coll1->search("*", {}, "", {"category"}, {}, {0}, 20, 1, FREQUENCY, {true},
+                                       Index::DROP_TOKENS_THRESHOLD,
+                                       spp::sparse_hash_set<std::string>(),
+                                       spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                       "", 10, {}, {}, {}, 0,
+                                       "<mark>", "</mark>", {}, 1000, true, false, true, "", false,
+                                       6000 * 1000, 4, 7, fallback,
+                                       4, {off}, 32767, 32767, 2,
+                                       false, true, vector_query).get();
+
+    ASSERT_EQ(0, ungrouped_res["found"].get<size_t>());
+    ASSERT_EQ(0, ungrouped_res["hits"].size());
+    ASSERT_EQ(1, ungrouped_res["facet_counts"].size());
+    ASSERT_EQ(0, ungrouped_res["facet_counts"][0]["counts"].size());
+
+    auto grouped_res = coll1->search("*", {}, "", {"category"}, {}, {0}, 20, 1, FREQUENCY, {true},
+                                     Index::DROP_TOKENS_THRESHOLD,
+                                     spp::sparse_hash_set<std::string>(),
+                                     spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                     "", 10, {}, {}, {"group"}, 1,
+                                     "<mark>", "</mark>", {}, 1000, true, false, true, "", false,
+                                     6000 * 1000, 4, 7, fallback,
+                                     4, {off}, 32767, 32767, 2,
+                                     false, true, vector_query).get();
+
+    ASSERT_EQ(0, grouped_res["found"].get<size_t>());
+    ASSERT_EQ(0, grouped_res["found_docs"].get<size_t>());
+    ASSERT_EQ(0, grouped_res["grouped_hits"].size());
+    ASSERT_EQ(1, grouped_res["facet_counts"].size());
+    ASSERT_EQ(0, grouped_res["facet_counts"][0]["counts"].size());
+}
+
+TEST_F(CollectionVectorTest, GroupByWithHybridSearchKeepsVectorOnlyGroups) {
+    nlohmann::json schema = R"({
+        "name": "grouped_hybrid_vector_only_group",
+        "fields": [
+            {"name": "group", "type": "string", "facet": true},
+            {"name": "category", "type": "string", "facet": true},
+            {"name": "title", "type": "string"},
+            {"name": "vec", "type": "float[]", "num_dim": 3}
+        ]
+    })"_json;
+
+    Collection* coll1 = collectionManager.create_collection(schema).get();
+
+    nlohmann::json doc;
+    doc["id"] = "0";
+    doc["group"] = "group-text";
+    doc["category"] = "text-only";
+    doc["title"] = "alpha text match";
+    doc["vec"] = {0.0, 1.0, 0.0};
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    doc["id"] = "1";
+    doc["group"] = "group-vector";
+    doc["category"] = "vector-only";
+    doc["title"] = "zzz";
+    doc["vec"] = {1.0, 0.0, 0.0};
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    const std::string vector_query = "vec:([1.0,0.0,0.0], distance_threshold:0.01)";
+
+    auto ungrouped_res = coll1->search("alpha", {"title"}, "", {"category"}, {}, {0}, 20, 1, FREQUENCY, {true},
+                                       Index::DROP_TOKENS_THRESHOLD,
+                                       spp::sparse_hash_set<std::string>(),
+                                       spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                       "", 10, {}, {}, {}, 0,
+                                       "<mark>", "</mark>", {}, 1000, true, false, true, "", false,
+                                       6000 * 1000, 4, 7, fallback,
+                                       4, {off}, 32767, 32767, 2,
+                                       false, true, vector_query).get();
+
+    ASSERT_EQ(2, ungrouped_res["found"].get<size_t>());
+    ASSERT_EQ(2, ungrouped_res["hits"].size());
+    ASSERT_EQ(1, ungrouped_res["facet_counts"].size());
+    ASSERT_EQ(2, ungrouped_res["facet_counts"][0]["counts"].size());
+
+    std::set<std::string> ungrouped_ids;
+    for (const auto& hit : ungrouped_res["hits"]) {
+        ungrouped_ids.insert(hit["document"]["id"].get<std::string>());
+    }
+    ASSERT_EQ(std::set<std::string>({"0", "1"}), ungrouped_ids);
+
+    auto grouped_res = coll1->search("alpha", {"title"}, "", {"category"}, {}, {0}, 20, 1, FREQUENCY, {true},
+                                     Index::DROP_TOKENS_THRESHOLD,
+                                     spp::sparse_hash_set<std::string>(),
+                                     spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                     "", 10, {}, {}, {"group"}, 1,
+                                     "<mark>", "</mark>", {}, 1000, true, false, true, "", false,
+                                     6000 * 1000, 4, 7, fallback,
+                                     4, {off}, 32767, 32767, 2,
+                                     false, true, vector_query).get();
+
+    ASSERT_EQ(2, grouped_res["found"].get<size_t>());
+    ASSERT_EQ(2, grouped_res["found_docs"].get<size_t>());
+    ASSERT_EQ(2, grouped_res["grouped_hits"].size());
+    ASSERT_EQ(1, grouped_res["facet_counts"].size());
+    ASSERT_EQ(2, grouped_res["facet_counts"][0]["counts"].size());
+
+    std::set<std::string> grouped_ids;
+    for (const auto& grouped_hit : grouped_res["grouped_hits"]) {
+        grouped_ids.insert(grouped_hit["hits"][0]["document"]["id"].get<std::string>());
+    }
+    ASSERT_EQ(std::set<std::string>({"0", "1"}), grouped_ids);
+}
+
 TEST_F(CollectionVectorTest, HybridSearchReturnAllInfo) {
     auto schema_json =
             R"({

--- a/test/collection_vector_search_test.cpp
+++ b/test/collection_vector_search_test.cpp
@@ -2524,6 +2524,78 @@ TEST_F(CollectionVectorTest, GroupByWithHybridSearchKeepsVectorOnlyGroups) {
     ASSERT_EQ(std::set<std::string>({"0", "1"}), grouped_ids);
 }
 
+TEST_F(CollectionVectorTest, GroupByWithVectorSearchDefaultKFindsDistinctGroups) {
+    nlohmann::json schema = R"({
+        "name": "grouped_vector_default_k_group_discovery",
+        "fields": [
+            {"name": "group", "type": "string", "facet": true},
+            {"name": "vec", "type": "float[]", "num_dim": 2}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    auto coll = create_op.get();
+
+    ASSERT_TRUE(coll->add(R"({
+        "id": "0",
+        "group": "g1",
+        "vec": [1.0, 0.0]
+    })"_json.dump()).ok());
+
+    ASSERT_TRUE(coll->add(R"({
+        "id": "1",
+        "group": "g1",
+        "vec": [0.999, 0.001]
+    })"_json.dump()).ok());
+
+    ASSERT_TRUE(coll->add(R"({
+        "id": "2",
+        "group": "g2",
+        "vec": [0.98, 0.02]
+    })"_json.dump()).ok());
+
+    auto grouped_with_explicit_k = coll->search("*", {}, "", {}, {}, {0}, 2, 1, FREQUENCY, {true},
+                                                Index::DROP_TOKENS_THRESHOLD,
+                                                spp::sparse_hash_set<std::string>(),
+                                                spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                                "", 10, {}, {}, {"group"}, 1,
+                                                "<mark>", "</mark>", {}, 1000, true, false, true, "", false,
+                                                6000 * 1000, 4, 7, fallback,
+                                                4, {off}, 32767, 32767, 2,
+                                                false, true, "vec:([1.0, 0.0], k:3)").get();
+
+    ASSERT_EQ(2, grouped_with_explicit_k["found"].get<size_t>());
+    ASSERT_EQ(3, grouped_with_explicit_k["found_docs"].get<size_t>());
+    ASSERT_EQ(2, grouped_with_explicit_k["grouped_hits"].size());
+
+    std::set<std::string> grouped_with_explicit_k_ids;
+    for (const auto& grouped_hit : grouped_with_explicit_k["grouped_hits"]) {
+        grouped_with_explicit_k_ids.insert(grouped_hit["hits"][0]["document"]["id"].get<std::string>());
+    }
+    ASSERT_EQ(std::set<std::string>({"0", "2"}), grouped_with_explicit_k_ids);
+
+    auto grouped_with_default_k = coll->search("*", {}, "", {}, {}, {0}, 2, 1, FREQUENCY, {true},
+                                               Index::DROP_TOKENS_THRESHOLD,
+                                               spp::sparse_hash_set<std::string>(),
+                                               spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                               "", 10, {}, {}, {"group"}, 1,
+                                               "<mark>", "</mark>", {}, 1000, true, false, true, "", false,
+                                               6000 * 1000, 4, 7, fallback,
+                                               4, {off}, 32767, 32767, 2,
+                                               false, true, "vec:([1.0, 0.0])").get();
+
+    ASSERT_EQ(2, grouped_with_default_k["found"].get<size_t>());
+    ASSERT_EQ(3, grouped_with_default_k["found_docs"].get<size_t>());
+    ASSERT_EQ(2, grouped_with_default_k["grouped_hits"].size());
+
+    std::set<std::string> grouped_with_default_k_ids;
+    for (const auto& grouped_hit : grouped_with_default_k["grouped_hits"]) {
+        grouped_with_default_k_ids.insert(grouped_hit["hits"][0]["document"]["id"].get<std::string>());
+    }
+    ASSERT_EQ(std::set<std::string>({"0", "2"}), grouped_with_default_k_ids);
+}
+
 TEST_F(CollectionVectorTest, HybridSearchReturnAllInfo) {
     auto schema_json =
             R"({

--- a/test/collection_vector_search_test.cpp
+++ b/test/collection_vector_search_test.cpp
@@ -2596,6 +2596,50 @@ TEST_F(CollectionVectorTest, GroupByWithVectorSearchDefaultKFindsDistinctGroups)
     ASSERT_EQ(std::set<std::string>({"0", "2"}), grouped_with_default_k_ids);
 }
 
+TEST_F(CollectionVectorTest, GroupByWithVectorSearchExplicitGroupMaxCandidatesShouldCountAllGroups) {
+    nlohmann::json schema = R"({
+        "name": "grouped_vector_exact_group_count",
+        "fields": [
+            {"name": "group", "type": "string", "facet": true},
+            {"name": "vec", "type": "float[]", "num_dim": 2}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    auto coll = create_op.get();
+
+    const size_t total_groups = 12;
+    for (size_t i = 0; i < total_groups; ++i) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["group"] = "g" + std::to_string(i);
+        doc["vec"] = {1.0, 0.0};
+        ASSERT_TRUE(coll->add(doc.dump()).ok());
+    }
+
+    std::map<std::string, std::string> req_params = {
+            {"collection", "grouped_vector_exact_group_count"},
+            {"q", "*"},
+            {"group_by", "group"},
+            {"group_limit", "1"},
+            {"per_page", "2"},
+            {"group_max_candidates", "1000"},
+            {"vector_query", "vec:([1.0, 0.0])"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    auto res = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, res["grouped_hits"].size());
+    ASSERT_EQ(total_groups, res["found"].get<size_t>());
+}
+
 TEST_F(CollectionVectorTest, HybridSearchReturnAllInfo) {
     auto schema_json =
             R"({


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
Grouped search runs in two passes.

The original implementation reused first-pass grouped state when building grouped results. That was fine for classic grouped search, but it broke for vector and hybrid queries because the first pass was not final-qualified by vector distance or hybrid reranking.

There were two separate issues:

1. First-pass grouped state could leak into the final response.
2. First-pass group discovery skipped vector logic entirely, so vector-qualified groups could be missing from the candidate group set.

### Fix
The fix keeps grouped search as a two-pass flow, but makes the responsibilities clearer:

1. The first grouped pass uses isolated temporary state.
2. The first grouped pass is vector-aware, so candidate groups reflect vector-qualified matches.
3. The final grouped response is derived from the final pass only for grouped vector queries.
4. Non-vector grouped queries keep their historical approximate count behavior.

### Cleanup

The first-pass temporary state has been moved into a private helper on `Index`:

- [include/index.h](/home/krunal/typesense/include/index.h#L404)

This keeps the `run_search` grouped flow smaller and avoids a long block of inline `vector`, raw pointer, and `unique_ptr` declarations in the middle of the function.

The helper's `take_ownership()` method adopts the raw `Topster*` pointers returned by `search(...)` into `unique_ptr` so the temporary grouped pass state is cleaned up automatically.
## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
