### PR TITLE
build: fix snowball dependency breaking ci builds

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -341,7 +341,8 @@ register_detected_cuda_toolchains()
 new_git_repository(
     name= "snowball",
     build_file = "//bazel:snowball.BUILD",
-    branch = "master",
+    # Pin snowball to the latest known-good upstream commit.
+    commit = "2c40f9d8d93faa141e2a8ab640e404b815726c25",
     remote = "https://github.com/snowballstem/snowball.git"
 )
 


### PR DESCRIPTION
## Change Summary
Tracking master makes CI non-reproducible and recently picked up a change that fails on Linux/GCC.

The reason for this comes from https://github.com/snowballstem/snowball/commit/ce3b0bb7694ce790ad43c364a5864eaffb190ca3 causing these failures on ci: 

```sh
RROR: /home/runner/.bazel/external/snowball/BUILD.bazel:21:5: Foreign Cc - Make: Building snowball failed: (Exit 2): bash failed: error executing command (from target @snowball//:snowball) /bin/bash -c bazel-out/k8-fastbuild/bin/external/snowball/snowball_foreign_cc/wrapper_build_script.sh
rules_foreign_cc: Build failed!
rules_foreign_cc: Keeping temp build directory and dependencies directory for debug.
rules_foreign_cc: Please note that the directories inside a sandbox are still cleaned unless you specify --sandbox_debug Bazel command line flag.
rules_foreign_cc: Printing build logs:
_____ BEGIN BUILD LOGS _____

Bazel external C/C++ Rules. Building library snowball

Environment:______________
BUILD_SCRIPT=bazel-out/k8-fastbuild/bin/external/snowball/snowball_foreign_cc/build_script.sh
EXT_BUILD_ROOT=/home/runner/.bazel/execroot/__main__
BUILD_LOG=bazel-out/k8-fastbuild/bin/external/snowball/snowball_foreign_cc/Make.log
***
BUILD_WRAPPER_SCRIPT=bazel-out/k8-fastbuild/bin/external/snowball/snowball_foreign_cc/wrapper_build_script.sh
TMPDIR=/tmp
EXT_BUILD_DEPS=/home/runner/.bazel/execroot/__main__/bazel-out/k8-fastbuild/bin/external/snowball/snowball.ext_build_deps
BAZEL_LINKLIBS=-l%:libstdc++.a -l%:libgcc.a
BUILD_TMPDIR=/home/runner/.bazel/execroot/__main__/bazel-out/k8-fastbuild/bin/external/snowball/snowball.build_tmpdir
SHLVL=2
BAZEL_CXXOPTS=-std=c++17
INSTALLDIR=/home/runner/.bazel/execroot/__main__/bazel-out/k8-fastbuild/bin/external/snowball/snowball
PATH=/home/runner/.bazel/execroot/__main__:/bin:/usr/bin:/usr/local/bin
_=/bin/env
__________________________
+ ARFLAGS=rcsD
+ AR_FLAGS=rcsD
+ ASFLAGS='-U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -fno-canonical-system-headers -Wno-builtin-macro-redefined -D__DATE__=redacted -D__TIMESTAMP__=redacted -D__TIME__=redacted'
+ CFLAGS='-U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -fno-canonical-system-headers -Wno-builtin-macro-redefined -D__DATE__=redacted -D__TIMESTAMP__=redacted -D__TIME__=redacted'
+ CXXFLAGS='-U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -std=c++17 -fno-canonical-system-headers -Wno-builtin-macro-redefined -D__DATE__=redacted -D__TIMESTAMP__=redacted -D__TIME__=redacted'
+ LDFLAGS='-fuse-ld=lld -Wl,-no-as-needed -Wl,-z,relro,-z,now -B/usr/bin -pass-exit-codes -l:libstdc++.a -l:libgcc.a'
+ AR=/usr/bin/ar
+ CC=/usr/bin/gcc
+ CXX=/usr/bin/g++
+ RANLIB=:
+ CPPFLAGS=
+ /home/runner/.bazel/execroot/__main__/bazel-out/k8-opt-exec-2B5CBBC6/bin/external/rules_foreign_cc/toolchains/make/bin/make -j12 PREFIX=/home/runner/.bazel/execroot/__main__/bazel-out/k8-fastbuild/bin/external/snowball/snowball
libstemmer/mkalgorithms.pl algorithms.mk libstemmer/modules.txt
/usr/bin/gcc -g -O2 -W -Wall -Wcast-qual -Wmissing-prototypes -Wmissing-declarations -Wshadow    -c -o compiler/analyser.o compiler/analyser.c
/usr/bin/gcc -g -O2 -W -Wall -Wcast-qual -Wmissing-prototypes -Wmissing-declarations -Wshadow    -c -o compiler/driver.o compiler/driver.c
/usr/bin/gcc -g -O2 -W -Wall -Wcast-qual -Wmissing-prototypes -Wmissing-declarations -Wshadow    -c -o compiler/generator.o compiler/generator.c
/usr/bin/gcc -g -O2 -W -Wall -Wcast-qual -Wmissing-prototypes -Wmissing-declarations -Wshadow    -c -o compiler/generator_ada.o compiler/generator_ada.c
/usr/bin/gcc -g -O2 -W -Wall -Wcast-qual -Wmissing-prototypes -Wmissing-declarations -Wshadow    -c -o compiler/generator_c.o compiler/generator_c.c
/usr/bin/gcc -g -O2 -W -Wall -Wcast-qual -Wmissing-prototypes -Wmissing-declarations -Wshadow    -c -o compiler/generator_csharp.o compiler/generator_csharp.c
/usr/bin/gcc -g -O2 -W -Wall -Wcast-qual -Wmissing-prototypes -Wmissing-declarations -Wshadow    -c -o compiler/generator_dart.o compiler/generator_dart.c
/usr/bin/gcc -g -O2 -W -Wall -Wcast-qual -Wmissing-prototypes -Wmissing-declarations -Wshadow    -c -o compiler/generator_go.o compiler/generator_go.c
/usr/bin/gcc -g -O2 -W -Wall -Wcast-qual -Wmissing-prototypes -Wmissing-declarations -Wshadow    -c -o compiler/generator_java.o compiler/generator_java.c
/usr/bin/gcc -g -O2 -W -Wall -Wcast-qual -Wmissing-prototypes -Wmissing-declarations -Wshadow    -c -o compiler/generator_js.o compiler/generator_js.c
/usr/bin/gcc -g -O2 -W -Wall -Wcast-qual -Wmissing-prototypes -Wmissing-declarations -Wshadow    -c -o compiler/generator_pascal.o compiler/generator_pascal.c
/usr/bin/gcc -g -O2 -W -Wall -Wcast-qual -Wmissing-prototypes -Wmissing-declarations -Wshadow    -c -o compiler/generator_php.o compiler/generator_php.c
compiler/analyser.c: In function 'read_C':
compiler/analyser.c:1397:25: error: a label can only be part of a statement and a declaration is not a statement
 1397 |                         struct node * lhs = n;
      |                         ^~~~~~
compiler/analyser.c:1398:25: error: expected expression before 'struct'
 1398 |                         struct node * rhs = read_AE(a, NULL, 0);
      |                         ^~~~~~
compiler/analyser.c:1401:29: error: 'rhs' undeclared (first use in this function); did you mean 'lhs'?
 1401 |                             rhs->type == c_number) {
      |                             ^~~
      |                             lhs
compiler/analyser.c:1401:29: note: each undeclared identifier is reported only once for each function it appears in
make: *** [<builtin>: compiler/analyser.o] Error 1
make: *** Waiting for unfinished jobs....
_____ END BUILD LOGS _____
rules_foreign_cc: Build wrapper script location: bazel-out/k8-fastbuild/bin/external/snowball/snowball_foreign_cc/wrapper_build_script.sh
rules_foreign_cc: Build script location: bazel-out/k8-fastbuild/bin/external/snowball/snowball_foreign_cc/build_script.sh
rules_foreign_cc: Build log location: bazel-out/k8-fastbuild/bin/external/snowball/snowball_foreign_cc/Make.log
```

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
