### PR TITLE
Alter reference fields.

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -676,6 +676,7 @@ private:
 
     Option<bool> batch_alter_data(const std::vector<field>& alter_fields,
                                   const std::vector<field>& del_fields,
+                                  const spp::sparse_hash_map<std::string, reference_info_t>& updated_reference_fields,
                                   const std::string& this_fallback_field_type);
 
     Option<bool> validate_alter_payload(nlohmann::json& schema_changes,
@@ -683,6 +684,7 @@ private:
                                         std::vector<field>& reindex_fields,
                                         std::vector<field>& del_fields,
                                         std::vector<field>& update_fields,
+                                        spp::sparse_hash_map<std::string, reference_info_t>& updated_reference_fields,
                                         std::string& fallback_field_type);
 
     void process_filter_sort_curations(std::vector<const curation_t*>& filter_curations,

--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -193,7 +193,7 @@ public:
     Option<bool> add_referenced_ins(std::string& referenced_collection_name, reference_info_t&& ref_info,
                                     std::set<update_reference_info_t>& update_ref_infos);
 
-    void remove_referenced_ins(const std::string& referenced_coll_name, const std::string& referring_coll_name = "");
+    void remove_referenced_ins_with_lock(const std::string& referencing_coll_name, const reference_info_t& ref_info);
 
     std::map<std::string, std::map<std::string, reference_info_t>> _get_referenced_ins() const;
 

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -638,7 +638,7 @@ nlohmann::json Collection::add_many(std::vector<std::string>& json_lines, nlohma
             std::unordered_map<std::string, field> dynamic_fields_copy;
             tsl::htrie_map<char, field> nested_fields_copy;
             spp::sparse_hash_map<std::string, reference_info_t> reference_fields_copy;
-            spp::sparse_hash_map<std::string, std::set<reference_pair_t>> async_referenced_ins_copy;
+
             tsl::htrie_map<char, field> search_schema_copy;
             tsl::htrie_set<char> object_reference_fields_copy;
             {
@@ -647,14 +647,13 @@ nlohmann::json Collection::add_many(std::vector<std::string>& json_lines, nlohma
                 dynamic_fields_copy = dynamic_fields;
                 nested_fields_copy = nested_fields;
                 reference_fields_copy = reference_fields;
-                async_referenced_ins_copy = async_referenced_ins;
                 search_schema_copy = search_schema;
                 object_reference_fields_copy = object_reference_fields;
             }
 
             // if `fallback_field_type` or `dynamic_fields` is enabled, update schema first before indexing
             if(!fallback_field_type_copy.empty() || !dynamic_fields_copy.empty() || !nested_fields_copy.empty() ||
-                !reference_fields_copy.empty() || !async_referenced_ins_copy.empty()) {
+                !reference_fields_copy.empty()) {
 
                 Option<bool> new_fields_op = detect_new_fields(record.doc, dirty_values,
                                                                search_schema_copy, dynamic_fields_copy,
@@ -6654,17 +6653,46 @@ Option<bool> Collection::persist_collection_meta() {
 
 Option<bool> Collection::batch_alter_data(const std::vector<field>& alter_fields,
                                           const std::vector<field>& del_fields,
+                                          const spp::sparse_hash_map<std::string, reference_info_t>& updated_reference_fields,
                                           const std::string& this_fallback_field_type) {
     // Update schema with additions (deletions can only be made later)
     std::vector<field> new_fields;
     tsl::htrie_map<char, field> schema_additions;
     bool found_embedding_field = false;
-    bool found_reference_field = false;
+    std::unordered_set<std::string> altered_reference_helper_fields;
 
-  std::unique_lock alter_ulock(alter_mutex);
-  std::unique_lock ulock(mutex);
+    std::unique_lock alter_ulock(alter_mutex);
+    std::unique_lock ulock(mutex);
 
     for(auto& f: alter_fields) {
+        if(!f.reference.empty()) {
+            altered_reference_helper_fields.insert(f.name + fields::REFERENCE_HELPER_FIELD_SUFFIX);
+            auto ref_info_it = updated_reference_fields.find(f.name);
+            if (ref_info_it == updated_reference_fields.end()) {
+                return Option<bool>(400, "`" + f.name + "` not present in updated_reference_fields map.");
+            }
+
+            auto ref_coll_name = ref_info_it->second.collection;
+            auto ref_info = reference_info_t{name, f.name, f.is_async_reference, f.is_array(), ref_info_it->second.field};
+            std::set<update_reference_info_t> update_ref_infos{};
+            auto op = CollectionManager::get_instance().add_referenced_ins(ref_coll_name,
+                                                                           std::move(ref_info),
+                                                                           update_ref_infos);
+            if (!op.ok()) {
+                return op;
+            }
+
+            reference_fields.emplace(f.name, ref_info_it->second);
+            if (f.nested) {
+                object_reference_fields.emplace(f.name);
+            }
+
+            reference_fields.at(f.name).collection = ref_coll_name;
+            for (auto& update_ref_info: update_ref_infos) {
+                update_reference_field(update_ref_info.field, update_ref_info.referenced_field);
+            }
+        }
+
         if(f.name == ".*") {
             fields.push_back(f);
             continue;
@@ -6682,10 +6710,6 @@ Option<bool> Collection::batch_alter_data(const std::vector<field>& alter_fields
             check_and_add_nested_field(nested_fields, f);
         }
 
-        if(!f.reference.empty()) {
-            found_reference_field = true;
-        }
-
         if(f.embed.count(fields::from) != 0) {
             found_embedding_field = true;
             const auto& text_embedders = EmbedderManager::get_instance()._get_text_embedders();
@@ -6701,6 +6725,21 @@ Option<bool> Collection::batch_alter_data(const std::vector<field>& alter_fields
         }
 
         fields.push_back(f);
+    }
+
+    // Only reference helper field should be removed from the document when a reference field is dropped in the schema.
+    for (auto& f: del_fields) {
+        if (f.reference.empty() || updated_reference_fields.count(f.name) > 0) {
+            continue;
+        }
+
+        // Removing the dropped field from the reference index now so reference helper field is not populated again when
+        // Join::populate_reference_helper_fields() is called downstream.
+        reference_fields.erase(f.name);
+        if (f.nested) {
+            object_reference_fields.erase(f.name);
+        }
+        altered_reference_helper_fields.insert(f.name + fields::REFERENCE_HELPER_FIELD_SUFFIX);
     }
 
     rebuild_read_state_snapshot_unlocked();
@@ -6742,8 +6781,12 @@ Option<bool> Collection::batch_alter_data(const std::vector<field>& alter_fields
             field::flatten_doc(document, nested_fields, {}, true, flattened_fields);
         }
 
+        for(const auto& helper_field_name: altered_reference_helper_fields) {
+            document.erase(helper_field_name);
+        }
         document.erase(fields::reference_helper_fields); // Avoid duplication of fields in `.ref[]`
-        auto populate_reference_helper_fields_op = Join::populate_reference_helper_fields(document, search_schema, reference_fields,
+        auto populate_reference_helper_fields_op = Join::populate_reference_helper_fields(document, search_schema,
+                                                                                          reference_fields,
                                                                                           object_reference_fields,
                                                                                           true);
         if (!populate_reference_helper_fields_op.ok()) {
@@ -6775,31 +6818,19 @@ Option<bool> Collection::batch_alter_data(const std::vector<field>& alter_fields
                                       fallback_field_type, token_separators, symbols_to_index, dummy, true, schema_additions);
             ulock.unlock();
             shlock.lock();
-            if(found_embedding_field) {
+            if(found_embedding_field || !altered_reference_helper_fields.empty()) {
                 for(auto& index_record : iter_batch) {
-                    if(index_record.indexed.ok()) {
-                        remove_flat_fields(index_record.doc);
-                        const std::string& serialized_json = index_record.doc.dump(-1, ' ', false, nlohmann::detail::error_handler_t::ignore);
-                        bool write_ok = store->insert(get_seq_id_key(index_record.seq_id), serialized_json);
-
-                        if(!write_ok) {
-                            LOG(ERROR) << "Inserting doc with new embedding field failed for seq id: " << index_record.seq_id;
-                            index_record.index_failure(500, "Could not write to on-disk storage.");
-                        } else {
-                            index_record.index_success();
-                        }
+                    if(!index_record.indexed.ok()) {
+                        continue;
                     }
-                }
-            }
 
-            if(found_reference_field) {
-                //if alter operation contains adding, reindexing reference field then need to update on disk too
-                for(auto& index_record : iter_batch) {
+                    remove_flat_fields(index_record.doc);
                     const std::string& serialized_json = index_record.doc.dump(-1, ' ', false, nlohmann::detail::error_handler_t::ignore);
                     bool write_ok = store->insert(get_seq_id_key(index_record.seq_id), serialized_json);
 
                     if(!write_ok) {
-                        LOG(ERROR) << "Inserting doc with new reference field failed for seq id: " << index_record.seq_id;
+                        LOG(ERROR) << "Inserting doc with " << (found_embedding_field ? "new embedding" : "reference")
+                                    << " field failed for seq id: " << index_record.seq_id;
                         index_record.index_failure(500, "Could not write to on-disk storage.");
                     } else {
                         index_record.index_success();
@@ -6886,11 +6917,13 @@ Option<bool> Collection::alter(nlohmann::json& alter_payload) {
     std::vector<field> addition_fields;
     std::vector<field> reindex_fields;
     std::vector<field> update_fields;
+    spp::sparse_hash_map<std::string, reference_info_t> updated_reference_fields;
 
     std::string this_fallback_field_type;
 
     auto validate_op = validate_alter_payload(alter_payload, addition_fields, reindex_fields,
-                                              del_fields, update_fields, this_fallback_field_type);
+                                              del_fields, update_fields, updated_reference_fields,
+                                              this_fallback_field_type);
     if(!validate_op.ok()) {
         auto error = "Alter failed validation: " + validate_op.error();
         LOG(INFO) << error;
@@ -6919,7 +6952,7 @@ Option<bool> Collection::alter(nlohmann::json& alter_payload) {
         LOG(INFO) << "Processing field additions and deletions first...";
     }
 
-    auto batch_alter_op = batch_alter_data(addition_fields, del_fields, fallback_field_type);
+    auto batch_alter_op = batch_alter_data(addition_fields, del_fields, updated_reference_fields, fallback_field_type);
     if(!batch_alter_op.ok()) {
         auto error = "Alter failed during alter data: " + batch_alter_op.error();
         LOG(INFO) << error;
@@ -6930,7 +6963,7 @@ Option<bool> Collection::alter(nlohmann::json& alter_payload) {
 
     if(!reindex_fields.empty()) {
         LOG(INFO) << "Processing field modifications now...";
-        batch_alter_op = batch_alter_data(reindex_fields, {}, fallback_field_type);
+        batch_alter_op = batch_alter_data(reindex_fields, {}, updated_reference_fields, fallback_field_type);
         if(!batch_alter_op.ok()) {
             auto error = "Alter failed during alter data: " + batch_alter_op.error();
             LOG(INFO) << error;
@@ -7085,11 +7118,13 @@ Option<bool> Collection::prune_doc(nlohmann::json& doc,
     return Join::include_references(doc, seq_id, collection_name, reference_filter_results,
                                     ref_include_exclude_fields_vec, original_doc);
 }
+
 Option<bool> Collection::validate_alter_payload(nlohmann::json& schema_changes,
                                                 std::vector<field>& addition_fields,
                                                 std::vector<field>& reindex_fields,
                                                 std::vector<field>& del_fields,
                                                 std::vector<field>& update_fields,
+                                                spp::sparse_hash_map<std::string, reference_info_t>& updated_reference_fields,
                                                 std::string& fallback_field_type) {
     if(!schema_changes.is_object()) {
         return Option<bool>(400, "Bad JSON.");
@@ -7114,6 +7149,8 @@ Option<bool> Collection::validate_alter_payload(nlohmann::json& schema_changes,
     tsl::htrie_map<char, field> updated_search_schema = search_schema;
     tsl::htrie_map<char, field> updated_nested_fields = nested_fields;
     tsl::htrie_map<char, field> updated_embedding_fields = embedding_fields;
+    updated_reference_fields = reference_fields;
+    auto updated_object_reference_fields = object_reference_fields;
     size_t num_auto_detect_fields = 0;
 
     // since fields can be deleted and added in the same change set,
@@ -7185,21 +7222,16 @@ Option<bool> Collection::validate_alter_payload(nlohmann::json& schema_changes,
                 return Option<bool>(400, "Field `" + field_name + "` is not part of collection schema.");
             }
 
-            if(found_field && field_it.value().embed.count(fields::from) != 0) {
-                updated_embedding_fields.erase(field_it.key());
-            }
-
             if(found_field) {
                 del_fields.push_back(field_it.value());
                 updated_search_schema.erase(field_it.key());
                 updated_nested_fields.erase(field_it.key());
 
                 if(!field_it->reference.empty()) {
-                    reference_fields.erase(field_name);
+                    updated_reference_fields.erase(field_name);
                     if (field_it->nested) {
-                        object_reference_fields.erase(field_name);
+                        updated_object_reference_fields.erase(field_name);
                     }
-                    rebuild_read_state_snapshot_unlocked();
 
                     //validated before only, so directly add to fields to delete
                     const auto ref_helper_field_name = field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX;
@@ -7219,6 +7251,13 @@ Option<bool> Collection::validate_alter_payload(nlohmann::json& schema_changes,
                         del_fields.push_back(prefix_kv.value());
                         updated_search_schema.erase(prefix_kv.key());
                         updated_nested_fields.erase(prefix_kv.key());
+
+                        if (!prefix_kv.value().reference.empty()) {
+                            updated_reference_fields.erase(prefix_kv.key());
+                            updated_object_reference_fields.erase(prefix_kv.key());
+                            // Reference helper field will also be removed since we're looping through all the fields
+                            // of an object.
+                        }
 
                         if(prefix_kv.value().embed.count(fields::from) != 0) {
                             updated_embedding_fields.erase(prefix_kv.key());
@@ -7272,23 +7311,11 @@ Option<bool> Collection::validate_alter_payload(nlohmann::json& schema_changes,
                     auto ref_info = reference_info_t{name, field.name, field.is_async_reference, field.is_array(),
                                                      ref_field_name};
 
-                    std::set<update_reference_info_t> update_ref_infos{};
-                    auto op = CollectionManager::get_instance().add_referenced_ins(ref_coll_name, std::move(ref_info),
-                                                                                   update_ref_infos);
-                    if (!op.ok()) {
-                        return op;
-                    }
-
-                    reference_fields.emplace(field.name,
-                                             reference_info_t(ref_coll_name, ref_field_name, field.is_async_reference,
-                                                              field.is_array()));
+                    updated_reference_fields.emplace(field.name,
+                                                     reference_info_t(ref_coll_name, ref_field_name,
+                                                                      field.is_async_reference, field.is_array()));
                     if (field.nested) {
-                        object_reference_fields.insert(field.name);
-                    }
-                    rebuild_read_state_snapshot_unlocked();
-
-                    for (auto& update_ref_info: update_ref_infos) {
-                        update_reference_field(update_ref_info.field, update_ref_info.referenced_field);
+                        updated_object_reference_fields.insert(field.name);
                     }
 
                     if (is_reindex) {
@@ -7325,7 +7352,7 @@ Option<bool> Collection::validate_alter_payload(nlohmann::json& schema_changes,
                 }
 
                 if(f.embed.count(fields::from) != 0) {
-                    embedding_fields.emplace(f.name, f);
+                    updated_embedding_fields.emplace(f.name, f);
                 }
 
 
@@ -7339,7 +7366,7 @@ Option<bool> Collection::validate_alter_payload(nlohmann::json& schema_changes,
                         check_and_add_nested_field(updated_nested_fields, prefix_kv.value());
 
                         if(prefix_kv.value().embed.count(fields::from) != 0) {
-                            embedding_fields.emplace(prefix_kv.key(), prefix_kv.value());
+                            updated_embedding_fields.emplace(prefix_kv.key(), prefix_kv.value());
                         }
 
                         if(is_reindex) {
@@ -7419,7 +7446,8 @@ Option<bool> Collection::validate_alter_payload(nlohmann::json& schema_changes,
                                                                                 nlohmann::detail::error_handler_t::ignore));
         }
 
-        if(!fallback_field_type.empty() || !new_dynamic_fields.empty() || !updated_nested_fields.empty()) {
+        if(!fallback_field_type.empty() || !new_dynamic_fields.empty() || !updated_nested_fields.empty() ||
+            !updated_reference_fields.empty()) {
             std::vector<field> new_fields;
             Option<bool> new_fields_op = detect_new_fields(document, DIRTY_VALUES::DROP,
                                                            updated_search_schema, new_dynamic_fields,
@@ -7427,7 +7455,7 @@ Option<bool> Collection::validate_alter_payload(nlohmann::json& schema_changes,
                                                            fallback_field_type, false,
                                                            new_fields,
                                                            enable_nested_fields,
-                                                           reference_fields, object_reference_fields);
+                                                           updated_reference_fields, updated_object_reference_fields);
             if(!new_fields_op.ok()) {
                 return new_fields_op;
             }

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -6667,7 +6667,7 @@ Option<bool> Collection::batch_alter_data(const std::vector<field>& alter_fields
     for(auto& f: alter_fields) {
         if(!f.reference.empty()) {
             altered_reference_helper_fields.insert(f.name + fields::REFERENCE_HELPER_FIELD_SUFFIX);
-            auto ref_info_it = updated_reference_fields.find(f.name);
+            const auto ref_info_it = updated_reference_fields.find(f.name);
             if (ref_info_it == updated_reference_fields.end()) {
                 return Option<bool>(400, "`" + f.name + "` not present in updated_reference_fields map.");
             }
@@ -6682,7 +6682,7 @@ Option<bool> Collection::batch_alter_data(const std::vector<field>& alter_fields
                 return op;
             }
 
-            reference_fields.emplace(f.name, ref_info_it->second);
+            reference_fields[f.name] = ref_info_it->second;
             if (f.nested) {
                 object_reference_fields.emplace(f.name);
             }
@@ -6729,13 +6729,25 @@ Option<bool> Collection::batch_alter_data(const std::vector<field>& alter_fields
 
     // Only reference helper field should be removed from the document when a reference field is dropped in the schema.
     for (auto& f: del_fields) {
-        if (f.reference.empty() || updated_reference_fields.count(f.name) > 0) {
+        if (f.reference.empty()) {
+            continue;
+        }
+
+        auto erase_it = reference_fields.find(f.name);
+        if (erase_it == reference_fields.end()) {
+            continue;
+        }
+
+        auto it = updated_reference_fields.find(f.name);
+        if (it != updated_reference_fields.end() && f.reference != (it->second.collection + it->second.field)) {
+            CollectionManager::get_instance().remove_referenced_ins_with_lock(name, erase_it->second);
+            // No need to remove the field from reference index if it still references the same field.
             continue;
         }
 
         // Removing the dropped field from the reference index now so reference helper field is not populated again when
         // Join::populate_reference_helper_fields() is called downstream.
-        reference_fields.erase(f.name);
+        reference_fields.erase(erase_it);
         if (f.nested) {
             object_reference_fields.erase(f.name);
         }
@@ -8500,6 +8512,9 @@ void Collection::remove_referenced_in(const std::string& collection_name, const 
     referenced_in.erase(collection_name);
     if (is_async) {
         async_referenced_ins[referenced_field_name].erase(reference_pair_t(collection_name, field_name));
+        if (async_referenced_ins[referenced_field_name].empty()) {
+            async_referenced_ins.erase(referenced_field_name);
+        }
     }
 }
 

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -6805,7 +6805,7 @@ Option<bool> Collection::batch_alter_data(const std::vector<field>& alter_fields
             // put delete first because a field could be deleted and added in the same change set
             if(!del_fields.empty()) {
                 for(auto& rec: iter_batch) {
-                    index->remove(seq_id, rec.doc, del_fields, true);
+                    index->remove(rec.seq_id, rec.doc, del_fields, true);
                 }
             }
 

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -944,19 +944,8 @@ Option<nlohmann::json> CollectionManager::drop_collection(const std::string& col
     auto reference_fields = collection->get_reference_fields();
     for (const auto& item: reference_fields) {
         const auto& reference_info = item.second;
-        const auto& field_name = item.first;
-        const auto& ref_coll_name = reference_info.collection;
 
-        remove_referenced_ins(ref_coll_name, actual_coll_name);
-
-        auto& cm = CollectionManager::get_instance();
-        auto ref_coll = cm.get_collection(ref_coll_name);
-        if (ref_coll == nullptr) {
-            LOG(ERROR) << "Referenced collection `" + ref_coll_name + "` not found.";
-            continue;
-        }
-
-        ref_coll->remove_referenced_in(actual_coll_name, field_name, reference_info.is_async, reference_info.field);
+        remove_referenced_ins_with_lock(collection_name, reference_info);
     }
 
     std::unique_lock u_lock(mutex);
@@ -2455,23 +2444,35 @@ Option<bool> CollectionManager::add_referenced_ins(std::string& referenced_colle
     return Option<bool>(true);
 }
 
-void CollectionManager::remove_referenced_ins(const std::string& referenced_coll_name,
-                                              const std::string& referring_coll_name) {
+void CollectionManager::remove_referenced_ins_with_lock(const std::string& referencing_coll_name,
+                                                        const reference_info_t& ref_info) {
     std::unique_lock lock(mutex);
-    if (referring_coll_name.empty()) {
-        referenced_ins.erase(referenced_coll_name);
+    if (referencing_coll_name.empty()) {
         return;
     }
 
-    auto it = referenced_ins.find(referenced_coll_name);
-    if (it == referenced_ins.end()) {
+    const auto& referenced_coll_name = ref_info.collection;
+    auto referenced_it = referenced_ins.find(referenced_coll_name);
+    if (referenced_it == referenced_ins.end()) {
         return;
     }
-    it->second.erase(referring_coll_name);
-
-    if (it->second.empty()) {
-        referenced_ins.erase(it);
+    auto referencing_it = referenced_it->second.find(referencing_coll_name);
+    if (referencing_it == referenced_it->second.end()) {
+        return;
     }
+    const auto referencing_field_name = referencing_it->second.field;
+    referenced_it->second.erase(referencing_it);
+    if (referenced_it->second.empty()) {
+        referenced_ins.erase(referenced_it);
+    }
+
+    auto ref_coll = get_collection_unsafe(referenced_coll_name);
+    if (ref_coll == nullptr) {
+        LOG(ERROR) << "Could not remove referenced in: Referenced collection `" + referenced_coll_name + "` not found.";
+        return;
+    }
+    ref_coll->remove_referenced_in(referencing_coll_name, referencing_field_name, ref_info.is_async,
+                                   ref_info.referenced_field.name);
 }
 
 std::map<std::string, std::map<std::string, reference_info_t>> CollectionManager::_get_referenced_ins() const {

--- a/src/join.cpp
+++ b/src/join.cpp
@@ -78,7 +78,12 @@ Option<bool> Join::populate_reference_helper_fields(nlohmann::json& document,
         auto field_name = pair.first;
         auto const reference_helper_field = field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX;
 
-        auto const& field = schema.at(field_name);
+        auto const& it = schema.find(field_name);
+        if (it == schema.end()) {
+            return Option<bool>(400, "Could not find `" + field_name + "` in the schema.");
+        }
+
+        auto const& field = it.value();
         auto const& optional = field.optional;
         auto const& is_async_reference = field.is_async_reference;
         // Strict checking for presence of non-optional reference field during indexing operation.

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -11873,6 +11873,162 @@ TEST_F(CollectionJoinTest, AlterReferenceFieldReindexesHelperIndexAcrossBatches)
     ASSERT_EQ(502, res_obj["found"].get<size_t>());
 }
 
+TEST_F(CollectionJoinTest, AlterArrayReferenceFieldReindexesHelperIndexAcrossBatches) {
+    auto schema_json =
+            R"({
+                "name": "authors",
+                "fields": [
+                    {"name": "first_name", "type": "string"},
+                    {"name": "last_name", "type": "string"}
+                ]
+            })"_json;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto authors = collection_create_op.get();
+
+    std::vector<nlohmann::json> documents = {
+            R"({
+                "id": "0",
+                "first_name": "Enid",
+                "last_name": "Blyton"
+            })"_json,
+            R"({
+                "id": "1",
+                "first_name": "Richard",
+                "last_name": "Lupoff"
+            })"_json
+    };
+    for (const auto& json: documents) {
+        ASSERT_TRUE(authors->add(json.dump()).ok());
+    }
+
+    schema_json =
+            R"({
+                "name": "authors_v2",
+                "fields": [
+                    {"name": "first_name", "type": "string"},
+                    {"name": "last_name", "type": "string"}
+                ]
+            })"_json;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto authors_v2 = collection_create_op.get();
+
+    documents = {
+            R"({
+                "id": "dummy_0",
+                "first_name": "dummy",
+                "last_name": "dummy"
+            })"_json,
+            R"({
+                "id": "dummy_1",
+                "first_name": "dummy",
+                "last_name": "dummy"
+            })"_json,
+            R"({
+                "id": "0",
+                "first_name": "Enid",
+                "last_name": "Blyton"
+            })"_json,
+            R"({
+                "id": "1",
+                "first_name": "Richard",
+                "last_name": "Lupoff"
+            })"_json
+    };
+    for (const auto& json: documents) {
+        ASSERT_TRUE(authors_v2->add(json.dump()).ok());
+    }
+
+    ASSERT_EQ(0, authors->doc_id_to_seq_id("0").get());
+    ASSERT_EQ(1, authors->doc_id_to_seq_id("1").get());
+    ASSERT_EQ(2, authors_v2->doc_id_to_seq_id("0").get());
+    ASSERT_EQ(3, authors_v2->doc_id_to_seq_id("1").get());
+
+    schema_json =
+            R"({
+                "name": "books",
+                "fields": [
+                    {"name": "title", "type": "string"},
+                    {"name": "author_ids", "type": "string[]", "reference": "authors.id", "async_reference": true}
+                ]
+            })"_json;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto books = collection_create_op.get();
+
+    for (size_t i = 0; i < 1005; i++) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["title"] = "Book " + std::to_string(i);
+        doc["author_ids"] = nlohmann::json::array({(i % 2 == 0) ? "0" : "1"});
+        ASSERT_TRUE(books->add(doc.dump()).ok());
+    }
+
+    auto related_ids_for_doc = [&](const std::string& doc_id) -> std::vector<uint32_t> {
+        auto seq_id_op = books->doc_id_to_seq_id(doc_id);
+        if (!seq_id_op.ok()) {
+            ADD_FAILURE() << seq_id_op.error();
+            return {};
+        }
+
+        std::vector<uint32_t> related_ids;
+        auto related_ids_op = books->get_related_ids_with_lock("author_ids", {seq_id_op.get()}, related_ids);
+        if (!related_ids_op.ok()) {
+            ADD_FAILURE() << related_ids_op.error();
+            return {};
+        }
+
+        return related_ids;
+    };
+
+    auto doc = books->get("0").get();
+    ASSERT_EQ(1, doc["author_ids_sequence_id"].size());
+    ASSERT_EQ(0, doc["author_ids_sequence_id"][0]);
+    auto related_ids = related_ids_for_doc("0");
+    ASSERT_EQ(std::vector<uint32_t>({0}), related_ids);
+
+    doc = books->get("1000").get();
+    ASSERT_EQ(1, doc["author_ids_sequence_id"].size());
+    ASSERT_EQ(0, doc["author_ids_sequence_id"][0]);
+    related_ids = related_ids_for_doc("1000");
+    ASSERT_EQ(std::vector<uint32_t>({0}), related_ids);
+
+    auto alter_schema = R"({
+        "fields":[
+            {"name": "author_ids", "drop": true},
+            {"name": "author_ids", "type": "string[]", "reference": "authors_v2.id", "async_reference": true}
+        ]
+    })"_json;
+
+    auto alter_op = books->alter(alter_schema);
+    ASSERT_TRUE(alter_op.ok()) << alter_op.error();
+
+    doc = books->get("0").get();
+    ASSERT_EQ(1, doc["author_ids_sequence_id"].size());
+    ASSERT_EQ(2, doc["author_ids_sequence_id"][0]);
+    related_ids = related_ids_for_doc("0");
+    ASSERT_EQ(std::vector<uint32_t>({2}), related_ids);
+
+    doc = books->get("1").get();
+    ASSERT_EQ(1, doc["author_ids_sequence_id"].size());
+    ASSERT_EQ(3, doc["author_ids_sequence_id"][0]);
+    related_ids = related_ids_for_doc("1");
+    ASSERT_EQ(std::vector<uint32_t>({3}), related_ids);
+
+    doc = books->get("1000").get();
+    ASSERT_EQ(1, doc["author_ids_sequence_id"].size());
+    ASSERT_EQ(2, doc["author_ids_sequence_id"][0]);
+    related_ids = related_ids_for_doc("1000");
+    ASSERT_EQ(std::vector<uint32_t>({2}), related_ids);
+
+    doc = books->get("1001").get();
+    ASSERT_EQ(1, doc["author_ids_sequence_id"].size());
+    ASSERT_EQ(3, doc["author_ids_sequence_id"][0]);
+    related_ids = related_ids_for_doc("1001");
+    ASSERT_EQ(std::vector<uint32_t>({3}), related_ids);
+}
+
 TEST_F(CollectionJoinTest, AlteredReferenceFieldOnRestart) {
     auto schema_json =
             R"({

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -11729,6 +11729,10 @@ TEST_F(CollectionJoinTest, DropObjectFieldRemovesNestedReferenceMetadata) {
     ASSERT_EQ(1, doc["author"].count("id"));
     ASSERT_EQ(0, doc.count("author.id_sequence_id")) << "Reference helper field should be removed from the document.";
     ASSERT_EQ(0, doc.count(".ref"));
+
+    auto referenced_in_op = collectionManager.is_referenced_in_with_lock("author", "books");
+    ASSERT_FALSE(referenced_in_op.ok());
+    ASSERT_EQ("referenced_coll_name: `author` not found.", referenced_in_op.error());
 }
 
 TEST_F(CollectionJoinTest, AlterReferenceFieldReindexesHelperIndexAcrossBatches) {
@@ -11871,6 +11875,165 @@ TEST_F(CollectionJoinTest, AlterReferenceFieldReindexesHelperIndexAcrossBatches)
 
     auto res_obj = nlohmann::json::parse(json_res);
     ASSERT_EQ(502, res_obj["found"].get<size_t>());
+}
+
+TEST_F(CollectionJoinTest, AlterReferenceFieldReplacesReferenceMetadataAndBookkeeping) {
+    auto schema_json =
+            R"({
+                "name": "authors",
+                "fields": [
+                    {"name": "first_name", "type": "string"},
+                    {"name": "slug", "type": "string"}
+                ]
+            })"_json;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto authors = collection_create_op.get();
+
+    std::vector<nlohmann::json> documents = {
+            R"({
+                "id": "0",
+                "first_name": "Enid",
+                "slug": "enid-blyton"
+            })"_json,
+            R"({
+                "id": "1",
+                "first_name": "Richard",
+                "slug": "richard-lupoff"
+            })"_json
+    };
+    for (const auto& json: documents) {
+        ASSERT_TRUE(authors->add(json.dump()).ok());
+    }
+
+    schema_json =
+            R"({
+                "name": "authors_v2",
+                "fields": [
+                    {"name": "first_name", "type": "string"}
+                ]
+            })"_json;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto authors_v2 = collection_create_op.get();
+
+    documents = {
+            R"({
+                "id": "dummy",
+                "first_name": "dummy"
+            })"_json,
+            R"({
+                "id": "enid-blyton",
+                "first_name": "Enid"
+            })"_json,
+            R"({
+                "id": "richard-lupoff",
+                "first_name": "Richard"
+            })"_json
+    };
+    for (const auto& json: documents) {
+        ASSERT_TRUE(authors_v2->add(json.dump()).ok());
+    }
+
+    schema_json =
+            R"({
+                "name": "books",
+                "fields": [
+                    {"name": "title", "type": "string"},
+                    {"name": "author_id", "type": "string", "reference": "authors.slug", "async_reference": true}
+                ]
+            })"_json;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto books = collection_create_op.get();
+
+    documents = {
+            R"({
+                "id": "0",
+                "title": "Famous Five",
+                "author_id": "enid-blyton"
+            })"_json,
+            R"({
+                "id": "1",
+                "title": "Space War Blues",
+                "author_id": "richard-lupoff"
+            })"_json
+    };
+    for (const auto& json: documents) {
+        ASSERT_TRUE(books->add(json.dump()).ok()) << json.dump();
+    }
+
+    ASSERT_TRUE(authors->is_referenced_in("books"));
+    auto authors_async_referenced_ins = authors->get_async_referenced_ins();
+    ASSERT_EQ(1, authors_async_referenced_ins.count("slug"));
+    ASSERT_EQ(1, authors_async_referenced_ins.at("slug").count(reference_pair_t("books", "author_id")));
+    ASSERT_FALSE(authors_v2->is_referenced_in("books"));
+
+    auto doc = books->get("0").get();
+    ASSERT_EQ(0, doc["author_id_sequence_id"]);
+
+    doc = books->get("1").get();
+    ASSERT_EQ(1, doc["author_id_sequence_id"]);
+
+    auto alter_schema = R"({
+        "fields":[
+            {"name": "author_id", "drop": true},
+            {"name": "author_id", "type": "string", "reference": "authors_v2.id", "async_reference": false}
+        ]
+    })"_json;
+
+    auto alter_op = books->alter(alter_schema);
+    ASSERT_TRUE(alter_op.ok()) << alter_op.error();
+
+    auto enid_ref_seq_id_op = authors_v2->doc_id_to_seq_id("enid-blyton");
+    ASSERT_TRUE(enid_ref_seq_id_op.ok());
+    ASSERT_EQ(1, enid_ref_seq_id_op.get());
+    auto richard_ref_seq_id_op = authors_v2->doc_id_to_seq_id("richard-lupoff");
+    ASSERT_TRUE(richard_ref_seq_id_op.ok());
+    ASSERT_EQ(2, richard_ref_seq_id_op.get());
+
+    doc = books->get("0").get();
+    ASSERT_EQ(enid_ref_seq_id_op.get(), doc["author_id_sequence_id"]);
+    doc = books->get("1").get();
+    ASSERT_EQ(richard_ref_seq_id_op.get(), doc["author_id_sequence_id"]);
+
+    auto schema = books->get_schema();
+    ASSERT_EQ(1, schema.count("author_id"));
+    ASSERT_EQ("authors_v2.id", schema.at("author_id").reference);
+
+    auto reference_fields = books->get_reference_fields();
+    ASSERT_EQ(1, reference_fields.count("author_id"));
+    ASSERT_EQ("authors_v2", reference_fields.at("author_id").collection);
+    ASSERT_EQ("id", reference_fields.at("author_id").field);
+    ASSERT_FALSE(reference_fields.at("author_id").is_async);
+    ASSERT_FALSE(reference_fields.at("author_id").is_array);
+
+    ASSERT_FALSE(authors->is_referenced_in("books"));
+    authors_async_referenced_ins = authors->get_async_referenced_ins();
+    ASSERT_EQ(0, authors_async_referenced_ins.count("slug"));
+    ASSERT_FALSE(collectionManager.is_referenced_in_with_lock("authors", "books").ok());
+
+    ASSERT_TRUE(authors_v2->is_referenced_in("books"));
+    auto authors_v2_async_referenced_ins = authors_v2->get_async_referenced_ins();
+    ASSERT_EQ(0, authors_v2_async_referenced_ins.count("id"));
+
+    auto referenced_in_op = collectionManager.is_referenced_in_with_lock("authors_v2", "books");
+    ASSERT_TRUE(referenced_in_op.ok());
+    auto referenced_in = referenced_in_op.get();
+    ASSERT_EQ("books", referenced_in.collection);
+    ASSERT_EQ("author_id", referenced_in.field);
+    ASSERT_EQ("id", referenced_in.referenced_field_name);
+    ASSERT_FALSE(referenced_in.is_async);
+
+    auto add_op = books->add(R"({
+        "id": "2",
+        "title": "The Enchanted Wood",
+        "author_id": "enid-blyton"
+    })");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    doc = books->get("2").get();
+    ASSERT_EQ(enid_ref_seq_id_op.get(), doc["author_id_sequence_id"]);
 }
 
 TEST_F(CollectionJoinTest, AlterArrayReferenceFieldReindexesHelperIndexAcrossBatches) {

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -11629,6 +11629,250 @@ TEST_F(CollectionJoinTest, AlterReferenceField) {
     ASSERT_EQ("1", res_obj["facet_counts"][0]["counts"][0]["value"].get<std::string>());
 }
 
+TEST_F(CollectionJoinTest, DropObjectFieldRemovesNestedReferenceMetadata) {
+    auto schema_json =
+            R"({
+                "name": "authors",
+                "fields": [
+                    {"name": "first_name", "type": "string"},
+                    {"name": "last_name", "type": "string"}
+                ]
+            })"_json;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto authors = collection_create_op.get();
+
+    std::vector<nlohmann::json> documents = {
+            R"({
+                "id": "0",
+                "first_name": "Enid",
+                "last_name": "Blyton"
+            })"_json,
+            R"({
+                "id": "1",
+                "first_name": "Richard",
+                "last_name": "Lupoff"
+            })"_json
+    };
+    for (const auto& json: documents) {
+        ASSERT_TRUE(authors->add(json.dump()).ok());
+    }
+
+    schema_json =
+            R"({
+                "name": "books",
+                "enable_nested_fields": true,
+                "fields": [
+                    {"name": "title", "type": "string"},
+                    {"name": "author", "type": "object", "optional": true},
+                    {"name": "author.id", "type": "string", "reference": "authors.id", "optional": true}
+                ]
+            })"_json;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto books = collection_create_op.get();
+
+    auto add_op = books->add(R"({
+        "id": "0",
+        "title": "Famous Five",
+        "author": {
+            "id": "0"
+        }
+    })");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    auto doc = books->get("0").get();
+    ASSERT_EQ(1, doc["author"].count("id"));
+    ASSERT_EQ(1, doc.count("author.id_sequence_id"));
+    ASSERT_EQ(0, doc["author.id_sequence_id"]);
+    ASSERT_EQ(1, doc.count(".ref"));
+    ASSERT_EQ(1, doc[".ref"].size());
+    ASSERT_EQ("author.id_sequence_id", doc[".ref"][0]);
+
+    auto schema = books->get_schema();
+    ASSERT_EQ(1, schema.count("author"));
+    ASSERT_EQ(1, schema.count("author.id"));
+    ASSERT_EQ(1, schema.count("author.id_sequence_id"));
+
+    auto reference_fields = books->get_reference_fields();
+    ASSERT_EQ(1, reference_fields.count("author.id"));
+    ASSERT_EQ("authors", reference_fields.at("author.id").collection);
+    ASSERT_EQ("id", reference_fields.at("author.id").field);
+    ASSERT_EQ(1, books->get_object_reference_fields().count("author.id"));
+
+    auto alter_schema = R"({
+        "fields": [
+            {"name": "author", "drop": true}
+        ]
+    })"_json;
+
+    auto alter_op = books->alter(alter_schema);
+    ASSERT_TRUE(alter_op.ok()) << alter_op.error();
+
+    schema = books->get_schema();
+    ASSERT_EQ(1, schema.count("title"));
+    ASSERT_EQ(0, schema.count("author"));
+    ASSERT_EQ(0, schema.count("author.id"));
+    ASSERT_EQ(0, schema.count("author.id_sequence_id"));
+
+    reference_fields = books->get_reference_fields();
+    ASSERT_EQ(0, reference_fields.count("author.id"));
+    ASSERT_EQ(0, books->get_object_reference_fields().count("author.id"));
+
+    auto collection_summary = books->get_summary_json();
+    ASSERT_EQ("books", collection_summary["name"]);
+    ASSERT_EQ(1, collection_summary["fields"].size());
+    ASSERT_EQ("title", collection_summary["fields"][0]["name"]);
+
+    doc = books->get("0").get();
+    ASSERT_EQ(1, doc.count("author"));
+    ASSERT_EQ(1, doc["author"].count("id"));
+    ASSERT_EQ(0, doc.count("author.id_sequence_id")) << "Reference helper field should be removed from the document.";
+    ASSERT_EQ(0, doc.count(".ref"));
+}
+
+TEST_F(CollectionJoinTest, AlterReferenceFieldReindexesHelperIndexAcrossBatches) {
+    auto schema_json =
+            R"({
+                "name": "authors",
+                "fields": [
+                    {"name": "first_name", "type": "string"},
+                    {"name": "last_name", "type": "string"}
+                ]
+            })"_json;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto authors = collection_create_op.get();
+
+    std::vector<nlohmann::json> documents = {
+            R"({
+                "id": "0",
+                "first_name": "Enid",
+                "last_name": "Blyton"
+            })"_json,
+            R"({
+                "id": "1",
+                "first_name": "Richard",
+                "last_name": "Lupoff"
+            })"_json
+    };
+    for (const auto& json: documents) {
+        ASSERT_TRUE(authors->add(json.dump()).ok());
+    }
+
+    schema_json =
+            R"({
+                "name": "authors_v2",
+                "fields": [
+                    {"name": "first_name", "type": "string"},
+                    {"name": "last_name", "type": "string"}
+                ]
+            })"_json;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto authors_v2 = collection_create_op.get();
+
+    documents = {
+            R"({
+                "id": "dummy_0",
+                "first_name": "dummy",
+                "last_name": "dummy"
+            })"_json,
+            R"({
+                "id": "dummy_1",
+                "first_name": "dummy",
+                "last_name": "dummy"
+            })"_json,
+            R"({
+                "id": "0",
+                "first_name": "Enid",
+                "last_name": "Blyton"
+            })"_json,
+            R"({
+                "id": "1",
+                "first_name": "Richard",
+                "last_name": "Lupoff"
+            })"_json
+    };
+    for (const auto& json: documents) {
+        ASSERT_TRUE(authors_v2->add(json.dump()).ok());
+    }
+
+    ASSERT_EQ(0, authors->doc_id_to_seq_id("0").get());
+    ASSERT_EQ(1, authors->doc_id_to_seq_id("1").get());
+    ASSERT_EQ(2, authors_v2->doc_id_to_seq_id("0").get());
+    ASSERT_EQ(3, authors_v2->doc_id_to_seq_id("1").get());
+
+    schema_json =
+            R"({
+                "name": "books",
+                "fields": [
+                    {"name": "title", "type": "string"},
+                    {"name": "author_id", "type": "string", "reference": "authors.id", "async_reference": true}
+                ]
+            })"_json;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto books = collection_create_op.get();
+
+    for (size_t i = 0; i < 1005; i++) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["title"] = "Book " + std::to_string(i);
+        doc["author_id"] = (i % 2 == 0) ? "0" : "1";
+        ASSERT_TRUE(books->add(doc.dump()).ok());
+    }
+
+    auto helper_filter_count = [&](const std::string& filter_by) -> uint32_t {
+        filter_result_t filter_result;
+        auto filter_op = books->get_filter_ids_with_lock(filter_by, filter_result, false);
+        if (!filter_op.ok()) {
+            ADD_FAILURE() << filter_op.error();
+            return 0;
+        }
+        return filter_result.count;
+    };
+
+    ASSERT_EQ(503, helper_filter_count("author_id_sequence_id:0"));
+    ASSERT_EQ(502, helper_filter_count("author_id_sequence_id:1"));
+
+    auto alter_schema = R"({
+        "fields":[
+            {"name": "author_id", "drop": true},
+            {"name": "author_id", "type": "string", "reference": "authors_v2.id", "async_reference": true, "facet": true}
+        ]
+    })"_json;
+
+    auto alter_op = books->alter(alter_schema);
+    ASSERT_TRUE(alter_op.ok()) << alter_op.error();
+
+    auto doc = books->get("0").get();
+    ASSERT_EQ(2, doc["author_id_sequence_id"]);
+    doc = books->get("1").get();
+    ASSERT_EQ(3, doc["author_id_sequence_id"]);
+
+    ASSERT_EQ(0, helper_filter_count("author_id_sequence_id:0"));
+    ASSERT_EQ(0, helper_filter_count("author_id_sequence_id:1"));
+    ASSERT_EQ(503, helper_filter_count("author_id_sequence_id:2"));
+    ASSERT_EQ(502, helper_filter_count("author_id_sequence_id:3"));
+
+    std::map<std::string, std::string> req_params = {
+            {"collection", "books"},
+            {"q", "*"},
+            {"filter_by", "$authors_v2(id:1)"}
+    };
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+    nlohmann::json embedded_params;
+    std::string json_res;
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok()) << search_op.error();
+
+    auto res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(502, res_obj["found"].get<size_t>());
+}
+
 TEST_F(CollectionJoinTest, AlteredReferenceFieldOnRestart) {
     auto schema_json =
             R"({


### PR DESCRIPTION
## Change Summary
Fixes alteration of reference index in `validate_alter_payload()` which is only called after obtaining a shared lock. Shifts the logic in `batch_alter_data()` instead.

Fixes `validate_alter_payload()` also altering embedding index directly.

If a reference field is dropped in alter request, we remove the associated reference_helper_field from the stored document now.

Fixes a bug in `Collection::batch_alter_data()` where `index->remove(seq_id, rec.doc, del_fields, true)` uses the outer batch `seq_id` instead of `rec.seq_id`.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
