### PR TITLE
fix: make split/join and drop-tokens paths group-aware #2828

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -2805,7 +2805,29 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
 
         for(size_t i = 1; i < weighted_search_fields.size(); i++) {
             field_query_tokens.emplace_back(query_tokens_t{});
-            field_query_tokens[i] = field_query_tokens[0];
+            auto search_field_i = search_schema.at(weighted_search_fields[i].name);
+            std::vector<std::string> field_q_include_tokens;
+            std::vector<std::string> field_q_unstemmed_tokens;
+
+            parse_search_query(query, field_q_include_tokens, field_q_unstemmed_tokens,
+                               field_query_tokens[i].q_exclude_tokens,
+                               field_query_tokens[i].q_phrases,
+                               search_field_i.locale, pre_segmented_query, stopwords_set,
+                               search_field_i.get_stemmer(),
+                               search_field_i.symbols_to_index,
+                               search_field_i.token_separators);
+
+            for(size_t j = 0; j < field_q_include_tokens.size(); j++) {
+                auto& token = field_q_include_tokens[j];
+                field_query_tokens[i].q_include_tokens.emplace_back(
+                    j, token, (j == field_q_include_tokens.size() - 1), token.size(), 0);
+            }
+
+            for(size_t j = 0; j < field_q_unstemmed_tokens.size(); j++) {
+                auto& token = field_q_unstemmed_tokens[j];
+                field_query_tokens[i].q_unstemmed_tokens.emplace_back(
+                    j, token, (j == field_q_include_tokens.size() - 1), token.size(), 0);
+            }
         }
     }
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -4038,24 +4038,76 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
             }
         }
 
-        auto fuzzy_search_fields_op = fuzzy_search_fields(the_fields, field_query_tokens[0].q_include_tokens, {}, match_type,
-                                                          excluded_result_ids, excluded_result_ids_size,
-                                                          filter_result_iterator, curated_ids_sorted,
-                                                          sort_fields_std, num_typos,
-                                                          searched_query_tokens,
-                                                          qtoken_set, topster, groups_processed,
-                                                          all_result_ids, all_result_ids_len,
-                                                          group_limit, group_by_fields, group_missing_values, prioritize_exact_match,
-                                                          prioritize_token_position, prioritize_num_matching_fields,
-                                                          query_hashes, token_order, prefixes,
-                                                          typo_tokens_threshold, exhaustive_search,
-                                                          max_candidates, min_len_1typo, min_len_2typo,
-                                                          syn_orig_num_tokens, field_query_tokens[0].q_include_tokens.size(), false, demote_synonym_match,sort_order, field_values, geopoint_indices,
-                                                          is_group_by_first_pass, group_by_missing_value_ids,
-                                                          enable_typos_for_numerical_tokens,
-                                                          enable_typos_for_alpha_numerical_tokens);
-        if (!fuzzy_search_fields_op.ok()) {
-            return fuzzy_search_fields_op;
+        // Group fields by their tokenized query so that fields sharing the same token set are
+        // searched together (preserving cross-field matching), while fields with different
+        // tokenization (due to per-field symbols_to_index / token_separators) form their own group.
+        auto tokens_equal_fn = [](const std::vector<token_t>& a, const std::vector<token_t>& b) {
+            if(a.size() != b.size()) return false;
+            for(size_t j = 0; j < a.size(); j++) {
+                if(a[j].value != b[j].value) return false;
+            }
+            return true;
+        };
+
+        struct field_group_t {
+            size_t token_field_idx;  // which field_query_tokens entry to use
+            std::vector<search_field_t> fields;
+            std::vector<uint32_t> num_typos;
+            std::vector<bool> prefixes;
+        };
+        std::vector<field_group_t> field_groups;
+
+        for(size_t i = 0; i < num_search_fields; i++) {
+            bool placed = false;
+            for(auto& grp : field_groups) {
+                if(tokens_equal_fn(field_query_tokens[i].q_include_tokens,
+                                   field_query_tokens[grp.token_field_idx].q_include_tokens)) {
+                    grp.fields.push_back(the_fields[i]);
+                    grp.num_typos.push_back(num_typos[i]);
+                    grp.prefixes.push_back(prefixes[i]);
+                    placed = true;
+                    break;
+                }
+            }
+            if(!placed) {
+                field_groups.push_back({i, {the_fields[i]}, {num_typos[i]}, {prefixes[i]}});
+            }
+        }
+
+        // Build per-group all_queries for the drop-tokens path.
+        // Group 0 already has its queries (including synonyms) in all_queries.
+        // Other groups use their own primary token set (no synonym expansion for non-first groups).
+        std::vector<std::vector<std::vector<token_t>>> group_all_queries(field_groups.size());
+        group_all_queries[0] = all_queries;
+        for(size_t gi = 1; gi < field_groups.size(); gi++) {
+            const auto& grp_tokens = field_query_tokens[field_groups[gi].token_field_idx];
+            const auto& base_tokens = grp_tokens.q_unstemmed_tokens.empty() ?
+                                      grp_tokens.q_include_tokens : grp_tokens.q_unstemmed_tokens;
+            group_all_queries[gi] = {base_tokens};
+        }
+
+        Option<bool> fuzzy_search_fields_op(true);
+        for(auto& grp : field_groups) {
+            const auto& gtokens = field_query_tokens[grp.token_field_idx].q_include_tokens;
+            fuzzy_search_fields_op = fuzzy_search_fields(grp.fields, gtokens, {}, match_type,
+                                                         excluded_result_ids, excluded_result_ids_size,
+                                                         filter_result_iterator, curated_ids_sorted,
+                                                         sort_fields_std, grp.num_typos,
+                                                         searched_query_tokens,
+                                                         qtoken_set, topster, groups_processed,
+                                                         all_result_ids, all_result_ids_len,
+                                                         group_limit, group_by_fields, group_missing_values, prioritize_exact_match,
+                                                         prioritize_token_position, prioritize_num_matching_fields,
+                                                         query_hashes, token_order, grp.prefixes,
+                                                         typo_tokens_threshold, exhaustive_search,
+                                                         max_candidates, min_len_1typo, min_len_2typo,
+                                                         syn_orig_num_tokens, gtokens.size(), false, demote_synonym_match, sort_order, field_values, geopoint_indices,
+                                                         is_group_by_first_pass, group_by_missing_value_ids,
+                                                         enable_typos_for_numerical_tokens,
+                                                         enable_typos_for_alpha_numerical_tokens);
+            if(!fuzzy_search_fields_op.ok()) {
+                return fuzzy_search_fields_op;
+            }
         }
 
         // try split/joining tokens if no results are found
@@ -4089,21 +4141,25 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                                                  space_resolved_queries[0][j].size(), 0);
                 }
 
