### PR TITLE
Fix same object filtering with on array[]

### DIFF
--- a/api_tests/tests/nested_curly_filter.test.ts
+++ b/api_tests/tests/nested_curly_filter.test.ts
@@ -5,12 +5,12 @@ import { fetchSingleNode } from "../src/request";
 const COLLECTION_NAME = "show_nested_curly_repro";
 const ALIAS_NAME = "show_v2_repro";
 const PERFORMANCE_COUNTS = [54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 60];
-const HIGH_LOAD_COLLECTION_NAME = "performance_nested_curly_high_load";
+const HIGH_LOAD_COLLECTION_NAME = "catalog_nested_offer_high_load";
 const HIGH_LOAD_QUERY_TIMEOUT_MS = 20_000;
-const HIGH_LOAD_SHOWS = 200;
-const HIGH_LOAD_PERFS_PER_SHOW = 25;
-const HIGH_LOAD_BANDS_PER_PERF_MIN = 4;
-const HIGH_LOAD_BANDS_PER_PERF_MAX = 7;
+const HIGH_LOAD_GROUPS = 200;
+const HIGH_LOAD_ITEMS_PER_GROUP = 25;
+const HIGH_LOAD_OFFERS_PER_ITEM_MIN = 4;
+const HIGH_LOAD_OFFERS_PER_ITEM_MAX = 7;
 
 function buildDocuments() {
   const docs: Array<Record<string, unknown>> = [];
@@ -95,75 +95,75 @@ function rngFactory(seed: number) {
   };
 }
 
