### PR TITLE
fix: fix exact phrase highlighting ordering

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -5417,8 +5417,10 @@ bool Collection::handle_highlight_text(std::string& text, const bool& normalise,
             phrases_by_first_token[phrase_lower[0]].push_back(phrase_lower);
         }
 
-        // Single pass through text tokens to find phrase matches (track all matches)
-        for(size_t i = 0; i < text_tokens.size() && !found_phrase_match; i++) {
+        // Single pass through text tokens to find phrase matches and collect every
+        // matching span. Nested array/object fields need the full union of all
+        // phrase occurrences, not just the first hit.
+        for(size_t i = 0; i < text_tokens.size(); i++) {
             std::string first_token_lower = text_tokens[i].token;
             StringUtils::tolowercase(first_token_lower);
             
@@ -5454,7 +5456,6 @@ bool Collection::handle_highlight_text(std::string& text, const bool& normalise,
                         const auto& pos = phrase_text_token_positions[i + j];
                         phrase_token_offsets[pos.first] = pos.second;
                     }
-                    break;
                 }
             }
         }

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -5417,9 +5417,7 @@ bool Collection::handle_highlight_text(std::string& text, const bool& normalise,
             phrases_by_first_token[phrase_lower[0]].push_back(phrase_lower);
         }
 
