### PR TITLE
fix: clean references when dropping collection aliases

### DIFF
--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -942,7 +942,7 @@ Option<nlohmann::json> CollectionManager::drop_collection(const std::string& col
     for (const auto& item: reference_fields) {
         const auto& reference_info = item.second;
 
-        remove_referenced_ins_with_lock(collection_name, reference_info);
+        remove_referenced_ins_with_lock(actual_coll_name, reference_info);
     }
 
     std::unique_lock u_lock(mutex);

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -1286,6 +1286,45 @@ TEST_F(CollectionManagerTest, DropCollectionCleanly) {
     delete it;
 }
 
+TEST_F(CollectionManagerTest, DropCollectionViaAliasRemovesReferencesByResolvedName) {
+    nlohmann::json products_schema = R"({
+        "name": "alias_products",
+        "fields": [
+            {"name": "product_id", "type": "string"}
+        ]
+    })"_json;
+    auto products_op = collectionManager.create_collection(products_schema);
+    ASSERT_TRUE(products_op.ok());
+
+    nlohmann::json orders_schema = R"({
+        "name": "alias_orders",
+        "fields": [
+            {"name": "product_id", "type": "string", "reference": "alias_products.product_id"}
+        ]
+    })"_json;
+    auto orders_op = collectionManager.create_collection(orders_schema);
+    ASSERT_TRUE(orders_op.ok());
+
+    auto referenced_ins = collectionManager._get_referenced_ins();
+    ASSERT_EQ(1, referenced_ins.count("alias_products"));
+    ASSERT_EQ(1, referenced_ins.at("alias_products").count("alias_orders"));
+    ASSERT_TRUE(products_op.get()->get_referenced_in_field_with_lock("alias_orders").ok());
+
+    auto symlink_op = collectionManager.upsert_symlink("alias_orders_link", "alias_orders");
+    ASSERT_TRUE(symlink_op.ok());
+
+    auto drop_op = collectionManager.drop_collection("alias_orders_link");
+    ASSERT_TRUE(drop_op.ok());
+
+    referenced_ins = collectionManager._get_referenced_ins();
+    if (referenced_ins.count("alias_products") != 0) {
+        ASSERT_EQ(0, referenced_ins.at("alias_products").count("alias_orders"));
+    }
+    ASSERT_FALSE(products_op.get()->get_referenced_in_field_with_lock("alias_orders").ok());
+
+    collectionManager.drop_collection("alias_products");
+}
+
 TEST_F(CollectionManagerTest, AuthWithMultiSearchKeys) {
     api_key_t key1("api_key", "some key", {"documents:create"}, {"foo"}, 64723363199);
     collectionManager.getAuthManager().create_key(key1);


### PR DESCRIPTION
## Change Summary
Bug: dropping through an alias resolved the real collection name, but reference cleanup used the alias/request name. Reference metadata is stored under the real collection name, so dropping alias_orders_link could leave stale reverse-reference state for alias_orders.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
