### PR TITLE
Updated so RAG/conversations with Azure APIs don't timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ typesense-data
 /dist
 /tmp
 *.tar.gz
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ typesense-data
 /dist
 /tmp
 *.tar.gz
-.vscode

--- a/src/conversation_model.cpp
+++ b/src/conversation_model.cpp
@@ -2067,7 +2067,7 @@ Option<std::string> AzureConversationModel::get_answer(const std::string& contex
     headers["api-key"] = api_key;
     headers["Content-Type"] = "application/json";
 
-    long status_code = HttpClient::post_response(url, request_body.dump(), response, res_headers, headers);
+    long status_code = HttpClient::post_response(url, request_body.dump(), response, res_headers, headers, HttpProxy::default_timeout_ms);
 
     if (status_code != 200) {
         return Option<std::string>(status_code, "Failed to get response from Azure API: " + response);


### PR DESCRIPTION
Updated so RAG/conversations with Azure APIs don't timeout after 4 seconds but instead timeout after 60 seconds like the other providers.

## Change Summary
Updated AzureConversationModel::get_answer to use HttpProxy::default_timeout_ms instead of leaving blank which defaults it to 4 seconds (vs 60 seconds).  This makes the Azure model/get answer in line with the other providers that use the HttpProxy::default_timeout_ms value that is 60s.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
