### PR TITLE
fix reloading nl models from snapshot recover

### DIFF
--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -16,6 +16,7 @@
 #include "core_api_utils.h"
 #include "synonym_index_manager.h"
 #include "curation_index_manager.h"
+#include "natural_language_search_model_manager.h"
 
 constexpr const size_t CollectionManager::DEFAULT_NUM_MEMORY_SHARDS;
 
@@ -531,6 +532,16 @@ Option<bool> CollectionManager::load(const size_t collection_batch_size, const s
 
     // load curation sets
     CurationIndexManager::get_instance().load_curation_indices();
+
+    //load NL models
+    auto natural_language_search_init = NaturalLanguageSearchModelManager::init(store);
+    if(!natural_language_search_init.ok()) {
+        LOG(INFO) << "Failed to initialize natural language search model manager: "
+                  << natural_language_search_init.error();
+    } else {
+        LOG(INFO) << "Loaded " << natural_language_search_init.get()
+                  << " natural language search model(s).";
+    }
 
     ThreadPool loading_pool(collection_batch_size);
 

--- a/src/raft_server.cpp
+++ b/src/raft_server.cpp
@@ -1,6 +1,5 @@
 #include "raft_server.h"
 #include "core_api.h"
-#include "natural_language_search_model_manager.h"
 #include "personalization_model_manager.h"
 #include "rocksdb/utilities/checkpoint.h"
 #include "store.h"
@@ -674,15 +673,6 @@ int ReplicationState::init_db() {
     } else {
         LOG(ERROR)<< "Typesense failed to start. " << "Could not load collections from disk: " << init_op.error();
         return 1;
-    }
-
-    auto natural_language_search_init = NaturalLanguageSearchModelManager::init(store);
-    if(!natural_language_search_init.ok()) {
-        LOG(INFO) << "Failed to initialize natural language search model manager: "
-                  << natural_language_search_init.error();
-    } else {
-        LOG(INFO) << "Loaded " << natural_language_search_init.get()
-                  << " natural language search model(s).";
     }
 
     // important to init conversation models only after all collections have been loaded

--- a/src/raft_server.cpp
+++ b/src/raft_server.cpp
@@ -1,5 +1,6 @@
 #include "raft_server.h"
 #include "core_api.h"
+#include "natural_language_search_model_manager.h"
 #include "personalization_model_manager.h"
 #include "rocksdb/utilities/checkpoint.h"
 #include "store.h"
@@ -673,6 +674,15 @@ int ReplicationState::init_db() {
     } else {
         LOG(ERROR)<< "Typesense failed to start. " << "Could not load collections from disk: " << init_op.error();
         return 1;
+    }
+
+    auto natural_language_search_init = NaturalLanguageSearchModelManager::init(store);
+    if(!natural_language_search_init.ok()) {
+        LOG(INFO) << "Failed to initialize natural language search model manager: "
+                  << natural_language_search_init.error();
+    } else {
+        LOG(INFO) << "Loaded " << natural_language_search_init.get()
+                  << " natural language search model(s).";
     }
 
     // important to init conversation models only after all collections have been loaded

--- a/src/typesense_server_utils.cpp
+++ b/src/typesense_server_utils.cpp
@@ -668,14 +668,6 @@ int run_server(const Config & config, const std::string & version, void (*master
         LOG(INFO) << "Failed to initialize conversation manager: " << conversations_init.error();
     }
 
-    auto natural_language_search_init = NaturalLanguageSearchModelManager::init(&store);
-
-    if(!natural_language_search_init.ok()) {
-        LOG(INFO) << "Failed to initialize natural language search model manager: " << natural_language_search_init.error();
-    } else {
-        LOG(INFO) << "Loaded " << natural_language_search_init.get() << " natural language search model(s).";
-    }
-
     std::thread raft_thread([&replication_state, &store, &config, &state_dir,
                              &app_thread_pool, &server_thread_pool, &replication_thread_pool, batch_indexer]() {
 

--- a/test/natural_language_search_model_manager_test.cpp
+++ b/test/natural_language_search_model_manager_test.cpp
@@ -6,6 +6,8 @@
 #include "natural_language_search_model.h"
 #include "collection_manager.h"
 #include "field.h"
+#include "raft_server.h"
+#include "tsconfig.h"
 
 class NaturalLanguageSearchModelManagerTest : public ::testing::Test {
 protected:
@@ -29,31 +31,38 @@ protected:
         collectionManager.dispose();
         delete store;
     }
+
+    nlohmann::json create_valid_model_config() {
+        return R"({
+          "model_name": "openai/gpt-3.5-turbo",
+          "api_key": "YOUR_OPENAI_API_KEY",
+          "max_bytes": 1024,
+          "temperature": 0.0
+        })"_json;
+    }
+
+    void add_valid_model_mock_response() {
+        NaturalLanguageSearchModel::add_mock_response(R"({
+          "object": "chat.completion",
+          "model": "gpt-3.5-turbo",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "Hello! How can I help you today?"
+              },
+              "finish_reason": "stop"
+            }
+          ]
+        })", 200, {});
+    }
 };
 
 TEST_F(NaturalLanguageSearchModelManagerTest, AddModelSuccess) {
-    // Mock a successful validation response
-    NaturalLanguageSearchModel::add_mock_response(R"({
-      "object": "chat.completion",
-      "model": "gpt-3.5-turbo",
-      "choices": [
-        {
-          "index": 0,
-          "message": {
-            "role": "assistant",
-            "content": "Hello! How can I help you today?"
-          },
-          "finish_reason": "stop"
-        }
-      ]
-    })", 200, {});
-    
-    nlohmann::json model_config = R"({
-      "model_name": "openai/gpt-3.5-turbo",
-      "api_key": "YOUR_OPENAI_API_KEY",
-      "max_bytes": 1024,
-      "temperature": 0.0
-    })"_json;
+    add_valid_model_mock_response();
+
+    nlohmann::json model_config = create_valid_model_config();
     std::string model_id = "test_model_id";
     auto result = NaturalLanguageSearchModelManager::add_model(model_config, model_id, false);
     ASSERT_EQ(result.error(), "");