-                auto fuzzy_search_fields_op = fuzzy_search_fields(the_fields, resolved_tokens, {}, match_type, excluded_result_ids,
-                                                                  excluded_result_ids_size, filter_result_iterator, curated_ids_sorted,
-                                                                  sort_fields_std, num_typos, searched_query_tokens,
-                                                                  qtoken_set, topster, groups_processed,
-                                                                  all_result_ids, all_result_ids_len,
-                                                                  group_limit, group_by_fields, group_missing_values, 
-                                                                  prioritize_exact_match, prioritize_token_position, 
-                                                                  prioritize_num_matching_fields, 
-                                                                  query_hashes, token_order,
-                                                                  prefixes, typo_tokens_threshold, exhaustive_search,
-                                                                  max_candidates, min_len_1typo, min_len_2typo,
-                                                                  syn_orig_num_tokens, resolved_tokens.size(), false, demote_synonym_match, sort_order, field_values, geopoint_indices,
-                                                                  is_group_by_first_pass, group_by_missing_value_ids);
-                if (!fuzzy_search_fields_op.ok()) {
-                    return fuzzy_search_fields_op;
+                for(auto& grp : field_groups) {
+                    fuzzy_search_fields_op = fuzzy_search_fields(grp.fields, resolved_tokens, {}, match_type,
+                                                                 excluded_result_ids, excluded_result_ids_size,
+                                                                 filter_result_iterator, curated_ids_sorted,
+                                                                 sort_fields_std, grp.num_typos, searched_query_tokens,
+                                                                 qtoken_set, topster, groups_processed,
+                                                                 all_result_ids, all_result_ids_len,
+                                                                 group_limit, group_by_fields, group_missing_values,
+                                                                 prioritize_exact_match, prioritize_token_position,
+                                                                 prioritize_num_matching_fields,
+                                                                 query_hashes, token_order,
+                                                                 grp.prefixes, typo_tokens_threshold, exhaustive_search,
+                                                                 max_candidates, min_len_1typo, min_len_2typo,
+                                                                 syn_orig_num_tokens, resolved_tokens.size(), false, demote_synonym_match,
+                                                                 sort_order, field_values, geopoint_indices,
+                                                                 is_group_by_first_pass, group_by_missing_value_ids);
+                    if(!fuzzy_search_fields_op.ok()) {
+                        return fuzzy_search_fields_op;
+                    }
                 }
             }
         }
