### PR TITLE
fix(tokenizer): preserve original utf8 byte length for offsets

### DIFF
--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -113,7 +113,7 @@ bool Tokenizer::next(std::string &token, size_t& token_index, size_t& start_inde
             std::string word;
             std::string original_word;
             unicode_text.tempSubStringBetween(start_pos, end_pos).toUTF8String(original_word);
-            size_t orig_word_size = original_word.size();
+            size_t offset_word_size = original_word.size();
 
             if(locale == "ko") {
                 UErrorCode errcode = U_ZERO_ERROR;
@@ -123,6 +123,8 @@ bool Tokenizer::next(std::string &token, size_t& token_index, size_t& start_inde
 
                 if(!U_FAILURE(errcode)) {
                     dst.toUTF8String(word);
+                    // Korean highlighting uses NFKD-normalized display text, so offsets must track normalized bytes.
+                    offset_word_size = word.size();
                 } else {
                     LOG(ERROR) << "Unicode error during parsing: " << errcode;
                 }
@@ -210,7 +212,7 @@ bool Tokenizer::next(std::string &token, size_t& token_index, size_t& start_inde
             }
 
             start_index = utf8_start_index;
-            end_index = utf8_start_index + orig_word_size - 1;
+            end_index = utf8_start_index + offset_word_size - 1;
             utf8_start_index = end_index + 1;
 
             start_pos = end_pos;

--- a/src/tokenizer.cpp
+++ b/src/tokenizer.cpp
@@ -111,6 +111,9 @@ bool Tokenizer::next(std::string &token, size_t& token_index, size_t& start_inde
         while (end_pos != icu::BreakIterator::DONE) {
             //LOG(INFO) << "Position: " << start_pos;
             std::string word;
+            std::string original_word;
+            unicode_text.tempSubStringBetween(start_pos, end_pos).toUTF8String(original_word);
+            size_t orig_word_size = original_word.size();
 
             if(locale == "ko") {
                 UErrorCode errcode = U_ZERO_ERROR;
@@ -167,7 +170,6 @@ bool Tokenizer::next(std::string &token, size_t& token_index, size_t& start_inde
             }
 
             bool emit_token = false;
-            size_t orig_word_size = word.size();
 
             if(locale == "zh" && (word == "，" || word == "─" || word == "。")) {
                 emit_token = false;

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -4167,6 +4167,81 @@ TEST_F(CollectionSpecificMoreTest, PhraseQueryHighlightingInNestedFields) {
     collectionManager.drop_collection("coll1");
 }
 
+TEST_F(CollectionSpecificMoreTest, NestedTransliterationHighlightShouldNotSplitUtf8Tokens) {
+    nlohmann::json schema = R"({
+        "name": "coll1",
+        "enable_nested_fields": true,
+        "fields": [
+            {"name": "enrichment", "type": "object"},
+            {"name": "enrichment.transliterations", "type": "object"},
+            {"name": "enrichment.transliterations.el", "type": "string[]", "locale": "el"},
+            {"name": "enrichment.transliterations.en", "type": "string[]"},
+            {"name": "name", "type": "string", "infix": true},
+            {"name": "genres", "type": "object[]"},
+            {"name": "genres.name", "type": "string[]"},
+            {"name": "lineup", "type": "object[]"},
+            {"name": "lineup.name", "type": "string[]"}
+        ]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+    Collection* coll1 = op.get();
+
+    nlohmann::json doc;
+    doc["id"] = "1";
+    doc["enrichment"]["transliterations"]["el"] = nlohmann::json::array({
+        "Λύσανδρος Κατραφούρης & Θεόφιλος Σαμουραΐτης προσκαλούν τους Alex Stone & Nina Vale στο Tegan Gang Jazz Club της Αθήνας",
+        "Κατραφούρης Σαμουραΐτης Tegan Gang Jazz Club",
+        "Tegan Gang Jazz Club Συναυλία"
+    });
+    doc["enrichment"]["transliterations"]["en"] = nlohmann::json::array({
+        "Lysandros Katrafouris and Theofilos Samouraitis present Alex Stone and Nina Vale at Tegan Gang Jazz Club Athens",
+        "Tegan Gang Jazz Club"
+    });
+    doc["name"] = "Katrafouris/Samouraitis invite Alex Stone & Nina Vale";
+    doc["genres"] = nlohmann::json::array({
+        nlohmann::json::object({{"id", "jazz"}, {"name", "jazz"}})
+    });
+    doc["lineup"] = nlohmann::json::array({
+        nlohmann::json::object({{"name", "Theofilos Samouraitis"}})
+    });
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    auto results = coll1->search("jazz club",
+                                 {"enrichment.transliterations.el", "enrichment.transliterations.en",
+                                  "name", "genres.name", "lineup.name"},
+                                 "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, 0,
+                                 spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(),
+                                 10, "", 30, 4, "").get();
+
+    ASSERT_EQ(1, results["found"].get<size_t>());
+    ASSERT_EQ(1, results["hits"].size());
+
+    const auto& el_highlights = results["hits"][0]["highlight"]["enrichment"]["transliterations"]["el"];
+    ASSERT_GE(el_highlights.size(), 1);
+
+    bool found_problematic_greek_entry = false;
+    for(const auto& highlight: el_highlights) {
+        const auto snippet = highlight["snippet"].get<std::string>();
+        if(snippet.find("Tegan Gang") == std::string::npos || snippet.find("Αθήνας") == std::string::npos) {
+            continue;
+        }
+
+        found_problematic_greek_entry = true;
+        ASSERT_EQ(2, highlight["matched_tokens"].size()) << highlight.dump();
+        ASSERT_EQ("Jazz", highlight["matched_tokens"][0].get<std::string>()) << highlight.dump();
+        ASSERT_EQ("Club", highlight["matched_tokens"][1].get<std::string>()) << highlight.dump();
+        ASSERT_NE(snippet.find("<mark>Jazz</mark> <mark>Club</mark>"), std::string::npos) << highlight.dump();
+        ASSERT_EQ(snippet.find("<mark> Clu</mark>"), std::string::npos) << highlight.dump();
+        ASSERT_EQ(snippet.find("<mark> τη</mark>"), std::string::npos) << highlight.dump();
+    }
+
+    ASSERT_TRUE(found_problematic_greek_entry) << el_highlights.dump(2);
+
+    collectionManager.drop_collection("coll1");
+}
+
 TEST_F(CollectionSpecificMoreTest, NestedFieldSingleTokenSnippetTruncation) {
     // verify that snippets for single-token matches in nested fields are properly truncated
     nlohmann::json schema = R"({

--- a/test/tokenizer_test.cpp
+++ b/test/tokenizer_test.cpp
@@ -345,6 +345,36 @@ TEST(TokenizerTest, ShouldTokenizeLocaleTextWithEnglishText) {
     ASSERT_EQ("math", ttokens[8]);
 }
 
+TEST(TokenizerTest, ShouldKeepByteOffsetsForGreekLocaleTokens) {
+    const std::string text =
+        "Λύσανδρος Κατραφούρης & Θεόφιλος Σαμουραΐτης προσκαλούν τους Alex Stone & Nina Vale "
+        "στο Tegan Gang Jazz Club της Αθήνας";
+
+    Tokenizer tokenizer(text, true, false, "el");
+
+    std::string token;
+    size_t token_index = 0;
+    size_t start_index = 0;
+    size_t end_index = 0;
+    bool found_jazz = false;
+    bool found_club = false;
+
+    while(tokenizer.next(token, token_index, start_index, end_index)) {
+        if(token == "jazz") {
+            found_jazz = true;
+            ASSERT_EQ("Jazz", text.substr(start_index, end_index - start_index + 1));
+        }
+
+        if(token == "club") {
+            found_club = true;
+            ASSERT_EQ("Club", text.substr(start_index, end_index - start_index + 1));
+        }
+    }
+
+    ASSERT_TRUE(found_jazz);
+    ASSERT_TRUE(found_club);
+}
+
 TEST(TokenizerTest, ShouldRemoveGenericPunctuationFromThaiText) {
     std::string tstr = "f’’b";
     std::vector<std::string> ttokens;


### PR DESCRIPTION
## Change Summary
- fix locale tokenizer offsets to use original utf-8 byte 
- add regression test for greek transliteration highlight drift
- add tokenizer test for greek locale token byte offsets



## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
