### PR TITLE
fix: make count min sketch hash seeding deterministic

### DIFF
--- a/include/count_min_sketch.h
+++ b/include/count_min_sketch.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cmath>
-#include <ctime>
+#include <cstdlib>
 #include <cstdint>
 
 /**
@@ -12,6 +12,8 @@
 **/
 class CountMinSketch {
 private:
+    static constexpr uint32_t LONG_PRIME = 32993;
+
     uint32_t w, d;
     float eps;
     float gamma;
@@ -34,7 +36,7 @@ public:
             C[i] = new uint32_t[w]{0};
         }
 
-        srand(time(NULL));
+        srand(LONG_PRIME);
 
         hashes = new int* [d];
         for (size_t i = 0; i < d; i++) {
@@ -77,7 +79,6 @@ public:
 };
 
 inline void CountMinSketch::genajbj(int* hash, int i) {
-    constexpr auto LONG_PRIME = 32993;
     hash[0] = int(float(rand())*float(LONG_PRIME)/float(RAND_MAX) + 1);
     hash[1] = int(float(rand())*float(LONG_PRIME)/float(RAND_MAX) + 1);
 }

--- a/include/count_min_sketch.h
+++ b/include/count_min_sketch.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <cmath>
-#include <cstdlib>
 #include <cstdint>
+#include <random>
 
 /**
     Daniel Alabi
@@ -19,12 +19,13 @@ private:
     float gamma;
     uint32_t **C;
     int **hashes;
+    std::mt19937 rng;
 
     void genajbj(int* hash, int i);
 
 public:
 
-    CountMinSketch(float ep, float gamm) {
+    CountMinSketch(float ep, float gamm) : rng(LONG_PRIME) {
         eps = (0.009 <= ep && ep < 1) ? ep : 0.01;
         gamma = (0 < gamm && gamm < 1) ? gamm : 0.1;
 
@@ -35,8 +36,6 @@ public:
         for (size_t i = 0; i < d; i++) {
             C[i] = new uint32_t[w]{0};
         }
-
-        srand(LONG_PRIME);
 
         hashes = new int* [d];
         for (size_t i = 0; i < d; i++) {
@@ -79,6 +78,6 @@ public:
 };
 
 inline void CountMinSketch::genajbj(int* hash, int i) {
-    hash[0] = int(float(rand())*float(LONG_PRIME)/float(RAND_MAX) + 1);
-    hash[1] = int(float(rand())*float(LONG_PRIME)/float(RAND_MAX) + 1);
+    hash[0] = int(float(rng()) * float(LONG_PRIME) / float(rng.max()) + 1);
+    hash[1] = int(float(rng()) * float(LONG_PRIME) / float(rng.max()) + 1);
 }


### PR DESCRIPTION

## Change Summary
Fix `CollectionGroupingTest.SortingMoreThanMaxTopsterSize`'s flakiness by seeding the RNG state with a given seed, instead of the invocation's time


## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