@@ -4132,97 +4188,104 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
         // gather up both original query and synonym queries and do drop tokens
 
         if (exhaustive_search || all_result_ids_len < drop_tokens_threshold) {
-            for (size_t qi = 0; qi < all_queries.size(); qi++) {
-                auto& orig_tokens = all_queries[qi];
-                size_t num_tokens_dropped = 0;
-                size_t total_dirs_done = 0;
+            for (size_t gi = 0; gi < field_groups.size(); gi++) {
+                auto& grp = field_groups[gi];
+                auto grp_search_field_it = search_schema.find(the_fields[grp.token_field_idx].name);
+                const bool grp_do_stemming = (grp_search_field_it != search_schema.end()) && grp_search_field_it->stem;
 
-                // NOTE: when dropping both sides we will ignore exhaustive search
+                for (size_t qi = 0; qi < group_all_queries[gi].size(); qi++) {
+                    auto& orig_tokens = group_all_queries[gi][qi];
+                    size_t num_tokens_dropped = 0;
+                    size_t total_dirs_done = 0;
 
-                auto curr_direction = drop_tokens_mode.mode;
-                bool drop_both_sides = false;
-                size_t orig_tokens_size = std::min<size_t>(orig_tokens.size(), 20);  // drop only upto N tokens
+                    // NOTE: when dropping both sides we will ignore exhaustive search
 
-                if(drop_tokens_mode.mode == both_sides) {
-                    if(orig_tokens_size <= drop_tokens_mode.token_limit) {
-                        drop_both_sides = true;
-                    } else {
-                        curr_direction = right_to_left;
-                    }
-                }
+                    auto curr_direction = drop_tokens_mode.mode;
+                    bool drop_both_sides = false;
+                    size_t orig_tokens_size = std::min<size_t>(orig_tokens.size(), 20);  // drop only upto N tokens
 
-                while(exhaustive_search || all_result_ids_len < drop_tokens_threshold || drop_both_sides) {
-                    // When atleast two tokens from the query are available we can drop one
-                    std::vector<token_t> truncated_tokens;
-                    std::vector<token_t> dropped_tokens;
-
-                    if(num_tokens_dropped >= orig_tokens_size - 1) {
-                        // swap direction and reset counter
-                        curr_direction = (curr_direction == right_to_left) ? left_to_right : right_to_left;
-                        num_tokens_dropped = 0;
-                        total_dirs_done++;
-                    }
-
-                    if(orig_tokens_size > 1 && total_dirs_done < 2) {
-                        bool prefix_search = false;
-                        if (curr_direction == right_to_left) {
-                            // drop from right
-                            size_t truncated_len = orig_tokens_size - num_tokens_dropped - 1;
-                            for (size_t i = 0; i < orig_tokens_size; i++) {
-                                if(i < truncated_len) {
-                                    if (do_stemming) {
-                                        auto stemmer = search_schema.at(the_fields[0].name).get_stemmer();
-                                        orig_tokens[i].value = stemmer->stem(orig_tokens[i].value);
-                                    }
-                                    truncated_tokens.emplace_back(orig_tokens[i]);
-                                } else {
-                                    dropped_tokens.emplace_back(orig_tokens[i]);
-                                }
-                            }
+                    if(drop_tokens_mode.mode == both_sides) {
+                        if(orig_tokens_size <= drop_tokens_mode.token_limit) {
+                            drop_both_sides = true;
                         } else {
-                            // drop from left
-                            prefix_search = true;
-                            size_t start_index = (num_tokens_dropped + 1);
-                            for(size_t i = 0; i < orig_tokens_size; i++) {
-                                if(i >= start_index) {
-                                    if (do_stemming) {
-                                        auto stemmer = search_schema.at(the_fields[0].name).get_stemmer();
-                                        orig_tokens[i].value = stemmer->stem(orig_tokens[i].value);
+                            curr_direction = right_to_left;
+                        }
+                    }
+
+                    while(exhaustive_search || all_result_ids_len < drop_tokens_threshold || drop_both_sides) {
+                        // When atleast two tokens from the query are available we can drop one
+                        std::vector<token_t> truncated_tokens;
+                        std::vector<token_t> dropped_tokens;
+
+                        if(num_tokens_dropped >= orig_tokens_size - 1) {
+                            // swap direction and reset counter
+                            curr_direction = (curr_direction == right_to_left) ? left_to_right : right_to_left;
+                            num_tokens_dropped = 0;
+                            total_dirs_done++;
+                        }
+
+                        if(orig_tokens_size > 1 && total_dirs_done < 2) {
+                            bool prefix_search = false;
+                            if (curr_direction == right_to_left) {
+                                // drop from right
+                                size_t truncated_len = orig_tokens_size - num_tokens_dropped - 1;
+                                for (size_t i = 0; i < orig_tokens_size; i++) {
+                                    if(i < truncated_len) {
+                                        if (grp_do_stemming) {
+                                            auto stemmer = search_schema.at(the_fields[grp.token_field_idx].name).get_stemmer();
+                                            orig_tokens[i].value = stemmer->stem(orig_tokens[i].value);
+                                        }
+                                        truncated_tokens.emplace_back(orig_tokens[i]);
+                                    } else {
+                                        dropped_tokens.emplace_back(orig_tokens[i]);
                                     }
-                                    truncated_tokens.emplace_back(orig_tokens[i]);
-                                } else {
-                                    dropped_tokens.emplace_back(orig_tokens[i]);
+                                }
+                            } else {
+                                // drop from left
+                                prefix_search = true;
+                                size_t start_index = (num_tokens_dropped + 1);
+                                for(size_t i = 0; i < orig_tokens_size; i++) {
+                                    if(i >= start_index) {
+                                        if (grp_do_stemming) {
+                                            auto stemmer = search_schema.at(the_fields[grp.token_field_idx].name).get_stemmer();
+                                            orig_tokens[i].value = stemmer->stem(orig_tokens[i].value);
+                                        }
+                                        truncated_tokens.emplace_back(orig_tokens[i]);
+                                    } else {
+                                        dropped_tokens.emplace_back(orig_tokens[i]);
+                                    }
                                 }
                             }
+
+                            num_tokens_dropped++;
+                            std::vector<bool> drop_token_prefixes;
+
+                            for (const auto p : grp.prefixes) {
+                                drop_token_prefixes.push_back(p && prefix_search);
+                            }
+
+                            fuzzy_search_fields_op = fuzzy_search_fields(grp.fields, truncated_tokens, dropped_tokens, match_type,
+                                                                         excluded_result_ids, excluded_result_ids_size,
+                                                                         filter_result_iterator,
+                                                                         curated_ids_sorted,
+                                                                         sort_fields_std, grp.num_typos, searched_query_tokens,
+                                                                         qtoken_set, topster, groups_processed,
+                                                                         all_result_ids, all_result_ids_len,
+                                                                         group_limit, group_by_fields, group_missing_values,
+                                                                         prioritize_exact_match, prioritize_token_position,
+                                                                         prioritize_num_matching_fields, query_hashes,
+                                                                         token_order, grp.prefixes, typo_tokens_threshold,
+                                                                         exhaustive_search, max_candidates, min_len_1typo,
+                                                                         min_len_2typo, -1, truncated_tokens.size(), false, false,
+                                                                         sort_order, field_values, geopoint_indices,
+                                                                         is_group_by_first_pass, group_by_missing_value_ids);
+                            if (!fuzzy_search_fields_op.ok()) {
+                                return fuzzy_search_fields_op;
+                            }
+
+                        } else {
+                            break;
                         }
-
-                        num_tokens_dropped++;
-                        std::vector<bool> drop_token_prefixes;
-
-                        for (const auto p : prefixes) {
-                            drop_token_prefixes.push_back(p && prefix_search);
-                        }
-
-                        auto fuzzy_search_fields_op = fuzzy_search_fields(the_fields, truncated_tokens, dropped_tokens, match_type,
-                                                                          excluded_result_ids, excluded_result_ids_size,
-                                                                          filter_result_iterator,
-                                                                          curated_ids_sorted,
-                                                                          sort_fields_std, num_typos, searched_query_tokens,
-                                                                          qtoken_set, topster, groups_processed, 
-                                                                          all_result_ids, all_result_ids_len,
-                                                                          group_limit, group_by_fields, group_missing_values,
-                                                                          prioritize_exact_match, prioritize_token_position, 
-                                                                          prioritize_num_matching_fields, query_hashes,
-                                                                          token_order, prefixes, typo_tokens_threshold,
-                                                                          exhaustive_search, max_candidates, min_len_1typo,
-                                                                          min_len_2typo, -1, truncated_tokens.size(), false, false, sort_order, field_values, geopoint_indices,
-                                                                          is_group_by_first_pass, group_by_missing_value_ids);
-                        if (!fuzzy_search_fields_op.ok()) {
-                            return fuzzy_search_fields_op;
-                        }
-
-                    } else {
-                        break;
                     }
                 }
             }

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -4815,3 +4815,99 @@ TEST_F(CollectionSpecificMoreTest, PhraseQueryHighlightShouldNotExpandToAllFlatF
 
     collectionManager.drop_collection("phrase_highlight_flat_multiple_occurrences");
 }
+
+TEST_F(CollectionSpecificMoreTest, PerFieldQueryRetokenization) {
+    // When fields have different tokenization configs, each field should be searched
+    // using its own symbols_to_index / token_separators rather than the first field's rules.
+    // Issue #2828: query_by=sku,title with sku having symbols_to_index:["-"] caused
+    // the query to not be split on "-" even when searching title (which has token_separators:["-"]).
+    nlohmann::json schema = R"({
+        "name": "retokenize_test",
+        "fields": [
+            {"name": "sku",   "type": "string", "symbols_to_index": ["-"]},
+            {"name": "title", "type": "string", "token_separators": ["-"]}
+        ]
+    })"_json;
+
+    Collection* coll1 = collectionManager.create_collection(schema).get();
+
+    nlohmann::json doc1;
+    doc1["id"]    = "1";
+    doc1["sku"]   = "ABC-1234";
+    doc1["title"] = "Wooden Desk";
+    ASSERT_TRUE(coll1->add(doc1.dump()).ok());
+
+    nlohmann::json doc2;
+    doc2["id"]    = "2";
+    doc2["sku"]   = "DEF-5678";
+    doc2["title"] = "Wooden Chair";
+    ASSERT_TRUE(coll1->add(doc2.dump()).ok());
+
+    // Baseline: searching title alone should split on "-" and find "Wooden Desk"
+    auto res = coll1->search("wooden-desk", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, 0).get();
+    ASSERT_EQ(1, res["hits"].size());
+    ASSERT_EQ("1", res["hits"][0]["document"]["id"].get<std::string>());
+
+    // Core regression: searching sku,title must re-tokenize the query for title
+    // using title's token_separators:["-"], not sku's symbols_to_index:["-"].
+    // Previously returned 0 results because "wooden-desk" was never split for title.
+    res = coll1->search("wooden-desk", {"sku", "title"}, "", {}, {}, {0, 0}, 10, 1, FREQUENCY, {true, true}, 0).get();
+    ASSERT_EQ(1, res["hits"].size());
+    ASSERT_EQ("1", res["hits"][0]["document"]["id"].get<std::string>());
+
+    // sku exact match should still work when sku is not the first field
+    res = coll1->search("ABC-1234", {"title", "sku"}, "", {}, {}, {0, 0}, 10, 1, FREQUENCY, {true, true}, 0).get();
+    ASSERT_EQ(1, res["hits"].size());
+    ASSERT_EQ("1", res["hits"][0]["document"]["id"].get<std::string>());
+
+    // sku exact match with sku as first field
+    res = coll1->search("ABC-1234", {"sku", "title"}, "", {}, {}, {0, 0}, 10, 1, FREQUENCY, {true, true}, 0).get();
+    ASSERT_EQ(1, res["hits"].size());
+    ASSERT_EQ("1", res["hits"][0]["document"]["id"].get<std::string>());
+
+    // Both fields match different documents: "wooden-chair" matches title of doc2 only.
+    // "wooden-chair" is not a valid sku value so only the title match should fire.
+    res = coll1->search("wooden-chair", {"sku", "title"}, "", {}, {}, {0, 0}, 10, 1, FREQUENCY, {true, true}, 0).get();
+    ASSERT_EQ(1, res["hits"].size());
+    ASSERT_EQ("2", res["hits"][0]["document"]["id"].get<std::string>());
+
+    collectionManager.drop_collection("retokenize_test");
+
+    // Three-field test with three distinct tokenization configs
+    nlohmann::json schema3 = R"({
+        "name": "retokenize_3field",
+        "fields": [
+            {"name": "code",  "type": "string", "symbols_to_index": ["-"]},
+            {"name": "title", "type": "string", "token_separators": ["-"]},
+            {"name": "desc",  "type": "string"}
+        ]
+    })"_json;
+
+    Collection* coll3 = collectionManager.create_collection(schema3).get();
+
+    nlohmann::json d1;
+    d1["id"]    = "1";
+    d1["code"]  = "ABC-XYZ";
+    d1["title"] = "Red-Widget";
+    d1["desc"]  = "A red widget";
+    ASSERT_TRUE(coll3->add(d1.dump()).ok());
+
+    nlohmann::json d2;
+    d2["id"]    = "2";
+    d2["code"]  = "DEF-GHI";
+    d2["title"] = "Blue-Widget";
+    d2["desc"]  = "A blue widget";
+    ASSERT_TRUE(coll3->add(d2.dump()).ok());
+
+    // Searching "red-widget" across all three fields: title should match doc1 via token_separators.
+    res = coll3->search("red-widget", {"code", "title", "desc"}, "", {}, {}, {0, 0, 0}, 10, 1, FREQUENCY, {true, true, true}, 0).get();
+    ASSERT_GE(res["hits"].size(), 1);
+    ASSERT_EQ("1", res["hits"][0]["document"]["id"].get<std::string>());
+
+    // Searching "blue-widget" across all three fields: title should match doc2.
+    res = coll3->search("blue-widget", {"code", "title", "desc"}, "", {}, {}, {0, 0, 0}, 10, 1, FREQUENCY, {true, true, true}, 0).get();
+    ASSERT_GE(res["hits"].size(), 1);
+    ASSERT_EQ("2", res["hits"][0]["document"]["id"].get<std::string>());
+
+    collectionManager.drop_collection("retokenize_3field");
+}


### PR DESCRIPTION
closes [#2828](https://github.com/typesense/typesense/issues/2828)

## Problem

When `query_by` spans multiple fields with different `symbols_to_index` or `token_separators` configurations, Typesense tokenized the query once using the first field’s rules and reused those tokens for every subsequent field.

This produced the wrong token set for fields that index content differently.

## Root Cause

In `collection.cpp`, `parse_search_query` was called once with `field[0]`’s:

- locale
- stemmer
- `symbols_to_index`
- `token_separators`

The result was then copied into every `field_query_tokens[i]` slot.

All downstream search paths used this single token set for all fields.

## Fix

### `src/collection.cpp`

Re-tokenize the query for each field individually.

Field `0` is unchanged. Fields `i > 0` each get their own `parse_search_query` call using their own:

- locale
- stemmer
- `symbols_to_index`
- `token_separators`

### `src/index.cpp`

Updated three search paths:

#### 1. Primary path

Fields are grouped by their resulting token set using `field_group_t`.

Fields that produce identical tokens share a group and are passed together to `fuzzy_search_fields`, preserving cross-field matching.

Fields with different token sets get separate calls with their own tokens.

This ensures `orig_num_tokens` is always coherent with the fields being searched, so scoring is not artificially penalized.

#### 2. Space-as-typos fallback

When the primary search returns zero results and `split_join_tokens=fallback`, the resolved token set is now searched per group rather than broadcast to all fields via a single call.

#### 3. Drop-tokens path

`all_queries` used to be built from `field_query_tokens[0]` only. Truncated subsets were then searched across all fields with `sku`-style tokens that other fields never indexed.

The fix builds `group_all_queries` per group, so each group drops tokens from its own `N`-token representation.

## Why not just union all tokens and pass all fields once?

`fuzzy_search_fields` treats its token list as the single correct query representation for all fields given to it.

`orig_num_tokens` is set to the token count of that list.

With a union like (Referring to example in original issue [here](https://github.com/typesense/typesense/issues/2828)):

```txt
["wooden-desk", "wooden", "desk"]
```

a document perfectly matching title scores 2/3, while a perfect sku match scores 1/3.

Both are penalized relative to what they should be.

Grouping ensures each call has a coherent token count for accurate scoring.

## Testing

Extended PerFieldQueryRetokenization to cover the regression, field-order invariance, cross-field correctness, and the three-field tokenization case.