### PR TITLE
add ssl wrapper for remote model http calls

### DIFF
--- a/api_tests/tests/ssl_verification.test.ts
+++ b/api_tests/tests/ssl_verification.test.ts
@@ -1,0 +1,125 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:https";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Phases } from "../src/constants";
+import { fetchSingleNode } from "../src/request";
+
+let tempDir: string;
+let mockServer: Server;
+let mockPort: number;
+
+function createSelfSignedCert() {
+  tempDir = mkdtempSync(join(tmpdir(), "typesense-api-ssl-"));
+  const configPath = join(tempDir, "openssl.cnf");
+  const keyPath = join(tempDir, "key.pem");
+  const certPath = join(tempDir, "cert.pem");
+
+  writeFileSync(configPath, [
+    "[req]",
+    "default_bits = 2048",
+    "prompt = no",
+    "default_md = sha256",
+    "distinguished_name = dn",
+    "x509_extensions = v3_req",
+    "",
+    "[dn]",
+    "CN = 127.0.0.1",
+    "",
+    "[v3_req]",
+    "subjectAltName = @alt_names",
+    "",
+    "[alt_names]",
+    "IP.1 = 127.0.0.1",
+    "DNS.1 = localhost",
+    "",
+  ].join("\n"));
+
+  execFileSync("openssl", [
+    "req",
+    "-x509",
+    "-newkey", "rsa:2048",
+    "-keyout", keyPath,
+    "-out", certPath,
+    "-days", "2",
+    "-nodes",
+    "-config", configPath,
+  ], { stdio: "ignore" });
+
+  return {
+    key: readFileSync(keyPath),
+    cert: readFileSync(certPath),
+  };
+}
+
+function proxyToMock(sslVerify: boolean) {
+  return fetchSingleNode("/proxy", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      url: `https://127.0.0.1:${mockPort}/ssl-check`,
+      method: "GET",
+      headers: {},
+      ssl_verify: sslVerify,
+    }),
+  });
+}
+
+function proxySseToMock(sslVerify: boolean) {
+  return fetchSingleNode("/proxy_sse", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      url: `https://127.0.0.1:${mockPort}/ssl-check`,
+      method: "POST",
+      body: "{}",
+      headers: { "content-type": "application/json" },
+      ssl_verify: sslVerify,
+    }),
+  });
+}
+
+describe(Phases.SINGLE_FRESH, () => {
+  beforeAll(async () => {
+    const credentials = createSelfSignedCert();
+    mockServer = createServer(credentials, (_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+
+    await new Promise<void>((resolve) => mockServer.listen(0, "127.0.0.1", resolve));
+    mockPort = (mockServer.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    if (mockServer) {
+      await new Promise<void>((resolve, reject) => {
+        mockServer.close((error) => error ? reject(error) : resolve());
+      });
+    }
+
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("should reject self-signed upstream certificates when ssl_verify is enabled", async () => {
+    const relaxedRes = await proxyToMock(false);
+    expect(relaxedRes.status).toBe(200);
+    expect(await relaxedRes.json()).toEqual({ ok: true });
+
+    const verifiedRes = await proxyToMock(true);
+    expect(verifiedRes.status).toBe(500);
+  });
+
+  it("should return a deterministic SSE proxy error when SSL verification fails", async () => {
+    const verifiedRes = await proxySseToMock(true);
+    expect(verifiedRes.status).toBe(500);
+
+    const body = await verifiedRes.json();
+    expect(body.message).toBe("Server error on remote server. Please try again later.");
+  });
+});

--- a/include/http_client.h
+++ b/include/http_client.h
@@ -10,6 +10,12 @@
   NOTE: This is a really primitive blocking client meant only for specific Typesense use cases.
 */
 class HttpClient {
+public:
+    enum class SSLVerifyMode {
+        VERIFY,
+        NO_VERIFY
+    };
+
 private:
     static std::string api_key;
     static std::string ca_cert_path;
@@ -30,15 +36,21 @@ private:
 
     static size_t curl_write_download(void *ptr, size_t size, size_t nmemb, FILE *stream);
 
-    static CURL* init_curl(const std::string& url, std::string& response, const size_t timeout_ms = 0);
+    static CURL* init_curl(const std::string& url, std::string& response, const size_t timeout_ms = 0,
+                           SSLVerifyMode ssl_verify_mode = SSLVerifyMode::NO_VERIFY);
 
     static CURL* init_curl_async(const std::string& url, deferred_req_res_t* req_res, curl_slist*& chunk,
-                                 bool send_ts_api_header);
+                                 bool send_ts_api_header,
+                                 SSLVerifyMode ssl_verify_mode = SSLVerifyMode::NO_VERIFY);
 
-    static CURL* init_curl_stream(const std::string& url, async_stream_response_t& res, long timeout_ms);
+    static CURL* init_curl_stream(const std::string& url, async_stream_response_t& res, long timeout_ms,
+                                  SSLVerifyMode ssl_verify_mode = SSLVerifyMode::NO_VERIFY);
 
     static CURL* init_curl_sse(const std::string& url, long timeout_ms,
-                                  deferred_req_res_t* req_res);
+                                  deferred_req_res_t* req_res,
+                                  SSLVerifyMode ssl_verify_mode = SSLVerifyMode::NO_VERIFY);
+
+    static void configure_ssl(CURL* curl, const std::string& url, SSLVerifyMode ssl_verify_mode);
 
     static size_t curl_req_send_callback(char* buffer, size_t size, size_t nitems, void *userdata);
 
@@ -54,25 +66,41 @@ public:
     HttpClient(HttpClient const&) = delete;
     void operator=(HttpClient const&) = delete;
 
-    void init(const std::string & api_key);
+    void init(const std::string & api_key, const std::string& ca_cert_path = "");
 
-    static long download_file(const std::string& url, const std::string& file_path);
+    static long download_file(const std::string& url, const std::string& file_path,
+                              SSLVerifyMode ssl_verify_mode = SSLVerifyMode::NO_VERIFY);
 
     static long get_response(const std::string& url, std::string& response,
                              std::map<std::string, std::string>& res_headers,
                              const std::unordered_map<std::string, std::string>& headers = {},
                              long timeout_ms=4000,
-                             bool send_ts_api_header = false);
+                             bool send_ts_api_header = false,
+                             SSLVerifyMode ssl_verify_mode = SSLVerifyMode::NO_VERIFY);
+
+    static long get_response_verified(const std::string& url, std::string& response,
+                                      std::map<std::string, std::string>& res_headers,
+                                      const std::unordered_map<std::string, std::string>& headers = {},
+                                      long timeout_ms=4000,
+                                      bool send_ts_api_header = false);
 
     static long delete_response(const std::string& url, std::string& response,
                                 std::map<std::string, std::string>& res_headers, long timeout_ms=4000,
-                                bool send_ts_api_header = false);
+                                bool send_ts_api_header = false,
+                                SSLVerifyMode ssl_verify_mode = SSLVerifyMode::NO_VERIFY);
 
     static long post_response(const std::string & url, const std::string & body, std::string & response,
                               std::map<std::string, std::string>& res_headers,
                               const std::unordered_map<std::string, std::string>& headers = {},
                               long timeout_ms=4000,
-                              bool send_ts_api_header = false);
+                              bool send_ts_api_header = false,
+                              SSLVerifyMode ssl_verify_mode = SSLVerifyMode::NO_VERIFY);
+
+    static long post_response_verified(const std::string & url, const std::string & body, std::string & response,
+                                       std::map<std::string, std::string>& res_headers,
+                                       const std::unordered_map<std::string, std::string>& headers = {},
+                                       long timeout_ms=4000,
+                                       bool send_ts_api_header = false);
 
     static long post_response_async(const std::string &url, const std::shared_ptr<http_req> request,
                                     const std::shared_ptr<http_res> response,
@@ -81,9 +109,17 @@ public:
 
     static long post_response_stream(const std::string &url, const std::string &body, async_stream_response_t &response,
                                     std::map<std::string, std::string>& res_headers,
-                                    const std::unordered_map<std::string, std::string>& headers, long timeout_ms=4000);
+                                    const std::unordered_map<std::string, std::string>& headers, long timeout_ms=4000,
+                                    SSLVerifyMode ssl_verify_mode = SSLVerifyMode::NO_VERIFY);
 
     static long post_response_sse(const std::string &url, const std::string &body,
+                                const std::unordered_map<std::string, std::string>& headers, long timeout_ms=4000,
+                                const std::shared_ptr<http_req> request = nullptr,
+                                const std::shared_ptr<http_res> response = nullptr,
+                                HttpServer* server = nullptr,
+                                SSLVerifyMode ssl_verify_mode = SSLVerifyMode::NO_VERIFY);
+
+    static long post_response_sse_verified(const std::string &url, const std::string &body,
                                 const std::unordered_map<std::string, std::string>& headers, long timeout_ms=4000,
                                 const std::shared_ptr<http_req> request = nullptr,
                                 const std::shared_ptr<http_res> response = nullptr,
@@ -91,11 +127,15 @@ public:
 
     static long put_response(const std::string & url, const std::string & body, std::string & response,
                              std::map<std::string, std::string>& res_headers, long timeout_ms=4000,
-                             bool send_ts_api_header = false);
+                             bool send_ts_api_header = false,
+                             SSLVerifyMode ssl_verify_mode = SSLVerifyMode::NO_VERIFY);
 
     static long patch_response(const std::string & url, const std::string & body, std::string & response,
                                std::map<std::string, std::string>& res_headers, long timeout_ms=4000,
-                               bool send_ts_api_header = false);
+                               bool send_ts_api_header = false,
+                               SSLVerifyMode ssl_verify_mode = SSLVerifyMode::NO_VERIFY);
+
+    static long download_file_verified(const std::string& url, const std::string& file_path);
 
     static void extract_response_headers(CURL* curl, std::map<std::string, std::string> &res_headers);
 

