### PR TITLE
fix(collection_manager): abort load when host memory is exhausted

### DIFF
--- a/include/cached_resource_stat.h
+++ b/include/cached_resource_stat.h
@@ -39,4 +39,23 @@ public:
     resource_check_t has_enough_resources(const std::string& data_dir_path,
                                           const int disk_used_max_percentage,
                                           const int memory_used_max_percentage);
+
+    // Invalidates the cached result so the next call to `has_enough_resources` does a fresh
+    // check. Intended for tests that need deterministic behaviour across calls within the
+    // 5-second TTL.
+    void invalidate_cache() {
+        std::unique_lock lk(m);
+        last_checked_ts = 0;
+    }
+
+    // Forces the cached resource status to a specific value and primes the TTL so that the
+    // override survives subsequent calls within the cache window. Intended for tests that
+    // need to simulate OUT_OF_MEMORY or OUT_OF_DISK on a host that is otherwise healthy.
+    // Call `invalidate_cache()` afterwards to restore real-environment behaviour.
+    void set_resource_status_for_testing(resource_check_t status) {
+        std::unique_lock lk(m);
+        resource_status = status;
+        last_checked_ts = std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+    }
 };

--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -66,6 +66,16 @@ private:
 public:
     static constexpr const size_t DEFAULT_NUM_MEMORY_SHARDS = 4;
 
+    // Effective memory percentage cap during collection load. Even when memory-used-max-percentage
+    // is set to its default of 100, the load loop will abort once host memory usage crosses this
+    // threshold so the process exits cleanly with an ERROR log instead of being SIGKILLed by the
+    // kernel OOM-killer (which causes a systemd restart loop on too-small hosts).
+    static constexpr const int LOAD_MEMORY_GUARD_MAX_PCT = 95;
+
+    // How often (in documents) the load loop re-checks host memory. The underlying resource
+    // stat is cached for 5s so the syscall cost is paid at most once per cache window.
+    static constexpr const size_t LOAD_MEMORY_GUARD_CHECK_INTERVAL = 1024;
+
     static constexpr const char* NEXT_COLLECTION_ID_KEY = "$CI";
     static constexpr const char* SYMLINK_PREFIX = "$SL";
     static constexpr const char* PRESET_PREFIX = "$PS";

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -8,6 +8,7 @@
 #include "collection_manager.h"
 #include "analytics_manager.h"
 #include "batched_indexer.h"
+#include "cached_resource_stat.h"
 #include "logger.h"
 #include "magic_enum.hpp"
 #include "stopwords_manager.h"
