### PR TITLE
Draft PR: Configurable `timeout_ms` and `num_retries` in `model_config`

### DIFF
--- a/include/field.h
+++ b/include/field.h
@@ -78,6 +78,8 @@ namespace fields {
     // For e.g. e5-small model requires prefix "passage:" for indexing and "query:" for querying
     static const std::string indexing_prefix = "indexing_prefix";
     static const std::string query_prefix = "query_prefix";
+    static const std::string timeout_ms = "timeout_ms";
+    static const std::string num_retries = "num_retries";
     static const std::string api_key = "api_key";
     static const std::string model_config = "model_config";
     static const std::string personalization_type = "personalization_type";

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -337,6 +337,18 @@ Option<bool> field::json_field_to_field(bool enable_nested_fields, nlohmann::jso
             }
         }
 
+        if(model_config.count(fields::timeout_ms) != 0) {
+            if(!model_config[fields::timeout_ms].is_number_unsigned() || model_config[fields::timeout_ms].get<size_t>() == 0) {
+                return Option<bool>(400, "Property `embed.model_config.timeout_ms` must be a positive integer.");
+            }
+        }
+
+        if(model_config.count(fields::num_retries) != 0) {
+            if(!model_config[fields::num_retries].is_number_unsigned()) {
+                return Option<bool>(400, "Property `embed.model_config.num_retries` must be a non-negative integer.");
+            }
+        }
+
         for(auto& embed_from_field : field_json[fields::embed][fields::from]) {
             if(!embed_from_field.is_string()) {
                 return Option<bool>(400, "Property `" + fields::embed + "." + fields::from + "` must contain only field names as strings.");

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -8229,8 +8229,15 @@ void Index::batch_embed_fields(std::vector<index_record*>& records,
                 LOG(ERROR) << "Error: " << embedder_op.error();
                 return;
             }
-            embeddings_text = embedder_op.get()->embed_documents(values_text, remote_embedding_batch_size, remote_embedding_timeout_ms,
-                                                            remote_embedding_num_tries);
+            const auto& mc = field.embed[fields::model_config];
+            size_t field_timeout_ms = mc.contains(fields::timeout_ms)
+                ? mc[fields::timeout_ms].get<size_t>()
+                : remote_embedding_timeout_ms;
+            size_t field_num_tries = mc.contains(fields::num_retries)
+                ? mc[fields::num_retries].get<size_t>() + 1
+                : remote_embedding_num_tries;
+            embeddings_text = embedder_op.get()->embed_documents(values_text, remote_embedding_batch_size, field_timeout_ms,
+                                                            field_num_tries);
         }
 
         if(!values_personalization.empty()) {

--- a/test/collection_schema_change_test.cpp
+++ b/test/collection_schema_change_test.cpp
@@ -2133,3 +2133,93 @@ TEST_F(CollectionSchemaChangeTest, DropObjectFieldWithSimilarPrefix) {
     ASSERT_EQ(1, schema_map.count("attributes_filter"));
     ASSERT_EQ(1, schema_map.count("attributes_nested_string"));
 }
+
+TEST_F(CollectionSchemaChangeTest, EmbeddingModelConfigValidSettings) {
+    // test valid model_config fields for timeout_ms and num_retries
+    
+    EmbedderManager::set_model_dir("/tmp/typesense_test/models");
+    
+    nlohmann::json schema = R"({
+        "name": "objects",
+        "fields": [
+            {"name": "title", "type": "string"},
+            {"name": "embedding", "type": "float[]", "embed": {
+                "from": ["title"],
+                "model_config": {"model_name": "ts/e5-small", "timeout_ms": 15000, "num_retries": 3}
+            }}
+        ]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+
+    auto emb_fields = op.get()->get_embedding_fields();  
+    auto& model_config = emb_fields.at("embedding").embed[fields::model_config];
+
+    ASSERT_TRUE(model_config.contains("timeout_ms"));
+    ASSERT_EQ(15000, model_config["timeout_ms"].get<size_t>());
+
+    ASSERT_TRUE(model_config.contains("num_retries"));
+    ASSERT_EQ(3, model_config["num_retries"].get<size_t>());
+}
+
+TEST_F(CollectionSchemaChangeTest, EmbeddingModelConfigInvalidTimeout) {
+    EmbedderManager::set_model_dir("/tmp/typesense_test/models");
+    
+    nlohmann::json schema = R"({
+        "name": "objects",
+        "fields": [
+            {"name": "embedding", "type": "float[]", "embed": {
+                "from": ["title"],
+                "model_config": {"model_name": "ts/e5-small", "timeout_ms": 0}
+            }}
+        ]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_FALSE(op.ok());
+
+    ASSERT_EQ("Property `embed.model_config.timeout_ms` must be a positive integer.", op.error());
+}
+
+TEST_F(CollectionSchemaChangeTest, EmbeddingModelConfigNumRetriesZeroValid) {
+    // verify that num_retries equal to 0 is a valid field
+
+    nlohmann::json schema = R"({
+        "name": "objects",
+        "fields": [
+            {"name": "title", "type": "string"},
+            {"name": "embedding", "type": "float[]", "embed": {
+                "from": ["title"],
+                "model_config": {"model_name": "ts/e5-small", "num_retries": 0}
+            }}
+        ]
+    })"_json;
+
+    EmbedderManager::set_model_dir("/tmp/typesense_test/models");
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+
+    auto emb_fields = op.get()->get_embedding_fields();
+    auto& model_config = emb_fields.at("embedding").embed[fields::model_config];
+    ASSERT_EQ(0, model_config["num_retries"].get<size_t>());
+}
+
+TEST_F(CollectionSchemaChangeTest, EmbeddingModelConfigNumRetriesInvalidType) {
+    EmbedderManager::set_model_dir("/tmp/typesense_test/models");
+    
+    nlohmann::json schema = R"({
+        "name": "objects",
+        "fields": [
+            {"name": "embedding", "type": "float[]", "embed": {
+                "from": ["title"],
+                "model_config": {"model_name": "ts/e5-small", "num_retries": "many"}
+            }}
+        ]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_FALSE(op.ok());
+
+    ASSERT_EQ("Property `embed.model_config.num_retries` must be a non-negative integer.", op.error());
+}


