### PR TITLE
fix: correct exhaustive faceting across multiple nested join paths

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -4492,7 +4492,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
 
         std::vector<std::vector<facet>> facet_batches(num_threads);
         std::vector<std::vector<facet>> value_facets(concurrency);
-        std::vector<std::unordered_map<std::string, reference_filter_result_t>> batch_reference_facet_ids;
+        std::vector<std::unordered_map<std::string, reference_filter_result_t>> batch_reference_facet_ids(num_threads);
 
         size_t num_value_facets = 0;
 
@@ -4546,15 +4546,20 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
 
         bool is_one_valid = false;
 
-        for (auto& item: reference_facet_ids) {
-            auto& reference_facet_result = item.second;
-            const auto& ref_ids_len = reference_facet_result.count;
-            const auto max_ids_len = std::max((size_t)ref_ids_len, all_result_ids_len);
+        for(size_t batch_index = 0; batch_index < num_threads; batch_index++) {
+            for (auto& item: reference_facet_ids) {
+                auto& reference_facet_result = item.second;
+                const auto& ref_ids_len = reference_facet_result.count;
+                const auto max_ids_len = std::max((size_t)ref_ids_len, all_result_ids_len);
+                const size_t ref_window_size = (num_threads == 0) ? 0 :
+                                               (max_ids_len + num_threads - 1) / num_threads;
+                const size_t reference_facet_index = batch_index * ref_window_size;
 
-            const size_t ref_window_size = (num_threads == 0) ? 0 :
-                                           (max_ids_len + num_threads - 1) / num_threads;
-            uint32_t batch_reference_facet_len = ref_window_size;
-            for(size_t reference_facet_index = 0; reference_facet_index < ref_ids_len; ) {
+                if (reference_facet_index >= ref_ids_len) {
+                    continue;
+                }
+
+                size_t batch_reference_facet_len = ref_window_size;
                 if (reference_facet_index + ref_window_size > ref_ids_len) {
                     batch_reference_facet_len = ref_ids_len - reference_facet_index;
                 }
@@ -4565,12 +4570,10 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                           reference_facet_result.docs + reference_facet_index + batch_reference_facet_len,
                           batch_res_ids);
 
-                std::unordered_map<std::string, reference_filter_result_t> batch_reference_facets;
-                batch_reference_facets[item.first] = reference_filter_result_t(batch_reference_facet_len, batch_res_ids);
-                batch_reference_facet_ids.emplace_back(std::move(batch_reference_facets));
+                batch_reference_facet_ids[batch_index][item.first] =
+                        reference_filter_result_t(batch_reference_facet_len, batch_res_ids);
 
-                reference_facet_index += batch_reference_facet_len;
-                if (reference_facet_index < reference_facet_result.count) {
+                if (reference_facet_index + batch_reference_facet_len < ref_ids_len) {
                     is_one_valid = true;
                 }
             }

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -11355,6 +11355,182 @@ TEST_F(CollectionJoinTest, FacetByReferenceExtended) {
     ASSERT_EQ("$Subjects(electives.grade: 87)", res_obj["facet_counts"][0]["counts"][2]["facet_filter"].get<std::string>());
 }
 
+TEST_F(CollectionJoinTest, FacetByMultipleNestedJoinPathsExhaustive) {
+    auto schema_json =
+            R"({
+                "name": "Regions",
+                "fields": [
+                    {"name": "name", "type": "string", "facet": true}
+                ]
+            })"_json;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+
+    std::vector<nlohmann::json> documents = {
+            R"({"name": "Europe"})"_json,
+            R"({"name": "Asia"})"_json
+    };
+    for (auto const& json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    schema_json =
+            R"({
+                "name": "Categories",
+                "fields": [
+                    {"name": "name", "type": "string", "facet": true}
+                ]
+            })"_json;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+
+    documents = {
+            R"({"name": "Electronics"})"_json,
+            R"({"name": "Books"})"_json
+    };
+    for (auto const& json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    schema_json =
+            R"({
+                "name": "Customers",
+                "fields": [
+                    {"name": "name", "type": "string", "facet": true},
+                    {"name": "region_id", "type": "string", "reference": "Regions.id"}
+                ]
+            })"_json;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+
+    documents = {
+            R"({"name": "Alice", "region_id": "0"})"_json,
+            R"({"name": "Bob", "region_id": "1"})"_json
+    };
+    for (auto const& json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    schema_json =
+            R"({
+                "name": "Products",
+                "fields": [
+                    {"name": "name", "type": "string", "facet": true},
+                    {"name": "category_id", "type": "string", "reference": "Categories.id"}
+                ]
+            })"_json;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+
+    documents = {
+            R"({"name": "Laptop", "category_id": "0"})"_json,
+            R"({"name": "Novel", "category_id": "1"})"_json
+    };
+    for (auto const& json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    schema_json =
+            R"({
+                "name": "Orders",
+                "fields": [
+                    {"name": "total", "type": "int32"},
+                    {"name": "customer_id", "type": "string", "reference": "Customers.id"},
+                    {"name": "product_id", "type": "string", "reference": "Products.id"}
+                ]
+            })"_json;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+
+    documents = {
+            R"({"total": 100, "customer_id": "0", "product_id": "0"})"_json,
+            R"({"total": 200, "customer_id": "1", "product_id": "1"})"_json
+    };
+    for (auto const& json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    std::map<std::string, std::string> req_params = {
+            {"collection", "Orders"},
+            {"q", "*"},
+            {"filter_by", "$Customers($Regions(id:*)) && $Products($Categories(id:*))"},
+            {"include_fields", "$Customers(name, $Regions(name)),$Products(name, $Categories(name))"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    auto res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, res_obj["found"].get<size_t>());
+    ASSERT_EQ(2, res_obj["hits"].size());
+    std::unordered_map<std::string, std::pair<std::string, std::string>> customer_to_joined_values;
+    for (const auto& hit: res_obj["hits"]) {
+        customer_to_joined_values[hit["document"]["Customers"]["name"]] = {
+                hit["document"]["Customers"]["Regions"]["name"],
+                hit["document"]["Products"]["Categories"]["name"]
+        };
+    }
+    ASSERT_EQ(2, customer_to_joined_values.size());
+    ASSERT_EQ("Europe", customer_to_joined_values["Alice"].first);
+    ASSERT_EQ("Electronics", customer_to_joined_values["Alice"].second);
+    ASSERT_EQ("Asia", customer_to_joined_values["Bob"].first);
+    ASSERT_EQ("Books", customer_to_joined_values["Bob"].second);
+
+    req_params = {
+            {"collection", "Orders"},
+            {"q", "*"},
+            {"filter_by", "$Customers($Regions(id:*)) && $Products($Categories(id:*))"},
+            {"facet_by", "$Regions(name),$Categories(name)"},
+            {"facet_strategy", "exhaustive"}
+    };
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, res_obj["found"].get<size_t>());
+    ASSERT_EQ(2, res_obj["facet_counts"].size());
+    ASSERT_EQ("$Regions(name)", res_obj["facet_counts"][0]["field_name"]);
+    ASSERT_EQ(2, res_obj["facet_counts"][0]["counts"].size());
+    ASSERT_EQ("$Categories(name)", res_obj["facet_counts"][1]["field_name"]);
+    ASSERT_EQ(2, res_obj["facet_counts"][1]["counts"].size());
+
+    req_params["facet_by"] = "$Categories(name),$Regions(name)";
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, res_obj["found"].get<size_t>());
+    ASSERT_EQ(2, res_obj["facet_counts"].size());
+    ASSERT_EQ("$Categories(name)", res_obj["facet_counts"][0]["field_name"]);
+    ASSERT_EQ(2, res_obj["facet_counts"][0]["counts"].size());
+    ASSERT_EQ("$Regions(name)", res_obj["facet_counts"][1]["field_name"]);
+    ASSERT_EQ(2, res_obj["facet_counts"][1]["counts"].size());
+}
+
 TEST_F(CollectionJoinTest, AlterReferenceField) {
     auto schema_json =
             R"({


### PR DESCRIPTION
## Change Summary
- add a regression test for facet_by with multiple nested join paths in exhaustive mode to verify include_fields still resolves both join paths correctly in the same setup
- fix reference facet batching in index::search so batches are built per thread rather than per referenced collection

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
