### PR TITLE
add prefix auth_key in access logs

### DIFF
--- a/include/app_metrics.h
+++ b/include/app_metrics.h
@@ -78,7 +78,11 @@ public:
 
     void increment_write_metrics(uint64_t route_hash, uint64_t duration);
 
-    void write_access_log(const uint64_t epoch_millis, const char* remote_ip, const std::string& path);
+    static std::string format_access_log(const uint64_t epoch_millis, const char* remote_ip, const std::string& path,
+                                         const std::string& api_key_prefix);
+
+    void write_access_log(const uint64_t epoch_millis, const char* remote_ip, const std::string& path,
+                          const std::string& api_key_prefix);
 
     void flush_access_log();
 

--- a/include/auth_manager.h
+++ b/include/auth_manager.h
@@ -158,6 +158,8 @@ public:
                                    const nlohmann::detail::iteration_proxy_value<nlohmann::json::iterator>& item,
                                    bool overwrite);
 
+    std::string get_api_key_prefix(const std::string& value) const;
+
     void do_housekeeping();
 
     std::vector<std::string> get_api_key_collections(const std::string& value);

--- a/include/core_api.h
+++ b/include/core_api.h
@@ -7,7 +7,8 @@
 bool handle_authentication(std::map<std::string, std::string>& req_params,
                            std::vector<nlohmann::json>& embedded_params_vec,
                            const std::string& body, const route_path& rpath,
-                           const std::string& req_auth_key);
+                           const std::string& req_auth_key,
+                           std::string* api_key_prefix = nullptr);
 
 bool get_alter_in_progress(const std::string& collection);
 

--- a/include/http_data.h
+++ b/include/http_data.h
@@ -270,6 +270,7 @@ struct http_req {
     std::map<std::string, std::string> params;
     std::vector<nlohmann::json> embedded_params_vec;
     std::string api_auth_key;
+    std::string api_auth_key_prefix;
 
     bool first_chunk_aggregate;
     std::atomic<bool> last_chunk_aggregate;
@@ -329,9 +330,11 @@ struct http_req {
 
     http_req(h2o_req_t* _req, const std::string & http_method, const std::string & path_without_query, uint64_t route_hash,
             const std::map<std::string, std::string>& params, std::vector<nlohmann::json>& embedded_params_vec,
-            const std::string& api_auth_key, const std::string& body, const std::string& client_ip, bool is_binary_body):
+            const std::string& api_auth_key, const std::string& api_auth_key_prefix, const std::string& body,
+            const std::string& client_ip, bool is_binary_body):
             _req(_req), http_method(http_method), path_without_query(path_without_query), route_hash(route_hash),
             params(params), embedded_params_vec(embedded_params_vec), api_auth_key(api_auth_key),
+            api_auth_key_prefix(api_auth_key_prefix),
             first_chunk_aggregate(true), last_chunk_aggregate(false),
             chunk_len(0), body(body), body_index(0), data(nullptr), ready(false),
             log_index(0), is_diposed(false), client_ip(client_ip), is_binary_body(is_binary_body) {

--- a/include/http_server.h
+++ b/include/http_server.h
@@ -167,7 +167,8 @@ private:
     bool (*auth_handler)(std::map<std::string, std::string>& params,
                          std::vector<nlohmann::json>& embedded_params_vec,
                          const std::string& body, const route_path& rpath,
-                         const std::string& auth_key);
+                         const std::string& auth_key,
+                         std::string* api_key_prefix);
 
     static void on_accept(h2o_socket_t *listener, const char *err);
 
@@ -228,7 +229,8 @@ public:
 
     void set_auth_handler(bool (*handler)(std::map<std::string, std::string>& params,
                                           std::vector<nlohmann::json>& embedded_params_vec, const std::string& body,
-                                          const route_path & rpath, const std::string & auth_key));
+                                          const route_path & rpath, const std::string & auth_key,
+                                          std::string* api_key_prefix));
 
     void get(const std::string & path, bool (*handler)(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res), bool async_req=false, bool async_res=false);
 

--- a/src/app_metrics.cpp
+++ b/src/app_metrics.cpp
@@ -190,9 +190,22 @@ void AppMetrics::window_reset() {
     current_durations = new spp::sparse_hash_map<std::string, TDigest>();
 }
 