### PR DESCRIPTION
This is a partial implementation of #2839, covering per-field timeout and retry configuration. The fallback provider mechanism is left pending design clarification (see questions below).

---

### Problem

When using an external embedding provider, Typesense's error handling behavior is entirely hardcoded: a 5-second CURL timeout and 2 retries, with no fallback. If a provider is unreliable, this results in slow requests (2 × 5s = 10s stall) with no way to fine tune or escape this behavior. The original issue also requests a fallback provider mechanism where if all retries against the primary fail, Typesense should attempt the request against a secondary provider. The original issue also references Plexus-style features such as provider cooldown and routing to the lowest-latency provider.

### Proposed Solution

Expose `timeout_ms` and `num_retries` as optional fields in `embed.model_config`, allowing per-field overrides of the collection-level defaults. Fallback provider support is deferred pending design input (see open questions). As for the Plexus-like features, they currently seem out of scope but can be revisited once the fallback design is settled, possibly in a different PR.

---

### Changes

**`include/field.h`** — Added `fields::timeout_ms` and `fields::num_retries` constants.

**`src/field.cpp`** — Validation in `json_field_to_field()`:
- `timeout_ms`: optional, must be a positive integer (`0` is rejected - a zero-ms timeout would cause all calls to fail)
- `num_retries`: optional, must be a non-negative integer (`0` is valid - means one attempt, no retries)

**`src/index.cpp`** — In `batch_embed_fields()`, field-level values are read from `model_config` and fall back to collection-level defaults when absent. Note: `num_retries` is user-facing (additional attempts), while `embed_documents` takes `num_tries` (total attempts), so `+1` is applied on read.

**`test/collection_schema_change_test.cpp`** — Four tests covering: valid settings, `timeout_ms: 0` rejection, `num_retries: 0` acceptance, and invalid num_retries type rejection.

---

### Open Questions (Fallback Design)

Before implementing fallback providers, input on the following would be helpful:

1. **Config structure** — Should `model_config` be able to accept an array of provider objects so fallbacks are defined inline? Or would a dedicated `fallback_config` field be preferable?

2. **Stickiness / cooldown** — If the primary provider fails and a fallback is used, should the fallback be sticky for a cooldown period before retrying the primary (requiring failure state to be tracked)? Or should the primary always be attempted first on each new document/request? 

Happy to extend this once the design direction is confirmed.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
