### PR TITLE
Fix joins crash

### DIFF
--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -3185,8 +3185,11 @@ void filter_result_iterator_t::compute_iterators() {
 
         is_filter_result_initialized = true;
 
-        if (validity != timed_out && filter_result.count == 0) {
-            validity = invalid;
+        if (filter_result.count == 0) {
+            if (validity != timed_out) {
+                validity = invalid;
+            }
+            approx_filter_ids_length = 0;
             return;
         }
 
@@ -3434,8 +3437,11 @@ void filter_result_iterator_t::compute_iterators() {
 
     is_filter_result_initialized = true;
 
-    if (validity != timed_out && filter_result.count == 0) {
-        validity = invalid;
+    if (filter_result.count == 0) {
+        if (validity != timed_out) {
+            validity = invalid;
+        }
+        approx_filter_ids_length = 0;
         return;
     }
 

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -3142,8 +3142,12 @@ void filter_result_iterator_t::compute_iterators() {
 
         // In a complex filter query a sub-expression might not match any document while the full expression does match
         // at least one document. If the full expression doesn't match any document, we return early in the search.
-        if (filter_result.count == 0 && validity != timed_out) {
-            validity = invalid;
+        if (filter_result.count == 0) {
+            if (validity != timed_out) {
+                validity = invalid;
+            }
+            // Updating approx_filter_ids_length to avoid having stale value in case && node matches 0 documents on compute.
+            approx_filter_ids_length = 0;
         } else if (filter_result.count > 0) {
             result_index = 0;
             seq_id = filter_result.docs[result_index];

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2006,6 +2006,9 @@ Option<bool> Index::do_reference_filtering_with_lock(filter_node_t* const filter
 
     auto& reference_docs = ref_filter_result->docs;
     count = ref_filter_result->count;
+    if (count == 0 && is_normal_join) {
+        return Option(true);
+    }
 
     auto const reference_helper_field_name = field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX;
     auto const is_nested_join = !ref_filter_result_iterator.reference.empty();

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2005,6 +2005,7 @@ Option<bool> Index::do_reference_filtering_with_lock(filter_node_t* const filter
     }
 
     auto& reference_docs = ref_filter_result->docs;
+    count = ref_filter_result->count;
 
     auto const reference_helper_field_name = field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX;
     auto const is_nested_join = !ref_filter_result_iterator.reference.empty();

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -12849,3 +12849,77 @@ TEST_F(CollectionJoinTest, MultipleJoinsSameCollection) {
     collectionManager.drop_collection("Customers");
     collectionManager.drop_collection("Products");
 }
+
+TEST_F(CollectionJoinTest, FilterByReference_UsesMaterializedReferenceCount) {
+    auto schema_json =
+            R"({
+                "name": "Products",
+                "fields": [
+                    {"name": "productId", "type": "int32", "sort": true},
+                    {"name": "name", "type": "string"}
+                ]
+            })"_json;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto products_coll = collection_create_op.get();
+
+    for (size_t i = 0; i < 100; i++) {
+        nlohmann::json document;
+        document["productId"] = i;
+        document["name"] = "product " + std::to_string(i);
+        auto add_op = products_coll->add(document.dump());
+        ASSERT_TRUE(add_op.ok()) << add_op.error();
+    }
+
+    schema_json =
+            R"({
+                "name": "ProductWarehouses",
+                "fields": [
+                    {"name": "productId", "type": "int32", "reference": "Products.productId",
+                     "async_reference": true, "cascade_delete": false, "range_index": true, "sort": true},
+                    {"name": "tags", "type": "string[]"}
+                ]
+            })"_json;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto product_warehouses_coll = collection_create_op.get();
+
+    for (size_t i = 0; i < 100; i++) {
+        nlohmann::json document;
+        document["productId"] = i;
+        document["tags"] = {i < 50 ? "left" : "right"};
+        auto add_op = product_warehouses_coll->add(document.dump());
+        ASSERT_TRUE(add_op.ok()) << add_op.error();
+    }
+
+    std::map<std::string, std::string> req_params = {
+            {"collection", "ProductWarehouses"},
+            {"q", "*"},
+            {"filter_by", "tags:!=left && tags:!=right"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok()) << search_op.error();
+
+    auto res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(0, res_obj["found"].get<size_t>());
+    ASSERT_TRUE(res_obj["hits"].empty());
+
+    req_params = {
+            {"collection", "Products"},
+            {"q", "*"},
+            {"filter_by", "$ProductWarehouses(tags:!=left && tags:!=right)"}
+    };
+    json_res.clear();
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok()) << search_op.error();
+
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(0, res_obj["found"].get<size_t>());
+    ASSERT_TRUE(res_obj["hits"].empty());
+}

--- a/test/filter_test.cpp
+++ b/test/filter_test.cpp
@@ -896,6 +896,34 @@ TEST_F(FilterTest, FilterTreeInitialization) {
 
     delete filter_tree_root;
     filter_tree_root = nullptr;
+
+    auto add_op = coll->add(
+            R"({"name": "Jeremy Howard", "top_3": [0, 0.0, 0.0], "rating": 0.0,"age": 63, "years": [1981, 1985],
+                 "timestamps": [348974822, 475205222], "tags": ["silver"]})");
+    ASSERT_TRUE(add_op.ok());
+    std::string dirty_values = "DROP";
+    auto alter_op = coll->update_matching_filter("id: 0", R"({"tags": ["gold"]})", dirty_values);
+    ASSERT_TRUE(alter_op.ok());
+
+    filter_op = filter::parse_filter_query("years:!= 2016 && tags: != silver", coll->get_schema(), store, doc_id_prefix,
+                                           filter_tree_root);
+    ASSERT_TRUE(filter_op.ok());
+
+    auto iter_0_matches = filter_result_iterator_t(coll->get_name(), coll->_get_index(),
+                                                   filter_tree_root, enable_lazy_evaluation);
+
+    ASSERT_TRUE(iter_0_matches.init_status().ok());
+    ASSERT_EQ(filter_result_iterator_t::valid, iter_0_matches.validity);
+    ASSERT_FALSE(iter_0_matches._get_is_filter_result_initialized());
+    ASSERT_EQ(3, iter_0_matches.approx_filter_ids_length);
+
+    iter_0_matches.compute_iterators();
+    ASSERT_EQ(filter_result_iterator_t::invalid, iter_0_matches.validity);
+    ASSERT_TRUE(iter_0_matches._get_is_filter_result_initialized());
+    ASSERT_EQ(0, iter_0_matches.approx_filter_ids_length);
+
+    delete filter_tree_root;
+    filter_tree_root = nullptr;
 }
 
 TEST_F(FilterTest, NotEqualsStringFilter) {


### PR DESCRIPTION
## Change Summary

Fix `filter_result_iterator_t::compute_iterators()` having stale `approx_filter_ids_length` value after computing && node that caused the following crash:

```bash
2026-04-13 00:19:51.000 UTC E #8    Source "src/core_api.cpp", line 1106, in post_multi_search [0x559295c315be]
2026-04-13 00:19:51.000 UTC E #7    Source "src/collection_manager.cpp", line 1452, in do_search [0x559295b92f24]
2026-04-13 00:19:51.000 UTC E #6    Source "src/collection.cpp", line 2883, in search [0x559295b0d717]
2026-04-13 00:19:51.000 UTC E #5    Source "src/index.cpp", line 2492, in run_search [0x559295d91767]
2026-04-13 00:19:51.000 UTC E #4    Source "src/filter_result_iterator.cpp", line 2588, in filter_result_iterator_t [0x559295cf0384]
2026-04-13 00:19:51.000 UTC E #3    Source "src/filter_result_iterator.cpp", line 1026, in init [0x559295cea38b]
2026-04-13 00:19:51.000 UTC E #2    Source "src/collection.cpp", line 4903, in get_reference_filter_ids [0x559295abda7b]
2026-04-13 00:19:51.000 UTC E #1  | Source "src/index.cpp", line 2075, in count
2026-04-13 00:19:51.000 UTC E     | Source "include/sparsepp.h", line 5028, in count
2026-04-13 00:19:51.000 UTC E       Source "include/sparsepp.h", line 4348, in do_reference_filtering_with_lock [0x559295d490c9]
2026-04-13 00:19:51.000 UTC E #0    Source "include/sparsepp.h", line 4238, in _find_position [0x559295daa072]
```
Update the `count` value in `do_reference_filtering_with_lock()` to the actual count of the matched documents: `ref_filter_result->count`.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
