### PR TITLE
fix: block collection recreate during drop cleanup

### DIFF
--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+#include <set>
 #include <string>
 #include <sparsepp.h>
 #include "store.h"
@@ -27,6 +28,8 @@ private:
     spp::sparse_hash_map<std::string, std::shared_ptr<Collection>> collections;
 
     spp::sparse_hash_map<uint32_t, std::string> collection_id_names;
+
+    std::set<std::string> collections_pending_drop;
 
     spp::sparse_hash_map<std::string, std::string> collection_symlinks;
 

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -685,6 +685,7 @@ void CollectionManager::dispose() {
     std::unique_lock lock(mutex);
 
     collections.clear();
+    collections_pending_drop.clear();
     collection_symlinks.clear();
     preset_configs.clear();
     referenced_ins.clear();
@@ -723,7 +724,8 @@ Option<Collection*> CollectionManager::create_collection(const std::string& name
                                                          const std::vector<std::string>& curation_sets) {
     std::unique_lock lock(mutex);
 
-    if(store->contains(Collection::get_meta_key(name))) {
+    if(collections.count(name) != 0 || collections_pending_drop.count(name) != 0 ||
+       store->contains(Collection::get_meta_key(name))) {
         return Option<Collection*>(409, std::string("A collection with name `") + name + "` already exists.");
     }
 
@@ -909,21 +911,31 @@ std::vector<std::string> CollectionManager::get_collection_names() const {
 Option<nlohmann::json> CollectionManager::drop_collection(const std::string& collection_name,
                                                           const bool remove_from_store,
                                                           const bool compact_store) {
-    std::shared_lock s_lock(mutex);
-    auto collection = get_collection_unsafe(collection_name);
+    std::shared_ptr<Collection> collection;
+    std::string actual_coll_name;
+    uint32_t collection_id = 0;
 
-    if(collection == nullptr) {
-        return Option<nlohmann::json>(404, "No collection with name `" + collection_name + "` found.");
+    {
+        std::unique_lock lock(mutex);
+        collection = get_collection_unsafe(collection_name);
+
+        if(collection == nullptr) {
+            return Option<nlohmann::json>(404, "No collection with name `" + collection_name + "` found.");
+        }
+
+        // to handle alias resolution
+        actual_coll_name = collection->get_name();
+        collection_id = collection->get_collection_id();
+        collections_pending_drop.insert(actual_coll_name);
+        collections.erase(actual_coll_name);
+        collection_id_names.erase(collection_id);
     }
-
-    // to handle alias resolution
-    const std::string actual_coll_name = collection->get_name();
 
     nlohmann::json collection_json = collection->get_summary_json();
 
     if(remove_from_store) {
-        const std::string& del_key_prefix = std::to_string(collection->get_collection_id()) + "_";
-        const std::string& del_end_prefix = std::to_string(collection->get_collection_id()) + "`";
+        const std::string& del_key_prefix = std::to_string(collection_id) + "_";
+        const std::string& del_end_prefix = std::to_string(collection_id) + "`";
         store->delete_range(del_key_prefix, del_end_prefix);
 
         if(compact_store) {
@@ -935,8 +947,6 @@ Option<nlohmann::json> CollectionManager::drop_collection(const std::string& col
         store->remove(Collection::get_meta_key(actual_coll_name));
     }
 
-    s_lock.unlock();
-
     // Remove the record of other collections being referenced in this collection.
     auto reference_fields = collection->get_reference_fields();
     for (const auto& item: reference_fields) {
@@ -945,18 +955,18 @@ Option<nlohmann::json> CollectionManager::drop_collection(const std::string& col
         remove_referenced_ins_with_lock(collection_name, reference_info);
     }
 
-    std::unique_lock u_lock(mutex);
-    collections.erase(actual_coll_name);
-    collection_id_names.erase(collection->get_collection_id());
-
     const auto& embedding_fields = collection->get_embedding_fields();
 
-    u_lock.unlock();
     for(const auto& embedding_field : embedding_fields) {
         const auto& model_name = embedding_field.embed[fields::model_config][fields::model_name].get<std::string>();
         if (embedding_field.embed.count(fields::personalization_type) == 0) {
             process_embedding_field_delete(model_name);
         }
+    }
+
+    {
+        std::unique_lock lock(mutex);
+        collections_pending_drop.erase(actual_coll_name);
     }
 
     return Option<nlohmann::json>(collection_json);

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -1286,6 +1286,16 @@ TEST_F(CollectionManagerTest, DropCollectionCleanly) {
     delete it;
 }
 
+TEST_F(CollectionManagerTest, CreateCollectionRejectsLoadedCollectionWithoutStoreMeta) {
+    ASSERT_TRUE(store->remove(Collection::get_meta_key("collection1")));
+
+    std::vector<field> fields = {field("title", field_types::STRING, false)};
+    auto create_op = collectionManager.create_collection("collection1", 1, fields);
+    ASSERT_FALSE(create_op.ok());
+    ASSERT_EQ(409, create_op.code());
+    ASSERT_EQ(collection1, collectionManager.get_collection("collection1").get());
+}
+
 TEST_F(CollectionManagerTest, AuthWithMultiSearchKeys) {
     api_key_t key1("api_key", "some key", {"documents:create"}, {"foo"}, 64723363199);
     collectionManager.getAuthManager().create_key(key1);


### PR DESCRIPTION
## Change Summary
Bug: old drop_collection removed store metadata before erasing the collection from the in-memory manager maps, while create_collection only checked store metadata. A concurrent create with the same name could see no store metadata and create a new collection while the old one was still loaded and mid-drop.

Crash: race-induced state corruption or use-after-free. You can end up with two collection objects for the same name/id window, stale manager mappings, store keys being deleted out from under a new collection, or the old collection being destroyed while other paths still observe conflicting state. With numeric fields, that can plausibly surface as corruption during Index / num_tree_t teardown.

Fix: create now rejects names already loaded or pending drop in collection_manager.cpp (line 727). Drop takes the manager lock, marks the real name pending, removes manager mappings before store cleanup, uses saved id/name for deletion, then clears pending at the end in collection_manager.cpp (line 918). This closes the recreate window.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