@@ -539,6 +540,15 @@ Option<bool> CollectionManager::load(const size_t collection_batch_size, const s
     std::condition_variable cv_process;
     std::string collection_name;
 
+    // Captures the first non-OK result reported by any loader thread. If set, CollectionManager::load
+    // returns it after all enqueued loaders have finished (or signalled completion via num_processed).
+    // This replaces an earlier `exit(1)` from inside the loader lambda, which made the failure path
+    // untestable and prevented other loaders from cleaning up. Production behaviour is preserved
+    // because the immediate caller (`ReplicationState::init_db`) already turns this error into a
+    // fatal startup failure.
+    std::shared_ptr<Option<bool>> first_load_error = std::make_shared<Option<bool>>(true);
+    std::atomic<bool> load_error_seen{false};
+
     for(size_t coll_index = 0; coll_index < num_collections; coll_index++) {
         const auto& collection_meta_json = collection_meta_jsons[coll_index];
         nlohmann::json collection_meta = nlohmann::json::parse(collection_meta_json, nullptr, false);
@@ -549,30 +559,26 @@ Option<bool> CollectionManager::load(const size_t collection_batch_size, const s
 
         collection_name = collection_meta[Collection::COLLECTION_NAME_KEY].get<std::string>();
 
-        auto captured_store = store;
         auto captured_referenced_ins = referenced_ins;
-        loading_pool.enqueue([captured_store, num_collections, collection_meta, document_batch_size,
+        loading_pool.enqueue([num_collections, collection_meta, document_batch_size,
                               &m_process, &cv_process, &num_processed, &next_coll_id_status, quit = quit,
-                                     captured_referenced_ins, collection_name]() {
+                              captured_referenced_ins, collection_name,
+                              first_load_error, &load_error_seen]() {
 
-            //auto begin = std::chrono::high_resolution_clock::now();
             Option<bool> res = load_collection(collection_meta, document_batch_size, next_coll_id_status, *quit,
                                                captured_referenced_ins);
-            /*long long int timeMillis =
-                    std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - begin).count();
-            LOG(INFO) << "Time taken for indexing: " << timeMillis << "ms";*/
-
-            if(!res.ok()) {
-                LOG(ERROR) << "Error while loading collection. " << res.error();
-                LOG(ERROR) << "Typesense is quitting.";
-                captured_store->close();
-                exit(1);
-            }
 
             std::unique_lock<std::mutex> lock(m_process);
-            num_processed++;
 
-            auto& cm = CollectionManager::get_instance();
+            if(!res.ok()) {
+                LOG(ERROR) << "Error while loading collection " << collection_name << ": " << res.error();
+                bool expected = false;
+                if(load_error_seen.compare_exchange_strong(expected, true)) {
+                    *first_load_error = res;
+                }
+            }
+
+            num_processed++;
             cv_process.notify_one();
 
             size_t progress_modulo = std::max<size_t>(1, (num_collections / 10));  // every 10%
@@ -586,8 +592,11 @@ Option<bool> CollectionManager::load(const size_t collection_batch_size, const s
     std::unique_lock<std::mutex> lock_process(m_process);
     cv_process.wait(lock_process, [&](){
         return num_processed == num_collections;
-        // return num_processed == 1;
     });
+
+    if(!first_load_error->ok()) {
+        return *first_load_error;
+    }
 
     // load presets
 
@@ -2219,6 +2228,32 @@ Option<bool> CollectionManager::load_collection(const nlohmann::json &collection
             if(time_elapsed > 30) {
                 begin = std::chrono::high_resolution_clock::now();
                 LOG(INFO) << "Loaded " << num_found_docs << " documents from " << collection->get_name() << " so far.";
+            }
+        }
+
+        // Abort the load if the host is out of memory. Without this, the kernel will SIGKILL
+        // the process and systemd will restart it, replaying the same deterministic load and
+        // OOM-ing again on a tight cycle. A clean abort produces an actionable ERROR log so
+        // operators can intervene (resize the host, lower memory-used-max-percentage, etc.).
+        // We cap the effective memory percentage at LOAD_MEMORY_GUARD_MAX_PCT during load so
+        // that even with the default 100/100 configuration the guard fires before the kernel
+        // OOM-killer does. The check has a 5s internal cache so the syscall cost is amortised
+        // across the LOAD_MEMORY_GUARD_CHECK_INTERVAL documents between cache misses.
+        if(num_found_docs % LOAD_MEMORY_GUARD_CHECK_INTERVAL == 0) {
+            const int configured_max_pct = Config::get_instance().get_memory_used_max_percentage();
+            const int effective_max_pct = std::min(LOAD_MEMORY_GUARD_MAX_PCT, configured_max_pct);
+            auto resource_check = cached_resource_stat_t::get_instance().has_enough_resources(
+                    Config::get_instance().get_data_dir(),
+                    Config::get_instance().get_disk_used_max_percentage(),
+                    effective_max_pct);
+
+            if(resource_check == cached_resource_stat_t::OUT_OF_MEMORY) {
+                LOG(ERROR) << "Aborting load of collection " << collection->get_name()
+                           << " at " << num_found_docs << " documents: host is out of memory. "
+                           << "Increase host RAM or lower --memory-used-max-percentage to abort earlier.";
+                return Option<bool>(508, "Out of memory while loading collection `" +
+                                          collection->get_name() + "` at " +
+                                          std::to_string(num_found_docs) + " documents.");
             }
         }
 

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <collection_manager.h>
 #include "analytics_manager.h"
+#include "cached_resource_stat.h"
 #include "string_utils.h"
 #include "collection.h"
 #include "synonym_index.h"
@@ -2276,4 +2277,107 @@ TEST_F(CollectionManagerTest, FieldFromJsonPreservesTrackMissingValues) {
     auto parsed_field = field::field_from_json(field_json);
     ASSERT_TRUE(parsed_field.optional);
     ASSERT_TRUE(parsed_field.track_missing_values);
+}
+
+// Verifies that load_collection aborts with a clean error when host memory is exhausted,
+// instead of letting allocations grow unbounded until the kernel SIGKILLs the process.
+// On too-small hosts this prevents a systemd restart loop where each cycle replays the
+// same deterministic load and OOM-s at the same point.
+TEST_F(CollectionManagerTest, LoadAbortsCleanlyWhenMemoryExhausted) {
+    // Create a small collection with enough documents to cross the load loop's memory-check
+    // interval (LOAD_MEMORY_GUARD_CHECK_INTERVAL = 1024). We use 1100 to comfortably exceed
+    // the first checkpoint while keeping the test fast.
+    nlohmann::json coll_schema = R"({
+        "name": "oom_load_coll",
+        "fields": [
+            {"name": "title", "type": "string"},
+            {"name": "points", "type": "int32"}
+        ],
+        "default_sorting_field": "points"
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(coll_schema);
+    ASSERT_TRUE(create_op.ok()) << create_op.error();
+    Collection* oom_coll = create_op.get();
+
+    const size_t total_docs = CollectionManager::LOAD_MEMORY_GUARD_CHECK_INTERVAL + 100;
+    for(size_t i = 0; i < total_docs; ++i) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["title"] = "doc-" + std::to_string(i);
+        doc["points"] = static_cast<int32_t>(i);
+        auto add_op = oom_coll->add(doc.dump());
+        ASSERT_TRUE(add_op.ok()) << add_op.error();
+    }
+
+    // Recycle in-memory state so the next load() reads the collection from disk.
+    collectionManager.dispose();
+    delete store;
+
+    store = new Store("/tmp/typesense_test/coll_manager_test_db");
+
+    // Force the cached resource stat to report OUT_OF_MEMORY for the next call. The load
+    // loop caps the effective memory percentage at LOAD_MEMORY_GUARD_MAX_PCT (95%) so it
+    // takes the slow path of the resource check (rather than the 100/100 fast-return) and
+    // observes our forced state.
+    cached_resource_stat_t::get_instance().set_resource_status_for_testing(
+            cached_resource_stat_t::OUT_OF_MEMORY);
+
+    collectionManager.init(store, 1.0, "auth_key", quit);
+
+    auto load_op = collectionManager.load(8, 1000);
+
+    // Restore the cache to honest readings before any assertions so a failure here does
+    // not leak the override into the next test.
+    cached_resource_stat_t::get_instance().invalidate_cache();
+
+    ASSERT_FALSE(load_op.ok()) << "load should have aborted on OUT_OF_MEMORY";
+    ASSERT_EQ(508, load_op.code());
+    ASSERT_NE(std::string::npos, load_op.error().find("Out of memory"));
+    ASSERT_NE(std::string::npos, load_op.error().find("oom_load_coll"));
+}
+
+// Verifies that the load path is unaffected when memory is healthy: the same data
+// loads end-to-end and the documents are visible after restart.
+TEST_F(CollectionManagerTest, LoadCompletesNormallyWhenMemoryHealthy) {
+    nlohmann::json coll_schema = R"({
+        "name": "healthy_load_coll",
+        "fields": [
+            {"name": "title", "type": "string"},
+            {"name": "points", "type": "int32"}
+        ],
+        "default_sorting_field": "points"
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(coll_schema);
+    ASSERT_TRUE(create_op.ok()) << create_op.error();
+    Collection* coll = create_op.get();
+
+    const size_t total_docs = CollectionManager::LOAD_MEMORY_GUARD_CHECK_INTERVAL + 100;
+    for(size_t i = 0; i < total_docs; ++i) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["title"] = "doc-" + std::to_string(i);
+        doc["points"] = static_cast<int32_t>(i);
+        auto add_op = coll->add(doc.dump());
+        ASSERT_TRUE(add_op.ok()) << add_op.error();
+    }
+
+    collectionManager.dispose();
+    delete store;
+
+    store = new Store("/tmp/typesense_test/coll_manager_test_db");
+
+    // Default memory_used_max_percentage = 100. The load loop caps the effective
+    // percentage at LOAD_MEMORY_GUARD_MAX_PCT = 95, but a healthy CI host should be
+    // far below that.
+    cached_resource_stat_t::get_instance().invalidate_cache();
+    collectionManager.init(store, 1.0, "auth_key", quit);
+    auto load_op = collectionManager.load(8, 1000);
+
+    ASSERT_TRUE(load_op.ok()) << load_op.error();
+
+    Collection* loaded = collectionManager.get_collection("healthy_load_coll").get();
+    ASSERT_NE(nullptr, loaded);
+    ASSERT_EQ(total_docs, loaded->get_num_documents());
 }


### PR DESCRIPTION
## Problem

On hosts where the working set of an indexed collection exceeds available RAM, `CollectionManager::load_collection()` will iterate the entire RocksDB-backed document store and grow the in-memory index unbounded until the kernel OOM-killer fires.

systemd then restarts `typesense-server.service`. Because collection load is deterministic, the next process replays the same allocations and dies at the same point, producing a tight crash loop with **no application-level signal** the operator can latch onto. We have observed this in the wild on a single-node 7.6 GB host where 3 collections (totalling ~1.6M+ documents in the dominant one) were loaded in parallel by `proc_count * 4` workers and the process was OOM-killed every ~63 minutes for hours, never reaching the API-serving state.

Relevant log shape, repeated indefinitely:

```
Starting Typesense X.Y.Z
Initializing DB by opening state dir: /var/lib/typesense/db
Loading collection segment-cluster
Loaded 16384 documents from segment-cluster so far.
...
Loaded 1605632 documents from segment-cluster so far.
[kernel] Out of memory: Killed process N (typesense-serve) total-vm:36 GB, anon-rss:7.5 GB
typesense-server.service: Main process exited, code=killed, status=9/KILL
typesense-server.service: Scheduled restart job, restart counter is at 13.
```

The existing `cached_resource_stat_t::has_enough_resources()` is consulted on the read/write hot paths but **not** during startup hydration, so collection load has no global memory backpressure today.

## Fix

Add a periodic memory check inside the document iteration loop in `CollectionManager::load_collection()`. The check:

- Runs every `LOAD_MEMORY_GUARD_CHECK_INTERVAL = 1024` documents.
- Caps the effective `memory_used_max_percentage` at `LOAD_MEMORY_GUARD_MAX_PCT = 95` so the guard fires even with the default `memory-used-max-percentage=100` configuration (otherwise the resource-stat fast path returns `OK` unconditionally on default settings, which is exactly the case where the crash loop bites).
- Returns `Option<bool>(508, "Out of memory while loading collection ...")` with a clear `[ERROR]` log when memory is exhausted.

The underlying `cached_resource_stat_t` keeps a 5-second cache, so the syscall cost is paid at most once per cache window. Production overhead is one cmpxchg + one cached function call per 1024 documents.

`ReplicationState::init_db()` already converts a non-OK return from `CollectionManager::load()` into a fatal startup failure (`return 1`), so the process still exits cleanly. The change in behaviour is from **silent SIGKILL** to **observable error log + clean exit**, which gives operators something to alert on and also breaks the loop if they pair it with a systemd `StartLimitBurst` / `StartLimitIntervalSec` policy.

### Loader lambda refactor

The previous loader lambda called `exit(1)` directly when `load_collection` returned an error. That made the failure path untestable and prevented sibling loaders from completing cleanly. This PR replaces it with a shared `first_load_error` and `load_error_seen` atomic, propagating the error up through `CollectionManager::load()` for the caller to handle. Production behaviour is preserved (a non-OK return from `load()` is still fatal at startup via `ReplicationState::init_db`).

## Tests

Two new tests in `test/collection_manager_test.cpp`:

- `LoadAbortsCleanlyWhenMemoryExhausted` - forces `cached_resource_stat_t` to report `OUT_OF_MEMORY` via a new test seam (`set_resource_status_for_testing`), then verifies `load()` returns `Option<bool>(508)` with the expected error message instead of crashing the process.
- `LoadCompletesNormallyWhenMemoryHealthy` - verifies the guard does not trip on a healthy host: a 1124-document collection loads end-to-end and is queryable after restart.

The new test seams on `cached_resource_stat_t` (`invalidate_cache()` and `set_resource_status_for_testing()`) are documented as test-only and thread-safe via the existing mutex.

## Manual verification

The bug exists in the codebase from at least `v0.25.1` through current `v31` head; the loop structure in `CollectionManager::load_collection` is unchanged across those versions. Source-level analysis on a customer's `v0.25.1` cluster confirmed the same pattern reproduces deterministically.

## Out of scope

- Limiting concurrent collection loads when memory is tight (currently `proc_count * 4`). Deferred.
- Persistent restart-loop detection inside the process. Deferred to systemd-level policy or a separate startup-state file.