### PR TITLE
Fix stale nested object array indexes on patch update

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -8040,6 +8040,21 @@ void Index::get_doc_changes(const index_operation_t op, const tsl::htrie_map<cha
     nlohmann::json final_update_doc = nlohmann::json::object(); // Temporary for changed fields
 
     // Recursive function to apply merge patch and track changes
+    const auto add_nested_child_deletions = [](const std::string& key, const nlohmann::json& old,
+                                               nlohmann::json& del) {
+        if(!old.contains(".flat")) {
+            return;
+        }
+
+        const std::string prefix = key + ".";
+        for(const auto& flat_key_json: old[".flat"]) {
+            const auto flat_key = flat_key_json.get<std::string>();
+            if(flat_key.rfind(prefix, 0) == 0 && old.contains(flat_key)) {
+                del[flat_key] = old[flat_key];
+            }
+        }
+    };
+
     std::function<void(nlohmann::json&, nlohmann::json&, const nlohmann::json&,
                        nlohmann::json&, nlohmann::json&)> apply_merge_patch =
             [&](nlohmann::json& target, nlohmann::json& patch, const nlohmann::json& old,
@@ -8078,6 +8093,7 @@ void Index::get_doc_changes(const index_operation_t op, const tsl::htrie_map<cha
                             }
 
                             del[key] = old[key];
+                            add_nested_child_deletions(key, old, del);
                         }
                         target.erase(key);
                         // Do not add to upd (ensures no nulls in final_update_doc)
@@ -8094,7 +8110,10 @@ void Index::get_doc_changes(const index_operation_t op, const tsl::htrie_map<cha
                         // Replacement or new field
                         nlohmann::json processed_value = process_value(value);
                         if (!old.contains(key) || processed_value != old[key]) {
-                            if (old.contains(key)) del[key] = old[key];
+                            if (old.contains(key)) {
+                                del[key] = old[key];
+                                add_nested_child_deletions(key, old, del);
+                            }
                             upd[key] = processed_value;
                             target[key] = processed_value;
                         }

--- a/test/collection_nested_fields_test.cpp
+++ b/test/collection_nested_fields_test.cpp
@@ -3589,6 +3589,52 @@ TEST_F(CollectionNestedFieldsTest, UpdateNestedDocument) {
     ASSERT_EQ(0, results["found"].get<size_t>());
 }
 
+TEST_F(CollectionNestedFieldsTest, UpdateNestedObjectArrayRemovesChildIndexes) {
+    nlohmann::json schema = R"({
+        "name": "books",
+        "enable_nested_fields": true,
+        "fields": [
+          {"name": "title", "type": "string", "optional": true},
+          {"name": "commentsToValidate", "type": "object[]", "optional": true},
+          {"name": "commentsToValidate.userId", "type": "int64[]", "facet": true, "optional": true},
+          {"name": "commentsToValidate.commentIds", "type": "int64[]", "facet": true, "optional": true}
+        ]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+    Collection* coll1 = op.get();
+
+    auto doc = R"({
+        "id": "0",
+        "title": "Title Alpha",
+        "commentsToValidate": [{"userId": 12345, "commentIds": [12, 234, 456]}]
+    })"_json;
+
+    auto add_op = coll1->add(doc.dump(), CREATE);
+    ASSERT_TRUE(add_op.ok());
+
+    auto results = coll1->search("*", {}, "commentsToValidate.userId:=12345", {}, {}, {0},
+                                 10, 1, FREQUENCY, {false}).get();
+    ASSERT_EQ(1, results["found"].get<size_t>());
+
+    doc = R"({
+        "id": "0",
+        "commentsToValidate": []
+    })"_json;
+
+    add_op = coll1->add(doc.dump(), UPDATE);
+    ASSERT_TRUE(add_op.ok());
+
+    results = coll1->search("*", {}, "commentsToValidate.userId:=12345", {}, {}, {0},
+                            10, 1, FREQUENCY, {false}).get();
+    ASSERT_EQ(0, results["found"].get<size_t>());
+
+    auto get_op = coll1->get("0");
+    ASSERT_TRUE(get_op.ok());
+    ASSERT_TRUE(get_op.get()["commentsToValidate"].empty());
+}
+
 TEST_F(CollectionNestedFieldsTest, UpdateNestedDocumentAutoSchema) {
     nlohmann::json schema = R"({
         "name": "coll1",

--- a/test/collection_nested_fields_test.cpp
+++ b/test/collection_nested_fields_test.cpp
@@ -3591,13 +3591,13 @@ TEST_F(CollectionNestedFieldsTest, UpdateNestedDocument) {
 
 TEST_F(CollectionNestedFieldsTest, UpdateNestedObjectArrayRemovesChildIndexes) {
     nlohmann::json schema = R"({
-        "name": "books",
+        "name": "review_tasks",
         "enable_nested_fields": true,
         "fields": [
           {"name": "title", "type": "string", "optional": true},
-          {"name": "commentsToValidate", "type": "object[]", "optional": true},
-          {"name": "commentsToValidate.userId", "type": "int64[]", "facet": true, "optional": true},
-          {"name": "commentsToValidate.commentIds", "type": "int64[]", "facet": true, "optional": true}
+          {"name": "reviewQueue", "type": "object[]", "optional": true},
+          {"name": "reviewQueue.reviewerId", "type": "int64[]", "facet": true, "optional": true},
+          {"name": "reviewQueue.taskIds", "type": "int64[]", "facet": true, "optional": true}
         ]
     })"_json;
 
@@ -3608,31 +3608,31 @@ TEST_F(CollectionNestedFieldsTest, UpdateNestedObjectArrayRemovesChildIndexes) {
     auto doc = R"({
         "id": "0",
         "title": "Title Alpha",
-        "commentsToValidate": [{"userId": 12345, "commentIds": [12, 234, 456]}]
+        "reviewQueue": [{"reviewerId": 9001, "taskIds": [11, 22, 33]}]
     })"_json;
 
     auto add_op = coll1->add(doc.dump(), CREATE);
     ASSERT_TRUE(add_op.ok());
 
