### PR TITLE
feat: add API key scopes for synonym and curation sets

### DIFF
--- a/include/auth_manager.h
+++ b/include/auth_manager.h
@@ -16,6 +16,8 @@ struct api_key_t {
     std::string description;
     std::vector<std::string> actions;
     std::vector<std::string> collections;
+    std::vector<std::string> synonym_sets;
+    std::vector<std::string> curation_sets;
     uint64_t expires_at;
     bool autodelete;
 
@@ -27,9 +29,10 @@ struct api_key_t {
     }
 
     api_key_t(const std::string &value, const std::string &description, const std::vector<std::string> &actions,
-              const std::vector<std::string> &collections, uint64_t expires_at, bool autodel=false) :
-            value(value), description(description), actions(actions), collections(collections), expires_at(expires_at),
-            autodelete(autodel) {
+              const std::vector<std::string> &collections, const std::vector<std::string> &synonym_sets,
+              const std::vector<std::string> &curation_sets, uint64_t expires_at, bool autodel=false) :
+            value(value), description(description), actions(actions), collections(collections), synonym_sets(synonym_sets),
+            curation_sets(curation_sets), expires_at(expires_at), autodelete(autodel) {
 
     }
 
@@ -62,6 +65,14 @@ struct api_key_t {
             autodelete = false;
         }
 
+        if(key_obj.count("synonym_sets") != 0) {
+            synonym_sets = key_obj["synonym_sets"].get<std::vector<std::string>>();
+        }
+
+        if(key_obj.count("curation_sets") != 0) {
+            curation_sets = key_obj["curation_sets"].get<std::vector<std::string>>();
+        }
+
         return Option<bool>(true);
     }
 
@@ -76,6 +87,14 @@ struct api_key_t {
         obj["collections"] = collections;
         obj["expires_at"] = expires_at;
         obj["autodelete"] = autodelete;
+
+        if(!synonym_sets.empty()) {
+            obj["synonym_sets"] = synonym_sets;
+        }
+
+        if(!curation_sets.empty()) {
+            obj["curation_sets"] = curation_sets;
+        }
 
         return obj;
     }
@@ -120,11 +139,18 @@ private:
 
     static std::string fmt_error(std::string&& error, const std::string& key);
 
+    static bool sets_allowed(const std::vector<std::string>& allowed_set_patterns,
+                                        const std::vector<std::string>& collection_sets);
+
     Option<bool> authenticate_parse_params(const collection_key_t& scoped_api_key, const std::string& action,
+                                           const std::map<std::string, std::string>& params,
+                                           const nlohmann::json& auth_context,
                                            nlohmann::json& embedded_params) const ;
 
     bool auth_against_key(const std::string& req_collection, const std::string& action,
-                          const api_key_t &api_key, const bool search_only) const;
+                          const api_key_t &api_key, const bool search_only,
+                          const std::map<std::string, std::string>& params,
+                          const nlohmann::json& auth_context) const;
 
     static bool regexp_match(const std::string& value, const std::string& regexp);
 
@@ -134,6 +160,10 @@ public:
     static const size_t GENERATED_KEY_LEN = 32;
     static const size_t HMAC_BASE64_LEN = 44;
     static constexpr const char* AUTH_RESOLVED_COLLECTION_PARAM = "__typesense_authorized_collection";
+    static constexpr const char* AUTH_REQUESTED_SYNONYM_SETS_PARAM = "__typesense_requested_synonym_sets";
+    static constexpr const char* AUTH_REQUESTED_CURATION_SETS_PARAM = "__typesense_requested_curation_sets";
+    static constexpr const char* AUTH_PRESET_SYNONYM_SETS_PARAM = "__typesense_preset_synonym_sets";
+    static constexpr const char* AUTH_PRESET_CURATION_SETS_PARAM = "__typesense_preset_curation_sets";
 
     AuthManager() = default;
 

--- a/src/auth_manager.cpp
+++ b/src/auth_manager.cpp
@@ -2,9 +2,91 @@
 #include <openssl/evp.h>
 #include <regex>
 #include <join.h>
+#include "collection_manager.h"
 
 constexpr const char* AuthManager::DOCUMENTS_SEARCH_ACTION;
 constexpr const uint64_t api_key_t::FAR_FUTURE_TIMESTAMP;