+namespace {
+std::string sanitize_access_log_field(const std::string& value) {
+    std::string sanitized = value;
+    for(char& ch: sanitized) {
+        if(ch == '\t' || ch == '\n' || ch == '\r' || static_cast<unsigned char>(ch) < 0x20 || ch == 0x7f) {
+            ch = '_';
+        }
+    }
+    return sanitized;
+}
+}
+
 std::string AppMetrics::format_access_log(const uint64_t epoch_millis, const char* remote_ip, const std::string& path,
                                           const std::string& api_key_prefix) {
-    return std::to_string(epoch_millis) + "\t" + remote_ip + "\t" + path + "\t" + api_key_prefix + "\n";
+    return std::to_string(epoch_millis) + "\t" + sanitize_access_log_field(remote_ip) + "\t" +
+           sanitize_access_log_field(path) + "\t" + sanitize_access_log_field(api_key_prefix) + "\n";
 }
 
 void AppMetrics::write_access_log(const uint64_t epoch_millis, const char* remote_ip, const std::string& path,

--- a/src/app_metrics.cpp
+++ b/src/app_metrics.cpp
@@ -190,9 +190,15 @@ void AppMetrics::window_reset() {
     current_durations = new spp::sparse_hash_map<std::string, TDigest>();
 }
 
-void AppMetrics::write_access_log(const uint64_t epoch_millis, const char* remote_ip, const std::string& path) {
+std::string AppMetrics::format_access_log(const uint64_t epoch_millis, const char* remote_ip, const std::string& path,
+                                          const std::string& api_key_prefix) {
+    return std::to_string(epoch_millis) + "\t" + remote_ip + "\t" + path + "\t" + api_key_prefix + "\n";
+}
+
+void AppMetrics::write_access_log(const uint64_t epoch_millis, const char* remote_ip, const std::string& path,
+                                  const std::string& api_key_prefix) {
     if(!access_log_path.empty()) {
-        access_log << epoch_millis << "\t" << remote_ip << "\t" << path << "\n";
+        access_log << format_access_log(epoch_millis, remote_ip, path, api_key_prefix);
     }
 }
 

--- a/src/auth_manager.cpp
+++ b/src/auth_manager.cpp
@@ -216,6 +216,36 @@ bool AuthManager::authenticate(const std::string& action,
     return (num_keys_matched == collection_keys.size());
 }
 
+std::string AuthManager::get_api_key_prefix(const std::string& value) const {
+    if(value.empty()) {
+        return "";
+    }
+
+    std::shared_lock lock(mutex);
+    if(value == bootstrap_auth_key || api_keys.find(value) != api_keys.end()) {
+        return value.substr(0, api_key_t::PREFIX_LEN);
+    }
+
+    const std::string& key_payload = StringUtils::base64_decode(value);
+    if(key_payload.size() >= HMAC_BASE64_LEN + api_key_t::PREFIX_LEN) {
+        const std::string& hmacSHA256 = key_payload.substr(0, HMAC_BASE64_LEN);
+        const std::string& key_prefix = key_payload.substr(HMAC_BASE64_LEN, api_key_t::PREFIX_LEN);
+        const std::string& custom_params = key_payload.substr(HMAC_BASE64_LEN + api_key_t::PREFIX_LEN);
+        auto embedded_params = nlohmann::json::parse(custom_params, nullptr, false);
+        if(embedded_params.is_object()) {
+            auto prefix_range = api_keys.equal_prefix_range(key_prefix);
+            for(auto it = prefix_range.first; it != prefix_range.second; ++it) {
+                const api_key_t& root_api_key = it.value();
+                if(StringUtils::hmac(root_api_key.value, custom_params) == hmacSHA256) {
+                    return key_prefix;
+                }
+            }
+        }
+    }
+
+    return value.substr(0, api_key_t::PREFIX_LEN);
+}
+
 namespace {
 Option<std::string> resolve_scoped_search_collection(const std::string& request_collection,
                                                      const nlohmann::json& embedded_params) {

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -2,6 +2,7 @@
 #include <thread>
 #include <app_metrics.h>
 #include <regex>
+#include <algorithm>
 #include <analytics_manager.h>
 #include "analytics_manager.h"
 #include <housekeeper.h>
@@ -93,7 +94,11 @@ bool handle_authentication(std::map<std::string, std::string>& req_params,
                            std::vector<nlohmann::json>& embedded_params_vec,
                            const std::string& body,
                            const route_path& rpath,
-                           const std::string& req_auth_key) {
+                           const std::string& req_auth_key,
+                           std::string* api_key_prefix) {
+    if(api_key_prefix != nullptr) {
+        api_key_prefix->clear();
+    }
 
     if(rpath.handler == get_health) {
         // health endpoint requires no authentication
@@ -102,10 +107,14 @@ bool handle_authentication(std::map<std::string, std::string>& req_params,
 
     if(rpath.handler == get_health_with_resource_usage) {
         // health_rusage end-point will be authenticated via pre-determined keys
-        return !req_auth_key.empty() && (
+        bool authenticated = !req_auth_key.empty() && (
                 req_auth_key == Config::get_instance().get_api_key() ||
                 req_auth_key == Config::get_instance().get_health_rusage_api_key()
                 );
+        if(authenticated && api_key_prefix != nullptr) {
+            *api_key_prefix = req_auth_key.substr(0, api_key_t::PREFIX_LEN);
+        }
+        return authenticated;
     }
 
     CollectionManager & collectionManager = CollectionManager::get_instance();
@@ -117,6 +126,22 @@ bool handle_authentication(std::map<std::string, std::string>& req_params,
                    << "collections.size: " << collections.size()
                    << ", embedded_params_vec.size: " << embedded_params_vec.size();
         return false;
+    }
+
+    if(api_key_prefix != nullptr) {
+        AuthManager& auth_manager = collectionManager.getAuthManager();
+        std::vector<std::string> api_key_prefixes;
+        for(const auto& collection: collections) {
+            auto prefix = auth_manager.get_api_key_prefix(collection.api_key);
+            if(!prefix.empty() && std::find(api_key_prefixes.begin(), api_key_prefixes.end(), prefix) == api_key_prefixes.end()) {
+                api_key_prefixes.push_back(prefix);
+            }
+        }
+        auto req_auth_key_prefix = auth_manager.get_api_key_prefix(req_auth_key);
+        if(api_key_prefixes.empty() && !req_auth_key_prefix.empty()) {
+            api_key_prefixes.push_back(req_auth_key_prefix);
+        }
+        *api_key_prefix = StringUtils::join(api_key_prefixes, ",");
     }
 
     const bool authenticated = collectionManager.auth_key_matches(req_auth_key, rpath.action, collections, req_params,

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -13,6 +13,7 @@
 #include "ratelimit_manager.h"
 #include "sole.hpp"
 #include "core_api.h"
+#include "collection_manager.h"
 
 HttpServer::HttpServer(const std::string & version, const std::string & listen_address,
                        uint32_t listen_port, const std::string & ssl_cert_path, const std::string & ssl_cert_key_path,
@@ -402,12 +403,14 @@ int HttpServer::catch_all_handler(h2o_handler_t *_h2o_handler, h2o_req_t *req) {
         api_auth_key_sent = query_map[http_req::AUTH_HEADER];
     }
 
-    if(Config::get_instance().get_enable_access_logging()) {
+    std::string api_auth_key_prefix;
+    const bool is_multi_search_request = (path_without_query == "/multi_search");
+    if(!is_multi_search_request && Config::get_instance().get_enable_access_logging()) {
         uint64_t now = std::chrono::duration_cast<std::chrono::microseconds>(
                 std::chrono::system_clock::now().time_since_epoch()).count();
         auto epoch_millis = now / 1000;
-        const auto api_key_prefix = api_auth_key_sent.substr(0, api_key_t::PREFIX_LEN);
-        AppMetrics::get_instance().write_access_log(epoch_millis, client_ip.c_str(), metric_identifier, api_key_prefix);
+        api_auth_key_prefix = CollectionManager::get_instance().getAuthManager().get_api_key_prefix(api_auth_key_sent);
+        AppMetrics::get_instance().write_access_log(epoch_millis, client_ip.c_str(), metric_identifier, api_auth_key_prefix);
     }
 
     // Handle CORS
@@ -565,7 +568,7 @@ int HttpServer::catch_all_handler(h2o_handler_t *_h2o_handler, h2o_req_t *req) {
         // multi_search needs to be handled later because the API key could be part of request body and
         // the whole request body might not be available right now.
         bool authenticated = h2o_handler->http_server->auth_handler(query_map, embedded_params_vec, body, *rpath,
-                                                                    api_auth_key_sent);
+                                                                    api_auth_key_sent, &api_auth_key_prefix);
         if(!authenticated) {
             std::string message = std::string("{\"message\": \"Forbidden - a valid `") + http_req::AUTH_HEADER +
                                   "` header must be sent.\"}";
@@ -583,7 +586,8 @@ int HttpServer::catch_all_handler(h2o_handler_t *_h2o_handler, h2o_req_t *req) {
 
     std::shared_ptr<http_req> request = std::make_shared<http_req>(req, rpath->http_method, path_without_query,
                                                                    route_hash, query_map, embedded_params_vec,
-                                                                   api_auth_key_sent, body, client_ip, is_binary_body);
+                                                                   api_auth_key_sent, api_auth_key_prefix, body, client_ip,
+                                                                   is_binary_body);
 
     // add custom generator with a dispose function for cleaning up resources
     h2o_custom_generator_t* custom_gen = new h2o_custom_generator_t;
@@ -806,11 +810,30 @@ int HttpServer::process_request(const std::shared_ptr<http_req>& request, const 
     if(root_resource == "multi_search") {
         // We can authenticate only when the full request body is available
         bool authenticated = handler->http_server->auth_handler(request->params, request->embedded_params_vec,
-                                                                request->body, *rpath, request->api_auth_key);
+                                                                request->body, *rpath, request->api_auth_key,
+                                                                &request->api_auth_key_prefix);
         if(!authenticated) {
+            if(Config::get_instance().get_enable_access_logging()) {
+                uint64_t now = std::chrono::duration_cast<std::chrono::microseconds>(
+                        std::chrono::system_clock::now().time_since_epoch()).count();
+                auto epoch_millis = now / 1000;
+                const auto metric_identifier = rpath->http_method + " " + request->path_without_query;
+                AppMetrics::get_instance().write_access_log(epoch_millis, request->client_ip.c_str(), metric_identifier,
+                                                            request->api_auth_key_prefix);
+            }
+
             std::string message = std::string("{\"message\": \"Forbidden - a valid `") + http_req::AUTH_HEADER +
                                   "` header must be sent.\"}";
             return send_response(request->_req, 401, message);
+        }
+
+        if(Config::get_instance().get_enable_access_logging()) {
+            uint64_t now = std::chrono::duration_cast<std::chrono::microseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()).count();
+            auto epoch_millis = now / 1000;
+            const auto metric_identifier = rpath->http_method + " " + request->path_without_query;
+            AppMetrics::get_instance().write_access_log(epoch_millis, request->client_ip.c_str(), metric_identifier,
+                                                        request->api_auth_key_prefix);
         }
     }
 
@@ -1006,7 +1029,8 @@ void HttpServer::stream_response(stream_response_state_t& state) {
 void HttpServer::set_auth_handler(bool (*handler)(std::map<std::string, std::string>& params,
                                                   std::vector<nlohmann::json>& embedded_params_vec,
                                                   const std::string& body,
-                                                  const route_path& rpath, const std::string& auth_key)) {
+                                                  const route_path& rpath, const std::string& auth_key,
+                                                  std::string* api_key_prefix)) {
     auth_handler = handler;
 }
 

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -377,11 +377,37 @@ int HttpServer::catch_all_handler(h2o_handler_t *_h2o_handler, h2o_req_t *req) {
 
     std::string client_ip = http_req::get_ip_addr(req).ip;
 
+    std::vector<std::string> path_parts;
+    StringUtils::split(path_without_query, path_parts, "/");
+
+    h2o_iovec_t query = req->query_at != SIZE_MAX ?
+                        h2o_iovec_init(req->path.base + req->query_at, req->path.len - req->query_at) :
+                        h2o_iovec_init(H2O_STRLIT(""));
+
+    std::string query_str(query.base, query.len);
+    std::map<std::string, std::string> query_map;
+    StringUtils::parse_query_string(query_str, query_map);
+
+    // cache ttl can be applied only from an embedded key: cannot be a get param
+    query_map.erase("cache_ttl");
+
+    // Extract auth key from header. If that does not exist, look for a GET parameter.
+    ssize_t auth_header_cursor = h2o_find_header_by_str(&req->headers, http_req::AUTH_HEADER, strlen(http_req::AUTH_HEADER), -1);
+    std::string api_auth_key_sent;
+
+    if(auth_header_cursor != -1) {
+        h2o_iovec_t & slot = req->headers.entries[auth_header_cursor].value;
+        api_auth_key_sent = std::string(slot.base, slot.len);
+    } else if(query_map.count(http_req::AUTH_HEADER) != 0) {
+        api_auth_key_sent = query_map[http_req::AUTH_HEADER];
+    }
+
     if(Config::get_instance().get_enable_access_logging()) {
         uint64_t now = std::chrono::duration_cast<std::chrono::microseconds>(
                 std::chrono::system_clock::now().time_since_epoch()).count();
         auto epoch_millis = now / 1000;
-        AppMetrics::get_instance().write_access_log(epoch_millis, client_ip.c_str(), metric_identifier);
+        const auto api_key_prefix = api_auth_key_sent.substr(0, api_key_t::PREFIX_LEN);
+        AppMetrics::get_instance().write_access_log(epoch_millis, client_ip.c_str(), metric_identifier, api_key_prefix);
     }
 
     // Handle CORS
@@ -436,35 +462,10 @@ int HttpServer::catch_all_handler(h2o_handler_t *_h2o_handler, h2o_req_t *req) {
         }
     }
 
-    std::vector<std::string> path_parts;
-    StringUtils::split(path_without_query, path_parts, "/");
-
-    h2o_iovec_t query = req->query_at != SIZE_MAX ?
-                        h2o_iovec_init(req->path.base + req->query_at, req->path.len - req->query_at) :
-                        h2o_iovec_init(H2O_STRLIT(""));
-
     if(query.len > 4000 && http_method == "GET" && !path_parts.empty() && path_parts.back() == "search") {
         nlohmann::json resp;
         resp["message"] = "Query string exceeds max allowed length of 4000. Use the /multi_search end-point for larger payloads.";
         return send_response(req, 400, resp.dump());
-    }
-
-    std::string query_str(query.base, query.len);
-    std::map<std::string, std::string> query_map;
-    StringUtils::parse_query_string(query_str, query_map);
-
-    // cache ttl can be applied only from an embedded key: cannot be a get param
-    query_map.erase("cache_ttl");
-
-    // Extract auth key from header. If that does not exist, look for a GET parameter.
-    ssize_t auth_header_cursor = h2o_find_header_by_str(&req->headers, http_req::AUTH_HEADER, strlen(http_req::AUTH_HEADER), -1);
-    std::string api_auth_key_sent;
-
-    if(auth_header_cursor != -1) {
-        h2o_iovec_t & slot = req->headers.entries[auth_header_cursor].value;
-        api_auth_key_sent = std::string(slot.base, slot.len);
-    } else if(query_map.count(http_req::AUTH_HEADER) != 0) {
-        api_auth_key_sent = query_map[http_req::AUTH_HEADER];
     }
 
     // extract user id from header, if not already present as GET param

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -88,6 +88,10 @@ void StringUtils::parse_query_string(const std::string& query, std::map<std::str
     int query_len = int(query.size());
     int i = 0;
 
+    if(query.empty()) {
+        return;
+    }
+
     if(query[0] == '?') {
         i++;
     }

--- a/test/app_metrics_test.cpp
+++ b/test/app_metrics_test.cpp
@@ -44,6 +44,14 @@ TEST_F(AppMetricsTest, StatefulRemoveDocs) {
     ASSERT_EQ(result["rps"]["GET /operations/vote"].get<double>(), 0.1);
 }
 
+TEST_F(AppMetricsTest, FormatsAccessLogWithApiKeyPrefix) {
+    ASSERT_EQ("123456\t1.2.3.4\tGET /collections\tabcd\n",
+              AppMetrics::format_access_log(123456, "1.2.3.4", "GET /collections", "abcd"));
+
+    ASSERT_EQ("123456\t1.2.3.4\tGET /health\t\n",
+              AppMetrics::format_access_log(123456, "1.2.3.4", "GET /health", ""));
+}
+
 TEST_F(AppMetricsTest, EstimateQuantileDuration) {
     //add 100 random durations
     std::mt19937 rng;

--- a/test/app_metrics_test.cpp
+++ b/test/app_metrics_test.cpp
@@ -50,6 +50,9 @@ TEST_F(AppMetricsTest, FormatsAccessLogWithApiKeyPrefix) {
 
     ASSERT_EQ("123456\t1.2.3.4\tGET /health\t\n",
               AppMetrics::format_access_log(123456, "1.2.3.4", "GET /health", ""));
+
+    ASSERT_EQ("123456\t1.2.3.4\tGET /collections\tab__\n",
+              AppMetrics::format_access_log(123456, "1.2.3.4", "GET /collections", "ab\t\n"));
 }
 
 TEST_F(AppMetricsTest, EstimateQuantileDuration) {

--- a/test/auth_manager_test.cpp
+++ b/test/auth_manager_test.cpp
@@ -443,6 +443,19 @@ TEST_F(AuthManagerTest, ScopedAPIKeys) {
     ASSERT_FALSE(auth_manager.authenticate("documents:search", {collection_key_t("coll1", "SXZqcVdOWjVNNUVsY3ZiTW9YajQ1QnhrUXJaRzRaS0VhTlFvUmlvQ3gycz1LZXlWeyJmaWx0ZXJfYnkiOiAidXNlcl9pZDoxMDgw In0=")}, empty_params, embedded_params));
 }
 
+TEST_F(AuthManagerTest, ResolvesScopedAPIKeyPrefix) {
+    api_key_t key_search_coll1("KeyVal", "test key", {"documents:search"}, {"coll1"}, FUTURE_TS);
+    auth_manager.create_key(key_search_coll1);
+
+    std::string scoped_key = StringUtils::base64_encode(
+      R"(IvjqWNZ5M5ElcvbMoXj45BxkQrZG4ZKEaNQoRioCx2s=KeyV{"filter_by": "user_id:1080"})"
+    );
+
+    ASSERT_EQ("KeyV", auth_manager.get_api_key_prefix(key_search_coll1.value));
+    ASSERT_EQ("KeyV", auth_manager.get_api_key_prefix(scoped_key));
+    ASSERT_EQ("", auth_manager.get_api_key_prefix(""));
+}
+
 TEST_F(AuthManagerTest, ValidateBadKeyProperties) {
     nlohmann::json key_obj1;
     key_obj1["description"] = "desc";

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -1103,6 +1103,62 @@ TEST_F(CoreAPIUtilsTest, ExtractCollectionsFromRequestBodyExtended) {
     ASSERT_EQ(1, embedded_params_vec.size());
 }
 
+TEST_F(CoreAPIUtilsTest, MultiSearchAuthenticationReturnsBodyApiKeyPrefixes) {
+    AuthManager& auth_manager = collectionManager.getAuthManager();
+    api_key_t body_key1("BodyKey1", "body key 1", {"documents:search"}, {"*"}, api_key_t::FAR_FUTURE_TIMESTAMP);
+    api_key_t body_key2("ZodyKey2", "body key 2", {"documents:search"}, {"*"}, api_key_t::FAR_FUTURE_TIMESTAMP);
+    auth_manager.create_key(body_key1);
+    auth_manager.create_key(body_key2);
+
+    route_path rpath_multi_search = route_path("POST", {"multi_search"}, post_multi_search, false, false);
+    std::map<std::string, std::string> req_params;
+    std::vector<nlohmann::json> embedded_params_vec;
+    std::string api_key_prefix;
+
+    std::string body = R"(
+        {"searches":[
+              {
+                "collection": "products",
+                "q": "battery",
+                "query_by": "name",
+                "x-typesense-api-key": "BodyKey1"
+              },
+              {
+                "collection": "products",
+                "q": "charger",
+                "query_by": "name",
+                "x-typesense-api-key": "ZodyKey2"
+              }
+          ]
+        }
+    )";
+
+    ASSERT_TRUE(handle_authentication(req_params, embedded_params_vec, body, rpath_multi_search, "", &api_key_prefix));
+    ASSERT_EQ("Body,Zody", api_key_prefix);
+}
+
+TEST_F(CoreAPIUtilsTest, MultiSearchAuthenticationReturnsBodyApiKeyPrefixOnFailure) {
+    route_path rpath_multi_search = route_path("POST", {"multi_search"}, post_multi_search, false, false);
+    std::map<std::string, std::string> req_params;
+    std::vector<nlohmann::json> embedded_params_vec;
+    std::string api_key_prefix;
+
+    std::string body = R"(
+        {"searches":[
+              {
+                "collection": "products",
+                "q": "battery",
+                "query_by": "name",
+                "x-typesense-api-key": "NopeKey1"
+              }
+          ]
+        }
+    )";
+
+    ASSERT_FALSE(handle_authentication(req_params, embedded_params_vec, body, rpath_multi_search, "", &api_key_prefix));
+    ASSERT_EQ("Nope", api_key_prefix);
+}
+
 TEST_F(CoreAPIUtilsTest, MultiSearchWithPresetShouldUsePresetForAuth) {
     nlohmann::json preset_value = R"(
         {"searches":[


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
 - Adds the triggering API key prefix to access log entries as a fourth tab-separated field.

- Also adds a regression test for access log formatting to ensure the API key prefix is emitted and empty prefixes are preserved for unauthenticated/no-key requests.
## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