-    auto results = coll1->search("*", {}, "commentsToValidate.userId:=12345", {}, {}, {0},
+    auto results = coll1->search("*", {}, "reviewQueue.reviewerId:=9001", {}, {}, {0},
                                  10, 1, FREQUENCY, {false}).get();
     ASSERT_EQ(1, results["found"].get<size_t>());
 
     doc = R"({
         "id": "0",
-        "commentsToValidate": []
+        "reviewQueue": []
     })"_json;
 
     add_op = coll1->add(doc.dump(), UPDATE);
     ASSERT_TRUE(add_op.ok());
 
-    results = coll1->search("*", {}, "commentsToValidate.userId:=12345", {}, {}, {0},
+    results = coll1->search("*", {}, "reviewQueue.reviewerId:=9001", {}, {}, {0},
                             10, 1, FREQUENCY, {false}).get();
     ASSERT_EQ(0, results["found"].get<size_t>());
 
     auto get_op = coll1->get("0");
     ASSERT_TRUE(get_op.ok());
-    ASSERT_TRUE(get_op.get()["commentsToValidate"].empty());
+    ASSERT_TRUE(get_op.get()["reviewQueue"].empty());
 }
 
 TEST_F(CollectionNestedFieldsTest, UpdateNestedDocumentAutoSchema) {


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
PATCH updates that replaced a nested `object[]` field with an empty array could leave old flattened child field values in the in-memory index.

Example shape:

```json
{
  "reviewQueue": [
    { "reviewerId": 9001, "taskIds": [11, 22, 33] }
  ]
}
```

After this PATCH:

```json
{
  "reviewQueue": []
}
```

the stored document was correct, but a filter like:

```text
reviewQueue.reviewerId:=9001
```

could still return the document.

### Cause
Nested object arrays are indexed through flattened synthetic child fields such as:

```text
reviewQueue.reviewerId
reviewQueue.taskIds
```

During update diffing, the old parent field was added to `del_doc`, but the old flattened child fields were not always added. As a result, `Index::remove()` did not remove stale child field entries from the numeric/facet indexes.

### Fix

When a nested parent field is deleted or replaced, the update diff now checks the old document's `.flat` metadata and adds matching flattened child fields to `del_doc`.

So replacing `reviewQueue` also schedules removals for fields like:

```text
reviewQueue.reviewerId
reviewQueue.taskIds
```

This keeps search/filter indexes consistent with the stored document after PATCH updates.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