--- a/include/http_proxy.h
+++ b/include/http_proxy.h
@@ -37,18 +37,22 @@ class HttpProxy {
         void operator=(const HttpProxy&) = delete;
         HttpProxy(HttpProxy&&) = delete;
         void operator=(HttpProxy&&) = delete;
-        http_proxy_res_t send(const std::string& url, const std::string& method, const std::string& req_body, std::unordered_map<std::string, std::string>& req_headers);
+        http_proxy_res_t send(const std::string& url, const std::string& method, const std::string& req_body,
+                              std::unordered_map<std::string, std::string>& req_headers,
+                              HttpClient::SSLVerifyMode ssl_verify_mode = HttpClient::SSLVerifyMode::NO_VERIFY);
         
         bool call_sse(const std::string& url, const std::string& method,
                     const std::string& req_body = "", const std::unordered_map<std::string, std::string>& req_headers = {},
                     const std::shared_ptr<http_req>& req = nullptr, const std::shared_ptr<http_res>& res = nullptr,
-                    const size_t timeout_ms = default_timeout_ms);
+                    const size_t timeout_ms = default_timeout_ms,
+                    HttpClient::SSLVerifyMode ssl_verify_mode = HttpClient::SSLVerifyMode::NO_VERIFY);
     private:
         HttpProxy();
         ~HttpProxy() = default;
         http_proxy_res_t call(const std::string& url, const std::string& method,
                               const std::string& req_body = "", const std::unordered_map<std::string, std::string>& req_headers = {},
-                              const size_t timeout_ms = default_timeout_ms);
+                              const size_t timeout_ms = default_timeout_ms,
+                              HttpClient::SSLVerifyMode ssl_verify_mode = HttpClient::SSLVerifyMode::NO_VERIFY);
 
 
         // lru cache for http requests

--- a/include/tsconfig.h
+++ b/include/tsconfig.h
@@ -36,6 +36,7 @@ private:
     std::string ssl_certificate;
     std::string ssl_certificate_key;
     uint32_t ssl_refresh_interval_seconds;
+    std::string http_client_ca_certificate;
 
     bool enable_cors;
     std::set<std::string> cors_domains;
@@ -261,6 +262,10 @@ public:
         this->ssl_certificate_key = ssl_cert_key;
     }
 
+    void set_http_client_ca_certificate(const std::string& ca_certificate) {
+        this->http_client_ca_certificate = ca_certificate;
+    }
+
     void set_enable_cors(bool enable_cors) {
         this->enable_cors = enable_cors;
     }