-function buildHighLoadPerformances() {
+function buildHighLoadItems() {
   const rng = rngFactory(42);
   const pick = <T>(arr: T[]) => arr[Math.floor(rng() * arr.length)]!;
   const intBetween = (lo: number, hi: number) => lo + Math.floor(rng() * (hi - lo + 1));
-  const seatTypes = ["Stalls", "Circle", "Upper", "Boxes", "Premium"];
-  const performances: Array<{
+  const categories = ["alpha", "beta", "gamma", "delta", "omega"];
+  const items: Array<{
     id: string;
-    showSlug: string;
-    sourceType: string;
-    sourceId: string;
-    "startDate.iso": string;
-    "startDate.unix": number;
-    "startDate.timezone": string;
-    "startDate.localTimeHour": number;
-    "startDate.localTimeDay": number;
-    bands: Array<{
-      seatType: string;
-      minSeatPrice: number;
-      maxSeatPrice: number;
-      sizes: number[];
+    groupKey: string;
+    sourceKind: string;
+    sourceRef: string;
+    "publishedAt.iso": string;
+    "publishedAt.unix": number;
+    "publishedAt.zone": string;
+    "publishedAt.hour": number;
+    "publishedAt.day": number;
+    offers: Array<{
+      category: string;
+      minCost: number;
+      maxCost: number;
+      quantities: number[];
     }>;
   }> = [];
   let id = 0;
 
-  for (let showIndex = 0; showIndex < HIGH_LOAD_SHOWS; showIndex++) {
-    const showSlug = `show-${showIndex.toString().padStart(4, "0")}`;
-    for (let perfIndex = 0; perfIndex < HIGH_LOAD_PERFS_PER_SHOW; perfIndex++) {
-      const bandCount = intBetween(HIGH_LOAD_BANDS_PER_PERF_MIN, HIGH_LOAD_BANDS_PER_PERF_MAX);
-      const bands = [];
-      for (let bandIndex = 0; bandIndex < bandCount; bandIndex++) {
-        const minSeatPrice = intBetween(1500, 9000);
-        const maxSeatPrice = minSeatPrice + intBetween(500, 5000);
-        const sizes = [
+  for (let groupIndex = 0; groupIndex < HIGH_LOAD_GROUPS; groupIndex++) {
+    const groupKey = `group-${groupIndex.toString().padStart(4, "0")}`;
+    for (let itemIndex = 0; itemIndex < HIGH_LOAD_ITEMS_PER_GROUP; itemIndex++) {
+      const offerCount = intBetween(HIGH_LOAD_OFFERS_PER_ITEM_MIN, HIGH_LOAD_OFFERS_PER_ITEM_MAX);
+      const offers = [];
+      for (let offerIndex = 0; offerIndex < offerCount; offerIndex++) {
+        const minCost = intBetween(1500, 9000);
+        const maxCost = minCost + intBetween(500, 5000);
+        const quantities = [
           ...new Set(
             Array.from({ length: intBetween(1, 3) }, () => intBetween(1, 6)),
           ),
         ].sort((a, b) => a - b);
-        bands.push({
-          seatType: pick(seatTypes),
-          minSeatPrice,
-          maxSeatPrice,
-          sizes,
+        offers.push({
+          category: pick(categories),
+          minCost,
+          maxCost,
+          quantities,
         });
       }
 
-      const startUnix = 1_770_000_000 + intBetween(0, 60 * 24 * 60 * 60);
-      performances.push({
-        id: `perf-${(id++).toString().padStart(6, "0")}`,
-        showSlug,
-        sourceType: "lineup",
-        sourceId: `src-${id}`,
-        "startDate.iso": new Date(startUnix * 1000).toISOString(),
-        "startDate.unix": startUnix,
-        "startDate.timezone": "Europe/London",
-        "startDate.localTimeHour": intBetween(10, 22),
-        "startDate.localTimeDay": intBetween(0, 6),
-        bands,
+      const publishedAt = 1_770_000_000 + intBetween(0, 60 * 24 * 60 * 60);
+      items.push({
+        id: `item-${(id++).toString().padStart(6, "0")}`,
+        groupKey,
+        sourceKind: "batch",
+        sourceRef: `src-${id}`,
+        "publishedAt.iso": new Date(publishedAt * 1000).toISOString(),
+        "publishedAt.unix": publishedAt,
+        "publishedAt.zone": "UTC",
+        "publishedAt.hour": intBetween(10, 22),
+        "publishedAt.day": intBetween(0, 6),
+        offers,
       });
     }
   }
 
-  return performances;
+  return items;
 }
 
 function countSameObjectMatches(
-  performances: ReturnType<typeof buildHighLoadPerformances>,
-  matcher: (band: ReturnType<typeof buildHighLoadPerformances>[number]["bands"][number]) => boolean,
+  items: ReturnType<typeof buildHighLoadItems>,
+  matcher: (offer: ReturnType<typeof buildHighLoadItems>[number]["offers"][number]) => boolean,
 ) {
-  return performances.filter((performance) => performance.bands.some(matcher)).length;
+  return items.filter((item) => item.offers.some(matcher)).length;
 }
 
 async function search(filterBy: string) {
@@ -302,28 +302,28 @@ describe(Phases.SINGLE_FRESH, () => {
         enable_nested_fields: true,
         fields: [
           { name: "id", type: "string" },
-          { name: "showSlug", type: "string", facet: true, index: true, sort: false },
-          { name: "sourceType", type: "string", index: true },
-          { name: "sourceId", type: "string", index: true },
-          { name: "startDate.iso", type: "string", index: false },
-          { name: "startDate.unix", type: "int64", index: true, sort: true },
-          { name: "startDate.timezone", type: "string", index: false },
-          { name: "startDate.localTimeHour", type: "int32", index: true, range_index: true },
-          { name: "startDate.localTimeDay", type: "int32", index: true, range_index: true },
-          { name: "bands", type: "object[]", optional: true, index: true, facet: false },
-          { name: "bands.seatType", type: "string[]", optional: true, facet: true, index: true },
-          { name: "bands.minSeatPrice", type: "int32[]", optional: true, index: true, range_index: true },
-          { name: "bands.maxSeatPrice", type: "int32[]", optional: true, index: true, range_index: true },
-          { name: "bands.sizes", type: "int32[]", optional: true, index: true, range_index: true },
+          { name: "groupKey", type: "string", facet: true, index: true, sort: false },
+          { name: "sourceKind", type: "string", index: true },
+          { name: "sourceRef", type: "string", index: true },
+          { name: "publishedAt.iso", type: "string", index: false },
+          { name: "publishedAt.unix", type: "int64", index: true, sort: true },
+          { name: "publishedAt.zone", type: "string", index: false },
+          { name: "publishedAt.hour", type: "int32", index: true, range_index: true },
+          { name: "publishedAt.day", type: "int32", index: true, range_index: true },
+          { name: "offers", type: "object[]", optional: true, index: true, facet: false },
+          { name: "offers.category", type: "string[]", optional: true, facet: true, index: true },
+          { name: "offers.minCost", type: "int32[]", optional: true, index: true, range_index: true },
+          { name: "offers.maxCost", type: "int32[]", optional: true, index: true, range_index: true },
+          { name: "offers.quantities", type: "int32[]", optional: true, index: true, range_index: true },
         ],
       }),
     });
     expect(res.ok).toBe(true);
 
-    const performances = buildHighLoadPerformances();
-    expect(performances.length).toBe(5000);
+    const items = buildHighLoadItems();
+    expect(items.length).toBe(5000);
 
-    const importBody = performances.map((doc) => JSON.stringify(doc)).join("\n");
+    const importBody = items.map((doc) => JSON.stringify(doc)).join("\n");
     res = await fetchSingleNode(`/collections/${HIGH_LOAD_COLLECTION_NAME}/documents/import?action=create`, {
       method: "POST",
       headers: {
@@ -334,22 +334,22 @@ describe(Phases.SINGLE_FRESH, () => {
     expect(res.ok).toBe(true);
 
     const twoPredicateExpected = countSameObjectMatches(
-      performances,
-      (band) => band.sizes.some((size) => size >= 2) && band.minSeatPrice <= 7500,
+      items,
+      (offer) => offer.quantities.some((quantity) => quantity >= 2) && offer.minCost <= 7500,
     );
     const threePredicateExpected = countSameObjectMatches(
-      performances,
-      (band) => band.sizes.some((size) => size >= 2) && band.minSeatPrice <= 7500 && band.maxSeatPrice >= 4000,
+      items,
+      (offer) => offer.quantities.some((quantity) => quantity >= 2) && offer.minCost <= 7500 && offer.maxCost >= 4000,
     );
 
     const twoPredicateResult = await highLoadSearchWithTimeout(
-      "bands.{sizes:>=2 && minSeatPrice:<=7500}",
+      "offers.{quantities:>=2 && minCost:<=7500}",
       HIGH_LOAD_QUERY_TIMEOUT_MS,
     );
     expect(twoPredicateResult.found).toBe(twoPredicateExpected);
 
     const threePredicateResult = await highLoadSearchWithTimeout(
-      "bands.{sizes:>=2 && minSeatPrice:<=7500 && maxSeatPrice:>=4000}",
+      "offers.{quantities:>=2 && minCost:<=7500 && maxCost:>=4000}",
       HIGH_LOAD_QUERY_TIMEOUT_MS,
     );
     expect(threePredicateResult.found).toBe(threePredicateExpected);

--- a/api_tests/tests/nested_curly_filter.test.ts
+++ b/api_tests/tests/nested_curly_filter.test.ts
@@ -5,6 +5,12 @@ import { fetchSingleNode } from "../src/request";
 const COLLECTION_NAME = "show_nested_curly_repro";
 const ALIAS_NAME = "show_v2_repro";
 const PERFORMANCE_COUNTS = [54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 60];
+const HIGH_LOAD_COLLECTION_NAME = "performance_nested_curly_high_load";
+const HIGH_LOAD_QUERY_TIMEOUT_MS = 20_000;
+const HIGH_LOAD_SHOWS = 200;
+const HIGH_LOAD_PERFS_PER_SHOW = 25;
+const HIGH_LOAD_BANDS_PER_PERF_MIN = 4;
+const HIGH_LOAD_BANDS_PER_PERF_MAX = 7;
 
 function buildDocuments() {
   const docs: Array<Record<string, unknown>> = [];
@@ -81,6 +87,85 @@ function buildDocuments() {
   return { docs, sameObjectTitles, splitObjectTitles };
 }
 
+function rngFactory(seed: number) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0xffffffff;
+  };
+}
+
+function buildHighLoadPerformances() {
+  const rng = rngFactory(42);
+  const pick = <T>(arr: T[]) => arr[Math.floor(rng() * arr.length)]!;
+  const intBetween = (lo: number, hi: number) => lo + Math.floor(rng() * (hi - lo + 1));
+  const seatTypes = ["Stalls", "Circle", "Upper", "Boxes", "Premium"];
+  const performances: Array<{
+    id: string;
+    showSlug: string;
+    sourceType: string;
+    sourceId: string;
+    "startDate.iso": string;
+    "startDate.unix": number;
+    "startDate.timezone": string;
+    "startDate.localTimeHour": number;
+    "startDate.localTimeDay": number;
+    bands: Array<{
+      seatType: string;
+      minSeatPrice: number;
+      maxSeatPrice: number;
+      sizes: number[];
+    }>;
+  }> = [];
+  let id = 0;
+
+  for (let showIndex = 0; showIndex < HIGH_LOAD_SHOWS; showIndex++) {
+    const showSlug = `show-${showIndex.toString().padStart(4, "0")}`;
+    for (let perfIndex = 0; perfIndex < HIGH_LOAD_PERFS_PER_SHOW; perfIndex++) {
+      const bandCount = intBetween(HIGH_LOAD_BANDS_PER_PERF_MIN, HIGH_LOAD_BANDS_PER_PERF_MAX);
+      const bands = [];
+      for (let bandIndex = 0; bandIndex < bandCount; bandIndex++) {
+        const minSeatPrice = intBetween(1500, 9000);
+        const maxSeatPrice = minSeatPrice + intBetween(500, 5000);
+        const sizes = [
+          ...new Set(
+            Array.from({ length: intBetween(1, 3) }, () => intBetween(1, 6)),
+          ),
+        ].sort((a, b) => a - b);
+        bands.push({
+          seatType: pick(seatTypes),
+          minSeatPrice,
+          maxSeatPrice,
+          sizes,
+        });
+      }
+
+      const startUnix = 1_770_000_000 + intBetween(0, 60 * 24 * 60 * 60);
+      performances.push({
+        id: `perf-${(id++).toString().padStart(6, "0")}`,
+        showSlug,
+        sourceType: "lineup",
+        sourceId: `src-${id}`,
+        "startDate.iso": new Date(startUnix * 1000).toISOString(),
+        "startDate.unix": startUnix,
+        "startDate.timezone": "Europe/London",
+        "startDate.localTimeHour": intBetween(10, 22),
+        "startDate.localTimeDay": intBetween(0, 6),
+        bands,
+      });
+    }
+  }
+
+  return performances;
+}
+
+function countSameObjectMatches(
+  performances: ReturnType<typeof buildHighLoadPerformances>,
+  matcher: (band: ReturnType<typeof buildHighLoadPerformances>[number]["bands"][number]) => boolean,
+) {
+  return performances.filter((performance) => performance.bands.some(matcher)).length;
+}
+
 async function search(filterBy: string) {
   const res = await fetchSingleNode(
     `/collections/${ALIAS_NAME}/documents/search?q=show&query_by=title&include_fields=title&per_page=50&filter_by=${encodeURIComponent(filterBy)}`,
@@ -114,6 +199,32 @@ async function searchWithTimeout(filterBy: string, timeoutMs: number) {
     found: number;
     hits: Array<{ document: { title: string } }>;
   };
+}
+
+async function highLoadSearchWithTimeout(filterBy: string, timeoutMs: number) {
+  const url = new URL(`http://localhost:8108/collections/${HIGH_LOAD_COLLECTION_NAME}/documents/search`);
+  url.searchParams.set("q", "*");
+  url.searchParams.set("include_fields", "id");
+  url.searchParams.set("per_page", "1");
+  url.searchParams.set("filter_by", filterBy);
+
+  let res: Response;
+  try {
+    res = await fetch(url.toString(), {
+      method: "GET",
+      headers: {
+        "X-TYPESENSE-API-KEY": "xyz",
+      },
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    throw new Error(`High-load same-object filter timed out after ${timeoutMs}ms: ${filterBy}`, {
+      cause: error,
+    });
+  }
+
+  expect(res.ok).toBe(true);
+  return (await res.json()) as { found: number };
 }
 
 describe(Phases.SINGLE_FRESH, () => {
@@ -179,5 +290,68 @@ describe(Phases.SINGLE_FRESH, () => {
     );
     expect(sameObject.found).toBe(sameObjectTitles.size);
     expect(new Set(sameObject.hits.map((hit) => hit.document.title))).toEqual(sameObjectTitles);
+  });
+
+  it("high-load same-object filters over array child fields should return promptly", async () => {
+    await fetchSingleNode(`/collections/${HIGH_LOAD_COLLECTION_NAME}`, { method: "DELETE" });
+
+    let res = await fetchSingleNode("/collections", {
+      method: "POST",
+      body: JSON.stringify({
+        name: HIGH_LOAD_COLLECTION_NAME,
+        enable_nested_fields: true,
+        fields: [
+          { name: "id", type: "string" },
+          { name: "showSlug", type: "string", facet: true, index: true, sort: false },
+          { name: "sourceType", type: "string", index: true },
+          { name: "sourceId", type: "string", index: true },
+          { name: "startDate.iso", type: "string", index: false },
+          { name: "startDate.unix", type: "int64", index: true, sort: true },
+          { name: "startDate.timezone", type: "string", index: false },
+          { name: "startDate.localTimeHour", type: "int32", index: true, range_index: true },
+          { name: "startDate.localTimeDay", type: "int32", index: true, range_index: true },
+          { name: "bands", type: "object[]", optional: true, index: true, facet: false },
+          { name: "bands.seatType", type: "string[]", optional: true, facet: true, index: true },
+          { name: "bands.minSeatPrice", type: "int32[]", optional: true, index: true, range_index: true },
+          { name: "bands.maxSeatPrice", type: "int32[]", optional: true, index: true, range_index: true },
+          { name: "bands.sizes", type: "int32[]", optional: true, index: true, range_index: true },
+        ],
+      }),
+    });
+    expect(res.ok).toBe(true);
+
+    const performances = buildHighLoadPerformances();
+    expect(performances.length).toBe(5000);
+
+    const importBody = performances.map((doc) => JSON.stringify(doc)).join("\n");
+    res = await fetchSingleNode(`/collections/${HIGH_LOAD_COLLECTION_NAME}/documents/import?action=create`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "text/plain",
+      },
+      body: importBody,
+    });
+    expect(res.ok).toBe(true);
+
+    const twoPredicateExpected = countSameObjectMatches(
+      performances,
+      (band) => band.sizes.some((size) => size >= 2) && band.minSeatPrice <= 7500,
+    );
+    const threePredicateExpected = countSameObjectMatches(
+      performances,
+      (band) => band.sizes.some((size) => size >= 2) && band.minSeatPrice <= 7500 && band.maxSeatPrice >= 4000,
+    );
+
+    const twoPredicateResult = await highLoadSearchWithTimeout(
+      "bands.{sizes:>=2 && minSeatPrice:<=7500}",
+      HIGH_LOAD_QUERY_TIMEOUT_MS,
+    );
+    expect(twoPredicateResult.found).toBe(twoPredicateExpected);
+
+    const threePredicateResult = await highLoadSearchWithTimeout(
+      "bands.{sizes:>=2 && minSeatPrice:<=7500 && maxSeatPrice:>=4000}",
+      HIGH_LOAD_QUERY_TIMEOUT_MS,
+    );
+    expect(threePredicateResult.found).toBe(threePredicateExpected);
   });
 });

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -3618,7 +3618,115 @@ bool filter_result_iterator_t::validate_object_filter_helper(
         field f = index->search_schema.at(filter_exp.field_name);
 
         using fieldType = std::variant<int64_t, float, bool, std::string>;
-        fieldType doc_val, filter_val;
+
+        const auto value_matches = [](const fieldType& doc_val, const fieldType& filter_val,
+                                      const NUM_COMPARATOR comparator) {
+            if (comparator == EQUALS) {
+                return doc_val == filter_val;
+            } else if (comparator == NOT_EQUALS) {
+                return doc_val != filter_val;
+            } else if(comparator == CONTAINS) {
+                if(std::holds_alternative<std::string>(doc_val) && std::holds_alternative<std::string>(filter_val)) {
+                    return std::get<std::string>(doc_val).find(std::get<std::string>(filter_val)) != std::string::npos;
+                }
+            } else if (comparator == LESS_THAN) {
+                if(std::holds_alternative<int64_t>(doc_val) && std::holds_alternative<int64_t>(filter_val)) {
+                    return std::get<int64_t>(doc_val) < std::get<int64_t>(filter_val);
+                } else if(std::holds_alternative<float>(doc_val) && std::holds_alternative<float>(filter_val)) {
+                    return std::get<float>(doc_val) < std::get<float>(filter_val);
+                }
+            } else if(comparator == LESS_THAN_EQUALS) {
+                if(std::holds_alternative<int64_t>(doc_val) && std::holds_alternative<int64_t>(filter_val)) {
+                    return std::get<int64_t>(doc_val) <= std::get<int64_t>(filter_val);
+                } else if(std::holds_alternative<float>(doc_val) && std::holds_alternative<float>(filter_val)) {
+                    return std::get<float>(doc_val) <= std::get<float>(filter_val);
+                }
+            } else if(comparator == GREATER_THAN) {
+                if(std::holds_alternative<int64_t>(doc_val) && std::holds_alternative<int64_t>(filter_val)) {
+                    return std::get<int64_t>(doc_val) > std::get<int64_t>(filter_val);
+                } else if(std::holds_alternative<float>(doc_val) && std::holds_alternative<float>(filter_val)) {
+                    return std::get<float>(doc_val) > std::get<float>(filter_val);
+                }
+            } else if(comparator == GREATER_THAN_EQUALS) {
+                if(std::holds_alternative<int64_t>(doc_val) && std::holds_alternative<int64_t>(filter_val)) {
+                    return std::get<int64_t>(doc_val) >= std::get<int64_t>(filter_val);
+                } else if(std::holds_alternative<float>(doc_val) && std::holds_alternative<float>(filter_val)) {
+                    return std::get<float>(doc_val) >= std::get<float>(filter_val);
+                }
+            }
+
+            return false;
+        };
+
+        const auto get_string_value = [&index, &f](const nlohmann::json& json_val) -> fieldType {
+            const auto& symbols = f.symbols_to_index.empty() ? index->symbols_to_index : f.symbols_to_index;
+            const auto& separators = f.token_separators.empty() ? index->token_separators : f.token_separators;
+
+            std::string doc_str = json_val.get<std::string>();
+            Tokenizer doc_tokenizer(doc_str, true, false, f.locale, symbols, separators, f.get_stemmer());
+
+            std::string tokenized_doc_val;
+            size_t doc_token_index = 0;
+            return doc_tokenizer.next(tokenized_doc_val, doc_token_index) ? tokenized_doc_val : doc_str;
+        };
+
+        const auto get_doc_value = [&get_string_value, &f](const nlohmann::json& json_val) -> fieldType {
+            if (f.is_string()) {
+                return get_string_value(json_val);
+            } else if (f.is_float()) {
+                return json_val.get<float>();
+            } else if (f.is_bool()) {
+                return json_val.get<bool>();
+            }
+
+            return json_val.get<int64_t>();
+        };
+
+        const auto doc_matches = [&get_doc_value, &value_matches](const nlohmann::json& json_val,
+                                                                  const fieldType& filter_val,
+                                                                  const NUM_COMPARATOR comparator) {
+            if (json_val.is_array()) {
+                if (comparator == NOT_EQUALS) {
+                    for (const auto& array_val: json_val) {
+                        if (value_matches(get_doc_value(array_val), filter_val, EQUALS)) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+
+                for (const auto& array_val: json_val) {
+                    if (value_matches(get_doc_value(array_val), filter_val, comparator)) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            return value_matches(get_doc_value(json_val), filter_val, comparator);
+        };
+
+        const auto doc_matches_range = [&get_doc_value, &value_matches](const nlohmann::json& json_val,
+                                                                        const fieldType& start_val,
+                                                                        const fieldType& end_val) {
+            if (json_val.is_array()) {
+                for (const auto& array_val: json_val) {
+                    const auto doc_val = get_doc_value(array_val);
+                    if (value_matches(doc_val, start_val, GREATER_THAN_EQUALS) &&
+                        value_matches(doc_val, end_val, LESS_THAN_EQUALS)) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            const auto doc_val = get_doc_value(json_val);
+            return value_matches(doc_val, start_val, GREATER_THAN_EQUALS) &&
+                   value_matches(doc_val, end_val, LESS_THAN_EQUALS);
+        };
 
         bool match_found = false;
 
@@ -3630,82 +3738,44 @@ bool filter_result_iterator_t::validate_object_filter_helper(
             auto val = filter_exp.values[i];
             auto comparator = filter_exp.comparators.size() < filter_exp.values.size() && f.is_string() ?
                                 filter_exp.comparators[0] : filter_exp.comparators[i];
+            auto effective_comparator = filter_exp.apply_not_equals && comparator == NOT_EQUALS ? EQUALS : comparator;
 
+            fieldType filter_val;
             if (f.is_string()) {
-                if(val.at(val.size() - 1) == '*' && comparator == CONTAINS) {//prefix match
+                if(val.at(val.size() - 1) == '*' && effective_comparator == CONTAINS) {//prefix match
                     val.pop_back();
                 }
 
                 const auto& symbols = f.symbols_to_index.empty() ? index->symbols_to_index : f.symbols_to_index;
                 const auto& separators = f.token_separators.empty() ? index->token_separators : f.token_separators;
                 Tokenizer tokenizer(val, true, false, f.locale, symbols, separators, f.get_stemmer());
-                
+
                 std::string tokenized_filter_val;
                 size_t token_index = 0;
                 filter_val = tokenizer.next(tokenized_filter_val, token_index) ? tokenized_filter_val : val;
-                
-                std::string doc_str = nested_doc->get<std::string>();
-                Tokenizer doc_tokenizer(doc_str, true, false, f.locale, symbols, separators, f.get_stemmer());
-                
-                std::string tokenized_doc_val;
-                size_t doc_token_index = 0;
-                doc_val = doc_tokenizer.next(tokenized_doc_val, doc_token_index) ? tokenized_doc_val : doc_str;
             } else if (f.is_float()) {
                 filter_val = std::stof(val);
-                doc_val = nested_doc->get<float>();
             } else if (f.is_bool()) {
                 filter_val = val == "1" ? true : false;
-                doc_val = nested_doc->get<bool>();
             } else if (f.is_integer()) {
                 filter_val = std::stoll(val);
-                doc_val = nested_doc->get<int64_t>();
             }
 
-            if (comparator == EQUALS) {
-                match_found = (doc_val == filter_val);
-            } else if (comparator == NOT_EQUALS) {
-                match_found = (doc_val != filter_val);
-            } else if(comparator == CONTAINS) {
-                if(std::holds_alternative<std::string>(doc_val) && std::holds_alternative<std::string>(filter_val)) {
-                    match_found = (std::get<std::string>(doc_val).find(std::get<std::string>(filter_val)) != std::string::npos);
-                }
-            } else if (comparator == LESS_THAN) { //further comparators for only float and integers
-                if(std::holds_alternative<int64_t>(doc_val) && std::holds_alternative<int64_t>(filter_val)) {
-                    match_found = (std::get<int64_t>(doc_val) < std::get<int64_t>(filter_val));
-                } else if(std::holds_alternative<float>(doc_val) && std::holds_alternative<float>(filter_val)) {
-                    match_found = (std::get<float>(doc_val) < std::get<float>(filter_val));
-                }
-            } else if(comparator == LESS_THAN_EQUALS) {
-                if(std::holds_alternative<int64_t>(doc_val) && std::holds_alternative<int64_t>(filter_val)) {
-                    match_found = (std::get<int64_t>(doc_val) <= std::get<int64_t>(filter_val));
-                } else if(std::holds_alternative<float>(doc_val) && std::holds_alternative<float>(filter_val)) {
-                    match_found = (std::get<float>(doc_val) <= std::get<float>(filter_val));
-                }
-            } else if(comparator == GREATER_THAN) {
-                if(std::holds_alternative<int64_t>(doc_val) && std::holds_alternative<int64_t>(filter_val)) {
-                    match_found = (std::get<int64_t>(doc_val) > std::get<int64_t>(filter_val));
-                } else if(std::holds_alternative<float>(doc_val) && std::holds_alternative<float>(filter_val)) {
-                    match_found = (std::get<float>(doc_val) > std::get<float>(filter_val));
-                }
-            } else if(comparator == GREATER_THAN_EQUALS) {
-                if(std::holds_alternative<int64_t>(doc_val) && std::holds_alternative<int64_t>(filter_val)) {
-                    match_found = (std::get<int64_t>(doc_val) >= std::get<int64_t>(filter_val));
-                } else if(std::holds_alternative<float>(doc_val) && std::holds_alternative<float>(filter_val)) {
-                    match_found = (std::get<float>(doc_val) >= std::get<float>(filter_val));
-                }
-            } else if(comparator == RANGE_INCLUSIVE) {
+            if(effective_comparator == RANGE_INCLUSIVE) {
                 auto range_end = filter_exp.values[++i];
 
-                if(std::holds_alternative<int64_t>(doc_val) && std::holds_alternative<int64_t>(filter_val)) {
+                if(std::holds_alternative<int64_t>(filter_val)) {
                     auto range_end_val = std::stoll(range_end);
-                    match_found = (std::get<int64_t>(doc_val) >= std::get<int64_t>(filter_val) && std::get<int64_t>(doc_val) <= range_end_val);
-                } else if(std::holds_alternative<float>(doc_val) && std::holds_alternative<float>(filter_val)) {
+                    match_found = doc_matches_range(*nested_doc, filter_val, range_end_val);
+                } else if(std::holds_alternative<float>(filter_val)) {
                     auto range_end_val = std::stof(range_end);
-                    match_found = (std::get<float>(doc_val) >= std::get<float>(filter_val) && std::get<float>(doc_val) <= range_end_val);
+                    match_found = doc_matches_range(*nested_doc, filter_val, range_end_val);
                 }
+            } else {
+                match_found = doc_matches(*nested_doc, filter_val, effective_comparator);
             }
         }
-        return match_found;
+        return filter_exp.apply_not_equals ? !match_found : match_found;
     }
 }
 

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -4431,14 +4431,12 @@ TEST_F(CollectionFilteringTest, ArrayFieldInsideObjectFilter) {
               search_titles("offers.{score:<1.5 && minCost:<=7500}"));
     ASSERT_EQ(std::vector<std::string>({"Range Quantity Match"}),
               search_titles("offers.{quantities:[3..4] && minCost:<=7400 && maxCost:>=4900}"));
-    ASSERT_EQ(std::vector<std::string>({"Range Quantity Match", "Split Marker Match",
-                                        "Split Offer Numeric Match", "String Marker Match"}),
+    ASSERT_EQ(std::vector<std::string>({"Range Quantity Match", "Split Marker Match", "String Marker Match"}),
               search_titles("offers.{quantities:!=3 && minCost:<=7400}"));
     ASSERT_EQ(std::vector<std::string>({"No Match", "Range Quantity Match", "Same Offer Numeric Match",
-                                        "Split Marker Match", "Split Offer Numeric Match"}),
+                                        "Split Offer Numeric Match"}),
               search_titles("offers.{markers:!=priority}"));
-    ASSERT_EQ(std::vector<std::string>({"No Match", "Same Offer Numeric Match", "Split Marker Match",
-                                        "Split Offer Numeric Match", "String Marker Match"}),
+    ASSERT_EQ(std::vector<std::string>({"No Match", "Split Marker Match", "String Marker Match"}),
               search_titles("offers.{quantities:![3..4]}"));
 }
 

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -4328,16 +4328,16 @@ TEST_F(CollectionFilteringTest, DeepNestedFieldsInsideObjectFilter) {
 TEST_F(CollectionFilteringTest, ArrayFieldInsideObjectFilter) {
     auto schema_json =
             R"({
-                "name": "performance_nested_bands",
+                "name": "inventory_nested_offers",
                 "fields": [
                     {"name": "title", "type": "string"},
-                    {"name": "bands", "type": "object[]"},
-                    {"name": "bands.sizes", "type": "int32[]", "range_index": true},
-                    {"name": "bands.labels", "type": "string[]"},
-                    {"name": "bands.accessible", "type": "bool[]"},
-                    {"name": "bands.discount", "type": "float[]"},
-                    {"name": "bands.minSeatPrice", "type": "int32[]", "range_index": true},
-                    {"name": "bands.maxSeatPrice", "type": "int32[]", "range_index": true}
+                    {"name": "offers", "type": "object[]"},
+                    {"name": "offers.quantities", "type": "int32[]", "range_index": true},
+                    {"name": "offers.markers", "type": "string[]"},
+                    {"name": "offers.enabled", "type": "bool[]"},
+                    {"name": "offers.score", "type": "float[]"},
+                    {"name": "offers.minCost", "type": "int32[]", "range_index": true},
+                    {"name": "offers.maxCost", "type": "int32[]", "range_index": true}
                 ],
                 "enable_nested_fields": true
             })"_json;
@@ -4347,42 +4347,42 @@ TEST_F(CollectionFilteringTest, ArrayFieldInsideObjectFilter) {
 
     std::vector<nlohmann::json> documents = {
             R"({
-                "title": "Same Band Numeric Match",
-                "bands": [
-                    {"sizes": [1, 3], "labels": ["standard"], "accessible": [false], "discount": [2.0], "minSeatPrice": 7000, "maxSeatPrice": 4500},
-                    {"sizes": [1], "labels": ["balcony"], "accessible": [false], "discount": [5.0], "minSeatPrice": 9000, "maxSeatPrice": 12000}
+                "title": "Same Offer Numeric Match",
+                "offers": [
+                    {"quantities": [1, 3], "markers": ["standard"], "enabled": [false], "score": [2.0], "minCost": 7000, "maxCost": 4500},
+                    {"quantities": [1], "markers": ["backup"], "enabled": [false], "score": [5.0], "minCost": 9000, "maxCost": 12000}
                 ]
             })"_json,
             R"({
-                "title": "Split Band Numeric Match",
-                "bands": [
-                    {"sizes": [2, 3], "labels": ["standard"], "accessible": [false], "discount": [1.0], "minSeatPrice": 9000, "maxSeatPrice": 12000},
-                    {"sizes": [1], "labels": ["balcony"], "accessible": [false], "discount": [5.0], "minSeatPrice": 7000, "maxSeatPrice": 4500}
+                "title": "Split Offer Numeric Match",
+                "offers": [
+                    {"quantities": [2, 3], "markers": ["standard"], "enabled": [false], "score": [1.0], "minCost": 9000, "maxCost": 12000},
+                    {"quantities": [1], "markers": ["backup"], "enabled": [false], "score": [5.0], "minCost": 7000, "maxCost": 4500}
                 ]
             })"_json,
             R"({
-                "title": "String Label Match",
-                "bands": [
-                    {"sizes": [1], "labels": ["vip", "accessible"], "accessible": [true, false], "discount": [1.25], "minSeatPrice": 7200, "maxSeatPrice": 5000}
+                "title": "String Marker Match",
+                "offers": [
+                    {"quantities": [1], "markers": ["priority", "manual"], "enabled": [true, false], "score": [1.25], "minCost": 7200, "maxCost": 5000}
                 ]
             })"_json,
             R"({
-                "title": "Split Label Match",
-                "bands": [
-                    {"sizes": [1], "labels": ["vip"], "accessible": [true], "discount": [1.0], "minSeatPrice": 9000, "maxSeatPrice": 10000},
-                    {"sizes": [1], "labels": ["standard"], "accessible": [false], "discount": [5.0], "minSeatPrice": 7200, "maxSeatPrice": 5000}
+                "title": "Split Marker Match",
+                "offers": [
+                    {"quantities": [1], "markers": ["priority"], "enabled": [true], "score": [1.0], "minCost": 9000, "maxCost": 10000},
+                    {"quantities": [1], "markers": ["standard"], "enabled": [false], "score": [5.0], "minCost": 7200, "maxCost": 5000}
                 ]
             })"_json,
             R"({
-                "title": "Range Size Match",
-                "bands": [
-                    {"sizes": [4], "labels": ["standard"], "accessible": [false], "discount": [1.75], "minSeatPrice": 7300, "maxSeatPrice": 5000}
+                "title": "Range Quantity Match",
+                "offers": [
+                    {"quantities": [4], "markers": ["standard"], "enabled": [false], "score": [1.75], "minCost": 7300, "maxCost": 5000}
                 ]
             })"_json,
             R"({
                 "title": "No Match",
-                "bands": [
-                    {"sizes": [1], "labels": ["standard"], "accessible": [false], "discount": [5.0], "minSeatPrice": 9000, "maxSeatPrice": 12000}
+                "offers": [
+                    {"quantities": [1], "markers": ["standard"], "enabled": [false], "score": [5.0], "minCost": 9000, "maxCost": 12000}
                 ]
             })"_json
     };
@@ -4397,10 +4397,10 @@ TEST_F(CollectionFilteringTest, ArrayFieldInsideObjectFilter) {
 
     const auto search_titles = [&](const std::string& filter_by) {
         std::map<std::string, std::string> req_params = {
-                {"collection",     "performance_nested_bands"},
+                {"collection",     "inventory_nested_offers"},
                 {"q",              "*"},
                 {"filter_by",      filter_by},
-                {"include_fields", "title, bands"}
+                {"include_fields", "title, offers"}
         };
         nlohmann::json embedded_params;
         std::string json_res;
@@ -4421,25 +4421,25 @@ TEST_F(CollectionFilteringTest, ArrayFieldInsideObjectFilter) {
         return titles;
     };
 
-    ASSERT_EQ(std::vector<std::string>({"Same Band Numeric Match"}),
-              search_titles("bands.{sizes:>=3 && minSeatPrice:<=7100 && maxSeatPrice:>=4000}"));
-    ASSERT_EQ(std::vector<std::string>({"String Label Match"}),
-              search_titles("bands.{labels:=vip && minSeatPrice:<=7500}"));
-    ASSERT_EQ(std::vector<std::string>({"String Label Match"}),
-              search_titles("bands.{accessible:true && minSeatPrice:<=7500}"));
-    ASSERT_EQ(std::vector<std::string>({"String Label Match"}),
-              search_titles("bands.{discount:<1.5 && minSeatPrice:<=7500}"));
-    ASSERT_EQ(std::vector<std::string>({"Range Size Match"}),
-              search_titles("bands.{sizes:[3..4] && minSeatPrice:<=7400 && maxSeatPrice:>=4900}"));
-    ASSERT_EQ(std::vector<std::string>({"Range Size Match", "Split Band Numeric Match",
-                                        "Split Label Match", "String Label Match"}),
-              search_titles("bands.{sizes:!=3 && minSeatPrice:<=7400}"));
-    ASSERT_EQ(std::vector<std::string>({"No Match", "Range Size Match", "Same Band Numeric Match",
-                                        "Split Band Numeric Match", "Split Label Match"}),
-              search_titles("bands.{labels:!=vip}"));
-    ASSERT_EQ(std::vector<std::string>({"No Match", "Same Band Numeric Match", "Split Band Numeric Match",
-                                        "Split Label Match", "String Label Match"}),
-              search_titles("bands.{sizes:![3..4]}"));
+    ASSERT_EQ(std::vector<std::string>({"Same Offer Numeric Match"}),
+              search_titles("offers.{quantities:>=3 && minCost:<=7100 && maxCost:>=4000}"));
+    ASSERT_EQ(std::vector<std::string>({"String Marker Match"}),
+              search_titles("offers.{markers:=priority && minCost:<=7500}"));
+    ASSERT_EQ(std::vector<std::string>({"String Marker Match"}),
+              search_titles("offers.{enabled:true && minCost:<=7500}"));
+    ASSERT_EQ(std::vector<std::string>({"String Marker Match"}),
+              search_titles("offers.{score:<1.5 && minCost:<=7500}"));
+    ASSERT_EQ(std::vector<std::string>({"Range Quantity Match"}),
+              search_titles("offers.{quantities:[3..4] && minCost:<=7400 && maxCost:>=4900}"));
+    ASSERT_EQ(std::vector<std::string>({"Range Quantity Match", "Split Marker Match",
+                                        "Split Offer Numeric Match", "String Marker Match"}),
+              search_titles("offers.{quantities:!=3 && minCost:<=7400}"));
+    ASSERT_EQ(std::vector<std::string>({"No Match", "Range Quantity Match", "Same Offer Numeric Match",
+                                        "Split Marker Match", "Split Offer Numeric Match"}),
+              search_titles("offers.{markers:!=priority}"));
+    ASSERT_EQ(std::vector<std::string>({"No Match", "Same Offer Numeric Match", "Split Marker Match",
+                                        "Split Offer Numeric Match", "String Marker Match"}),
+              search_titles("offers.{quantities:![3..4]}"));
 }
 
 TEST_F(CollectionFilteringTest, MissingFilterSchemaValidation) {

--- a/test/collection_filtering_test.cpp
+++ b/test/collection_filtering_test.cpp
@@ -4325,6 +4325,123 @@ TEST_F(CollectionFilteringTest, DeepNestedFieldsInsideObjectFilter) {
     ASSERT_EQ("Same Object Match", result["hits"][0]["document"]["title"]);
 }
 
+TEST_F(CollectionFilteringTest, ArrayFieldInsideObjectFilter) {
+    auto schema_json =
+            R"({
+                "name": "performance_nested_bands",
+                "fields": [
+                    {"name": "title", "type": "string"},
+                    {"name": "bands", "type": "object[]"},
+                    {"name": "bands.sizes", "type": "int32[]", "range_index": true},
+                    {"name": "bands.labels", "type": "string[]"},
+                    {"name": "bands.accessible", "type": "bool[]"},
+                    {"name": "bands.discount", "type": "float[]"},
+                    {"name": "bands.minSeatPrice", "type": "int32[]", "range_index": true},
+                    {"name": "bands.maxSeatPrice", "type": "int32[]", "range_index": true}
+                ],
+                "enable_nested_fields": true
+            })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+
+    std::vector<nlohmann::json> documents = {
+            R"({
+                "title": "Same Band Numeric Match",
+                "bands": [
+                    {"sizes": [1, 3], "labels": ["standard"], "accessible": [false], "discount": [2.0], "minSeatPrice": 7000, "maxSeatPrice": 4500},
+                    {"sizes": [1], "labels": ["balcony"], "accessible": [false], "discount": [5.0], "minSeatPrice": 9000, "maxSeatPrice": 12000}
+                ]
+            })"_json,
+            R"({
+                "title": "Split Band Numeric Match",
+                "bands": [
+                    {"sizes": [2, 3], "labels": ["standard"], "accessible": [false], "discount": [1.0], "minSeatPrice": 9000, "maxSeatPrice": 12000},
+                    {"sizes": [1], "labels": ["balcony"], "accessible": [false], "discount": [5.0], "minSeatPrice": 7000, "maxSeatPrice": 4500}
+                ]
+            })"_json,
+            R"({
+                "title": "String Label Match",
+                "bands": [
+                    {"sizes": [1], "labels": ["vip", "accessible"], "accessible": [true, false], "discount": [1.25], "minSeatPrice": 7200, "maxSeatPrice": 5000}
+                ]
+            })"_json,
+            R"({
+                "title": "Split Label Match",
+                "bands": [
+                    {"sizes": [1], "labels": ["vip"], "accessible": [true], "discount": [1.0], "minSeatPrice": 9000, "maxSeatPrice": 10000},
+                    {"sizes": [1], "labels": ["standard"], "accessible": [false], "discount": [5.0], "minSeatPrice": 7200, "maxSeatPrice": 5000}
+                ]
+            })"_json,
+            R"({
+                "title": "Range Size Match",
+                "bands": [
+                    {"sizes": [4], "labels": ["standard"], "accessible": [false], "discount": [1.75], "minSeatPrice": 7300, "maxSeatPrice": 5000}
+                ]
+            })"_json,
+            R"({
+                "title": "No Match",
+                "bands": [
+                    {"sizes": [1], "labels": ["standard"], "accessible": [false], "discount": [5.0], "minSeatPrice": 9000, "maxSeatPrice": 12000}
+                ]
+            })"_json
+    };
+
+    for (auto const& json: documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    const auto search_titles = [&](const std::string& filter_by) {
+        std::map<std::string, std::string> req_params = {
+                {"collection",     "performance_nested_bands"},
+                {"q",              "*"},
+                {"filter_by",      filter_by},
+                {"include_fields", "title, bands"}
+        };
+        nlohmann::json embedded_params;
+        std::string json_res;
+        auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+
+        auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+        EXPECT_TRUE(search_op.ok()) << search_op.error();
+
+        std::vector<std::string> titles;
+        if (search_op.ok()) {
+            auto result = nlohmann::json::parse(json_res);
+            for (const auto& hit: result["hits"]) {
+                titles.push_back(hit["document"]["title"].get<std::string>());
+            }
+        }
+        std::sort(titles.begin(), titles.end());
+        return titles;
+    };
+
+    ASSERT_EQ(std::vector<std::string>({"Same Band Numeric Match"}),
+              search_titles("bands.{sizes:>=3 && minSeatPrice:<=7100 && maxSeatPrice:>=4000}"));
+    ASSERT_EQ(std::vector<std::string>({"String Label Match"}),
+              search_titles("bands.{labels:=vip && minSeatPrice:<=7500}"));
+    ASSERT_EQ(std::vector<std::string>({"String Label Match"}),
+              search_titles("bands.{accessible:true && minSeatPrice:<=7500}"));
+    ASSERT_EQ(std::vector<std::string>({"String Label Match"}),
+              search_titles("bands.{discount:<1.5 && minSeatPrice:<=7500}"));
+    ASSERT_EQ(std::vector<std::string>({"Range Size Match"}),
+              search_titles("bands.{sizes:[3..4] && minSeatPrice:<=7400 && maxSeatPrice:>=4900}"));
+    ASSERT_EQ(std::vector<std::string>({"Range Size Match", "Split Band Numeric Match",
+                                        "Split Label Match", "String Label Match"}),
+              search_titles("bands.{sizes:!=3 && minSeatPrice:<=7400}"));
+    ASSERT_EQ(std::vector<std::string>({"No Match", "Range Size Match", "Same Band Numeric Match",
+                                        "Split Band Numeric Match", "Split Label Match"}),
+              search_titles("bands.{labels:!=vip}"));
+    ASSERT_EQ(std::vector<std::string>({"No Match", "Same Band Numeric Match", "Split Band Numeric Match",
+                                        "Split Label Match", "String Label Match"}),
+              search_titles("bands.{sizes:![3..4]}"));
+}
+
 TEST_F(CollectionFilteringTest, MissingFilterSchemaValidation) {
     // track_missing_values on non-optional field should fail
     auto schema = R"({


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
Fixes same-object filters where a nested object contains array fields.

Example shape:

```text
bands.{sizes:>=2 && minSeatPrice:<=7500}
```

This now treats array fields inside the same nested object correctly and avoids false matches where each condition is satisfied by a different nested object.

Covered:

- numeric, string, boolean, and float array fields
- range and negated filters
- high-load API timeout regression

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
