### PR TITLE
fix: keep deferred collection state alive across drops

### DIFF
--- a/include/core_api_utils.h
+++ b/include/core_api_utils.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include <cstdlib>
+#include <memory>
 #include <vector>
 #include "collection.h"
 #include "http_data.h"
 
 struct deletion_state_t: public req_state_t {
-    Collection* collection;
+    std::shared_ptr<Collection> collection;
     std::vector<std::pair<size_t, uint32_t*>> index_ids;  // ids_len -> ids
     std::vector<size_t> offsets;
     size_t num_removed;
@@ -24,7 +25,7 @@ struct deletion_state_t: public req_state_t {
 };
 
 struct export_state_t: public req_state_t {
-    Collection* collection;
+    std::shared_ptr<Collection> collection;
     filter_result_t filter_result;
     size_t offset = 0;
     tsl::htrie_set<char> include_fields;

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -1486,7 +1486,7 @@ bool get_export_documents(const std::shared_ptr<http_req>& req, const std::share
 
     if(req->data == nullptr) {
         export_state = new export_state_t();
-        export_state->collection = collection.get();
+        export_state->collection = collection;
 
         // destruction of data is managed by req destructor
         req->data = export_state;
@@ -2209,7 +2209,7 @@ bool del_remove_documents(const std::shared_ptr<http_req>& req, const std::share
         for (size_t i = 0; i < deletion_state->index_ids.size(); i++) {
             deletion_state->offsets.push_back(0);
         }
-        deletion_state->collection = collection.get();
+        deletion_state->collection = collection;
         deletion_state->num_removed = 0;
     } else {
         deletion_state = dynamic_cast<deletion_state_t *>(req->data);

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <fstream>
 #include <collection_manager.h>
+#include <core_api_utils.h>
 #include "analytics_manager.h"
 #include "string_utils.h"
 #include "collection.h"
@@ -1284,6 +1285,26 @@ TEST_F(CollectionManagerTest, DropCollectionCleanly) {
     ASSERT_EQ(1, collectionManager.get_next_collection_id());
 
     delete it;
+}
+
+TEST_F(CollectionManagerTest, DropCollectionKeepsDeferredRequestStateCollectionsAlive) {
+    auto collection = collectionManager.get_collection("collection1");
+    ASSERT_NE(nullptr, collection.get());
+
+    export_state_t export_state;
+    export_state.collection = collection;
+    deletion_state_t deletion_state;
+    deletion_state.collection = collection;
+    collection.reset();
+
+    auto drop_op = collectionManager.drop_collection("collection1");
+    ASSERT_TRUE(drop_op.ok());
+    ASSERT_EQ(nullptr, collectionManager.get_collection("collection1").get());
+
+    ASSERT_NE(nullptr, export_state.collection);
+    ASSERT_EQ("collection1", export_state.collection->get_name());
+    ASSERT_NE(nullptr, deletion_state.collection);
+    ASSERT_EQ("collection1", deletion_state.collection->get_name());
 }
 
 TEST_F(CollectionManagerTest, AuthWithMultiSearchKeys) {

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -76,15 +76,15 @@ protected:
 };
 
 TEST_F(CoreAPIUtilsTest, StatefulRemoveDocs) {
-    Collection *coll1;
-
     std::vector<field> fields = {field("title", field_types::STRING, false),
                                  field("points", field_types::INT32, false),};
 
-    coll1 = collectionManager.get_collection("coll1").get();
-    if(coll1 == nullptr) {
-        coll1 = collectionManager.create_collection("coll1", 2, fields, "points").get();
+    auto coll1_shared = collectionManager.get_collection("coll1");
+    if(coll1_shared == nullptr) {
+        collectionManager.create_collection("coll1", 2, fields, "points").get();
+        coll1_shared = collectionManager.get_collection("coll1");
     }
+    Collection* coll1 = coll1_shared.get();
 
     for(size_t i=0; i<100; i++) {
         nlohmann::json doc;
@@ -98,7 +98,7 @@ TEST_F(CoreAPIUtilsTest, StatefulRemoveDocs) {
 
     bool done;
     deletion_state_t deletion_state;
-    deletion_state.collection = coll1;
+    deletion_state.collection = coll1_shared;
     deletion_state.num_removed = 0;
 
     // single document match
@@ -1603,14 +1603,15 @@ TEST_F(CoreAPIUtilsTest, Union) {
 }
 
 TEST_F(CoreAPIUtilsTest, ExportWithFilter) {
-    Collection *coll1;
     std::vector<field> fields = {field("title", field_types::STRING, false),
                                  field("points", field_types::INT32, false),};
 
-    coll1 = collectionManager.get_collection("coll1").get();
-    if(coll1 == nullptr) {
-        coll1 = collectionManager.create_collection("coll1", 2, fields, "points").get();
+    auto coll1_shared = collectionManager.get_collection("coll1");
+    if(coll1_shared == nullptr) {
+        collectionManager.create_collection("coll1", 2, fields, "points").get();
+        coll1_shared = collectionManager.get_collection("coll1");
     }
+    Collection* coll1 = coll1_shared.get();
 
     for(size_t i=0; i<4; i++) {
         nlohmann::json doc;
@@ -1627,7 +1628,7 @@ TEST_F(CoreAPIUtilsTest, ExportWithFilter) {
     filter_result_t filter_result;
     coll1->get_filter_ids_with_lock("points:>=0", export_state.filter_result);
 
-    export_state.collection = coll1;
+    export_state.collection = coll1_shared;
     export_state.res_body = &res_body;
 
     stateful_export_docs(&export_state, 2, done);
@@ -1737,7 +1738,7 @@ TEST_F(CoreAPIUtilsTest, ExportWithJoin) {
     export_state_t export_state;
     auto coll1 = collectionManager.get_collection_unsafe("Products");
     coll1->get_filter_ids_with_lock("$Customers(customer_id:customer_a)", export_state.filter_result);
-    export_state.collection = coll1.get();
+    export_state.collection = coll1;
     export_state.res_body = &res_body;
     export_state.include_fields.insert("product_name");
     export_state.ref_include_exclude_fields_vec.emplace_back(ref_include_exclude_fields{"Customers", {"product_price"}, "",
@@ -3454,15 +3455,15 @@ TEST_F(CoreAPIUtilsTest, TruncateFieldValidationNegative) {
 }
 
 TEST_F(CoreAPIUtilsTest, StatefulRemoveDocsWithReturnValues) {
-    Collection *coll1;
-
     std::vector<field> fields = {field("title", field_types::STRING, false),
                                  field("points", field_types::INT32, false),};
 
-    coll1 = collectionManager.get_collection("coll1").get();
-    if(coll1 == nullptr) {
-        coll1 = collectionManager.create_collection("coll1", 2, fields, "points").get();
+    auto coll1_shared = collectionManager.get_collection("coll1");
+    if(coll1_shared == nullptr) {
+        collectionManager.create_collection("coll1", 2, fields, "points").get();
+        coll1_shared = collectionManager.get_collection("coll1");
     }
+    Collection* coll1 = coll1_shared.get();
 
     for(size_t i=0; i<10; i++) {
         nlohmann::json doc;
@@ -3476,7 +3477,7 @@ TEST_F(CoreAPIUtilsTest, StatefulRemoveDocsWithReturnValues) {
 
     bool done;
     deletion_state_t deletion_state;
-    deletion_state.collection = coll1;
+    deletion_state.collection = coll1_shared;
     deletion_state.num_removed = 0;
     deletion_state.return_doc = true;
     deletion_state.return_id = true;
@@ -3717,14 +3718,15 @@ TEST_F(CoreAPIUtilsTest, RemoveIfFoundManyWithCascadeReference) {
 }
 
 TEST_F(CoreAPIUtilsTest, StatefulRemoveDocsUsesBoundedInternalBatch) {
-    Collection *coll1;
     std::vector<field> fields = {field("title", field_types::STRING, false),
                                  field("points", field_types::INT32, false),};
 
-    coll1 = collectionManager.get_collection("coll1").get();
-    if(coll1 == nullptr) {
-        coll1 = collectionManager.create_collection("coll1", 2, fields, "points").get();
+    auto coll1_shared = collectionManager.get_collection("coll1");
+    if(coll1_shared == nullptr) {
+        collectionManager.create_collection("coll1", 2, fields, "points").get();
+        coll1_shared = collectionManager.get_collection("coll1");
     }
+    Collection* coll1 = coll1_shared.get();
 
     for(size_t i = 0; i < 1205; i++) {
         nlohmann::json doc;
@@ -3735,7 +3737,7 @@ TEST_F(CoreAPIUtilsTest, StatefulRemoveDocsUsesBoundedInternalBatch) {
     }
 
     deletion_state_t deletion_state;
-    deletion_state.collection = coll1;
+    deletion_state.collection = coll1_shared;
     deletion_state.num_removed = 0;
 
     filter_result_t filter_results;


### PR DESCRIPTION
## Change Summary
Bug: deferred export/delete request state stored a raw Collection*. If a chunked export or delete paused, then the collection was dropped before the next chunk, the manager could destroy Collection -> Index -> num_tree_t while the request state still held a dangling pointer. This results in a use-after-free crash on the next deferred chunk when stateful_export_docs or stateful_remove_docs touches the freed Collection, or it could corrupt memory and later show up during Index / num_tree_t destruction like the stack trace.

Fix: export_state_t and deletion_state_t now hold std::shared_ptr<Collection> in core_api_utils.h (line 10), and the route handlers store the request’s shared pointer in core_api.cpp (line 1489) and core_api.cpp (line 2212). That keeps the collection alive until the deferred request state is destroyed.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