+
+std::vector<std::string> parse_requested_search_set_value(const nlohmann::json& value) {
+    if(value.is_string()) {
+        std::vector<std::string> parsed_values;
+        StringUtils::split(value.get<std::string>(), parsed_values, ",");
+        return parsed_values;
+    }
+
+    if(!value.is_array()) {
+        return {};
+    }
+
+    std::vector<std::string> parsed_values;
+    for(const auto& item: value) {
+        if(item.is_string() && !item.get<std::string>().empty()) {
+            parsed_values.push_back(item.get<std::string>());
+        }
+    }
+
+    return parsed_values;
+}
+
+std::vector<std::string> resolve_requested_search_sets(const std::map<std::string, std::string>& params,
+                                                                    const nlohmann::json& auth_context,
+                                                                    const char* request_param,
+                                                                    const char* requested_auth_param,
+                                                                    const char* preset_auth_param) {
+    const auto params_it = params.find(request_param);
+    if(params_it != params.end()) {
+        std::vector<std::string> parsed_values;
+        StringUtils::split(params_it->second, parsed_values, ",");
+        return parsed_values;
+    }
+
+    const auto auth_context_it = auth_context.find(requested_auth_param);
+    if(auth_context_it != auth_context.end()) {
+        return parse_requested_search_set_value(*auth_context_it);
+    }
+
+    const auto embedded_param_it = auth_context.find(request_param);
+    if(embedded_param_it != auth_context.end()) {
+        return parse_requested_search_set_value(*embedded_param_it);
+    }
+
+    const auto preset_auth_context_it = auth_context.find(preset_auth_param);
+    if(preset_auth_context_it != auth_context.end()) {
+        return parse_requested_search_set_value(*preset_auth_context_it);
+    }
+
+    return {};
+}
+
+std::vector<std::string> merge_requested_sets(std::vector<std::string> effective_sets,
+                                                           const std::vector<std::string>& requested_sets) {
+    std::unordered_set<std::string> effective_set_set(effective_sets.begin(), effective_sets.end());
+    for(const auto& requested_set: requested_sets) {
+        if(effective_set_set.find(requested_set) == effective_set_set.end()) {
+            effective_sets.push_back(requested_set);
+            effective_set_set.insert(requested_set);
+        }
+    }
+
+    return effective_sets;
+}
+
+bool has_non_wildcard_constraint(const std::vector<std::string>& allowed_sets) {
+    return !allowed_sets.empty() &&
+           std::find(allowed_sets.begin(), allowed_sets.end(), "*") == allowed_sets.end();
+}
+
+nlohmann::json merge_auth_context(const nlohmann::json& auth_context,
+                                               const nlohmann::json& embedded_params) {
+    nlohmann::json merged_auth_context = auth_context;
+    for(const auto& item: embedded_params.items()) {
+        if(merged_auth_context.count(item.key()) == 0) {
+            merged_auth_context[item.key()] = item.value();
+        }
+    }
+
+    return merged_auth_context;
+}
 
 Option<bool> AuthManager::init(Store* store, const std::string& bootstrap_auth_key) {
     // This function must be idempotent, i.e. when called multiple times, must produce the same state without leaks
@@ -191,16 +273,17 @@ bool AuthManager::authenticate(const std::string& action,
         }
 
         const auto& key_it = api_keys.find(coll_key.api_key);
+        const auto& auth_context = embedded_params_vec[i];
         nlohmann::json embedded_params;
 
         if(key_it != api_keys.end()) {
             const api_key_t& api_key = key_it.value();
-            if(!auth_against_key(coll_key.collection, action, api_key, false)) {
+            if(!auth_against_key(coll_key.collection, action, api_key, false, params, auth_context)) {
                 return false;
             }
         } else {
             // could be a scoped API key
-            Option<bool> auth_op = authenticate_parse_params(coll_key, action, embedded_params);
+            Option<bool> auth_op = authenticate_parse_params(coll_key, action, params, auth_context, embedded_params);
             if(!auth_op.ok()) {
                 return false;
             }
@@ -216,9 +299,8 @@ bool AuthManager::authenticate(const std::string& action,
     return (num_keys_matched == collection_keys.size());
 }
 
-namespace {
 Option<std::string> resolve_scoped_search_collection(const std::string& request_collection,
-                                                     const nlohmann::json& embedded_params) {
+                                                                  const nlohmann::json& embedded_params) {
     const auto collection_it = embedded_params.find("collection");
     if(collection_it == embedded_params.end()) {
         return Option<std::string>(request_collection);
@@ -243,6 +325,17 @@ Option<std::string> resolve_scoped_search_collection(const std::string& request_
 
     return Option<std::string>(request_collection);
 }
+
+bool AuthManager::sets_allowed(const std::vector<std::string>& allowed_set_patterns,
+                                          const std::vector<std::string>& collection_sets) {
+    return std::all_of(collection_sets.begin(), collection_sets.end(),
+                       [&](const std::string& collection_set) {
+                           return std::any_of(allowed_set_patterns.begin(), allowed_set_patterns.end(),
+                                              [&](const std::string& allowed_set_pattern) {
+                                                  return allowed_set_pattern == collection_set ||
+                                                         regexp_match(collection_set, allowed_set_pattern);
+                                              });
+                       });
 }
 
 bool AuthManager::regexp_match(const std::string& value, const std::string& regexp) {
@@ -255,7 +348,9 @@ bool AuthManager::regexp_match(const std::string& value, const std::string& rege
 }
 
 bool AuthManager::auth_against_key(const std::string& req_collection, const std::string& action,
-                                   const api_key_t& api_key, const bool search_only) const {
+                                   const api_key_t& api_key, const bool search_only,
+                                   const std::map<std::string, std::string>& params,
+                                   const nlohmann::json& auth_context) const {
 
     if(uint64_t(std::time(0)) > api_key.expires_at) {
         LOG(ERROR) << fmt_error("Rejecting expired API key.", api_key.value);
@@ -310,10 +405,51 @@ bool AuthManager::auth_against_key(const std::string& req_collection, const std:
         return false;
     }
 
+    const bool check_synonym_sets = has_non_wildcard_constraint(api_key.synonym_sets);
+    const bool check_curation_sets = has_non_wildcard_constraint(api_key.curation_sets);
+
+    if(!check_synonym_sets && !check_curation_sets) {
+        return true;
+    }
+
+    auto coll = CollectionManager::get_instance().get_collection(req_collection);
+    if(!coll) {
+        return true;
+    }
+
+
+    if(check_synonym_sets) {
+        auto search_synonym_sets = resolve_requested_search_sets(params, auth_context,
+                                      "synonym_sets",
+                                      AUTH_REQUESTED_SYNONYM_SETS_PARAM,
+                                      AUTH_PRESET_SYNONYM_SETS_PARAM);
+
+        auto effective_synonym_sets = merge_requested_sets(coll->get_synonym_sets(),
+                                                           search_synonym_sets);
+        if(!sets_allowed(api_key.synonym_sets, effective_synonym_sets)) {
+            return false;
+        }
+    }
+
+    if(check_curation_sets) {
+        auto search_curation_sets = resolve_requested_search_sets(params, auth_context,
+                                      "curation_sets",
+                                        AUTH_REQUESTED_CURATION_SETS_PARAM,
+                                        AUTH_PRESET_CURATION_SETS_PARAM);
+
+        auto effective_curation_sets = merge_requested_sets(coll->get_curation_sets(),
+                                                            search_curation_sets);
+        if(!sets_allowed(api_key.curation_sets, effective_curation_sets)) {
+            return false;
+        }
+    }
+
     return true;
 }
 
 Option<bool> AuthManager::authenticate_parse_params(const collection_key_t& scoped_api_key, const std::string& action,
+                                                    const std::map<std::string, std::string>& params,
+                                                    const nlohmann::json& auth_context,
                                                     nlohmann::json& embedded_params) const {
 
     // allow only searches from scoped keys
@@ -364,7 +500,8 @@ Option<bool> AuthManager::authenticate_parse_params(const collection_key_t& scop
             const auto effective_collection = effective_collection_op.get();
 
             // ensure that parent key collection filter matches the final collection that will be executed
-            bool auth_success = auth_against_key(effective_collection, action, root_api_key, true);
+            bool auth_success = auth_against_key(effective_collection, action, root_api_key, true,
+                                                 params, merge_auth_context(auth_context, embedded_params));
             if(!auth_success) {
                 return Option<bool>(403, "Forbidden.");
             }
@@ -443,6 +580,30 @@ Option<uint32_t> api_key_t::validate(const nlohmann::json &key_obj) {
         }
     }
 
+    if(key_obj.count("synonym_sets") != 0) {
+        if(!key_obj["synonym_sets"].is_array()) {
+            return Option<uint32_t>(400,"Wrong format for `synonym_sets`. It should be an array of string.");
+        }
+
+        for(const nlohmann::json & item: key_obj["synonym_sets"]) {
+            if(!item.is_string()) {
+                return Option<uint32_t>(400,"Wrong format for `synonym_sets`. It should be an array of string.");
+            }
+        }
+    }
+
+    if(key_obj.count("curation_sets") != 0) {
+        if(!key_obj["curation_sets"].is_array()) {
+            return Option<uint32_t>(400,"Wrong format for `curation_sets`. It should be an array of string.");
+        }
+
+        for(const nlohmann::json & item: key_obj["curation_sets"]) {
+            if(!item.is_string()) {
+                return Option<uint32_t>(400,"Wrong format for `curation_sets`. It should be an array of string.");
+            }
+        }
+    }
+    
     return Option<uint32_t>(200);
 }
 

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -76,6 +76,25 @@ bool get_alter_in_progress(const std::string& collection) {
     return alters_in_progress.count(collection) != 0;
 }
 
+void maybe_set_auth_search_set(nlohmann::json& auth_context,
+                               const nlohmann::json& source,
+                               const char* source_key,
+                               const char* auth_key,
+                               const bool overwrite) {
+    const auto param_it = source.find(source_key);
+    if(param_it == source.end()) {
+        return;
+    }
+
+    if(!param_it->is_string() && !param_it->is_array()) {
+        return;
+    }
+
+    if(overwrite || auth_context.count(auth_key) == 0) {
+        auth_context[auth_key] = *param_it;
+    }
+}
+
 bool handle_authentication(std::map<std::string, std::string>& req_params,
                            std::vector<nlohmann::json>& embedded_params_vec,
                            const std::string& body,
@@ -165,6 +184,7 @@ void get_collections_for_auth(std::map<std::string, std::string>& req_params,
             for(auto& el : req_obj["searches"]) {
                 if(el.is_object()) {
                     std::string coll_name;
+                    nlohmann::json auth_context = nlohmann::json::object();
                     if(el.count("collection") != 0 && el["collection"].is_string()) {
                         coll_name = el["collection"].get<std::string>();
                     } else if(req_params.count("collection") != 0) {
@@ -182,13 +202,37 @@ void get_collections_for_auth(std::map<std::string, std::string>& req_params,
                         }
                     }
 
+                    if(el.count("preset") != 0 && el["preset"].is_string()) {
+                        nlohmann::json preset_obj;
+                        auto preset_op = CollectionManager::get_instance().get_preset(el["preset"].get<std::string>(), preset_obj);
+                        if(preset_op.ok()) {
+                            maybe_set_auth_search_set(auth_context, preset_obj,
+                                                    "synonym_sets",
+                                                    AuthManager::AUTH_PRESET_SYNONYM_SETS_PARAM,
+                                                    false);
+                            maybe_set_auth_search_set(auth_context, preset_obj,
+                                                    "curation_sets",
+                                                    AuthManager::AUTH_PRESET_CURATION_SETS_PARAM,
+                                                    false);
+                        }
+                    }
+
+                    maybe_set_auth_search_set(auth_context, el,
+                                              "synonym_sets",
+                                              AuthManager::AUTH_REQUESTED_SYNONYM_SETS_PARAM,
+                                              true);
+                    maybe_set_auth_search_set(auth_context, el,
+                                              "curation_sets",
+                                              AuthManager::AUTH_REQUESTED_CURATION_SETS_PARAM,
+                                              true);
+
                     const std::string& access_key = (el.count("x-typesense-api-key") != 0 &&
                                                      el["x-typesense-api-key"].is_string()) ?
                                                     el["x-typesense-api-key"].get<std::string>() :
                                                     req_auth_key;
 
                     collections.emplace_back(coll_name, access_key);
-                    embedded_params_vec.emplace_back(nlohmann::json::object());
+                    embedded_params_vec.emplace_back(std::move(auth_context));
                 } else {
                     collections.emplace_back("", req_auth_key);
                     embedded_params_vec.emplace_back(nlohmann::json::object());
@@ -211,8 +255,24 @@ void get_collections_for_auth(std::map<std::string, std::string>& req_params,
             }
 
         } else if(req_params.count("collection") != 0) {
+            nlohmann::json auth_context = nlohmann::json::object();
+            const auto preset_it = req_params.find("preset");
+            if(preset_it != req_params.end()) {
+                nlohmann::json preset_obj;
+                auto preset_op = CollectionManager::get_instance().get_preset(preset_it->second, preset_obj);
+                if(preset_op.ok()) {
+                    maybe_set_auth_search_set(auth_context, preset_obj,
+                                            "synonym_sets",
+                                            AuthManager::AUTH_PRESET_SYNONYM_SETS_PARAM,
+                                            false);
+                    maybe_set_auth_search_set(auth_context, preset_obj,
+                                            "curation_sets",
+                                            AuthManager::AUTH_PRESET_CURATION_SETS_PARAM,
+                                            false);
+                }
+            }
             collections.emplace_back(req_params.at("collection"), req_auth_key);
-            embedded_params_vec.emplace_back(nlohmann::json::object());
+            embedded_params_vec.emplace_back(std::move(auth_context));
         }
     }
 
@@ -2345,6 +2405,14 @@ bool post_create_key(const std::shared_ptr<http_req>& req, const std::shared_ptr
         req_json["autodelete"] = false;
     }
 
+    if(req_json.count("synonym_sets") == 0) {
+        req_json["synonym_sets"] = nlohmann::json::array();
+    }
+
+    if(req_json.count("curation_sets") == 0) {
+        req_json["curation_sets"] = nlohmann::json::array();
+    }
+
     const std::string &rand_key = (req_json.count("value") != 0) ?
             req_json["value"].get<std::string>() : req->metadata;
 
@@ -2353,6 +2421,8 @@ bool post_create_key(const std::shared_ptr<http_req>& req, const std::shared_ptr
         req_json["description"].get<std::string>(),
         req_json["actions"].get<std::vector<std::string>>(),
         req_json["collections"].get<std::vector<std::string>>(),
+        req_json["synonym_sets"].get<std::vector<std::string>>(),
+        req_json["curation_sets"].get<std::vector<std::string>>(),
         req_json["expires_at"].get<uint64_t>(),
         req_json["autodelete"].get<bool>()
     );
@@ -2412,11 +2482,21 @@ bool patch_key(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_
         merged_json["autodelete"] = false;
     }
 
+    if(merged_json.count("synonym_sets") == 0) {
+        merged_json["synonym_sets"] = nlohmann::json::array();
+    }
+
+    if(merged_json.count("curation_sets") == 0) {
+        merged_json["curation_sets"] = nlohmann::json::array();
+    }
+
     api_key_t api_key(
         existing_key.value,
         merged_json["description"].get<std::string>(),
         merged_json["actions"].get<std::vector<std::string>>(),
         merged_json["collections"].get<std::vector<std::string>>(),
+        merged_json["synonym_sets"].get<std::vector<std::string>>(),
+        merged_json["curation_sets"].get<std::vector<std::string>>(),
         merged_json["expires_at"].get<uint64_t>(),
         merged_json["autodelete"].get<bool>()
     );

--- a/test/auth_manager_test.cpp
+++ b/test/auth_manager_test.cpp
@@ -30,6 +30,7 @@ protected:
     }
 
     virtual void TearDown() {
+        collectionManager.dispose();
         delete store;
     }
 };
@@ -45,8 +46,8 @@ TEST_F(AuthManagerTest, CreateListDeleteAPIKeys) {
 
     // test inserts
 
-    api_key_t api_key1("abcd1", "test key 1", {"read", "write"}, {"collection1", "collection2"}, FUTURE_TS);
-    api_key_t api_key2("abcd2", "test key 2", {"admin"}, {"*"}, FUTURE_TS);
+    api_key_t api_key1("abcd1", "test key 1", {"read", "write"}, {"collection1", "collection2"}, {}, {}, FUTURE_TS);
+    api_key_t api_key2("abcd2", "test key 2", {"admin"}, {"*"}, {}, {}, FUTURE_TS);
 
     ASSERT_EQ("abcd1", api_key1.value);
     ASSERT_EQ("abcd2", api_key2.value);
@@ -116,8 +117,8 @@ TEST_F(AuthManagerTest, CreateListDeleteAPIKeys) {
 }
 
 TEST_F(AuthManagerTest, CheckRestoreOfAPIKeys) {
-    api_key_t api_key1("abcd1", "test key 1", {"read", "write"}, {"collection1", "collection2"}, FUTURE_TS);
-    api_key_t api_key2("abcd2", "test key 2", {"admin"}, {"*"}, FUTURE_TS);
+    api_key_t api_key1("abcd1", "test key 1", {"read", "write"}, {"collection1", "collection2"}, {}, {}, FUTURE_TS);
+    api_key_t api_key2("abcd2", "test key 2", {"admin"}, {"*"}, {}, {}, FUTURE_TS);
 
     std::string key_value1 = auth_manager.create_key(api_key1).get().value;
     std::string key_value2 = auth_manager.create_key(api_key2).get().value;
@@ -148,7 +149,7 @@ TEST_F(AuthManagerTest, VerifyAuthentication) {
     ASSERT_FALSE(auth_manager.authenticate("", {collection_key_t("", "jdlaslasdasd")}, sparams, embedded_params));
 
     // wildcard permission
-    api_key_t wildcard_all_key = api_key_t("abcd1", "wildcard all key", {"*"}, {"*"}, FUTURE_TS);
+    api_key_t wildcard_all_key = api_key_t("abcd1", "wildcard all key", {"*"}, {"*"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(wildcard_all_key);
 
     ASSERT_FALSE(auth_manager.authenticate("documents:create", {collection_key_t("collection1", "jdlaslasdasd")}, sparams, embedded_params));
@@ -156,13 +157,13 @@ TEST_F(AuthManagerTest, VerifyAuthentication) {
 
     // long API key
     std::string long_api_key_str = StringUtils::randstring(50);
-    api_key_t long_api_key = api_key_t(long_api_key_str, "long api key", {"*"}, {"*"}, FUTURE_TS);
+    api_key_t long_api_key = api_key_t(long_api_key_str, "long api key", {"*"}, {"*"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(long_api_key);
 
     ASSERT_TRUE(auth_manager.authenticate("metrics:get", {collection_key_t(long_api_key_str, wildcard_all_key.value)}, sparams, embedded_params));
 
     // wildcard on a collection
-    api_key_t wildcard_coll_key = api_key_t("abcd2", "wildcard coll key", {"*"}, {"collection1"}, FUTURE_TS);
+    api_key_t wildcard_coll_key = api_key_t("abcd2", "wildcard coll key", {"*"}, {"collection1"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(wildcard_coll_key);
 
     ASSERT_FALSE(auth_manager.authenticate("documents:create", {collection_key_t("collection1", "adasda")}, sparams, embedded_params));
@@ -170,7 +171,7 @@ TEST_F(AuthManagerTest, VerifyAuthentication) {
     ASSERT_FALSE(auth_manager.authenticate("documents:get", {collection_key_t("collection2", wildcard_coll_key.value)}, sparams, embedded_params));
 
     // wildcard on multiple collections
-    api_key_t wildcard_colls_key = api_key_t("abcd3", "wildcard coll key", {"*"}, {"collection1", "collection2", "collection3"}, FUTURE_TS);
+    api_key_t wildcard_colls_key = api_key_t("abcd3", "wildcard coll key", {"*"}, {"collection1", "collection2", "collection3"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(wildcard_colls_key);
 
     ASSERT_TRUE(auth_manager.authenticate("documents:get", {collection_key_t("collection1", wildcard_colls_key.value)}, sparams, embedded_params));
@@ -180,7 +181,7 @@ TEST_F(AuthManagerTest, VerifyAuthentication) {
     ASSERT_FALSE(auth_manager.authenticate("documents:get", {collection_key_t("*", wildcard_colls_key.value)}, sparams, embedded_params));
 
     // only 1 action on multiple collections
-    api_key_t one_action_key = api_key_t("abcd4", "one action key", {"documents:search"}, {"collection1", "collection2"}, FUTURE_TS);
+    api_key_t one_action_key = api_key_t("abcd4", "one action key", {"documents:search"}, {"collection1", "collection2"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(one_action_key);
 
     ASSERT_TRUE(auth_manager.authenticate("documents:search", {collection_key_t("collection1", one_action_key.value)}, sparams, embedded_params));
@@ -190,7 +191,7 @@ TEST_F(AuthManagerTest, VerifyAuthentication) {
 
     // multiple actions on multiple collections
     api_key_t mul_acoll_key = api_key_t("abcd5", "multiple action/collection key",
-                                        {"documents:get", "collections:list"}, {"metacollection", "collection2"}, FUTURE_TS);
+                                        {"documents:get", "collections:list"}, {"metacollection", "collection2"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(mul_acoll_key);
 
     ASSERT_TRUE(auth_manager.authenticate("documents:get", {collection_key_t("metacollection", mul_acoll_key.value)}, sparams, embedded_params));
@@ -202,28 +203,28 @@ TEST_F(AuthManagerTest, VerifyAuthentication) {
 
     // regexp match
 
-    api_key_t regexp_colls_key1 = api_key_t("abcd6", "regexp coll key", {"*"}, {"coll.*"}, FUTURE_TS);
+    api_key_t regexp_colls_key1 = api_key_t("abcd6", "regexp coll key", {"*"}, {"coll.*"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(regexp_colls_key1);
     ASSERT_TRUE(auth_manager.authenticate("collections:list", {collection_key_t("collection2", regexp_colls_key1.value)}, sparams, embedded_params));
     ASSERT_TRUE(auth_manager.authenticate("documents:get", {collection_key_t("collection5", regexp_colls_key1.value)}, sparams, embedded_params));
 
-    api_key_t regexp_colls_key2 = api_key_t("abcd7", "regexp coll key", {"*"}, {".*meta.*"}, FUTURE_TS);
+    api_key_t regexp_colls_key2 = api_key_t("abcd7", "regexp coll key", {"*"}, {".*meta.*"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(regexp_colls_key2);
     ASSERT_TRUE(auth_manager.authenticate("collections:list", {collection_key_t("metacollection", regexp_colls_key2.value)}, sparams, embedded_params));
     ASSERT_TRUE(auth_manager.authenticate("collections:list", {collection_key_t("ametacollection", regexp_colls_key2.value)}, sparams, embedded_params));
 
     // check for expiry
 
-    api_key_t expired_key1 = api_key_t("abcd8", "expiry key", {"*"}, {"*"}, 1606542716);
+    api_key_t expired_key1 = api_key_t("abcd8", "expiry key", {"*"}, {"*"}, {}, {}, 1606542716);
     auth_manager.create_key(expired_key1);
     ASSERT_FALSE(auth_manager.authenticate("collections:list", {collection_key_t("collection", expired_key1.value)}, sparams, embedded_params));
 
-    api_key_t unexpired_key1 = api_key_t("abcd9", "expiry key", {"*"}, {"*"}, 2237712220);
+    api_key_t unexpired_key1 = api_key_t("abcd9", "expiry key", {"*"}, {"*"}, {}, {}, 2237712220);
     auth_manager.create_key(unexpired_key1);
     ASSERT_TRUE(auth_manager.authenticate("collections:list", {collection_key_t("collection", unexpired_key1.value)}, sparams, embedded_params));
 
     // wildcard action on any collection
-    api_key_t wildcard_action_coll_key = api_key_t("abcd10", "wildcard coll action key", {"collections:*"}, {"*"}, FUTURE_TS);
+    api_key_t wildcard_action_coll_key = api_key_t("abcd10", "wildcard coll action key", {"collections:*"}, {"*"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(wildcard_action_coll_key);
 
     ASSERT_TRUE(auth_manager.authenticate("collections:create", {collection_key_t("collection1", wildcard_action_coll_key.value)}, sparams, embedded_params));
@@ -231,15 +232,15 @@ TEST_F(AuthManagerTest, VerifyAuthentication) {
     ASSERT_FALSE(auth_manager.authenticate("documents:create", {collection_key_t("collection1", wildcard_action_coll_key.value)}, sparams, embedded_params));
 
     // create action on a specific collection
-    api_key_t create_action_coll_key = api_key_t("abcd11", "create action+coll key", {"collections:create"}, {"collection1"}, FUTURE_TS);
+    api_key_t create_action_coll_key = api_key_t("abcd11", "create action+coll key", {"collections:create"}, {"collection1"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(create_action_coll_key);
 
     ASSERT_TRUE(auth_manager.authenticate("collections:create", {collection_key_t("collection1", create_action_coll_key.value)}, sparams, embedded_params));
     ASSERT_FALSE(auth_manager.authenticate("collections:create", {collection_key_t("collection2", create_action_coll_key.value)}, sparams, embedded_params));
 
     // two keys against 2 different collections: both should be valid
-    api_key_t coll_a_key = api_key_t("coll_a", "one action key", {"documents:search"}, {"collectionA"}, FUTURE_TS);
-    api_key_t coll_b_key = api_key_t("coll_b", "one action key", {"documents:search"}, {"collectionB"}, FUTURE_TS);
+    api_key_t coll_a_key = api_key_t("coll_a", "one action key", {"documents:search"}, {"collectionA"}, {}, {}, FUTURE_TS);
+    api_key_t coll_b_key = api_key_t("coll_b", "one action key", {"documents:search"}, {"collectionB"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(coll_a_key);
     auth_manager.create_key(coll_b_key);
     ASSERT_TRUE(auth_manager.authenticate("documents:search",
@@ -258,14 +259,14 @@ TEST_F(AuthManagerTest, VerifyAuthentication) {
                                            sparams, embedded_params));
 
     // bad collection allow regexp
-    api_key_t coll_c_key = api_key_t("coll_c", "one action key", {"documents:search"}, {"*coll_c"}, FUTURE_TS);
+    api_key_t coll_c_key = api_key_t("coll_c", "one action key", {"documents:search"}, {"*coll_c"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(coll_c_key);
     ASSERT_FALSE(auth_manager.authenticate("documents:search",
                                            {collection_key_t("coll_c", coll_c_key.value),},
                                            sparams, embedded_params));
 
     //operation key exception case
-    api_key_t operation_key = api_key_t("zxcvbnm", "operation get", {"operations/schema_changes:get"}, {"*"}, FUTURE_TS);
+    api_key_t operation_key = api_key_t("zxcvbnm", "operation get", {"operations/schema_changes:get"}, {"*"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(operation_key);
     ASSERT_FALSE(auth_manager.authenticate("operations/schema_changes:list", {collection_key_t("", operation_key.value)}, sparams, embedded_params));
     ASSERT_TRUE(auth_manager.authenticate("operations/schema_changes:get", {collection_key_t("", operation_key.value)}, sparams, embedded_params));
@@ -325,13 +326,88 @@ TEST_F(AuthManagerTest, HandleAuthenticationWithNonStringNestedMultiSearchPreset
     EXPECT_TRUE(authenticated);
 }
 
+TEST_F(AuthManagerTest, SearchSetAuthChecksRequestedAndPresetSets) {
+    const std::string coll_name = "search_set_auth_" + StringUtils::randstring(8);
+    const std::string restricted_key_value = "Restricted" + StringUtils::randstring(8);
+    const std::string wildcard_key_value = "Wildcard" + StringUtils::randstring(8);
+
+    nlohmann::json schema = {
+        {"name", coll_name},
+        {"fields", nlohmann::json::array({
+            {{"name", "title"}, {"type", "string"}}
+        })}
+    };
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    ASSERT_TRUE(collectionManager.update_collection_synonym_sets(coll_name, {"base_syn"}, false).ok());
+    ASSERT_TRUE(collectionManager.update_collection_curation_sets(coll_name, {"base_cur"}, false).ok());
+
+    api_key_t restricted_key(restricted_key_value, "restricted key", {"documents:search"}, {coll_name},
+                             {"base_syn"}, {"base_cur"}, FUTURE_TS);
+    auto key_op = auth_manager.create_key(restricted_key);
+    ASSERT_TRUE(key_op.ok());
+
+    api_key_t wildcard_key(wildcard_key_value, "wildcard key", {"documents:search"}, {coll_name},
+                           {"*"}, {"*"}, FUTURE_TS);
+    key_op = auth_manager.create_key(wildcard_key);
+    ASSERT_TRUE(key_op.ok());
+
+    std::map<std::string, std::string> params;
+    std::vector<nlohmann::json> embedded_params = {nlohmann::json::object()};
+
+    params["synonym_sets"] = "base_syn";
+    params["curation_sets"] = "base_cur";
+    ASSERT_TRUE(auth_manager.authenticate("documents:search", {collection_key_t(coll_name, restricted_key.value)},
+                                          params, embedded_params));
+
+    params["synonym_sets"] = "extra_syn";
+    ASSERT_FALSE(auth_manager.authenticate("documents:search", {collection_key_t(coll_name, restricted_key.value)},
+                                           params, embedded_params));
+    ASSERT_TRUE(auth_manager.authenticate("documents:search", {collection_key_t(coll_name, wildcard_key.value)},
+                                          params, embedded_params));
+
+    params["synonym_sets"] = "base_syn";
+    params["curation_sets"] = "extra_cur";
+    ASSERT_FALSE(auth_manager.authenticate("documents:search", {collection_key_t(coll_name, restricted_key.value)},
+                                           params, embedded_params));
+    ASSERT_TRUE(auth_manager.authenticate("documents:search", {collection_key_t(coll_name, wildcard_key.value)},
+                                          params, embedded_params));
+
+    params.clear();
+    embedded_params[0] = {
+        {AuthManager::AUTH_REQUESTED_SYNONYM_SETS_PARAM, "base_syn"},
+        {AuthManager::AUTH_REQUESTED_CURATION_SETS_PARAM, nlohmann::json::array({"base_cur"})}
+    };
+    ASSERT_TRUE(auth_manager.authenticate("documents:search", {collection_key_t(coll_name, restricted_key.value)},
+                                          params, embedded_params));
+
+    embedded_params[0] = {
+        {"synonym_sets", "extra_syn"},
+        {"curation_sets", nlohmann::json::array({"extra_cur"})}
+    };
+    ASSERT_FALSE(auth_manager.authenticate("documents:search", {collection_key_t(coll_name, restricted_key.value)},
+                                           params, embedded_params));
+    ASSERT_TRUE(auth_manager.authenticate("documents:search", {collection_key_t(coll_name, wildcard_key.value)},
+                                          params, embedded_params));
+
+    params["synonym_sets"] = "base_syn";
+    params["curation_sets"] = "base_cur";
+    embedded_params[0] = {
+        {AuthManager::AUTH_PRESET_SYNONYM_SETS_PARAM, "extra_syn"},
+        {AuthManager::AUTH_PRESET_CURATION_SETS_PARAM, nlohmann::json::array({"extra_cur"})}
+    };
+    ASSERT_TRUE(auth_manager.authenticate("documents:search", {collection_key_t(coll_name, restricted_key.value)},
+                                          params, embedded_params));
+}
+
 TEST_F(AuthManagerTest, ScopedAPIKeys) {
     std::map<std::string, std::string> params;
     params["filter_by"] = "country:USA";
     std::vector<nlohmann::json> embedded_params(2);
 
     // create a API key bound to search scope and a given collection
-    api_key_t key_search_coll1("KeyVal", "test key", {"documents:search"}, {"coll1"}, FUTURE_TS);
+    api_key_t key_search_coll1("KeyVal", "test key", {"documents:search"}, {"coll1"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(key_search_coll1);
 
     std::string scoped_key = StringUtils::base64_encode(
@@ -372,7 +448,7 @@ TEST_F(AuthManagerTest, ScopedAPIKeys) {
     // when more than a single key prefix matches, must pick the correct underlying key
     embedded_params.clear();
     embedded_params.push_back(nlohmann::json::object());
-    api_key_t key_search_coll2("KeyVal2", "test key", {"documents:search"}, {"coll2"}, FUTURE_TS);
+    api_key_t key_search_coll2("KeyVal2", "test key", {"documents:search"}, {"coll2"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(key_search_coll2);
     ASSERT_TRUE(auth_manager.authenticate("documents:search", {collection_key_t("coll1", scoped_key)}, empty_params, embedded_params));
     ASSERT_FALSE(auth_manager.authenticate("documents:search", {collection_key_t("coll2", scoped_key)}, empty_params, embedded_params));
@@ -387,7 +463,7 @@ TEST_F(AuthManagerTest, ScopedAPIKeys) {
     // should only allow scoped API keys derived from parent key with documents:search action
     embedded_params.clear();
     embedded_params.push_back(nlohmann::json::object());
-    api_key_t key_search_admin("AdminKey", "admin key", {"*"}, {"*"}, FUTURE_TS);
+    api_key_t key_search_admin("AdminKey", "admin key", {"*"}, {"*"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(key_search_admin);
     std::string scoped_key2 = StringUtils::base64_encode(
       "BXbsk+xLT1gxOjDyip6+PE4MtOzOm/H7kbkN1d/j/s4=Admi{\"filter_by\": \"user_id:1080\"}"
@@ -397,7 +473,7 @@ TEST_F(AuthManagerTest, ScopedAPIKeys) {
     // expiration of scoped api key
 
     // {"filter_by": "user_id:1080", "expires_at": 2237712220} (NOT expired)
-    api_key_t key_expiry("ExpireKey", "expire key", {"documents:search"}, {"*"}, FUTURE_TS);
+    api_key_t key_expiry("ExpireKey", "expire key", {"documents:search"}, {"*"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(key_expiry);
 
     embedded_params.clear();
@@ -412,7 +488,7 @@ TEST_F(AuthManagerTest, ScopedAPIKeys) {
 
     // {"filter_by": "user_id:1080", "expires_at": 1606563316} (expired)
 
-    api_key_t key_expiry2("ExpireKey2", "expire key", {"documents:search"}, {"*"}, FUTURE_TS);
+    api_key_t key_expiry2("ExpireKey2", "expire key", {"documents:search"}, {"*"}, {}, {}, FUTURE_TS);
     auth_manager.create_key(key_expiry2);
 
     embedded_params.clear();
@@ -426,7 +502,7 @@ TEST_F(AuthManagerTest, ScopedAPIKeys) {
     // {"filter_by": "user_id:1080", "expires_at": 64723363200} (greater than parent key expiry)
     // embedded key's param cannot exceed parent's expiry
 
-    api_key_t key_expiry3("ExpireKey3", "expire key", {"documents:search"}, {"*"}, 1606563841);
+    api_key_t key_expiry3("ExpireKey3", "expire key", {"documents:search"}, {"*"}, {}, {}, 1606563841);
     auth_manager.create_key(key_expiry3);
 
     embedded_params.clear();
@@ -515,11 +591,11 @@ TEST_F(AuthManagerTest, AutoDeleteKeysOnExpiry) {
     ASSERT_EQ(0, list_op.get().size());
 
     //regular key(future ts)
-    api_key_t api_key1("abcd", "test key 1", {"read", "write"}, {"collection1", "collection2"}, FUTURE_TS);
+    api_key_t api_key1("abcd", "test key 1", {"read", "write"}, {"collection1", "collection2"}, {}, {}, FUTURE_TS);
 
     //key is expired (past ts)
     uint64_t PAST_TS = uint64_t(std::time(0)) - 100;
-    api_key_t api_key2("wxyz", "test key 2", {"admin"}, {"*"}, PAST_TS, true);
+    api_key_t api_key2("wxyz", "test key 2", {"admin"}, {"*"}, {}, {}, PAST_TS, true);
 
     auto insert_op = auth_manager.create_key(api_key1);
     ASSERT_TRUE(insert_op.ok());

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -1140,7 +1140,7 @@ TEST_F(CollectionManagerTest, DropCollectionCleanly) {
 }
 
 TEST_F(CollectionManagerTest, AuthWithMultiSearchKeys) {
-    api_key_t key1("api_key", "some key", {"documents:create"}, {"foo"}, 64723363199);
+    api_key_t key1("api_key", "some key", {"documents:create"}, {"foo"}, {}, {}, 64723363199);
     collectionManager.getAuthManager().create_key(key1);
 
     std::vector<collection_key_t> collection_keys = {

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -319,7 +319,7 @@ TEST_F(CoreAPIUtilsTest, ScopedKeyEmbeddedCollectionCanSupplyMissingMultiSearchC
     scoped_coll->add(R"({"id":"1","title":"scoped doc"})", CREATE);
 
     api_key_t parent_key("ScopedKeyMissingCollection1", "scoped search parent", {"documents:search"}, {"scoped_coll"},
-                         api_key_t::FAR_FUTURE_TIMESTAMP);
+                         {}, {}, api_key_t::FAR_FUTURE_TIMESTAMP);
     auto key_op = collectionManager.getAuthManager().create_key(parent_key);
     ASSERT_TRUE(key_op.ok());
 
@@ -363,7 +363,7 @@ TEST_F(CoreAPIUtilsTest, ScopedKeyEmbeddedCollectionConflictFailsAuthentication)
     ASSERT_TRUE(op.ok());
 
     api_key_t parent_key("ScopedKeyConflictCollection2", "scoped search parent", {"documents:search"}, {"allowed_coll"},
-                         api_key_t::FAR_FUTURE_TIMESTAMP);
+                         {}, {}, api_key_t::FAR_FUTURE_TIMESTAMP);
     auto key_op = collectionManager.getAuthManager().create_key(parent_key);
     ASSERT_TRUE(key_op.ok());
 
@@ -451,7 +451,7 @@ TEST_F(CoreAPIUtilsTest, SearchCacheShouldRespectScopedEmbeddedFilters) {
     ASSERT_TRUE(coll->add("{\"id\":\"2\",\"title\":\"" + query + "\",\"user_id\":2}", CREATE).ok());
 
     api_key_t parent_key("ScopedCacheLeak" + StringUtils::randstring(8), "scoped cache parent", {"documents:search"},
-                         {coll_name}, api_key_t::FAR_FUTURE_TIMESTAMP);
+                         {coll_name}, {}, {}, api_key_t::FAR_FUTURE_TIMESTAMP);
     auto key_op = collectionManager.getAuthManager().create_key(parent_key);
     ASSERT_TRUE(key_op.ok());
 
@@ -989,8 +989,8 @@ TEST_F(CoreAPIUtilsTest, ExtractCollectionsFromRequestBodyExtended) {
 TEST_F(CoreAPIUtilsTest, MultiSearchWithPresetShouldUsePresetForAuth) {
     nlohmann::json preset_value = R"(
         {"searches":[
-            {"collection":"foo","q":"apple", "query_by": "title"},
-            {"collection":"bar","q":"apple", "query_by": "title"}
+            {"collection":"foo","q":"apple", "query_by": "title", "synonym_sets": ["preset_syn_1"], "curation_sets": "preset_cur_1"},
+            {"collection":"bar","q":"apple", "query_by": "title", "synonym_sets": "preset_syn_2", "curation_sets": ["preset_cur_2"]}
         ]}
     )"_json;
 
@@ -1004,8 +1004,8 @@ TEST_F(CoreAPIUtilsTest, MultiSearchWithPresetShouldUsePresetForAuth) {
 
     std::string search_body = R"(
         {"searches":[
-            {"collection":"foo1","q":"apple", "query_by": "title"},
-            {"collection":"bar1","q":"apple", "query_by": "title"}
+            {"collection":"foo1","q":"apple", "query_by": "title", "synonym_sets": "req_syn_1", "curation_sets": ["req_cur_1"]},
+            {"collection":"bar1","q":"apple", "query_by": "title", "synonym_sets": ["req_syn_2"], "curation_sets": "req_cur_2"}
         ]}
     )";
 
@@ -1017,6 +1017,14 @@ TEST_F(CoreAPIUtilsTest, MultiSearchWithPresetShouldUsePresetForAuth) {
     ASSERT_EQ("foo1", collections[0].collection);
     ASSERT_EQ("bar1", collections[1].collection);
     ASSERT_EQ(2, embedded_params_vec.size());
+    ASSERT_EQ("req_syn_1",
+              embedded_params_vec[0][AuthManager::AUTH_REQUESTED_SYNONYM_SETS_PARAM].get<std::string>());
+    ASSERT_EQ("req_cur_1",
+              embedded_params_vec[0][AuthManager::AUTH_REQUESTED_CURATION_SETS_PARAM][0].get<std::string>());
+    ASSERT_EQ("req_syn_2",
+              embedded_params_vec[1][AuthManager::AUTH_REQUESTED_SYNONYM_SETS_PARAM][0].get<std::string>());
+    ASSERT_EQ("req_cur_2",
+              embedded_params_vec[1][AuthManager::AUTH_REQUESTED_CURATION_SETS_PARAM].get<std::string>());
 
     // with preset parameter, use collections from preset configuration
     collections.clear();
@@ -1029,11 +1037,19 @@ TEST_F(CoreAPIUtilsTest, MultiSearchWithPresetShouldUsePresetForAuth) {
     ASSERT_EQ("foo", collections[0].collection);
     ASSERT_EQ("bar", collections[1].collection);
     ASSERT_EQ(2, embedded_params_vec.size());
+    ASSERT_EQ("preset_syn_1",
+              embedded_params_vec[0][AuthManager::AUTH_REQUESTED_SYNONYM_SETS_PARAM][0].get<std::string>());
+    ASSERT_EQ("preset_cur_1",
+              embedded_params_vec[0][AuthManager::AUTH_REQUESTED_CURATION_SETS_PARAM].get<std::string>());
+    ASSERT_EQ("preset_syn_2",
+              embedded_params_vec[1][AuthManager::AUTH_REQUESTED_SYNONYM_SETS_PARAM].get<std::string>());
+    ASSERT_EQ("preset_cur_2",
+              embedded_params_vec[1][AuthManager::AUTH_REQUESTED_CURATION_SETS_PARAM][0].get<std::string>());
 
     // try using multi_search preset within individual search param
 
     preset_value = R"(
-        {"collection":"preset_coll"}
+        {"collection":"preset_coll", "synonym_sets":"preset_syn", "curation_sets":["preset_cur"]}
     )"_json;
 
     collectionManager.upsert_preset("single_preset", preset_value);
@@ -1044,8 +1060,8 @@ TEST_F(CoreAPIUtilsTest, MultiSearchWithPresetShouldUsePresetForAuth) {
 
     search_body = R"(
         {"searches":[
-            {"collection":"foo1","q":"apple", "query_by": "title", "preset": "single_preset"},
-            {"collection":"bar1","q":"apple", "query_by": "title", "preset": "single_preset"}
+            {"collection":"foo1","q":"apple", "query_by": "title", "preset": "single_preset", "synonym_sets":["req_syn"], "curation_sets":"req_cur"},
+            {"collection":"bar1","q":"apple", "query_by": "title", "preset": "single_preset", "synonym_sets":"req_syn_2", "curation_sets":["req_cur_2"]}
         ]}
     )";
 
@@ -1055,6 +1071,22 @@ TEST_F(CoreAPIUtilsTest, MultiSearchWithPresetShouldUsePresetForAuth) {
     ASSERT_EQ("foo1", collections[0].collection);
     ASSERT_EQ("bar1", collections[1].collection);
     ASSERT_EQ(2, embedded_params_vec.size());
+    ASSERT_EQ("preset_syn",
+              embedded_params_vec[0][AuthManager::AUTH_PRESET_SYNONYM_SETS_PARAM].get<std::string>());
+    ASSERT_EQ("preset_cur",
+              embedded_params_vec[0][AuthManager::AUTH_PRESET_CURATION_SETS_PARAM][0].get<std::string>());
+    ASSERT_EQ("req_syn",
+              embedded_params_vec[0][AuthManager::AUTH_REQUESTED_SYNONYM_SETS_PARAM][0].get<std::string>());
+    ASSERT_EQ("req_cur",
+              embedded_params_vec[0][AuthManager::AUTH_REQUESTED_CURATION_SETS_PARAM].get<std::string>());
+    ASSERT_EQ("preset_syn",
+              embedded_params_vec[1][AuthManager::AUTH_PRESET_SYNONYM_SETS_PARAM].get<std::string>());
+    ASSERT_EQ("preset_cur",
+              embedded_params_vec[1][AuthManager::AUTH_PRESET_CURATION_SETS_PARAM][0].get<std::string>());
+    ASSERT_EQ("req_syn_2",
+              embedded_params_vec[1][AuthManager::AUTH_REQUESTED_SYNONYM_SETS_PARAM].get<std::string>());
+    ASSERT_EQ("req_cur_2",
+              embedded_params_vec[1][AuthManager::AUTH_REQUESTED_CURATION_SETS_PARAM][0].get<std::string>());
 
     // without collection in search array
     req_params.clear();
@@ -1074,6 +1106,43 @@ TEST_F(CoreAPIUtilsTest, MultiSearchWithPresetShouldUsePresetForAuth) {
     ASSERT_EQ("preset_coll", collections[0].collection);
     ASSERT_EQ("preset_coll", collections[1].collection);
     ASSERT_EQ(2, embedded_params_vec.size());
+    ASSERT_EQ("preset_syn",
+              embedded_params_vec[0][AuthManager::AUTH_PRESET_SYNONYM_SETS_PARAM].get<std::string>());
+    ASSERT_EQ("preset_cur",
+              embedded_params_vec[0][AuthManager::AUTH_PRESET_CURATION_SETS_PARAM][0].get<std::string>());
+    ASSERT_EQ("preset_syn",
+              embedded_params_vec[1][AuthManager::AUTH_PRESET_SYNONYM_SETS_PARAM].get<std::string>());
+    ASSERT_EQ("preset_cur",
+              embedded_params_vec[1][AuthManager::AUTH_PRESET_CURATION_SETS_PARAM][0].get<std::string>());
+}
+
+TEST_F(CoreAPIUtilsTest, SearchPresetShouldPopulateAuthContext) {
+    nlohmann::json preset_value = R"(
+        {"collection":"preset_coll", "synonym_sets":"preset_syn", "curation_sets":["preset_cur"]}
+    )"_json;
+
+    auto preset_op = collectionManager.upsert_preset("single_search_preset_auth", preset_value);
+    ASSERT_TRUE(preset_op.ok());
+
+    route_path rpath_search = route_path("GET", {"collections", ":collection", "documents", "search"},
+                                         get_search, false, false);
+    std::map<std::string, std::string> req_params = {
+        {"collection", "req_coll"},
+        {"preset", "single_search_preset_auth"}
+    };
+
+    std::vector<collection_key_t> collections;
+    std::vector<nlohmann::json> embedded_params_vec;
+
+    get_collections_for_auth(req_params, "", rpath_search, "", collections, embedded_params_vec);
+
+    ASSERT_EQ(1, collections.size());
+    ASSERT_EQ("req_coll", collections[0].collection);
+    ASSERT_EQ(1, embedded_params_vec.size());
+    ASSERT_EQ("preset_syn",
+              embedded_params_vec[0][AuthManager::AUTH_PRESET_SYNONYM_SETS_PARAM].get<std::string>());
+    ASSERT_EQ("preset_cur",
+              embedded_params_vec[0][AuthManager::AUTH_PRESET_CURATION_SETS_PARAM][0].get<std::string>());
 }
 
 TEST_F(CoreAPIUtilsTest, PresetMultiSearch) {


### PR DESCRIPTION
## Change Summary
  - Enforce `synonym_sets` / `curation_sets` API key scope during search authentication, not only against collection-configured sets but also against sets requested at search time.
  - Cover search-set values coming from direct search params, scoped embedded params, and preset-backed searches.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
