### PR TITLE
fix(http_client): suppress chunked TE in async follower-to-leader forwarding

### DIFF
--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -515,9 +515,13 @@ CURL *HttpClient::init_curl_async(const std::string& url, deferred_req_res_t* re
         chunk = curl_slist_append(chunk, api_key_header.c_str());
     }
 
-    // set content length
-    std::string content_length_header = std::string("content-length: ") + std::to_string(req_res->req->_req->content_length);
-    chunk = curl_slist_append(chunk, content_length_header.c_str());
+    // Use POSTFIELDSIZE_LARGE (curl_off_t) to handle bodies over 2 GB safely.
+    // h2o uses SIZE_MAX as a sentinel for "no Content-Length header"; map that to -1
+    // so libcurl falls back to chunked encoding when the size is genuinely unknown.
+    curl_off_t post_size = (req_res->req->_req->content_length == SIZE_MAX)
+        ? -1
+        : static_cast<curl_off_t>(req_res->req->_req->content_length);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE_LARGE, post_size);
 
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
 


### PR DESCRIPTION
## Change Summary

When a follower node forwards a write request to the leader via `init_curl_async`, it manually appends a `content-length` header to the slist while also setting `CURLOPT_READFUNCTION` without `CURLOPT_POSTFIELDSIZE`. Since libcurl 7.66.0, manually setting `Content-Length` via `CURLOPT_HTTPHEADER` does not prevent libcurl from adding `Transfer-Encoding: chunked` when the body size is unknown to curl. This produces an HTTP/1.1 request with both headers simultaneously, violating [RFC 7230 §3.3.2](https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2) ("A sender MUST NOT send a Content-Length header field in any message that contains a Transfer-Encoding header field"), and causing HTTP proxies and service meshes (e.g. Istio/Envoy) to reject the forwarded request with a protocol error.

Fix: replace the manual `curl_slist_append` header with `CURLOPT_POSTFIELDSIZE_LARGE` (using `curl_off_t` to handle large import payloads correctly on all platforms). This tells libcurl the body size upfront and suppresses chunked encoding. The `SIZE_MAX` sentinel (h2o's signal for "no Content-Length header present") is mapped explicitly to `-1`, which is libcurl's documented way to request chunked encoding when the size is genuinely unknown.

Reproduces with any HTTP/1.1 proxy that enforces RFC 7230 §3.3.2 strict mode when a write request is routed to a follower node and forwarded internally to the leader.

Note: no unit test is included as there is currently no established test seam for `init_curl_async`'s curl option configuration (the function requires a fully initialised h2o request object and the cluster networking stack). Happy to add a test if the maintainers can point to a preferred pattern.

Closes #2893

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).