### PR TITLE
fix(collection): handle special-character and empty search queries

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -4750,12 +4750,12 @@ void Collection::process_tokens(std::vector<std::string>& tokens, std::vector<st
     }
 
     if(q_include_tokens.empty()) {
-        if(!stopwords_set.empty() && q_phrases.empty()) {
-            // this can happen when all tokens in the include are stopwords
-            q_include_tokens.emplace_back("##hrhdh##");
-        } else {
-            // this can happen if the only query token is an exclusion token
+        if(!q_exclude_tokens.empty() || !q_phrases.empty()) {
+            // phrase-only and exclusion-only queries use wildcard filtering internally.
             q_include_tokens.emplace_back("*");
+        } else {
+            // this can happen when the query is empty after tokenization, e.g. stopwords or punctuation only
+            q_include_tokens.emplace_back("##hrhdh##");
         }
     }
 }
@@ -4769,6 +4769,9 @@ void Collection::parse_search_query(const std::string &query, std::vector<std::s
     if(query == "*") {
         q_exclude_tokens = {};
         q_include_tokens = {query};
+    } else if(query.empty()) {
+        q_exclude_tokens = {};
+        q_include_tokens = {"*"};
     } else {
         std::vector<std::string> tokens;
         std::vector<std::string> tokens_non_stemmed;

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -1504,8 +1504,17 @@ TEST_F(CollectionSpecificMoreTest, QueryWithOnlySpecialChars) {
     ASSERT_TRUE(res_op.ok());
     auto res = res_op.get();
 
-    ASSERT_EQ(1, res["hits"].size());
-    ASSERT_EQ("0", res["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_EQ(0, res["hits"].size());
+
+    ASSERT_EQ(0, res["found"].get<int>());
+
+    res_op = coll1->search("@", {"title"}, "", {}, {}, {2}, 10, 1, FREQUENCY, {true});
+
+    ASSERT_TRUE(res_op.ok());
+    res = res_op.get();
+
+    ASSERT_EQ(0, res["hits"].size());
+    ASSERT_EQ(0, res["found"].get<int>());
 }
 
 TEST_F(CollectionSpecificMoreTest, HandleStringFieldWithObjectValueEarlier) {
@@ -2493,31 +2502,6 @@ TEST_F(CollectionSpecificMoreTest, DropTokensLeftToRightFirst) {
                            0, "exhaustive", 30000, 2, "", {}, {}, "both_sides:x");
     ASSERT_FALSE(res_op.ok());
     ASSERT_EQ("Invalid format for drop tokens mode.", res_op.error());
-}
-
-TEST_F(CollectionSpecificMoreTest, DoNotHighlightFieldsForSpecialCharacterQuery) {
-    nlohmann::json schema = R"({
-        "name": "coll1",
-        "fields": [
-            {"name": "title", "type": "string"},
-            {"name": "description", "type": "string"}
-        ]
-    })"_json;
-
-    Collection* coll1 = collectionManager.create_collection(schema).get();
-
-    nlohmann::json doc;
-    doc["title"] = "alpha beta gamma";
-    doc["description"] = "alpha beta gamma";
-    ASSERT_TRUE(coll1->add(doc.dump()).ok());
-
-    auto res = coll1->search("'", {"title", "description"}, "", {}, {}, {0}, 3, 1, FREQUENCY, {false}, 1,
-                             spp::sparse_hash_set<std::string>(),
-                             spp::sparse_hash_set<std::string>()).get();
-
-    ASSERT_EQ(1, res["hits"].size());
-    ASSERT_EQ(0, res["hits"][0]["highlight"].size());
-    ASSERT_EQ(0, res["hits"][0]["highlights"].size());
 }
 
 TEST_F(CollectionSpecificMoreTest, SearchForURL) {


### PR DESCRIPTION
## Change Summary
  - treat punctuation-only and stopword-only queries as no-match results
  - preserve wildcard handling for phrase-only, exclusion-only, and empty queries
  - closes #2909 


## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