-        // Single pass through text tokens to find phrase matches and collect every
-        // matching span. Nested array/object fields need the full union of all
-        // phrase occurrences, not just the first hit.
+        // Single pass through text tokens to find phrase matches (track all matches)
         for(size_t i = 0; i < text_tokens.size(); i++) {
             std::string first_token_lower = text_tokens[i].token;
             StringUtils::tolowercase(first_token_lower);
@@ -5449,8 +5447,10 @@ bool Collection::handle_highlight_text(std::string& text, const bool& normalise,
                 }
                 
                 if(phrase_matches) {
+                    if(!found_phrase_match) {
+                        first_phrase_token_idx = i;
+                    }
                     found_phrase_match = true;
-                    first_phrase_token_idx = i;
                     // Record ALL matches, not just first
                     for(size_t j = 0; j < phrase.size(); j++) {
                         const auto& pos = phrase_text_token_positions[i + j];

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -5365,19 +5365,23 @@ bool Collection::handle_highlight_text(std::string& text, const bool& normalise,
         text = string_utils.unicode_nfkd(text);
     }
 
+    bool is_phrase_query = !q_phrases.empty();
+    bool use_exact_phrase_highlight = is_phrase_query && is_arr_obj_ele && match.offsets.empty();
+    std::map<size_t, size_t> phrase_token_offsets;
+    std::vector<std::pair<size_t, size_t>> phrase_text_token_positions;
+    bool found_phrase_match = false;
+    size_t first_phrase_token_idx = 0;
     // special handling for phrase queries in nested array fields (array of objects)
     // when is_arr_obj_ele is true, match.offsets is empty, so we need to manually check for phrase matches
-    bool is_phrase_query = !q_phrases.empty();
-    if (is_phrase_query && is_arr_obj_ele && match.offsets.empty() && !text.empty()) {
+    if(is_phrase_query && !text.empty()) {
         struct TextToken {
             std::string token;
             size_t token_index;
             size_t tok_start;
             size_t tok_end;
         };
-        std::vector<TextToken> text_tokens;
-        std::vector<std::pair<size_t, size_t>> text_token_positions; // (start, end) offsets
 
+        std::vector<TextToken> text_tokens;
         Tokenizer text_tokenizer(text, normalise, false, search_field.locale, symbols_to_index, token_separators, search_field.get_stemmer());
         Tokenizer text_word_tokenizer("", true, false, search_field.locale, symbols_to_index, token_separators, search_field.get_stemmer());
 
@@ -5393,31 +5397,28 @@ bool Collection::handle_highlight_text(std::string& text, const bool& normalise,
                 }
             }
             text_tokens.push_back({token, token_index, tok_start, tok_end});
-            text_token_positions.push_back({tok_start, tok_end});
+            phrase_text_token_positions.push_back({tok_start, tok_end});
         }
 
         std::unordered_map<std::string, std::vector<std::vector<std::string>>> phrases_by_first_token;
-        
         for(const auto& phrase : q_phrases) {
-            if(!phrase.empty()) {
-                std::vector<std::string> phrase_lower;
-                phrase_lower.reserve(phrase.size());
-                for(const auto& token : phrase) {
-                    std::string token_lower = token;
-                    StringUtils::tolowercase(token_lower);
-                    phrase_lower.push_back(token_lower);
-                }
-                
-                std::string first_lower = phrase_lower[0];
-                phrases_by_first_token[first_lower].push_back(phrase_lower);
+            if(phrase.empty()) {
+                continue;
             }
-        }
-        
-        // Single pass through text tokens to find phrase matches (track all matches)
-        bool found_phrase_match = false;
-        std::map<size_t, size_t> phrase_token_offsets;
 
-        for(size_t i = 0; i < text_tokens.size(); i++) {
+            std::vector<std::string> phrase_lower;
+            phrase_lower.reserve(phrase.size());
+            for(const auto& phrase_token : phrase) {
+                std::string token_lower = phrase_token;
+                StringUtils::tolowercase(token_lower);
+                phrase_lower.push_back(token_lower);
+            }
+
+            phrases_by_first_token[phrase_lower[0]].push_back(phrase_lower);
+        }
+
+        // Single pass through text tokens to find phrase matches (track all matches)
+        for(size_t i = 0; i < text_tokens.size() && !found_phrase_match; i++) {
             std::string first_token_lower = text_tokens[i].token;
             StringUtils::tolowercase(first_token_lower);
             
@@ -5447,20 +5448,30 @@ bool Collection::handle_highlight_text(std::string& text, const bool& normalise,
                 
                 if(phrase_matches) {
                     found_phrase_match = true;
+                    first_phrase_token_idx = i;
                     // Record ALL matches, not just first
                     for(size_t j = 0; j < phrase.size(); j++) {
-                        const auto& pos = text_token_positions[i + j];
+                        const auto& pos = phrase_text_token_positions[i + j];
                         phrase_token_offsets[pos.first] = pos.second;
                     }
+                    break;
                 }
             }
         }
 
+        if(!use_exact_phrase_highlight && !match.offsets.empty() && found_phrase_match &&
+           first_phrase_token_idx != match.offsets.front().offset) {
+            use_exact_phrase_highlight = true;
+        }
+    }
+
+    if(use_exact_phrase_highlight && !text.empty()) {
         if(!found_phrase_match) {
             return false;
         }
 
         std::map<size_t, size_t> token_offsets = phrase_token_offsets;
+        const std::vector<std::pair<size_t, size_t>>& text_token_positions = phrase_text_token_positions;
 
         // set snippet boundaries with context around matched tokens
         size_t snippet_start_offset = 0;

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -4665,3 +4665,86 @@ TEST_F(CollectionSpecificMoreTest, PrioritizeTokenPositionSingleTokenOffsetsAreN
 
     collectionManager.drop_collection("token_offsets");
 }
+TEST_F(CollectionSpecificMoreTest, PhraseQueryHighlightShouldMarkAllNestedPhrasesInValue) {
+    nlohmann::json schema = R"({
+        "name": "nested_phrase_highlight_multiple_phrases",
+        "enable_nested_fields": true,
+        "fields": [
+            {"name": "experiences", "type": "object[]"},
+            {"name": "experiences.description", "type": "string[]"}
+        ]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+    Collection* coll1 = op.get();
+
+    nlohmann::json doc1;
+    doc1["id"] = "1";
+    doc1["experiences"] = nlohmann::json::array();
+    nlohmann::json exp1;
+    exp1["description"] = "Harvard Business School collaborated with Stanford University on a joint program.";
+    doc1["experiences"].push_back(exp1);
+    ASSERT_TRUE(coll1->add(doc1.dump()).ok());
+
+    auto results = coll1->search("\"harvard business school\" \"stanford university\"", {"experiences.description"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, 0,
+                                 spp::sparse_hash_set<std::string>(),
+                                 spp::sparse_hash_set<std::string>(), 10, "", 30, 4, "experiences.description", 20, {}, {}, {}, 0,
+                                 "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7,
+                                 fallback, 1000).get();
+
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_TRUE(results["hits"][0].count("highlight") > 0);
+    ASSERT_TRUE(results["hits"][0]["highlight"].count("experiences") > 0);
+    ASSERT_EQ(1, results["hits"][0]["highlight"]["experiences"].size());
+    ASSERT_TRUE(results["hits"][0]["highlight"]["experiences"][0].count("description") > 0);
+    ASSERT_TRUE(results["hits"][0]["highlight"]["experiences"][0]["description"].count("value") > 0);
+    ASSERT_EQ("<mark>Harvard</mark> <mark>Business</mark> <mark>School</mark> collaborated with "
+              "<mark>Stanford</mark> <mark>University</mark> on a joint program.",
+              results["hits"][0]["highlight"]["experiences"][0]["description"]["value"].get<std::string>());
+
+    collectionManager.drop_collection("nested_phrase_highlight_multiple_phrases");
+}
+
+TEST_F(CollectionSpecificMoreTest, PhraseQueryHighlightShouldMarkAllNestedPhraseOccurrencesInValue) {
+    nlohmann::json schema = R"({
+        "name": "nested_phrase_highlight_multiple_occurrences",
+        "enable_nested_fields": true,
+        "fields": [
+            {"name": "experiences", "type": "object[]"},
+            {"name": "experiences.description", "type": "string[]"}
+        ]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+    Collection* coll1 = op.get();
+
+    nlohmann::json doc1;
+    doc1["id"] = "1";
+    doc1["experiences"] = nlohmann::json::array();
+    nlohmann::json exp1;
+    exp1["description"] = "Harvard Business School works closely with Harvard Business School alumni.";
+    doc1["experiences"].push_back(exp1);
+    ASSERT_TRUE(coll1->add(doc1.dump()).ok());
+
+    auto results = coll1->search("\"harvard business school\"", {"experiences.description"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, 0,
+                                 spp::sparse_hash_set<std::string>(),
+                                 spp::sparse_hash_set<std::string>(), 10, "", 30, 4, "experiences.description", 20, {}, {}, {}, 0,
+                                 "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7,
+                                 fallback, 1000).get();
+
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_TRUE(results["hits"][0].count("highlight") > 0);
+    ASSERT_TRUE(results["hits"][0]["highlight"].count("experiences") > 0);
+    ASSERT_EQ(1, results["hits"][0]["highlight"]["experiences"].size());
+    ASSERT_TRUE(results["hits"][0]["highlight"]["experiences"][0].count("description") > 0);
+    ASSERT_TRUE(results["hits"][0]["highlight"]["experiences"][0]["description"].count("value") > 0);
+    ASSERT_EQ("<mark>Harvard</mark> <mark>Business</mark> <mark>School</mark> works closely with "
+              "<mark>Harvard</mark> <mark>Business</mark> <mark>School</mark> alumni.",
+              results["hits"][0]["highlight"]["experiences"][0]["description"]["value"].get<std::string>());
+
+    collectionManager.drop_collection("nested_phrase_highlight_multiple_occurrences");
+}

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -4748,3 +4748,28 @@ TEST_F(CollectionSpecificMoreTest, PhraseQueryHighlightShouldMarkAllNestedPhrase
 
     collectionManager.drop_collection("nested_phrase_highlight_multiple_occurrences");
 }
+
+TEST_F(CollectionSpecificMoreTest, PhraseQueryHighlightShouldNotExpandToAllFlatFieldOccurrences) {
+    std::vector<field> fields = {field("textContent", field_types::STRING, false)};
+    Collection* coll1 = collectionManager.create_collection("phrase_highlight_flat_multiple_occurrences", 1, fields).get();
+
+    nlohmann::json doc1;
+    doc1["id"] = "1";
+    doc1["textContent"] = "Earnings per share improved. Later, earnings per share declined.";
+    ASSERT_TRUE(coll1->add(doc1.dump()).ok());
+
+    auto results = coll1->search("\"earnings per share\"", {"textContent"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, 0,
+                                 spp::sparse_hash_set<std::string>(),
+                                 spp::sparse_hash_set<std::string>(), 10, "", 30, 4, "textContent", 20, {}, {}, {}, 0,
+                                 "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7,
+                                 fallback, 1000).get();
+
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_EQ(1, results["hits"][0]["highlights"].size());
+    ASSERT_EQ("textContent", results["hits"][0]["highlights"][0]["field"].get<std::string>());
+    ASSERT_EQ("<mark>Earnings</mark> <mark>per</mark> <mark>share</mark> improved. Later, earnings per share declined.",
+              results["hits"][0]["highlights"][0]["value"].get<std::string>());
+
+    collectionManager.drop_collection("phrase_highlight_flat_multiple_occurrences");
+}

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -3842,6 +3842,33 @@ TEST_F(CollectionSpecificMoreTest, SingleTokenPhraseQueryShouldHighlightExactMat
     collectionManager.drop_collection("single_token_phrase_highlight");
 }
 
+TEST_F(CollectionSpecificMoreTest, PhraseQueryHighlightShouldUseExactPhraseTokens) {
+    std::vector<field> fields = {field("textContent", field_types::STRING, false)};
+    Collection* coll1 = collectionManager.create_collection("phrase_highlight_exact_tokens", 1, fields).get();
+
+    nlohmann::json doc1;
+    doc1["id"] = "1";
+    doc1["textContent"] = "The value of the share. Earnings per share (EPS) are calculated.";
+    ASSERT_TRUE(coll1->add(doc1.dump()).ok());
+
+    auto results = coll1->search("\"earnings per share\"", {"textContent"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, 0,
+                                 spp::sparse_hash_set<std::string>(),
+                                 spp::sparse_hash_set<std::string>(), 10, "", 30, 4, "textContent", 20, {}, {}, {}, 0,
+                                 "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7,
+                                 fallback, 1000).get();
+
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_EQ(1, results["hits"][0]["highlights"].size());
+    ASSERT_EQ("textContent", results["hits"][0]["highlights"][0]["field"].get<std::string>());
+
+    const std::string snippet = results["hits"][0]["highlights"][0]["snippet"].get<std::string>();
+    ASSERT_NE(snippet.find("<mark>Earnings</mark> <mark>per</mark> <mark>share</mark>"), std::string::npos);
+    ASSERT_EQ(snippet.find("<mark>share</mark> . <mark>Earnings</mark>"), std::string::npos);
+
+    collectionManager.drop_collection("phrase_highlight_exact_tokens");
+}
+
 TEST_F(CollectionSpecificMoreTest, PhraseQueryHighlightingInNestedFields) {
     nlohmann::json schema = R"({
         "name": "coll1",


### PR DESCRIPTION
## Change Summary
* make phrase highlight respect exact token order
* add test to ensure only continuous phrase tokens get highlighted
* avoid weird cross-boundary highlights


## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