@@ -375,6 +380,10 @@ public:
 
     std::string get_ssl_cert_key() const {
         return this->ssl_certificate_key;
+    }
+
+    std::string get_http_client_ca_certificate() const {
+        return this->http_client_ca_certificate;
     }
 
     std::string get_config_file() const {

--- a/src/aq_model_manager.cpp
+++ b/src/aq_model_manager.cpp
@@ -27,7 +27,7 @@ const Option<nlohmann::json> VQModelManager::get_config() {
     auto& client = HttpClient::get_instance();  
     std::string res;
     std::map<std::string, std::string> headers;
-    auto response = client.get_response(config_url, res, headers);
+    auto response = client.get_response_verified(config_url, res, headers);
 
     if (response != 200) {
         return Option<nlohmann::json>(400, "Failed to get model config file");
@@ -82,7 +82,7 @@ Option<bool> VQModelManager::download_model(const std::string& model_name) {
     std::unique_lock<std::mutex> lock(download_mutex);
     auto model_url = get_model_url(model_name);
     auto& client = HttpClient::get_instance();
-    auto response = client.download_file(model_url, model_path);
+    auto response = client.download_file_verified(model_url, model_path);
     LOG(INFO) << "Downloading model " << model_name << " from " << model_url << " to " << model_path;
     if (response != 200) {
         LOG(INFO) << response;

--- a/src/conversation_model.cpp
+++ b/src/conversation_model.cpp
@@ -807,6 +807,7 @@ Option<std::string> OpenAIConversationModel::get_answer_stream(const std::string
         proxy_req_body["url"] = openai_url + openai_path;
         proxy_req_body["body"] = req_body.dump();
         proxy_req_body["headers"] = headers;
+        proxy_req_body["ssl_verify"] = true;
         std::unordered_map<std::string, std::string> header_;
         header_["x-typesense-api-key"] = HttpClient::get_api_key();
 
@@ -815,8 +816,8 @@ Option<std::string> OpenAIConversationModel::get_answer_stream(const std::string
                                                                    HttpProxy::default_timeout_ms, req, res, server);
     } else {
         res->proxied_stream = true;
-        HttpClient::get_instance().post_response_sse(openai_url + openai_path, req_body.dump(), headers,
-                                                     HttpProxy::default_timeout_ms, req, res, server);
+        HttpClient::get_instance().post_response_sse_verified(openai_url + openai_path, req_body.dump(), headers,
+                                                              HttpProxy::default_timeout_ms, req, res, server);
     }
 
     auto& async_conversation = async_conversations[req];
@@ -1004,12 +1005,13 @@ Option<std::string> CFConversationModel::get_answer_stream(const std::string& co
         proxy_req_body["url"] = url;
         proxy_req_body["body"] = req_body.dump();
         proxy_req_body["headers"] = headers;
+        proxy_req_body["ssl_verify"] = true;
         std::unordered_map<std::string, std::string> header_;
         header_["x-typesense-api-key"] = HttpClient::get_api_key();
 
         HttpClient::get_instance().post_response_sse(proxy_url, proxy_req_body.dump(), header_, HttpProxy::default_timeout_ms, req, res, server);
     } else {
-        HttpClient::get_instance().post_response_sse(url, req_body.dump(), headers, HttpProxy::default_timeout_ms, req, res, server);
+        HttpClient::get_instance().post_response_sse_verified(url, req_body.dump(), headers, HttpProxy::default_timeout_ms, req, res, server);
     }
 
     auto& async_conversation = async_conversations[req];
@@ -1437,12 +1439,13 @@ Option<std::string> vLLMConversationModel::get_answer_stream(const std::string& 
         proxy_req_body["url"] = get_chat_completion_url(vllm_url);
         proxy_req_body["body"] = req_body.dump();
         proxy_req_body["headers"] = headers;
+        proxy_req_body["ssl_verify"] = true;
         std::unordered_map<std::string, std::string> header_;
         header_["x-typesense-api-key"] = HttpClient::get_api_key();
 
         HttpClient::get_instance().post_response_sse(proxy_url, proxy_req_body.dump(), header_, HttpProxy::default_timeout_ms, req, res, server);
     } else {
-        HttpClient::get_instance().post_response_sse(get_chat_completion_url(vllm_url), req_body.dump(), headers, HttpProxy::default_timeout_ms, req, res, server);
+        HttpClient::get_instance().post_response_sse_verified(get_chat_completion_url(vllm_url), req_body.dump(), headers, HttpProxy::default_timeout_ms, req, res, server);
     }
 
     auto& async_conversation = async_conversations[req];
@@ -1835,12 +1838,13 @@ Option<std::string> GeminiConversationModel::get_answer_stream(const std::string
         proxy_req_body["url"] = url;
         proxy_req_body["body"] = req_body.dump();
         proxy_req_body["headers"] = headers;
+        proxy_req_body["ssl_verify"] = true;
         std::unordered_map<std::string, std::string> header_;
         header_["x-typesense-api-key"] = HttpClient::get_api_key();
 
         HttpClient::get_instance().post_response_sse(proxy_url, proxy_req_body.dump(), header_, HttpProxy::default_timeout_ms, req, res, server);
     } else {
-        HttpClient::get_instance().post_response_sse(url, req_body.dump(), headers, HttpProxy::default_timeout_ms, req, res, server);
+        HttpClient::get_instance().post_response_sse_verified(url, req_body.dump(), headers, HttpProxy::default_timeout_ms, req, res, server);
     }
     auto& async_conversation = async_conversations[req];
 
@@ -2067,7 +2071,7 @@ Option<std::string> AzureConversationModel::get_answer(const std::string& contex
     headers["api-key"] = api_key;
     headers["Content-Type"] = "application/json";
 
-    long status_code = HttpClient::post_response(url, request_body.dump(), response, res_headers, headers);
+    long status_code = HttpClient::post_response_verified(url, request_body.dump(), response, res_headers, headers);
 
     if (status_code != 200) {
         return Option<std::string>(status_code, "Failed to get response from Azure API: " + response);
@@ -2372,12 +2376,13 @@ Option<std::string> AzureConversationModel::get_answer_stream(const nlohmann::js
         proxy_req_body["url"] = azure_url;
         proxy_req_body["body"] = req_body.dump();
         proxy_req_body["headers"] = headers;
+        proxy_req_body["ssl_verify"] = true;
         std::unordered_map<std::string, std::string> header_;
         header_["x-typesense-api-key"] = HttpClient::get_api_key();
 
         HttpClient::get_instance().post_response_sse(proxy_url, proxy_req_body.dump(), header_, HttpProxy::default_timeout_ms, req, res, server);
     } else {
-        HttpClient::get_instance().post_response_sse(azure_url, req_body.dump(), headers, HttpProxy::default_timeout_ms, req, res, server);
+        HttpClient::get_instance().post_response_sse_verified(azure_url, req_body.dump(), headers, HttpProxy::default_timeout_ms, req, res, server);
     }
 
     auto& async_conversation = async_conversations[req];

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -3151,6 +3151,7 @@ bool post_proxy(const std::shared_ptr<http_req>& req, const std::shared_ptr<http
     }
 
     std::string body, url, method;
+    bool ssl_verify = false;
     std::unordered_map<std::string, std::string> headers;
 
     if(req_json.count("url") == 0 || req_json.count("method") == 0) {
@@ -3172,6 +3173,10 @@ bool post_proxy(const std::shared_ptr<http_req>& req, const std::shared_ptr<http
             res->set_400("Headers must be a JSON object.");
             return false;
         }
+        if(req_json.count("ssl_verify") != 0 && !req_json["ssl_verify"].is_boolean()) {
+            res->set_400("SSL verify must be a boolean.");
+            return false;
+        }
         if(req_json.count("body")) {
             body = req_json["body"].get<std::string>();
         }
@@ -3179,6 +3184,9 @@ bool post_proxy(const std::shared_ptr<http_req>& req, const std::shared_ptr<http
         method = req_json["method"].get<std::string>();
         if(req_json.count("headers")) {
             headers = req_json["headers"].get<std::unordered_map<std::string, std::string>>();
+        }
+        if(req_json.count("ssl_verify")) {
+            ssl_verify = req_json["ssl_verify"].get<bool>();
         }
     } catch(const std::exception& e) {
         LOG(ERROR) << "JSON error: " << e.what();
@@ -3195,7 +3203,8 @@ bool post_proxy(const std::shared_ptr<http_req>& req, const std::shared_ptr<http
         return false;
     }
 
-    auto response = proxy.send(url, method, body, headers);
+    auto response = proxy.send(url, method, body, headers,
+                               ssl_verify ? HttpClient::SSLVerifyMode::VERIFY : HttpClient::SSLVerifyMode::NO_VERIFY);
 
     if(response.status_code != 200) {
         int code = response.status_code;
@@ -3462,6 +3471,7 @@ bool post_proxy_sse(const std::shared_ptr<http_req>& req, const std::shared_ptr<
     }
 
     std::string body, url, method;
+    bool ssl_verify = false;
     std::unordered_map<std::string, std::string> headers;
 
     if(req_json.count("url") == 0 || req_json.count("method") == 0) {
@@ -3491,6 +3501,12 @@ bool post_proxy_sse(const std::shared_ptr<http_req>& req, const std::shared_ptr<
             stream_response(req, res);
             return false;
         }
+        if(req_json.count("ssl_verify") != 0 && !req_json["ssl_verify"].is_boolean()) {
+            res->set_400("SSL verify must be a boolean.");
+            res->final = true;
+            stream_response(req, res);
+            return false;
+        }
         if(req_json.count("body")) {
             body = req_json["body"].get<std::string>();
         }
@@ -3498,6 +3514,9 @@ bool post_proxy_sse(const std::shared_ptr<http_req>& req, const std::shared_ptr<
         method = req_json["method"].get<std::string>();
         if(req_json.count("headers")) {
             headers = req_json["headers"].get<std::unordered_map<std::string, std::string>>();
+        }
+        if(req_json.count("ssl_verify")) {
+            ssl_verify = req_json["ssl_verify"].get<bool>();
         }
     } catch(const std::exception& e) {
         LOG(ERROR) << "JSON error: " << e.what();
@@ -3518,7 +3537,8 @@ bool post_proxy_sse(const std::shared_ptr<http_req>& req, const std::shared_ptr<
         return false;
     }
 
-    return proxy.call_sse(url, method, body, headers, req, res);
+    return proxy.call_sse(url, method, body, headers, req, res, HttpProxy::default_timeout_ms,
+                          ssl_verify ? HttpClient::SSLVerifyMode::VERIFY : HttpClient::SSLVerifyMode::NO_VERIFY);
 }
 
 bool get_nl_search_models(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {

--- a/src/embedder_manager.cpp
+++ b/src/embedder_manager.cpp
@@ -358,7 +358,7 @@ Option<bool> EmbedderManager::download_public_model(const text_embedding_model& 
         std::filesystem::create_directories(model_subdir);
     }
     if(!check_md5(get_absolute_model_path(actual_model_name, true), model.model_md5)) {
-        long res = httpClient.download_file(get_model_url(model), get_absolute_model_path(actual_model_name, true));
+        long res = httpClient.download_file_verified(get_model_url(model), get_absolute_model_path(actual_model_name, true));
         if(res != 200) {
             LOG(INFO) << "Failed to download public model: " << model.model_name;
             return Option<bool>(400, "Failed to download model file");
@@ -367,7 +367,7 @@ Option<bool> EmbedderManager::download_public_model(const text_embedding_model& 
 
     if(!model.data_file_md5.empty()) {
         if(!check_md5(get_absolute_model_path(actual_model_name, true) + "_data", model.data_file_md5)) {
-            long res = httpClient.download_file(get_model_data_url(model), get_absolute_model_path(actual_model_name, true) + "_data");
+            long res = httpClient.download_file_verified(get_model_data_url(model), get_absolute_model_path(actual_model_name, true) + "_data");
             if(res != 200) {
                 LOG(INFO) << "Failed to download public model data file: " << model.model_name;
                 return Option<bool>(400, "Failed to download model data file");
@@ -376,7 +376,7 @@ Option<bool> EmbedderManager::download_public_model(const text_embedding_model& 
     }
     
     if(!model.vocab_md5.empty() && !check_md5(get_absolute_vocab_path(actual_model_name, model.vocab_file_name, true), model.vocab_md5)) {
-        long res = httpClient.download_file(get_vocab_url(model), get_absolute_vocab_path(actual_model_name, model.vocab_file_name, true));
+        long res = httpClient.download_file_verified(get_vocab_url(model), get_absolute_vocab_path(actual_model_name, model.vocab_file_name, true));
         if(res != 200) {
             LOG(INFO) << "Failed to download default vocab for model: " << model.model_name;
             return Option<bool>(400, "Failed to download vocab file");
@@ -386,7 +386,7 @@ Option<bool> EmbedderManager::download_public_model(const text_embedding_model& 
     if(!model.tokenizer_md5.empty()) {
         auto tokenizer_file_path = get_model_subdir(actual_model_name, true) + "/" + model.tokenizer_file_name;
         if(!check_md5(tokenizer_file_path, model.tokenizer_md5)) {
-            long res = httpClient.download_file(MODELS_REPO_URL + actual_model_name + "/" + model.tokenizer_file_name, tokenizer_file_path);
+            long res = httpClient.download_file_verified(MODELS_REPO_URL + actual_model_name + "/" + model.tokenizer_file_name, tokenizer_file_path);
             if(res != 200) {
                 LOG(INFO) << "Failed to download tokenizer file for model: " << model.model_name;
                 return Option<bool>(400, "Failed to download tokenizer file");
@@ -397,7 +397,7 @@ Option<bool> EmbedderManager::download_public_model(const text_embedding_model& 
     if(!model.image_processor_md5.empty()) {
         auto image_processor_file_path = get_model_subdir(actual_model_name, true) + "/" + model.image_processor_file_name;
         if(!check_md5(image_processor_file_path, model.image_processor_md5)) {
-            long res = httpClient.download_file(MODELS_REPO_URL + actual_model_name + "/" + model.image_processor_file_name, image_processor_file_path);
+            long res = httpClient.download_file_verified(MODELS_REPO_URL + actual_model_name + "/" + model.image_processor_file_name, image_processor_file_path);
             if(res != 200) {
                 LOG(INFO) << "Failed to download image processor file for model: " << model.model_name;
                 return Option<bool>(400, "Failed to download image processor file");
@@ -528,8 +528,8 @@ Option<nlohmann::json> EmbedderManager::get_public_model_config(const std::strin
     headers["Accept"] = "application/json";
     std::map<std::string, std::string> response_headers;
     std::string response_body;
-    long res = httpClient.get_response(MODELS_REPO_URL + actual_model_name + "/" + MODEL_CONFIG_FILE, response_body,
-                                       response_headers, headers, 30*1000);
+    long res = httpClient.get_response_verified(MODELS_REPO_URL + actual_model_name + "/" + MODEL_CONFIG_FILE, response_body,
+                                                response_headers, headers, 30*1000);
     if(res == 200 || res == 302) {
         return Option<nlohmann::json>(nlohmann::json::parse(response_body));
     }

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -16,6 +16,72 @@ struct client_state_t: public req_state_t {
     }
 };
 
+namespace {
+    long get_curl_failure_status_code(CURLcode res_code) {
+        return res_code == CURLE_OPERATION_TIMEDOUT ? 408 : 500;
+    }
+
+    void log_curl_failure(CURL* curl, CURLcode res_code) {
+        char* url = nullptr;
+        char* method = nullptr;
+
+        curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &url);
+        curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_METHOD, &method);
+
+        const char* effective_url = url == nullptr ? "" : url;
+        const char* effective_method = method == nullptr ? "" : method;
+
+        if(res_code == CURLE_OPERATION_TIMEDOUT) {
+            double total_time = 0;
+            curl_easy_getinfo(curl, CURLINFO_TOTAL_TIME, &total_time);
+            LOG(ERROR) << "CURL timeout. Time taken: " << total_time << ", method: " << effective_method
+                       << ", url: " << effective_url;
+            return;
+        }
+
+        LOG(ERROR) << "CURL failed. Code: " << res_code << ", strerror: " << curl_easy_strerror(res_code)
+                   << ", method: " << effective_method << ", url: " << effective_url;
+    }
+
+    std::string get_curl_failure_response_body(long status_code) {
+        const std::string message = status_code == 408 ?
+            "Remote server request timed out." :
+            "Server error on remote server. Please try again later.";
+
+        nlohmann::json res;
+        res["message"] = message;
+        res["error"]["message"] = message;
+        return res.dump();
+    }
+
+    void fail_sse_response(deferred_req_res_t* req_res, long status_code, const std::string& response_body) {
+        if(req_res == nullptr || req_res->req == nullptr || req_res->res == nullptr) {
+            return;
+        }
+
+        std::string content_type = "application/json; charset=utf-8";
+        if(req_res->req->async_res_set_headers_callback) {
+            req_res->req->async_res_set_headers_callback(response_body, req_res->req, status_code, content_type);
+        }
+
+        if(req_res->req->async_res_done_callback) {
+            req_res->req->async_res_done_callback(req_res->req, req_res->res);
+            return;
+        }
+
+        req_res->res->status_code = status_code;
+        req_res->res->content_type_header = content_type;
+        req_res->res->body = response_body;
+        req_res->res->final = true;
+
+        if(req_res->server != nullptr) {
+            req_res->res->wait();
+            auto* async_req_res = new async_req_res_t(req_res->req, req_res->res, true);
+            req_res->server->get_message_dispatcher()->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, async_req_res);
+        }
+    }
+}
+
 long HttpClient::post_response(const std::string &url, const std::string &body, std::string &response,
                                std::map<std::string, std::string>& res_headers,
                                const std::unordered_map<std::string, std::string>& headers, long timeout_ms,
@@ -106,10 +172,22 @@ long HttpClient::post_response_sse(const std::string &url, const std::string &bo
 
     curl_easy_setopt(curl, CURLOPT_POST, 1L);
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
-    curl_easy_perform(curl);
+    CURLcode res_code = curl_easy_perform(curl);
 
     long status_code = 0;
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status_code);
+    if(res_code != CURLE_OK || status_code == 0) {
+        if(res_code != CURLE_OK) {
+            log_curl_failure(curl, res_code);
+            status_code = get_curl_failure_status_code(res_code);
+        } else {
+            status_code = 500;
+        }
+
+        if(req_res->res == nullptr || req_res->res->status_code == 0) {
+            fail_sse_response(req_res, status_code, get_curl_failure_response_body(status_code));
+        }
+    }
     curl_easy_cleanup(curl);
     curl_slist_free_all(chunk);
 
@@ -433,6 +511,11 @@ size_t HttpClient::curl_write_async_done(void *context, curl_socket_t item) {
     deferred_req_res_t* req_res = static_cast<deferred_req_res_t *>(context);
     if(req_res->req->is_write) {
        req_res->server->decr_pending_writes();
+    }
+
+    if(req_res->res->status_code == 0) {
+        close(item);
+        return 0;
     }
 
     if(req_res->req->async_res_done_callback) {

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -19,8 +19,8 @@ struct client_state_t: public req_state_t {
 long HttpClient::post_response(const std::string &url, const std::string &body, std::string &response,
                                std::map<std::string, std::string>& res_headers,
                                const std::unordered_map<std::string, std::string>& headers, long timeout_ms,
-                               bool send_ts_api_header) {
-    CURL *curl = init_curl(url, response, timeout_ms);
+                               bool send_ts_api_header, SSLVerifyMode ssl_verify_mode) {
+    CURL *curl = init_curl(url, response, timeout_ms, ssl_verify_mode);
     if(curl == nullptr) {
         return 500;
     }
@@ -36,13 +36,63 @@ long HttpClient::post_response(const std::string &url, const std::string &body, 
     return perform_curl(curl, res_headers, chunk, send_ts_api_header);
 }
 
+long HttpClient::post_response_verified(const std::string &url, const std::string &body, std::string &response,
+                                        std::map<std::string, std::string>& res_headers,
+                                        const std::unordered_map<std::string, std::string>& headers, long timeout_ms,
+                                        bool send_ts_api_header) {
+    return post_response(url, body, response, res_headers, headers, timeout_ms, send_ts_api_header,
+                         SSLVerifyMode::VERIFY);
+}
 
 long HttpClient::post_response_stream(const std::string &url, const std::string &body, async_stream_response_t &response,
                                      std::map<std::string, std::string>& res_headers,
-                                     const std::unordered_map<std::string, std::string>& headers, long timeout_ms) {
+                                     const std::unordered_map<std::string, std::string>& headers, long timeout_ms,
+                                     SSLVerifyMode ssl_verify_mode) {
     struct curl_slist* chunk = nullptr;
 
-    CURL *curl = init_curl_stream(url, response, timeout_ms);
+    CURL *curl = init_curl_stream(url, response, timeout_ms, ssl_verify_mode);
+    if(curl == nullptr) {
+        return 500;
+    }
+
+    for(const auto& header: headers) {
+        std::string header_str = header.first + ": " + header.second;
+        chunk = curl_slist_append(chunk, header_str.c_str());
+    }
+
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
+
+    curl_easy_setopt(curl, CURLOPT_POST, 1L);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
+    CURLcode res_code = curl_easy_perform(curl);
+
+    long status_code = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status_code);
+    if(res_code != CURLE_OK || status_code == 0) {
+        std::unique_lock<std::mutex> lock(response.mutex);
+        response.ready = true;
+        response.cv.notify_one();
+        if(status_code == 0) {
+            status_code = res_code == CURLE_OPERATION_TIMEDOUT ? 408 : 500;
+        }
+    }
+    curl_easy_cleanup(curl);
+    curl_slist_free_all(chunk);
+
+    return status_code;
+}
+
+long HttpClient::post_response_sse(const std::string &url, const std::string &body,
+                                const std::unordered_map<std::string, std::string>& headers, long timeout_ms,
+                                const std::shared_ptr<http_req> request,
+                                const std::shared_ptr<http_res> response,
+                                HttpServer* server,
+                                SSLVerifyMode ssl_verify_mode) {
+    struct curl_slist* chunk = nullptr;
+    deferred_req_res_t* req_res = new deferred_req_res_t(request, response, server, false);
+    std::unique_ptr<deferred_req_res_t> req_res_guard(req_res);
+
+    CURL *curl = init_curl_sse(url, timeout_ms, req_res, ssl_verify_mode);
     if(curl == nullptr) {
         return 500;
     }
@@ -66,37 +116,12 @@ long HttpClient::post_response_stream(const std::string &url, const std::string 
     return status_code;
 }
 
-long HttpClient::post_response_sse(const std::string &url, const std::string &body,
+long HttpClient::post_response_sse_verified(const std::string &url, const std::string &body,
                                 const std::unordered_map<std::string, std::string>& headers, long timeout_ms,
                                 const std::shared_ptr<http_req> request,
                                 const std::shared_ptr<http_res> response,
                                 HttpServer* server) {
-    struct curl_slist* chunk = nullptr;
-    deferred_req_res_t* req_res = new deferred_req_res_t(request, response, server, false);
-    std::unique_ptr<deferred_req_res_t> req_res_guard(req_res);
-
-    CURL *curl = init_curl_sse(url, timeout_ms, req_res);
-    if(curl == nullptr) {
-        return 500;
-    }
-
-    for(const auto& header: headers) {
-        std::string header_str = header.first + ": " + header.second;
-        chunk = curl_slist_append(chunk, header_str.c_str());
-    }
-
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
-
-    curl_easy_setopt(curl, CURLOPT_POST, 1L);
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
-    curl_easy_perform(curl);
-
-    long status_code = 0;
-    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &status_code);
-    curl_easy_cleanup(curl);
-    curl_slist_free_all(chunk);
-
-    return status_code;
+    return post_response_sse(url, body, headers, timeout_ms, request, response, server, SSLVerifyMode::VERIFY);
 }
 
 long HttpClient::post_response_async(const std::string &url, const std::shared_ptr<http_req> request,
@@ -122,8 +147,8 @@ long HttpClient::post_response_async(const std::string &url, const std::shared_p
 
 long HttpClient::put_response(const std::string &url, const std::string &body, std::string &response,
                               std::map<std::string, std::string>& res_headers, long timeout_ms,
-                              bool send_ts_api_header) {
-    CURL *curl = init_curl(url, response, timeout_ms);
+                              bool send_ts_api_header, SSLVerifyMode ssl_verify_mode) {
+    CURL *curl = init_curl(url, response, timeout_ms, ssl_verify_mode);
     if(curl == nullptr) {
         return 500;
     }
@@ -135,8 +160,8 @@ long HttpClient::put_response(const std::string &url, const std::string &body, s
 
 long HttpClient::patch_response(const std::string &url, const std::string &body, std::string &response,
                               std::map<std::string, std::string>& res_headers, long timeout_ms,
-                              bool send_ts_api_header) {
-    CURL *curl = init_curl(url, response, timeout_ms);
+                              bool send_ts_api_header, SSLVerifyMode ssl_verify_mode) {
+    CURL *curl = init_curl(url, response, timeout_ms, ssl_verify_mode);
     if(curl == nullptr) {
         return 500;
     }
@@ -148,8 +173,8 @@ long HttpClient::patch_response(const std::string &url, const std::string &body,
 
 long HttpClient::delete_response(const std::string &url, std::string &response,
                                  std::map<std::string, std::string>& res_headers, long timeout_ms,
-                                 bool send_ts_api_header) {
-    CURL *curl = init_curl(url, response, timeout_ms);
+                                 bool send_ts_api_header, SSLVerifyMode ssl_verify_mode) {
+    CURL *curl = init_curl(url, response, timeout_ms, ssl_verify_mode);
     if(curl == nullptr) {
         return 500;
     }
@@ -161,8 +186,8 @@ long HttpClient::delete_response(const std::string &url, std::string &response,
 long HttpClient::get_response(const std::string &url, std::string &response,
                               std::map<std::string, std::string>& res_headers,
                               const std::unordered_map<std::string, std::string>& headers,
-                              long timeout_ms, bool send_ts_api_header) {
-    CURL *curl = init_curl(url, response, timeout_ms);
+                              long timeout_ms, bool send_ts_api_header, SSLVerifyMode ssl_verify_mode) {
+    CURL *curl = init_curl(url, response, timeout_ms, ssl_verify_mode);
     if(curl == nullptr) {
         return 500;
     }
@@ -178,8 +203,20 @@ long HttpClient::get_response(const std::string &url, std::string &response,
     return perform_curl(curl, res_headers, chunk, send_ts_api_header);
 }
 
-void HttpClient::init(const std::string &api_key) {
+long HttpClient::get_response_verified(const std::string &url, std::string &response,
+                                       std::map<std::string, std::string>& res_headers,
+                                       const std::unordered_map<std::string, std::string>& headers,
+                                       long timeout_ms, bool send_ts_api_header) {
+    return get_response(url, response, res_headers, headers, timeout_ms, send_ts_api_header,
+                        SSLVerifyMode::VERIFY);
+}
+
+void HttpClient::init(const std::string &api_key, const std::string& ca_cert_path) {
     HttpClient::api_key = api_key;
+    if(!ca_cert_path.empty()) {
+        HttpClient::ca_cert_path = ca_cert_path;
+        return;
+    }
 
     // try to locate ca cert file (from: https://serverfault.com/a/722646/117601)
     std::vector<std::string> locations = {
@@ -432,15 +469,32 @@ size_t HttpClient::curl_write_async_done(void *context, curl_socket_t item) {
     return 0;
 }
 
-CURL *HttpClient::init_curl_stream(const std::string& url, async_stream_response_t& res, long timeout_ms) {
-    CURL* curl = curl_easy_init();
+void HttpClient::configure_ssl(CURL* curl, const std::string& url, SSLVerifyMode ssl_verify_mode) {
+    if(curl == nullptr || url.compare(0, 8, "https://") != 0) {
+        return;
+    }
 
     if(!ca_cert_path.empty()) {
         curl_easy_setopt(curl, CURLOPT_CAINFO, ca_cert_path.c_str());
-    } else if (url.compare(0, 5, "https") == 0) {
+    } else {
         LOG(WARNING) << "Unable to locate system SSL certificates.";
     }
 
+    if(ssl_verify_mode == SSLVerifyMode::VERIFY) {
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
+    } else {
+        // Legacy internal cluster/self-signed paths still opt out until they are migrated.
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+    }
+}
+
+CURL *HttpClient::init_curl_stream(const std::string& url, async_stream_response_t& res, long timeout_ms,
+                                   SSLVerifyMode ssl_verify_mode) {
+    CURL* curl = curl_easy_init();
+
+    configure_ssl(curl, url, ssl_verify_mode);
 
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 4000);
@@ -448,10 +502,6 @@ CURL *HttpClient::init_curl_stream(const std::string& url, async_stream_response
     curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE);
 
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "Typesense/1.0");
-
-    // to allow self-signed certs
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, HttpClient::curl_write_stream);  
 
@@ -466,17 +516,14 @@ CURL *HttpClient::init_curl_stream(const std::string& url, async_stream_response
 
 
 CURL *HttpClient::init_curl_sse(const std::string& url, long timeout_ms,
-                                deferred_req_res_t* req_res) {
+                                deferred_req_res_t* req_res,
+                                SSLVerifyMode ssl_verify_mode) {
     CURL* curl = curl_easy_init();
     if(curl == nullptr) {
         return nullptr;
     }
 
-    if(!ca_cert_path.empty()) {
-    curl_easy_setopt(curl, CURLOPT_CAINFO, ca_cert_path.c_str());
-    } else {
-    LOG(WARNING) << "Unable to locate system SSL certificates.";
-    }
+    configure_ssl(curl, url, ssl_verify_mode);
 
     req_res->req->data = new client_state_t(curl);  // destruction of data is managed by req destructor
 
@@ -488,10 +535,6 @@ CURL *HttpClient::init_curl_sse(const std::string& url, long timeout_ms,
 
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "Typesense/1.0");
 
-    // to allow self-signed certs
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
-
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, HttpClient::curl_write_async);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, req_res);
 
@@ -501,7 +544,7 @@ CURL *HttpClient::init_curl_sse(const std::string& url, long timeout_ms,
 }
 
 CURL *HttpClient::init_curl_async(const std::string& url, deferred_req_res_t* req_res, curl_slist*& chunk,
-                                  bool send_ts_api_header) {
+                                  bool send_ts_api_header, SSLVerifyMode ssl_verify_mode) {
     CURL *curl = curl_easy_init();
 
     if(curl == nullptr) {
@@ -530,20 +573,12 @@ CURL *HttpClient::init_curl_async(const std::string& url, deferred_req_res_t* re
     // context to callback
     curl_easy_setopt(curl, CURLOPT_READDATA, (void *)req_res);
 
-    if(!ca_cert_path.empty()) {
-        curl_easy_setopt(curl, CURLOPT_CAINFO, ca_cert_path.c_str());
-    } else if (url.compare(0, 5, "https") == 0) {
-        LOG(WARNING) << "Unable to locate system SSL certificates.";
-    }
+    configure_ssl(curl, url, ssl_verify_mode);
 
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 4000);
 
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "Typesense/1.0");
-
-    // to allow self-signed certs
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, HttpClient::curl_write_async);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, req_res);
@@ -554,7 +589,8 @@ CURL *HttpClient::init_curl_async(const std::string& url, deferred_req_res_t* re
     return curl;
 }
 
-CURL *HttpClient::init_curl(const std::string& url, std::string& response, const size_t timeout_ms) {
+CURL *HttpClient::init_curl(const std::string& url, std::string& response, const size_t timeout_ms,
+                            SSLVerifyMode ssl_verify_mode) {
     CURL *curl = curl_easy_init();
 
     if(curl == nullptr) {
@@ -564,11 +600,7 @@ CURL *HttpClient::init_curl(const std::string& url, std::string& response, const
         return nullptr;
     }
 
-    if(!ca_cert_path.empty()) {
-        curl_easy_setopt(curl, CURLOPT_CAINFO, ca_cert_path.c_str());
-    } else if (url.compare(0, 5, "https") == 0) {
-        LOG(WARNING) << "Unable to locate system SSL certificates.";
-    }
+    configure_ssl(curl, url, ssl_verify_mode);
 
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 4000);
@@ -576,10 +608,6 @@ CURL *HttpClient::init_curl(const std::string& url, std::string& response, const
     curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE);
 
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "Typesense/1.0");
-
-    // to allow self-signed certs
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
 
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, HttpClient::curl_write);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
@@ -597,7 +625,8 @@ size_t HttpClient::curl_write_download(void *ptr, size_t size, size_t nmemb, FIL
     return written;
 }
 
-long HttpClient::download_file(const std::string& url, const std::string& file_path) {
+long HttpClient::download_file(const std::string& url, const std::string& file_path,
+                               SSLVerifyMode ssl_verify_mode) {
     CURL *curl = curl_easy_init();
     
 
@@ -609,12 +638,15 @@ long HttpClient::download_file(const std::string& url, const std::string& file_p
 
     if(fp == nullptr) {
         LOG(ERROR) << "Unable to open file for writing: " << file_path;
+        curl_easy_cleanup(curl);
         return -1;
     }
 
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, 30000); //30s
-    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1L);
+    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, 30L);
+    configure_ssl(curl, url, ssl_verify_mode);
 
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_write_download);
@@ -625,6 +657,8 @@ long HttpClient::download_file(const std::string& url, const std::string& file_p
 
     if(res_code != CURLE_OK) {
         LOG(ERROR) << "Unable to download file: " << url << " to " << file_path << " - " << curl_easy_strerror(res_code);
+        curl_easy_cleanup(curl);
+        fclose(fp);
         return -1;
     }
     long http_code = 0;
@@ -636,3 +670,6 @@ long HttpClient::download_file(const std::string& url, const std::string& file_p
     return http_code;
 }
 
+long HttpClient::download_file_verified(const std::string& url, const std::string& file_path) {
+    return download_file(url, file_path, SSLVerifyMode::VERIFY);
+}

--- a/src/http_proxy.cpp
+++ b/src/http_proxy.cpp
@@ -12,20 +12,26 @@ HttpProxy::HttpProxy() : cache(30s), sse_cache(30s) {
 http_proxy_res_t HttpProxy::call(const std::string& url, const std::string& method,
                                  const std::string& req_body,
                                  const std::unordered_map<std::string, std::string>& req_headers,
-                                 const size_t timeout_ms) {
+                                 const size_t timeout_ms,
+                                 HttpClient::SSLVerifyMode ssl_verify_mode) {
     HttpClient& client = HttpClient::get_instance();
     http_proxy_res_t res;
     if(method == "GET") {
-        res.status_code = client.get_response(url, res.body, res.headers, req_headers, timeout_ms);
+        res.status_code = client.get_response(url, res.body, res.headers, req_headers, timeout_ms, false,
+                                              ssl_verify_mode);
     } else if(method == "POST") {
-        res.status_code = client.post_response(url, req_body, res.body, res.headers, req_headers, timeout_ms);
+        res.status_code = client.post_response(url, req_body, res.body, res.headers, req_headers, timeout_ms, false,
+                                               ssl_verify_mode);
     } else if(method == "PUT") {
-        res.status_code = client.put_response(url, req_body, res.body, res.headers, timeout_ms);
+        res.status_code = client.put_response(url, req_body, res.body, res.headers, timeout_ms, false,
+                                              ssl_verify_mode);
     } else if(method == "DELETE") {
-        res.status_code = client.delete_response(url, res.body, res.headers, timeout_ms);
+        res.status_code = client.delete_response(url, res.body, res.headers, timeout_ms, false,
+                                                 ssl_verify_mode);
     } else if(method == "POST_STREAM") {
         async_stream_response_t stream_res;
-        res.status_code = client.post_response_stream(url, req_body, stream_res, res.headers, req_headers, timeout_ms);
+        res.status_code = client.post_response_stream(url, req_body, stream_res, res.headers, req_headers, timeout_ms,
+                                                      ssl_verify_mode);
         std::unique_lock lock(stream_res.mutex);
         stream_res.cv.wait(lock, [&](){
             return stream_res.ready;
@@ -44,11 +50,13 @@ http_proxy_res_t HttpProxy::call(const std::string& url, const std::string& meth
 
 
 http_proxy_res_t HttpProxy::send(const std::string& url, const std::string& method, const std::string& req_body,
-                                 std::unordered_map<std::string, std::string>& req_headers) {
+                                 std::unordered_map<std::string, std::string>& req_headers,
+                                 HttpClient::SSLVerifyMode ssl_verify_mode) {
     // check if url is in cache
     uint64_t key = StringUtils::hash_wy(url.c_str(), url.size());
     key = StringUtils::hash_combine(key, StringUtils::hash_wy(method.c_str(), method.size()));
     key = StringUtils::hash_combine(key, StringUtils::hash_wy(req_body.c_str(), req_body.size()));
+    key = StringUtils::hash_combine(key, ssl_verify_mode == HttpClient::SSLVerifyMode::VERIFY ? 1 : 0);
 
     size_t timeout_ms = default_timeout_ms;
     size_t num_try = default_num_try;
@@ -77,7 +85,7 @@ http_proxy_res_t HttpProxy::send(const std::string& url, const std::string& meth
 
     http_proxy_res_t res;
     for(size_t i = 0; i < num_try; i++){
-        res = call(url, method, req_body, req_headers, timeout_ms);
+        res = call(url, method, req_body, req_headers, timeout_ms, ssl_verify_mode);
 
         if(res.status_code != 408 && res.status_code < 500){
             break;
@@ -105,7 +113,8 @@ http_proxy_res_t HttpProxy::send(const std::string& url, const std::string& meth
 bool HttpProxy::call_sse(const std::string& url, const std::string& method,
                         const std::string& req_body, const std::unordered_map<std::string, std::string>& req_headers,
                         const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res,
-                        const size_t timeout_ms) {
+                        const size_t timeout_ms,
+                        HttpClient::SSLVerifyMode ssl_verify_mode) {
     if(method != "POST") {
         res->status_code = 400;
         res->body = "{\"message\": \"SSE only supports POST method.\"}";
@@ -118,9 +127,11 @@ bool HttpProxy::call_sse(const std::string& url, const std::string& method,
     uint64_t key = StringUtils::hash_wy(url.c_str(), url.size());
     key = StringUtils::hash_combine(key, StringUtils::hash_wy(method.c_str(), method.size()));
     key = StringUtils::hash_combine(key, StringUtils::hash_wy(req_body.c_str(), req_body.size()));
+    key = StringUtils::hash_combine(key, ssl_verify_mode == HttpClient::SSLVerifyMode::VERIFY ? 1 : 0);
 
     res->proxied_stream = true;
-    res->status_code =  client.post_response_sse(url, req_body, req_headers, timeout_ms, req, res, server);
+    res->status_code =  client.post_response_sse(url, req_body, req_headers, timeout_ms, req, res, server,
+                                                 ssl_verify_mode);
     if(res->status_code != 200){
         return false;
     }

--- a/src/natural_language_search_model.cpp
+++ b/src/natural_language_search_model.cpp
@@ -874,7 +874,8 @@ long NaturalLanguageSearchModel::post_response(const std::string& url, const std
         res_headers = mock_headers;
         return status;
     }
-    return HttpClient::post_response(url, body, response, res_headers, headers, timeout_ms, send_ts_api_header);
+    return HttpClient::post_response_verified(url, body, response, res_headers, headers, timeout_ms,
+                                              send_ts_api_header);
 }
 
 void NaturalLanguageSearchModel::add_mock_response(const std::string& response_body, long status_code, const std::map<std::string, std::string>& response_headers) {

--- a/src/text_embedder_remote.cpp
+++ b/src/text_embedder_remote.cpp
@@ -31,7 +31,8 @@ long RemoteEmbedder::call_remote_api(const std::string& method, const std::strin
     if(raft_server == nullptr || raft_server->get_leader_url().empty()) {
         // call proxy's internal send() directly
         if(method == "GET" || method == "POST") {
-            auto proxy_res = HttpProxy::get_instance().send(url, method, req_body, req_headers);
+            auto proxy_res = HttpProxy::get_instance().send(url, method, req_body, req_headers,
+                                                            HttpClient::SSLVerifyMode::VERIFY);
             res_body = std::move(proxy_res.body);
             res_headers = std::move(proxy_res.headers);
             return proxy_res.status_code;
@@ -46,6 +47,7 @@ long RemoteEmbedder::call_remote_api(const std::string& method, const std::strin
     proxy_req_body["url"] = url;
     proxy_req_body["body"] = req_body;
     proxy_req_body["headers"] = req_headers;
+    proxy_req_body["ssl_verify"] = true;
 
     size_t per_call_timeout_ms = HttpProxy::default_timeout_ms;
     size_t num_try = HttpProxy::default_num_try;

--- a/src/tsconfig.cpp
+++ b/src/tsconfig.cpp
@@ -185,6 +185,7 @@ void Config::load_config_env() {
     this->master = get_env("TYPESENSE_MASTER");
     this->ssl_certificate = get_env("TYPESENSE_SSL_CERTIFICATE");
     this->ssl_certificate_key = get_env("TYPESENSE_SSL_CERTIFICATE_KEY");
+    this->http_client_ca_certificate = get_env("TYPESENSE_HTTP_CLIENT_CA_CERTIFICATE");
 
     const std::string enable_cors = get_env("TYPESENSE_ENABLE_CORS");
     this->enable_cors = ("TRUE" == enable_cors || enable_cors.empty());
@@ -404,6 +405,10 @@ void Config::load_config_file(cmdline::parser& options) {
 
     if(reader.Exists("server", "ssl-certificate-key")) {
         this->ssl_certificate_key = reader.Get("server", "ssl-certificate-key", "");
+    }
+
+    if(reader.Exists("server", "http-client-ca-certificate")) {
+        this->http_client_ca_certificate = reader.Get("server", "http-client-ca-certificate", "");
     }
 
     if(reader.Exists("server", "listen-port")) {
@@ -645,6 +650,10 @@ void Config::load_config_cmd_args(cmdline::parser& options)  {
 
     if(options.exist("ssl-certificate-key")) {
         this->ssl_certificate_key = options.get<std::string>("ssl-certificate-key");
+    }
+
+    if(options.exist("http-client-ca-certificate")) {
+        this->http_client_ca_certificate = options.get<std::string>("http-client-ca-certificate");
     }
 
     if(options.exist("listen-port")) {

--- a/src/typesense_server_utils.cpp
+++ b/src/typesense_server_utils.cpp
@@ -101,6 +101,7 @@ void init_cmdline_options(cmdline::parser & options, int argc, char **argv) {
     options.add<std::string>("ssl-certificate", 'c', "Path to the SSL certificate file.", false, "");
     options.add<std::string>("ssl-certificate-key", 'k', "Path to the SSL certificate key file.", false, "");
     options.add<uint32_t>("ssl-refresh-interval-seconds", '\0', "Frequency of automatic reloading of SSL certs from disk.", false, 8 * 60 * 60);
+    options.add<std::string>("http-client-ca-certificate", '\0', "Path to the CA certificate bundle used for verified outbound HTTPS calls.", false, "");
 
     options.add<bool>("enable-cors", '\0', "Enable CORS requests.", false, true);
     options.add<std::string>("cors-domains", '\0', "Comma separated list of domains that are allowed for CORS.", false, "");
@@ -596,7 +597,7 @@ int run_server(const Config & config, const std::string & version, void (*master
 
     curl_global_init(CURL_GLOBAL_SSL);
     HttpClient & httpClient = HttpClient::get_instance();
-    httpClient.init(config.get_api_key());
+    httpClient.init(config.get_api_key(), config.get_http_client_ca_certificate());
 
     server = new HttpServer(
         version,

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -2208,6 +2208,17 @@ TEST_F(CoreAPIUtilsTest, TestProxyInvalid) {
 
     ASSERT_EQ(400, resp->status_code);
     ASSERT_EQ("Headers must be a JSON object.", nlohmann::json::parse(resp->body)["message"]);
+
+    // test with ssl_verify as string
+    body["headers"] = nlohmann::json::object();
+    body["ssl_verify"] = "true";
+
+    req->body = body.dump();
+
+    post_proxy(req, resp);
+
+    ASSERT_EQ(400, resp->status_code);
+    ASSERT_EQ("SSL verify must be a boolean.", nlohmann::json::parse(resp->body)["message"]);
 }
 
 TEST_F(CoreAPIUtilsTest, TestProxyTimeout) {

--- a/test/tsconfig_test.cpp
+++ b/test/tsconfig_test.cpp
@@ -96,6 +96,7 @@ TEST(ConfigTest, LoadConfigFile) {
     ASSERT_EQ("/tmp/logs", config.get_log_dir());
     ASSERT_EQ(9090, config.get_api_port());
     ASSERT_EQ(true, config.get_enable_cors());
+    ASSERT_EQ("/tmp/ca.pem", config.get_http_client_ca_certificate());
 }
 
 TEST(ConfigTest, LoadIncompleteConfigFile) {

--- a/test/valid_config.ini
+++ b/test/valid_config.ini
@@ -9,6 +9,7 @@ log-dir = /tmp/logs
 
 listen-port = 9090
 enable-cors = True
+http-client-ca-certificate = /tmp/ca.pem
 
 analytics-dir=/tmp/analytics
 


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
Remote model/provider traffic now uses verified HTTPS, while existing internal Typesense calls keep the legacy unverified behavior by default.

### What Changed

- Added `HttpClient::SSLVerifyMode` with `VERIFY` and `NO_VERIFY`.
- Centralized curl SSL setup in `HttpClient::configure_ssl(...)`.
- Added verified helpers:
  - `get_response_verified(...)`
  - `post_response_verified(...)`
  - `post_response_sse_verified(...)`
  - `download_file_verified(...)`
- Migrated remote model calls and public model downloads to verified helpers.
- Added `ssl_verify` propagation through `/proxy` and `/proxy_sse` for leader-side provider calls.
- Added outbound CA bundle config:
  - env: `TYPESENSE_HTTP_CLIENT_CA_CERTIFICATE`
  - config: `http-client-ca-certificate`
  - CLI: `--http-client-ca-certificate`

### New Args

Use this when a verified remote provider uses a private or self-signed CA:

```bash
--http-client-ca-certificate=/path/to/ca.pem
```

Equivalent env/config options:

```bash
TYPESENSE_HTTP_CLIENT_CA_CERTIFICATE=/path/to/ca.pem
```

```ini
http-client-ca-certificate = /path/to/ca.pem
```

Manual `/proxy` and `/proxy_sse` requests can opt into outbound verification with:

```json
{
  "url": "https://example.com",
  "method": "GET",
  "headers": {},
  "ssl_verify": true
}
```
### Compatibility

Default `HttpClient` calls remain `NO_VERIFY`, so raft/internal/self-signed cluster paths are not changed.

Only remote model/provider and public model download paths opt into `VERIFY`.
## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
