### PR TITLE
perf(index): split grouped second-pass string filters into chunks

### DIFF
--- a/include/filter.h
+++ b/include/filter.h
@@ -83,7 +83,8 @@ struct filter {
                                            const std::string& doc_id_prefix,
                                            filter_node_t*& root,
                                            const bool& validate_field_names = true,
-                                           const std::string& object_field_prefix = "");
+                                           const std::string& object_field_prefix = "",
+                                           const bool& validate_max_ops = true);
 
     static Option<bool> tokenize_filter_query(const std::string& filter_query, std::queue<std::string>& tokens);
 

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -895,7 +895,8 @@ Option<bool> filter::parse_filter_query(const std::string& filter_query,
                                         const std::string& doc_id_prefix,
                                         filter_node_t*& root,
                                         const bool& validate_field_names,
-                                        const std::string& object_field_prefix) {
+                                        const std::string& object_field_prefix,
+                                        const bool& validate_max_ops) {
     auto _filter_query = filter_query;
     StringUtils::trim(_filter_query);
     if (_filter_query.empty()) {
@@ -915,10 +916,12 @@ Option<bool> filter::parse_filter_query(const std::string& filter_query,
         return toPostfix_op;
     }
 
-    auto const& max_ops = CollectionManager::get_instance().filter_by_max_ops;
-    if (postfix.size() > max_ops) {
-        return Option<bool>(400, "`filter_by` has too many operations. Maximum allowed: " + std::to_string(max_ops) +
-                                 ". Use `--filter-by-max-ops` command line argument to customize this value.");
+    if (validate_max_ops) {
+        auto const& max_ops = CollectionManager::get_instance().filter_by_max_ops;
+        if (postfix.size() > max_ops) {
+            return Option<bool>(400, "`filter_by` has too many operations. Maximum allowed: " + std::to_string(max_ops) +
+                                     ". Use `--filter-by-max-ops` command line argument to customize this value.");
+        }
     }
 
     Option<bool> toParseTree_op = toParseTree(postfix,

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2737,8 +2737,12 @@ Option<bool> Index::run_search(search_args* search_params) {
             }
 
             filter_node_t* new_filter_tree_root = nullptr;
+            // The grouped second-pass filter is internally generated and chunked into many ORed
+            // sub-filters, which can exceed filter_by_max_ops even when the user's filter wouldn't.
             Option<bool> filter_op = filter::parse_filter_query(filter_by, search_schema, store, "", new_filter_tree_root,
-                                                                search_params->validate_field_names);
+                                                                search_params->validate_field_names,
+                                                                "",
+                                                                false);
             if (!filter_op.ok()) {
                 delete new_filter_tree_root;
                 return filter_op;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -51,6 +51,10 @@ spp::sparse_hash_map<uint32_t, int64_t, Hasher32> Index::vector_distance_sentine
 spp::sparse_hash_map<uint32_t, int64_t, Hasher32> Index::vector_query_sentinel_value;
 spp::sparse_hash_map<uint32_t, int64_t, Hasher32> Index::union_search_index_sentinel_value;
 
+// Split grouped second-pass string filters into chunks of this many values so each
+// chunk's approx_filter_ids_length stays small enough to be computed in init().
+static constexpr size_t GROUPED_STRING_FILTER_VALUES_CHUNK_SIZE = 50;
+
 Index::Index(const std::string& name, const uint32_t collection_id, const Store* store,
             ThreadPool* thread_pool,
              const tsl::htrie_map<char, field> & search_schema,
@@ -2689,16 +2693,40 @@ Option<bool> Index::run_search(search_args* search_params) {
                     continue;
                 }
 
-                std::string clause = field_name + ": [";
-                for (size_t j = 0; j < valid_values.size(); j++) {
-                    clause += valid_values[j];
-                    if (j + 1 < valid_values.size()) {
-                        clause += ",";
-                    }
-                }
-                clause += "]";
+                // For string fields, split into chunks so each leaf filter stays small enough
+                // for init() to materialize it via the string_filter_ids_threshold path. A single
+                // mega-filter would otherwise exceed the threshold and stay lazy.
+                const size_t chunk_size = group_by_fields[i].is_string
+                                              ? GROUPED_STRING_FILTER_VALUES_CHUNK_SIZE
+                                              : valid_values.size();
 
-                clauses.push_back(std::move(clause));
+                std::vector<std::string> field_clauses;
+                for (size_t start = 0; start < valid_values.size(); start += chunk_size) {
+                    const size_t end = std::min(start + chunk_size, valid_values.size());
+                    std::string clause = field_name + ": [";
+                    for (size_t j = start; j < end; j++) {
+                        clause += valid_values[j];
+                        if (j + 1 < end) {
+                            clause += ",";
+                        }
+                    }
+                    clause += "]";
+                    field_clauses.push_back(std::move(clause));
+                }
+
+                if (field_clauses.size() == 1) {
+                    clauses.push_back(std::move(field_clauses[0]));
+                } else {
+                    std::string combined = "(";
+                    for (size_t k = 0; k < field_clauses.size(); k++) {
+                        combined += field_clauses[k];
+                        if (k + 1 < field_clauses.size()) {
+                            combined += " || ";
+                        }
+                    }
+                    combined += ")";
+                    clauses.push_back(std::move(combined));
+                }
             }
 
             for (size_t i = 0; i < clauses.size(); i++) {
@@ -2750,6 +2778,11 @@ Option<bool> Index::run_search(search_args* search_params) {
                 filter_result_iterator = new filter_result_iterator_t(OR, filter_iterator_guard.release(), new_iterator,
                                                                       filter_root, new_filter_tree_root);
                 filter_iterator_guard.reset(filter_result_iterator);
+            }
+
+            if (!search_params->enable_lazy_filter ||
+                    filter_result_iterator->approx_filter_ids_length < COMPUTE_FILTER_ITERATOR_THRESHOLD) {
+                filter_result_iterator->compute_iterators();
             }
 
             return Option<bool>(true);


### PR DESCRIPTION
## Change Summary
- chunk string group values into groups of 50 so each leaf filter fits under string_filter_ids_threshold and is computed in init()
- replace the string-value-count force-compute heuristic with the general approx_filter_ids_length / lazy-filter check


## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