@@ -75,28 +84,9 @@ TEST_F(NaturalLanguageSearchModelManagerTest, AddModelFailure) {
 }
 
 TEST_F(NaturalLanguageSearchModelManagerTest, GetModelSuccess) {
-    // Mock a successful validation response
-    NaturalLanguageSearchModel::add_mock_response(R"({
-      "object": "chat.completion",
-      "model": "gpt-3.5-turbo",
-      "choices": [
-        {
-          "index": 0,
-          "message": {
-            "role": "assistant",
-            "content": "Hello! How can I help you today?"
-          },
-          "finish_reason": "stop"
-        }
-      ]
-    })", 200, {});
-    
-    nlohmann::json model_config = R"({
-      "model_name": "openai/gpt-3.5-turbo",
-      "api_key": "YOUR_OPENAI_API_KEY",
-      "max_bytes": 1024,
-      "temperature": 0.0
-    })"_json;
+    add_valid_model_mock_response();
+
+    nlohmann::json model_config = create_valid_model_config();
     std::string model_id = "test_model_id";
     auto result = NaturalLanguageSearchModelManager::add_model(model_config, model_id, false);
     ASSERT_TRUE(result.ok());
@@ -112,28 +102,9 @@ TEST_F(NaturalLanguageSearchModelManagerTest, GetModelFailure) {
 }
 
 TEST_F(NaturalLanguageSearchModelManagerTest, DeleteModelSuccess) {
-    // Mock a successful validation response
-    NaturalLanguageSearchModel::add_mock_response(R"({
-      "object": "chat.completion",
-      "model": "gpt-3.5-turbo",
-      "choices": [
-        {
-          "index": 0,
-          "message": {
-            "role": "assistant",
-            "content": "Hello! How can I help you today?"
-          },
-          "finish_reason": "stop"
-        }
-      ]
-    })", 200, {});
-    
-    nlohmann::json model_config = R"({
-      "model_name": "openai/gpt-3.5-turbo",
-      "api_key": "YOUR_OPENAI_API_KEY",
-      "max_bytes": 1024,
-      "temperature": 0.0
-    })"_json;
+    add_valid_model_mock_response();
+
+    nlohmann::json model_config = create_valid_model_config();
     std::string model_id = "test_model_id";
     auto result = NaturalLanguageSearchModelManager::add_model(model_config, model_id, false);
     ASSERT_TRUE(result.ok());
@@ -298,6 +269,37 @@ TEST_F(NaturalLanguageSearchModelManagerTest, GetAllModelsSuccess) {
     ASSERT_EQ(models.get()[0]["model_name"], "openai/gpt-3.5-turbo");
     ASSERT_EQ(models.get()[1]["id"], model_id_1);
     ASSERT_EQ(models.get()[1]["model_name"], "openai/gpt-3.5-turbo");
+}
+
+TEST_F(NaturalLanguageSearchModelManagerTest, ReplicationInitDbReloadsNaturalLanguageSearchModelsFromStore) {
+    add_valid_model_mock_response();
+
+    auto model_config = create_valid_model_config();
+    auto add_result = NaturalLanguageSearchModelManager::add_model(model_config, "persisted_model", true);
+    ASSERT_TRUE(add_result.ok());
+
+    auto models_before_reload = NaturalLanguageSearchModelManager::get_all_models();
+    ASSERT_TRUE(models_before_reload.ok());
+    ASSERT_EQ(models_before_reload.get().size(), 1);
+
+    NaturalLanguageSearchModelManager::dispose();
+
+    auto models_after_dispose = NaturalLanguageSearchModelManager::get_all_models();
+    ASSERT_TRUE(models_after_dispose.ok());
+    ASSERT_TRUE(models_after_dispose.get().empty());
+
+    add_valid_model_mock_response();
+
+    Config::get_instance().set_data_dir(state_dir_path);
+    ReplicationState replication_state(nullptr, nullptr, store, nullptr, nullptr, nullptr, false,
+                                       &Config::get_instance(), 8, 1000);
+
+    ASSERT_EQ(replication_state.init_db(), 0);
+
+    auto models_after_init_db = NaturalLanguageSearchModelManager::get_all_models();
+    ASSERT_TRUE(models_after_init_db.ok());
+    ASSERT_EQ(models_after_init_db.get().size(), 1);
+    ASSERT_EQ(models_after_init_db.get()[0]["id"], "persisted_model");
 }
 
 TEST_F(NaturalLanguageSearchModelManagerTest, UpdateModelSuccess) {


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
#### Issue
Natural language search models were being initialized only once during server startup, before Raft snapshot restore completed.

That meant:
- NL model metadata could still exist on disk in RocksDB
- collections, conversation models, and personalization models would be reloaded after snapshot restore
- but `NaturalLanguageSearchModelManager` would keep an empty in-memory cache for the lifetime of the process

#### Changes
- Moved NL model initialization into the Raft reload path
- Removed the old one-time startup init
- Added test

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
