### PR TITLE
restrict schema alter types to safe transitions

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -40,6 +40,18 @@ const std::string curation_t::MATCH_CONTAINS = "contains";
 
 const int ALTER_STATUS_MSG_COUNT = 5; // we keep track of last 5 status of alter op
 
+namespace {
+bool is_dynamic_alter_type(const field& f) {
+    return f.is_dynamic() || f.is_auto() || f.is_string_star();
+}
+
+bool is_allowed_alter_type_transition(const std::string& from_type, const std::string& to_type) {
+    return from_type == to_type ||
+           (from_type == field_types::INT32 && to_type == field_types::INT64) ||
+           (from_type == field_types::INT32_ARRAY && to_type == field_types::INT64_ARRAY);
+}
+}
+
 struct sort_fields_guard_t {
     std::vector<sort_by> sort_fields_std;
 
@@ -7259,10 +7271,30 @@ Option<bool> Collection::validate_alter_payload(nlohmann::json& schema_changes,
                 }
 
                 auto& f = diff_fields.back();
+                const field& new_field = (f.is_reference_helper && diff_fields.size() > 1)
+                                         ? diff_fields[diff_fields.size() - 2]
+                                         : f;
+
+                if(!new_field.has_valid_type()) {
+                    return Option<bool>(400, "Field `" + new_field.name +
+                                        "` has an invalid data type `" + new_field.type +
+                                        "`, see docs for supported data types.");
+                }
+
+                if(is_reindex) {
+                    const field& old_field = found_field ? field_it.value() : dyn_field_it->second;
+                    if(!is_dynamic_alter_type(old_field) &&
+                       !is_dynamic_alter_type(new_field) &&
+                       !is_allowed_alter_type_transition(old_field.type, new_field.type)) {
+                        return Option<bool>(400, "Field `" + field_name + "` cannot be altered from `"
+                                            + old_field.type + "` to `" + new_field.type +
+                                            "`: only widening or same-meaning type changes are allowed.");
+                    }
+                }
 
                 if (f.is_reference_helper && diff_fields.size() > 1 &&
                             !diff_fields[diff_fields.size() - 2].reference.empty()) {
-                    const auto& field = diff_fields[diff_fields.size() - 2];
+                    const auto& field = new_field;
 
                     updated_search_schema[field.name] = field;
 

--- a/test/collection_faceting_test.cpp
+++ b/test/collection_faceting_test.cpp
@@ -3570,7 +3570,7 @@ TEST_F(CollectionFacetingTest, RangeFacetAlphanumericLabels) {
     ASSERT_EQ("10thAD", results["facet_counts"][0]["counts"][2]["value"]);
 }
 
-TEST_F(CollectionFacetingTest, FacetingWithCoercedString) {
+TEST_F(CollectionFacetingTest, RejectCoerciveTypeChangeForFaceting) {
     std::vector<field> fields = {field("years", field_types::INT64_ARRAY, true)};
 
     Collection* coll1 = collectionManager.create_collection(
@@ -3589,15 +3589,10 @@ TEST_F(CollectionFacetingTest, FacetingWithCoercedString) {
         ]
     })"_json;
 
-    // schema change will not change the data on disk, so we have to account for this during hash based faceting
     auto alter_op = coll1->alter(schema_changes);
-    ASSERT_TRUE(alter_op.ok());
-
-    auto results = coll1->search("*", {}, "", {"years"}, {}, {2}, 10,
-                                 1, FREQUENCY, {true}).get();
-
-    ASSERT_EQ(3, results["facet_counts"][0]["counts"].size());
-    ASSERT_EQ(1, results["facet_counts"][0]["counts"][0]["count"]);
+    ASSERT_FALSE(alter_op.ok());
+    ASSERT_EQ("Field `years` cannot be altered from `int64[]` to `string[]`: only widening or same-meaning "
+              "type changes are allowed.", alter_op.error());
 }
 
 TEST_F(CollectionFacetingTest, RangeFacetsWithSortDisabled) {

--- a/test/collection_schema_change_test.cpp
+++ b/test/collection_schema_change_test.cpp
@@ -534,7 +534,8 @@ TEST_F(CollectionSchemaChangeTest, AbilityToDropAndReAddIndexAtTheSameTime) {
         "name": "coll1",
         "fields": [
             {"name": "title", "type": "string"},
-            {"name": "timestamp", "type": "int32"}
+            {"name": "timestamp", "type": "int32"},
+            {"name": "timestamps", "type": "int32[]"}
         ]
     })"_json;
 
@@ -547,6 +548,7 @@ TEST_F(CollectionSchemaChangeTest, AbilityToDropAndReAddIndexAtTheSameTime) {
     doc["id"] = "0";
     doc["title"] = "Hello";
     doc["timestamp"] = 3433232;
+    doc["timestamps"] = {1, 2, 3};
 
     ASSERT_TRUE(coll1->add(doc.dump()).ok());
 
@@ -561,8 +563,8 @@ TEST_F(CollectionSchemaChangeTest, AbilityToDropAndReAddIndexAtTheSameTime) {
 
     auto alter_op = coll1->alter(schema_changes);
     ASSERT_FALSE(alter_op.ok());
-    ASSERT_EQ("Schema change is incompatible with the type of documents already stored in this collection. "
-              "Existing data for field `title` cannot be coerced into an int32.", alter_op.error());
+    ASSERT_EQ("Field `title` cannot be altered from `string` to `int32`: only widening or same-meaning "
+              "type changes are allowed.", alter_op.error());
 
     // existing data should not have been touched
     auto res = coll1->search("he", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, 10).get();
@@ -603,6 +605,19 @@ TEST_F(CollectionSchemaChangeTest, AbilityToDropAndReAddIndexAtTheSameTime) {
     ASSERT_TRUE(alter_op.ok());
 
     ASSERT_EQ("int64", coll1->get_schema()["timestamp"].type);
+
+    // migrate int32[] to int64[]
+    schema_changes = R"({
+        "fields": [
+            {"name": "timestamps", "drop": true},
+            {"name": "timestamps", "type": "int64[]"}
+        ]
+    })"_json;
+
+    alter_op = coll1->alter(schema_changes);
+    ASSERT_TRUE(alter_op.ok());
+
+    ASSERT_EQ("int64[]", coll1->get_schema()["timestamps"].type);
 
     collectionManager.drop_collection("coll1");
 }
@@ -861,7 +876,9 @@ TEST_F(CollectionSchemaChangeTest, ChangeFieldToCoercableTypeIsAllowed) {
     })"_json;
 
     auto alter_op = coll1->alter(schema_changes);
-    ASSERT_TRUE(alter_op.ok());
+    ASSERT_FALSE(alter_op.ok());
+    ASSERT_EQ("Field `points` cannot be altered from `int32` to `string`: only widening or same-meaning "
+              "type changes are allowed.", alter_op.error());
 }
 
 TEST_F(CollectionSchemaChangeTest, ChangeFromPrimitiveToDynamicField) {
@@ -1077,6 +1094,8 @@ TEST_F(CollectionSchemaChangeTest, OrderOfDropShouldNotMatter) {
 
     auto alter_op = coll1->alter(schema_changes);
     ASSERT_FALSE(alter_op.ok());
+    ASSERT_EQ("Field `loc` cannot be altered from `geopoint` to `int32`: only widening or same-meaning "
+              "type changes are allowed.", alter_op.error());
 
     schema_changes = R"({
         "fields": [
@@ -1087,6 +1106,8 @@ TEST_F(CollectionSchemaChangeTest, OrderOfDropShouldNotMatter) {
 
     alter_op = coll1->alter(schema_changes);
     ASSERT_FALSE(alter_op.ok());
+    ASSERT_EQ("Field `loc` cannot be altered from `geopoint` to `int32`: only widening or same-meaning "
+              "type changes are allowed.", alter_op.error());
 }
 
 TEST_F(CollectionSchemaChangeTest, IndexFalseToTrue) {


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- Allow only widening or same type changes in schema alter
- update tests

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
