### PR TITLE
fix: ignore null response chunks in stream response parsing

### DIFF
--- a/src/conversation_model.cpp
+++ b/src/conversation_model.cpp
@@ -1148,6 +1148,9 @@ Option<std::string> CFConversationModel::parse_stream_response(const std::string
                 }
                 nlohmann::json json_line;
                 json_line = nlohmann::json::parse(substr_line);
+                if(json_line.contains("response") && json_line["response"].is_null()) {
+                    continue;
+                }
                 parsed_response += json_line["response"];
             }
         }

--- a/src/conversation_model.cpp
+++ b/src/conversation_model.cpp
@@ -1148,7 +1148,7 @@ Option<std::string> CFConversationModel::parse_stream_response(const std::string
                 }
                 nlohmann::json json_line;
                 json_line = nlohmann::json::parse(substr_line);
-                if(json_line.contains("response") && json_line["response"].is_null()) {
+                if(!json_line.contains("response") || json_line["response"].is_null()) {
                     continue;
                 }
                 parsed_response += json_line["response"];

--- a/test/collection_vector_search_test.cpp
+++ b/test/collection_vector_search_test.cpp
@@ -5484,19 +5484,30 @@ TEST_F(CollectionVectorTest, TestCFModelResponseParsing) {
     ASSERT_EQ("00,\n\"publishDateYear\": 2011,\n\"title\": \"SOPA\",\n\"topics\": [\n\"Links to xkcd.com\",\n\"April fools' comics\",\n\"Interactive comics\",\n\"Comics with animation\",\n\"Dynamic comics\",\n\"Comics with audio\"\n ],\n\"transcript\": \" \"\n},\n{\n\"altTitle\": \"I'm currently getting totally blacked out.\",\n\"id\": \"1006\",\n\"imageUrl\": \"https://imgs.xkcd.com/comics/blackout.png\",\n\"publishDateDay\": 18,\n\"publishDateMonth\": 1,\n\"publishDateTimestamp\": 1326866400,\n\"publishDateYear\": 2011,\n\"title\": \"Blackout\",\n\"topics\": [\n\"Links to xkcd.com\",\n\"April fools' comics\",\n\"Interactive comics\",\n\"Comics with animation\",\n\"Dynamic comics\",\n\"Comics with audio\"\n ],\n\"", parsed_string.get());
 }
 
-TEST_F(CollectionVectorTest, TestParsingStreamResponseIgnoresNullResponseChunks) {
-    std::string res = R"({
-        "response": [
-            "data: {\"response\":\"Hello\"}\n\n",
-            "data: {\"response\":null,\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n\n",
-            "data: {\"response\":\" world\"}\n\n",
-            "data: [DONE]\n\n"
-        ]
-    })";
-
-    auto parsed_string = CFConversationModel::parse_stream_response(res);
-    ASSERT_TRUE(parsed_string.ok());
-    ASSERT_EQ("Hello world", parsed_string.get());
+TEST_F(CollectionVectorTest, TestParsingIgnoresNonStringResponseChunks) {
+    const auto responses = {
+        R"({
+            "response": [
+                "data: {\"response\":\"Hello\"}\n\n",
+                "data: {\"response\":null,\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n\n",
+                "data: {\"response\":\" world\"}\n\n",
+                "data: [DONE]\n\n"
+            ]
+        })",
+        R"({
+            "response": [
+                "data: {\"response\":\"Hello\"}\n\n",
+                "data: {\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n\n",
+                "data: {\"response\":\" world\"}\n\n",
+                "data: [DONE]\n\n"
+            ]
+        })"
+    };
+    for(const auto& res : responses) {
+        auto parsed_string = CFConversationModel::parse_stream_response(res);
+        ASSERT_TRUE(parsed_string.ok());
+        ASSERT_EQ("Hello world", parsed_string.get());
+    }
 }
 
 TEST_F(CollectionVectorTest, TestInvalidOpenAIURL) {

--- a/test/collection_vector_search_test.cpp
+++ b/test/collection_vector_search_test.cpp
@@ -5484,6 +5484,21 @@ TEST_F(CollectionVectorTest, TestCFModelResponseParsing) {
     ASSERT_EQ("00,\n\"publishDateYear\": 2011,\n\"title\": \"SOPA\",\n\"topics\": [\n\"Links to xkcd.com\",\n\"April fools' comics\",\n\"Interactive comics\",\n\"Comics with animation\",\n\"Dynamic comics\",\n\"Comics with audio\"\n ],\n\"transcript\": \" \"\n},\n{\n\"altTitle\": \"I'm currently getting totally blacked out.\",\n\"id\": \"1006\",\n\"imageUrl\": \"https://imgs.xkcd.com/comics/blackout.png\",\n\"publishDateDay\": 18,\n\"publishDateMonth\": 1,\n\"publishDateTimestamp\": 1326866400,\n\"publishDateYear\": 2011,\n\"title\": \"Blackout\",\n\"topics\": [\n\"Links to xkcd.com\",\n\"April fools' comics\",\n\"Interactive comics\",\n\"Comics with animation\",\n\"Dynamic comics\",\n\"Comics with audio\"\n ],\n\"", parsed_string.get());
 }
 
+TEST_F(CollectionVectorTest, TestParsingStreamResponseIgnoresNullResponseChunks) {
+    std::string res = R"({
+        "response": [
+            "data: {\"response\":\"Hello\"}\n\n",
+            "data: {\"response\":null,\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n\n",
+            "data: {\"response\":\" world\"}\n\n",
+            "data: [DONE]\n\n"
+        ]
+    })";
+
+    auto parsed_string = CFConversationModel::parse_stream_response(res);
+    ASSERT_TRUE(parsed_string.ok());
+    ASSERT_EQ("Hello world", parsed_string.get());
+}
+
 TEST_F(CollectionVectorTest, TestInvalidOpenAIURL) {
     nlohmann::json schema_json = R"({
         "name": "test",


### PR DESCRIPTION
## Change Summary
For CF conversation models with streaming, any response chunk with `null` or undefined response value causes whole stream to fail. Instead, this PR proposes ignoring the such chunks.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
