### PR TITLE
fix deep nested object array filter

### DIFF
--- a/api_tests/tests/nested_curly_filter.test.ts
+++ b/api_tests/tests/nested_curly_filter.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "bun:test";
+import { Phases } from "../src/constants";
+import { fetchSingleNode } from "../src/request";
+
+const COLLECTION_NAME = "show_nested_curly_repro";
+const ALIAS_NAME = "show_v2_repro";
+const PERFORMANCE_COUNTS = [54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 60];
+
+function buildDocuments() {
+  const docs: Array<Record<string, unknown>> = [];
+  const sameObjectTitles = new Set<string>();
+  const splitObjectTitles = new Set<string>();
+
+  for (let showIndex = 0; showIndex < PERFORMANCE_COUNTS.length; showIndex++) {
+    const showNum = showIndex + 1;
+    const title = `Show ${showNum.toString().padStart(2, "0")}`;
+    const performances: Array<Record<string, unknown>> = [];
+    const matchMode = showIndex % 3;
+
+    if (matchMode === 0) {
+      sameObjectTitles.add(title);
+    } else if (matchMode === 1) {
+      splitObjectTitles.add(title);
+    }
+
+    for (let perfIndex = 1; perfIndex <= PERFORMANCE_COUNTS[showIndex]!; perfIndex++) {
+      let localTimeHour: number;
+      let minPrice: number;
+
+      if (matchMode === 0 && perfIndex === 1) {
+        localTimeHour = 19;
+        minPrice = 4500;
+      } else if (matchMode === 1 && perfIndex === 1) {
+        localTimeHour = 19;
+        minPrice = 6500;
+      } else if (matchMode === 1 && perfIndex === 2) {
+        localTimeHour = 18;
+        minPrice = 4500;
+      } else {
+        switch ((perfIndex + showNum) % 6) {
+          case 0:
+            localTimeHour = 16;
+            break;
+          case 1:
+            localTimeHour = 17;
+            break;
+          case 2:
+            localTimeHour = 18;
+            break;
+          case 3:
+            localTimeHour = 20;
+            break;
+          case 4:
+            localTimeHour = 21;
+            break;
+          default:
+            localTimeHour = 22;
+            break;
+        }
+
+        minPrice = 6000 + showNum * 100 + perfIndex * 10;
+      }
+
+      performances.push({
+        id: `show-${showNum.toString().padStart(2, "0")}-perf-${perfIndex.toString().padStart(3, "0")}`,
+        startDate: { localTimeHour },
+        pricing: {
+          minPrice,
+          maxPrice: minPrice + 1200,
+        },
+      });
+    }
+
+    docs.push({
+      id: `show-${showNum.toString().padStart(2, "0")}`,
+      title,
+      performances,
+    });
+  }
+
+  return { docs, sameObjectTitles, splitObjectTitles };
+}
+
+async function search(filterBy: string) {
+  const res = await fetchSingleNode(
+    `/collections/${ALIAS_NAME}/documents/search?q=show&query_by=title&include_fields=title&per_page=50&filter_by=${encodeURIComponent(filterBy)}`,
+    { method: "GET" },
+  );
+  expect(res.ok).toBe(true);
+  return (await res.json()) as {
+    found: number;
+    hits: Array<{ document: { title: string } }>;
+  };
+}
+
+async function searchWithTimeout(filterBy: string, timeoutMs: number) {
+  const url = new URL(`http://localhost:8108/collections/${ALIAS_NAME}/documents/search`);
+  url.searchParams.set("q", "show");
+  url.searchParams.set("query_by", "title");
+  url.searchParams.set("include_fields", "title");
+  url.searchParams.set("per_page", "50");
+  url.searchParams.set("filter_by", filterBy);
+
+  const res = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      "X-TYPESENSE-API-KEY": "xyz",
+    },
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+
+  expect(res.ok).toBe(true);
+  return (await res.json()) as {
+    found: number;
+    hits: Array<{ document: { title: string } }>;
+  };
+}
+
+describe(Phases.SINGLE_FRESH, () => {
+  it("repro query should return promptly for deep same-object curly filters", async () => {
+    const totalPerformances = PERFORMANCE_COUNTS.reduce((sum, count) => sum + count, 0);
+    expect(PERFORMANCE_COUNTS.length).toBe(16);
+    expect(totalPerformances).toBe(975);
+
+    await fetchSingleNode(`/aliases/${ALIAS_NAME}`, { method: "DELETE" });
+    await fetchSingleNode(`/collections/${COLLECTION_NAME}`, { method: "DELETE" });
+
+    let res = await fetchSingleNode("/collections", {
+      method: "POST",
+      body: JSON.stringify({
+        name: COLLECTION_NAME,
+        enable_nested_fields: true,
+        fields: [
+          { name: "title", type: "string" },
+          { name: "performances", type: "object[]" },
+          { name: "performances.startDate.localTimeHour", type: "int32[]", range_index: true },
+          { name: "performances.pricing.minPrice", type: "int64[]" },
+          { name: "performances.pricing.maxPrice", type: "int64[]" },
+        ],
+      }),
+    });
+    expect(res.ok).toBe(true);
+
+    res = await fetchSingleNode(`/aliases/${ALIAS_NAME}`, {
+      method: "PUT",
+      body: JSON.stringify({
+        collection_name: COLLECTION_NAME,
+      }),
+    });
+    expect(res.ok).toBe(true);
+
+    const { docs, sameObjectTitles, splitObjectTitles } = buildDocuments();
+    const importBody = docs.map((doc) => JSON.stringify(doc)).join("\n");
+
+    res = await fetchSingleNode(`/collections/${ALIAS_NAME}/documents/import?action=upsert`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "text/plain",
+      },
+      body: importBody,
+    });
+    expect(res.ok).toBe(true);
+
+    const nonCurly = await search("performances.startDate.localTimeHour:19 && performances.pricing.minPrice:<5000");
+    expect(nonCurly.found).toBe(11);
+    expect(new Set(nonCurly.hits.map((hit) => hit.document.title))).toEqual(
+      new Set([...sameObjectTitles, ...splitObjectTitles]),
+    );
+
+    const hourOnly = await search("performances.{startDate.localTimeHour:19}");
+    expect(hourOnly.found).toBe(11);
+
+    const priceOnly = await search("performances.{pricing.minPrice:<5000}");
+    expect(priceOnly.found).toBe(11);
+
+    const sameObject = await searchWithTimeout(
+      "performances.{startDate.localTimeHour:19 && pricing.minPrice:<5000}",
+      5000,
+    );
+    expect(sameObject.found).toBe(sameObjectTitles.size);
+    expect(new Set(sameObject.hits.map((hit) => hit.document.title))).toEqual(sameObjectTitles);
+  });
+});

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -3726,6 +3726,7 @@ bool filter_result_iterator_t::validate_object_filter() {
         size_t result_count = 0;
         for (size_t i = 0; i < filter_result.count; i++) {
             if (timeout_info != nullptr && is_timed_out()) {
+                filter_result.count = result_count;
                 return false;
             }
 

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -441,6 +441,10 @@ void filter_result_t::or_filter_results(const filter_result_t& a, const filter_r
 
 void filter_result_iterator_t::and_filter_iterators() {
     while (left_it->validity && right_it->validity) {
+        if (timeout_info != nullptr && is_timed_out()) {
+            return;
+        }
+
         if (left_it->seq_id < right_it->seq_id) {
             auto const& left_validity = left_it->is_valid(right_it->seq_id);
 
@@ -519,6 +523,10 @@ void filter_result_iterator_t::and_filter_iterators() {
 void filter_result_iterator_t::or_filter_iterators() {
     if (filter_node->is_object_filter_root) {
         while (left_it->validity || right_it->validity) {
+            if (timeout_info != nullptr && is_timed_out()) {
+                return;
+            }
+
             if (left_it->validity && right_it->validity) {
                 if (left_it->seq_id < right_it->seq_id) {
                     seq_id = left_it->seq_id;
@@ -3580,9 +3588,23 @@ bool filter_result_iterator_t::validate_object_filter_helper(
                    match_it->second.count(object_index) != 0;
         }
 
-        auto pos = filter_exp.field_name.rfind(".");
+        auto nested_field_path = filter_exp.field_name;
+        const auto object_prefix = object_field_name + ".";
+        if (nested_field_path.rfind(object_prefix, 0) == 0) {
+            nested_field_path = nested_field_path.substr(object_prefix.size());
+        }
 
-        const auto& nested_field = filter_exp.field_name.substr(pos+1, filter_exp.field_name.size() - (pos+1));
+        const nlohmann::json* nested_doc = &doc;
+        std::vector<std::string> nested_field_parts;
+        StringUtils::split(nested_field_path, nested_field_parts, ".");
+        for (const auto& nested_field_part : nested_field_parts) {
+            if (!nested_doc->is_object() || nested_doc->count(nested_field_part) == 0) {
+                return false;
+            }
+
+            nested_doc = &nested_doc->at(nested_field_part);
+        }
+
         field f = index->search_schema.at(filter_exp.field_name);
 
         using fieldType = std::variant<int64_t, float, bool, std::string>;
@@ -3612,7 +3634,7 @@ bool filter_result_iterator_t::validate_object_filter_helper(
                 size_t token_index = 0;
                 filter_val = tokenizer.next(tokenized_filter_val, token_index) ? tokenized_filter_val : val;
                 
-                std::string doc_str = doc[nested_field].get<std::string>();
+                std::string doc_str = nested_doc->get<std::string>();
                 Tokenizer doc_tokenizer(doc_str, true, false, f.locale, symbols, separators, f.get_stemmer());
                 
                 std::string tokenized_doc_val;
@@ -3620,13 +3642,13 @@ bool filter_result_iterator_t::validate_object_filter_helper(
                 doc_val = doc_tokenizer.next(tokenized_doc_val, doc_token_index) ? tokenized_doc_val : doc_str;
             } else if (f.is_float()) {
                 filter_val = std::stof(val);
-                doc_val = doc[nested_field].get<float>();
+                doc_val = nested_doc->get<float>();
             } else if (f.is_bool()) {
                 filter_val = val == "1" ? true : false;
-                doc_val = doc[nested_field].get<bool>();
+                doc_val = nested_doc->get<bool>();
             } else if (f.is_integer()) {
                 filter_val = std::stoll(val);
-                doc_val = doc[nested_field].get<int64_t>();
+                doc_val = nested_doc->get<int64_t>();
             }
 
             if (comparator == EQUALS) {
@@ -3684,6 +3706,10 @@ bool filter_result_iterator_t::validate_object_filter() {
 
         nlohmann::json return_doc = document;
         for(auto i = 0; i < results.size(); ++i) {
+            if (!return_doc.is_object() || return_doc.count(results[i]) == 0) {
+                return nlohmann::json();
+            }
+
             return_doc = return_doc[results[i]];
         }
 
@@ -3699,6 +3725,10 @@ bool filter_result_iterator_t::validate_object_filter() {
     if (is_filter_result_initialized) {
         size_t result_count = 0;
         for (size_t i = 0; i < filter_result.count; i++) {
+            if (timeout_info != nullptr && is_timed_out()) {
+                return false;
+            }
+
             const auto& id = filter_result.docs[i];
             const std::string& seq_id_key = collection->get_seq_id_key(id);
 
@@ -3742,8 +3772,17 @@ bool filter_result_iterator_t::validate_object_filter() {
     }
     auto object_join_matches = build_object_join_matches(collection_name, filter_node->object_field_name,
                                                          document, &reference);
-    for (uint32_t object_index = 0; object_index < document[filter_node->object_field_name].size(); object_index++) {
-        const auto& nested_object = document[filter_node->object_field_name][object_index];
+    const auto& nested_doc = get_nested_field_doc(filter_node->object_field_name, document);
+    if (!nested_doc.is_array()) {
+        return false;
+    }
+
+    for (uint32_t object_index = 0; object_index < nested_doc.size(); object_index++) {
+        if (timeout_info != nullptr && is_timed_out()) {
+            return false;
+        }
+
+        const auto& nested_object = nested_doc[object_index];
         if (validate_object_filter_helper(index, nested_object, filter_node,
                                           collection_name, filter_node->object_field_name,
                                           &object_join_matches, object_index)) {

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -4260,6 +4260,71 @@ TEST_F(CollectionFilteringTest, DeepNestedObjectFieldsFiltering) {
     ASSERT_EQ("Pasta", result["hits"][1]["document"]["root"]["main"]["name"]);
 }
 
+TEST_F(CollectionFilteringTest, DeepNestedFieldsInsideObjectFilter) {
+    auto schema_json =
+            R"({
+                "name": "show_nested",
+                "fields": [
+                    {"name": "title", "type": "string"},
+                    {"name": "performances", "type": "object[]"},
+                    {"name": "performances.startDate.localTimeHour", "type": "int32[]"},
+                    {"name": "performances.pricing.minPrice", "type": "int64[]"}
+                ],
+                "enable_nested_fields": true
+            })"_json;
+
+    std::vector<nlohmann::json> documents = {
+            R"({
+                "title": "Same Object Match",
+                "performances": [
+                    {"startDate": {"localTimeHour": 19}, "pricing": {"minPrice": 4500}},
+                    {"startDate": {"localTimeHour": 18}, "pricing": {"minPrice": 9000}}
+                ]
+            })"_json,
+            R"({
+                "title": "Split Object Match",
+                "performances": [
+                    {"startDate": {"localTimeHour": 19}, "pricing": {"minPrice": 9000}},
+                    {"startDate": {"localTimeHour": 18}, "pricing": {"minPrice": 4500}}
+                ]
+            })"_json,
+            R"({
+                "title": "No Match",
+                "performances": [
+                    {"startDate": {"localTimeHour": 20}, "pricing": {"minPrice": 9000}}
+                ]
+            })"_json
+    };
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    for (auto const& json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    std::map<std::string, std::string> req_params = {
+            {"collection",     "show_nested"},
+            {"q",              "*"},
+            {"filter_by",      "performances.{startDate.localTimeHour:19 && pricing.minPrice:<5000}"},
+            {"include_fields", "title, performances"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    auto result = nlohmann::json::parse(json_res);
+    ASSERT_EQ(1, result["found"].get<size_t>());
+    ASSERT_EQ(1, result["hits"].size());
+    ASSERT_EQ("Same Object Match", result["hits"][0]["document"]["title"]);
+}
+
 TEST_F(CollectionFilteringTest, MissingFilterSchemaValidation) {
     // track_missing_values on non-optional field should fail
     auto schema = R"({


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
#### Summary
This PR fixes the issue of deep nested object[] filtering

#### Issue
For object filters, the validator was deriving the nested field to inspect by taking only the last path segment from the schema field name.
Examples:

- `performances.startDate.localTimeHour` became `localTimeHour`
- `performances.pricing.minPrice` became `minPrice`

That works only when the field being validated is a direct child of the nested object, such as:

```text
ingredients.{name: cheese && concentration:<50}
```

because `name` and `concentration` are directly present on each `ingredients[]` element.

It fails for deeper paths like:

```text
performances.{startDate.localTimeHour:19 && pricing.minPrice:<5000}
```

because each `performances[]` element does not have `localTimeHour` or `minPrice` at the top level. Those values live under:

- `startDate.localTimeHour`
- `pricing.minPrice`

So the same-object validator was checking the wrong JSON shape.

#### Fixes
- Fixed deep-path traversal in object-filter validation
- Instead of using only the last segment of the field path, the validator now: removes the object-filter prefix, such as `performances.` and splits the remaining relative path, such as `startDate.localTimeHour`, walks the nested JSON object step by step and evaluates the comparator against the actual deep value
- These paths previously had weak or missing timeout checks during object-filter traversal and validation. The added checks do not change the matching logic, but they prevent the system from sitting in long-running object-filter work without surfacing timeout state.
- Added a regression test
## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
