### PR TITLE
fix(curations-synonyms): fully replace set contents on PUT

### DIFF
--- a/api_tests/tests/curation_sets.test.ts
+++ b/api_tests/tests/curation_sets.test.ts
@@ -66,11 +66,18 @@ const PatchCollectionCurationSetsResponse = z.object({
 const initialCurations = [
   { id: "ov-pin-romance", rule: { query: "romantic", match: "contains" }, includes: [{ id: "1", position: 1 }] },
   { id: "ov-drop-scifi", rule: { query: "sci-fi", match: "contains" }, excludes: [{ id: "2" }] },
+  { id: "ov-boost-drama", rule: { query: "drama", match: "contains" }, includes: [{ id: "4", position: 1 }] },
+  { id: "ov-filter-kids", rule: { query: "kids", match: "exact" }, filter_by: "rating:=G" },
 ];
 
 const updatedCurations = [
+  { id: "ov-pin-romance", rule: { query: "romance", match: "exact" }, includes: [{ id: "5", position: 1 }] },
   { id: "ov-pin-thriller", rule: { query: "thriller", match: "exact" }, includes: [{ id: "3", position: 1 }] },
 ];
+
+const expectCurationIds = (items: Array<{ id: string }>, expectedIds: string[]) => {
+  expect(items.map((o) => o.id).sort()).toEqual([...expectedIds].sort());
+};
 
 describe(Phases.SINGLE_FRESH, () => {
   it("create an curation set", async () => {
@@ -94,7 +101,12 @@ describe(Phases.SINGLE_FRESH, () => {
     expect(res.ok).toBe(true);
     const ov = CurationSetResponse.safeParse(await res.json());
     expect(ov.success).toBe(true);
-    expect(ov.data?.items.length).toBe(2);
+    expectCurationIds(ov.data?.items ?? [], [
+      "ov-pin-romance",
+      "ov-drop-scifi",
+      "ov-boost-drama",
+      "ov-filter-kids",
+    ]);
   });
 
   it("list curation sets", async () => {
@@ -145,7 +157,12 @@ describe(Phases.SINGLE_FRESH, () => {
     expect(res.ok).toBe(true);
     const ov = CurationSetResponse.safeParse(await res.json());
     expect(ov.success).toBe(true);
-    expect(ov.data?.items.length).toBe(2);
+    expectCurationIds(ov.data?.items ?? [], [
+      "ov-pin-romance",
+      "ov-drop-scifi",
+      "ov-boost-drama",
+      "ov-filter-kids",
+    ]);
   });
 
   it("create a collection with curation_sets", async () => {
@@ -184,7 +201,7 @@ describe(Phases.SINGLE_FRESH, () => {
     expect(coll.data?.curation_sets).toContain("movies-core");
   });
 
-  it("update curation set contents", async () => {
+  it("fully replaces curation set contents", async () => {
     const res = await fetchSingleNode("/curation_sets/movies-core", {
       method: "PUT",
       body: JSON.stringify({ items: updatedCurations }),
@@ -192,8 +209,7 @@ describe(Phases.SINGLE_FRESH, () => {
     expect(res.ok).toBe(true);
     const ov = CurationSetResponse.safeParse(await res.json());
     expect(ov.success).toBe(true);
-    const updatedIds = ov.data?.items.map((o) => o.id);
-    expect(updatedIds).toContain("ov-pin-thriller");
+    expectCurationIds(ov.data?.items ?? [], ["ov-pin-romance", "ov-pin-thriller"]);
   });
 
   it("delete a temporary curation set", async () => {
@@ -217,8 +233,7 @@ describe(Phases.SINGLE_RESTARTED, () => {
     expect(res.ok).toBe(true);
     let ov = CurationSetResponse.safeParse(await res.json());
     expect(ov.success).toBe(true);
-    const ids = ov.data?.items.map((o) => o.id);
-    expect(ids).toContain("ov-pin-thriller");
+    expectCurationIds(ov.data?.items ?? [], ["ov-pin-romance", "ov-pin-thriller"]);
 
     res = await fetchSingleNode("/collections/movies", { method: "GET" });
     expect(res.ok).toBe(true);
@@ -234,6 +249,7 @@ describe(Phases.SINGLE_SNAPSHOT, () => {
     expect(res.ok).toBe(true);
     let ov = CurationSetResponse.safeParse(await res.json());
     expect(ov.success).toBe(true);
+    expectCurationIds(ov.data?.items ?? [], ["ov-pin-romance", "ov-pin-thriller"]);
 
     res = await fetchSingleNode("/collections/movies", { method: "GET" });
     expect(res.ok).toBe(true);
@@ -268,11 +284,17 @@ describe(Phases.MULTI_FRESH, () => {
 
     res = await fetchMultiNode(1, "/curation_sets/movies-core", {
       method: "PUT",
-      body: JSON.stringify({ items: [{ id: "ov-y", rule: { query: "y", match: "exact" }, includes: [{ id: "1", position: 1 }] }] }),
+      body: JSON.stringify({ items: initialCurations }),
     });
     expect(res.ok).toBe(true);
     ov = CurationSetResponse.safeParse(await res.json());
     expect(ov.success).toBe(true);
+    expectCurationIds(ov.data?.items ?? [], [
+      "ov-pin-romance",
+      "ov-drop-scifi",
+      "ov-boost-drama",
+      "ov-filter-kids",
+    ]);
   });
 
   it("list curation sets", async () => {
@@ -318,6 +340,17 @@ describe(Phases.MULTI_FRESH, () => {
     expect(del.success).toBe(true);
     expect(del.data?.name).toBe("movies-core-2");
   });
+
+  it("fully replaces curation set contents", async () => {
+    const res = await fetchMultiNode(1, "/curation_sets/movies-core", {
+      method: "PUT",
+      body: JSON.stringify({ items: updatedCurations }),
+    });
+    expect(res.ok).toBe(true);
+    const ov = CurationSetResponse.safeParse(await res.json());
+    expect(ov.success).toBe(true);
+    expectCurationIds(ov.data?.items ?? [], ["ov-pin-romance", "ov-pin-thriller"]);
+  });
 });
 
 describe(Phases.MULTI_RESTARTED, () => {
@@ -326,6 +359,7 @@ describe(Phases.MULTI_RESTARTED, () => {
     expect(res.ok).toBe(true);
     let ov = CurationSetResponse.safeParse(await res.json());
     expect(ov.success).toBe(true);
+    expectCurationIds(ov.data?.items ?? [], ["ov-pin-romance", "ov-pin-thriller"]);
 
     res = await fetchMultiNode(2, "/collections/movies", { method: "GET" });
     expect(res.ok).toBe(true);
@@ -341,6 +375,7 @@ describe(Phases.MULTI_SNAPSHOT, () => {
     expect(res.ok).toBe(true);
     let ov = CurationSetResponse.safeParse(await res.json());
     expect(ov.success).toBe(true);
+    expectCurationIds(ov.data?.items ?? [], ["ov-pin-romance", "ov-pin-thriller"]);
 
     res = await fetchMultiNode(2, "/collections/movies", { method: "GET" });
     expect(res.ok).toBe(true);

--- a/api_tests/tests/synonym_sets.test.ts
+++ b/api_tests/tests/synonym_sets.test.ts
@@ -53,12 +53,17 @@ const initialSynonyms = [
   { id: "syn-tv", root: "tv", synonyms: ["television", "smart tv"] },
   { id: "syn-usa", root: "usa", synonyms: ["united states", "united states of america"] },
   { id: "syn-laptop", root: "laptop", synonyms: ["notebook", "ultrabook"] },
+  { id: "syn-phone", root: "phone", synonyms: ["cellphone", "mobile"] },
 ];
 
 const updatedSynonyms = [
-  { id: "syn-phone", root: "phone", synonyms: ["cellphone", "mobile", "smartphone"] },
+  { id: "syn-tv", root: "tv", synonyms: ["television", "telly"] },
   { id: "syn-monitor", root: "monitor", synonyms: ["display", "screen"] },
 ];
+
+const expectSynonymIds = (items: Array<{ id: string }>, expectedIds: string[]) => {
+  expect(items.map((s) => s.id).sort()).toEqual([...expectedIds].sort());
+};
 
 describe(Phases.SINGLE_FRESH, () => {
   it("create a synonym set", async () => {
@@ -81,11 +86,12 @@ describe(Phases.SINGLE_FRESH, () => {
     expect(res.ok).toBe(true);
     const syn = SynonymSetResponse.safeParse(await res.json());
     expect(syn.success).toBe(true);
-    expect(syn.data?.items.length).toBe(3);
+    expect(syn.data?.items.length).toBe(4);
     const ids = syn.data?.items.map((s) => s.id);
     expect(ids).toContain("syn-tv");
     expect(ids).toContain("syn-usa");
     expect(ids).toContain("syn-laptop");
+    expect(ids).toContain("syn-phone");
   });
 
   it("list synonym sets", async () => {
@@ -136,7 +142,7 @@ describe(Phases.SINGLE_FRESH, () => {
     expect(res.ok).toBe(true);
     const syn = SynonymSetResponse.safeParse(await res.json());
     expect(syn.success).toBe(true);
-    expect(syn.data?.items.length).toBe(3);
+    expect(syn.data?.items.length).toBe(4);
   });
 
   it("create a collection with synonym_sets", async () => {
@@ -175,7 +181,7 @@ describe(Phases.SINGLE_FRESH, () => {
     expect(coll.data?.synonym_sets).toContain("products-core");
   });
 
-  it("update synonym set contents", async () => {
+  it("fully replaces synonym set contents", async () => {
     const res = await fetchSingleNode("/synonym_sets/products-core", {
       method: "PUT",
       body: JSON.stringify({ items: updatedSynonyms }),
@@ -183,9 +189,7 @@ describe(Phases.SINGLE_FRESH, () => {
     expect(res.ok).toBe(true);
     const syn = SynonymSetResponse.safeParse(await res.json());
     expect(syn.success).toBe(true);
-    const updatedIds = syn.data?.items.map((s) => s.id);
-    expect(updatedIds).toContain("syn-phone");
-    expect(updatedIds).toContain("syn-monitor");
+    expectSynonymIds(syn.data?.items ?? [], ["syn-tv", "syn-monitor"]);
   });
 
   it("delete a temporary synonym set", async () => {
@@ -209,9 +213,7 @@ describe(Phases.SINGLE_RESTARTED, () => {
     expect(res.ok).toBe(true);
     let syn = SynonymSetResponse.safeParse(await res.json());
     expect(syn.success).toBe(true);
-    const ids = syn.data?.items.map((s) => s.id);
-    expect(ids).toContain("syn-phone");
-    expect(ids).toContain("syn-monitor");
+    expectSynonymIds(syn.data?.items ?? [], ["syn-tv", "syn-monitor"]);
 
     res = await fetchSingleNode("/collections/products", { method: "GET" });
     expect(res.ok).toBe(true);
@@ -227,6 +229,7 @@ describe(Phases.SINGLE_SNAPSHOT, () => {
     expect(res.ok).toBe(true);
     let syn = SynonymSetResponse.safeParse(await res.json());
     expect(syn.success).toBe(true);
+    expectSynonymIds(syn.data?.items ?? [], ["syn-tv", "syn-monitor"]);
 
     res = await fetchSingleNode("/collections/products", { method: "GET" });
     expect(res.ok).toBe(true);
@@ -261,11 +264,12 @@ describe(Phases.MULTI_FRESH, () => {
 
     res = await fetchMultiNode(1, "/synonym_sets/products-core", {
       method: "PUT",
-      body: JSON.stringify({ items: [{ id: "syn-y", root: "y", synonyms: ["ey"] }] }),
+      body: JSON.stringify({ items: initialSynonyms }),
     });
     expect(res.ok).toBe(true);
     syn = SynonymSetResponse.safeParse(await res.json());
     expect(syn.success).toBe(true);
+    expectSynonymIds(syn.data?.items ?? [], ["syn-tv", "syn-usa", "syn-laptop", "syn-phone"]);
   });
 
   it("list synonym sets", async () => {
@@ -311,6 +315,17 @@ describe(Phases.MULTI_FRESH, () => {
     expect(del.success).toBe(true);
     expect(del.data?.name).toBe("products-core-2");
   });
+
+  it("fully replaces synonym set contents", async () => {
+    const res = await fetchMultiNode(1, "/synonym_sets/products-core", {
+      method: "PUT",
+      body: JSON.stringify({ items: updatedSynonyms }),
+    });
+    expect(res.ok).toBe(true);
+    const syn = SynonymSetResponse.safeParse(await res.json());
+    expect(syn.success).toBe(true);
+    expectSynonymIds(syn.data?.items ?? [], ["syn-tv", "syn-monitor"]);
+  });
 });
 
 describe(Phases.MULTI_RESTARTED, () => {
@@ -319,6 +334,7 @@ describe(Phases.MULTI_RESTARTED, () => {
     expect(res.ok).toBe(true);
     let syn = SynonymSetResponse.safeParse(await res.json());
     expect(syn.success).toBe(true);
+    expectSynonymIds(syn.data?.items ?? [], ["syn-tv", "syn-monitor"]);
 
     res = await fetchMultiNode(2, "/collections/products", { method: "GET" });
     expect(res.ok).toBe(true);
@@ -334,6 +350,7 @@ describe(Phases.MULTI_SNAPSHOT, () => {
     expect(res.ok).toBe(true);
     let syn = SynonymSetResponse.safeParse(await res.json());
     expect(syn.success).toBe(true);
+    expectSynonymIds(syn.data?.items ?? [], ["syn-tv", "syn-monitor"]);
 
     res = await fetchMultiNode(2, "/collections/products", { method: "GET" });
     expect(res.ok).toBe(true);
@@ -342,5 +359,3 @@ describe(Phases.MULTI_SNAPSHOT, () => {
     expect(coll.data?.synonym_sets).toContain("products-core");
   });
 });
-
-

--- a/src/curation_index_manager.cpp
+++ b/src/curation_index_manager.cpp
@@ -145,16 +145,28 @@ Option<nlohmann::json> CurationIndexManager::upsert_curation_set(const std::stri
     if(!store) {
         return Option<nlohmann::json>(500, "Store not initialized.");
     }
-    CurationIndex index{store, name};
     if(!items_array.is_array()) {
         return Option<nlohmann::json>(400, "Invalid 'items' field; must be an array");
     }
+
+    std::vector<curation_t> curations;
     for(const auto& item: items_array) {
         curation_t ov;
         auto op = curation_t::parse(item, item.value("id", std::string{}), ov);
         if(!op.ok()) {
             return Option<nlohmann::json>(op.code(), op.error());
         }
+        curations.push_back(std::move(ov));
+    }
+
+    auto delete_op = store->delete_range(CurationIndex::COLLECTION_CURATION_SET_PREFIX + std::string("_") + name + "_",
+                                         CurationIndex::COLLECTION_CURATION_SET_PREFIX + std::string("_") + name + "`");
+    if(!delete_op.ok()) {
+        return Option<nlohmann::json>(500, "Error while removing existing curations from disk.");
+    }
+
+    CurationIndex index{store, name};
+    for(const auto& ov: curations) {
         auto add_op = index.add_curation(ov, true);
         if(!add_op.ok()) {
             return Option<nlohmann::json>(add_op.code(), add_op.error());
@@ -223,5 +235,4 @@ void CurationIndexManager::dispose() {
     curation_index_map.clear();
     this->store = nullptr;
 }
-
 

--- a/src/synonym_index_manager.cpp
+++ b/src/synonym_index_manager.cpp
@@ -158,17 +158,28 @@ Option<nlohmann::json> SynonymIndexManager::upsert_synonym_set(const std::string
         return Option<nlohmann::json>(500, "Store not initialized.");
     }
 
-    SynonymIndex index{store, name};
     if(!items_array.is_array()) {
         return Option<nlohmann::json>(400, "Invalid 'items' field; must be an array");
     }
 
+    std::vector<synonym_t> synonym_entries;
     for(const auto& synonym : items_array) {
         synonym_t synonym_entry;
         auto parse_op = synonym_t::parse(synonym, synonym_entry);
         if(!parse_op.ok()) {
             return Option<nlohmann::json>(parse_op.code(), parse_op.error());
         }
+        synonym_entries.push_back(std::move(synonym_entry));
+    }
+
+    auto delete_op = store->delete_range(SynonymIndex::COLLECTION_SYNONYM_PREFIX + std::string("_") + name + "_",
+                                         SynonymIndex::COLLECTION_SYNONYM_PREFIX + std::string("_") + name + "`");
+    if(!delete_op.ok()) {
+        return Option<nlohmann::json>(500, "Error while removing existing synonyms from disk.");
+    }
+
+    SynonymIndex index{store, name};
+    for(const auto& synonym_entry : synonym_entries) {
         auto add_op = index.add_synonym(synonym_entry, true);
         if(!add_op.ok()) {
             return Option<nlohmann::json>(add_op.code(), add_op.error());


### PR DESCRIPTION
## Change Summary
  - Fix `PUT` set replacement for curation sets so stale items are removed from disk before new items are written.
  - Apply the same replace semantics to synonym sets to prevent old entries from surviving updates.
  - Parse and validate the full incoming payload before mutating stored set contents.
  - Add API tests for curation set replacement across fresh, restarted, snapshot, and multi-node scenarios.
  - Verify updated sets contain only the new item IDs after replacement.
  - Fix https://github.com/typesense/typesense/issues/2898

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
