### PR TITLE
feat(facet): support :weighted modifier on reference facets

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -1278,7 +1278,7 @@ public:
     Option<std::string> get_referenced_in_field_with_lock(const std::string& collection_name) const;
 
     Option<bool> get_related_ids_with_lock(const std::string& field_name, const std::vector<uint32_t>& seq_id_vec,
-                                           std::vector<uint32_t>& result) const;
+                                           std::vector<uint32_t>& result, bool keep_multiplicity = false) const;
 
     Option<bool> update_async_references_with_lock(const std::string& ref_coll_name, const std::string& filter,
                                                    const std::set<std::string>& filter_values,
@@ -1304,7 +1304,7 @@ public:
                                              uint32_t& result) const;
 
     Option<bool> get_related_ids(const std::string& ref_field_name, const std::vector<uint32_t>& seq_id_vec,
-                                 std::vector<uint32_t>& result) const;
+                                 std::vector<uint32_t>& result, bool keep_multiplicity = false) const;
 
     Option<int64_t> get_referenced_geo_distance_with_lock(const sort_by& sort_field, const bool& is_asc, const uint32_t& seq_id,
                                                           const std::map<basic_string<char>, reference_filter_result_t>& references,

--- a/include/field.h
+++ b/include/field.h
@@ -832,6 +832,12 @@ struct facet {
 
     bool is_top_k = false;
 
+    // When true, facets on joined reference fields multiply stats by the
+    // number of child rows pointing at each parent doc (instead of the
+    // default behavior that deduplicates to one count per parent).
+    // Opt-in via syntax: facet_by=$other(field):weighted
+    bool weighted = false;
+
     bool get_range(int64_t key, std::pair<int64_t, std::string>& range_pair) {
         if(facet_range_map.empty()) {
             LOG (ERROR) << "Facet range is not defined!!!";
@@ -855,10 +861,10 @@ struct facet {
     explicit facet(const std::string& field_name, uint32_t orig_index, bool is_top_k = false, std::map<int64_t, range_specs_t> facet_range = {},
                    bool is_range_q = false, bool sort_by_alpha=false, const std::string& order="",
                    const std::string& sort_by_field="", const std::string& reference_collection_name = "",
-                   const std::string& reference_collection_alias_name = "")
+                   const std::string& reference_collection_alias_name = "", bool weighted = false)
                    : field_name(field_name), facet_range_map(facet_range),
                    is_range_query(is_range_q), is_sort_by_alpha(sort_by_alpha), sort_order(order),
-                   sort_field(sort_by_field), orig_index(orig_index), is_top_k(is_top_k),
+                   sort_field(sort_by_field), orig_index(orig_index), is_top_k(is_top_k), weighted(weighted),
                    reference_collection_name(reference_collection_name),
                    reference_collection_alias_name(reference_collection_alias_name) {
     }

--- a/include/index.h
+++ b/include/index.h
@@ -658,10 +658,12 @@ private:
                                    const size_t remote_embedding_timeout_ms = 60000, const size_t remote_embedding_num_tries = 2);
 
     Option<bool> get_related_ids(const std::string& reference_helper_field_name,
-                                 const std::vector<uint32_t>& seq_id_vec, std::vector<uint32_t>& related_ids) const;
+                                 const std::vector<uint32_t>& seq_id_vec, std::vector<uint32_t>& related_ids,
+                                 bool keep_multiplicity = false) const;
 
     Option<bool> get_related_ids(const std::string& reference_helper_field_name,
-                                 const uint32_t& seq_id, std::vector<uint32_t>& result) const;
+                                 const uint32_t& seq_id, std::vector<uint32_t>& result,
+                                 bool keep_multiplicity = false) const;
 
     static void process_embed_results(const std::vector<std::pair<index_record*, std::string>>& values_to_embed_text,
                                       const std::vector<embedding_res_t>& embeddings_text,
@@ -982,7 +984,8 @@ public:
     void get_reference_facet_ids(const uint32_t* all_result_ids, const size_t& all_result_ids_len,
                                  const std::string& collection_name, Collection const *const ref_collection,
                                  filter_result_iterator_t& filter_result_iterator,
-                                 std::unordered_map<std::string, reference_filter_result_t>& reference_facet_ids) const;
+                                 std::unordered_map<std::string, reference_filter_result_t>& reference_facet_ids,
+                                 bool keep_child_multiplicity = false) const;
 
     Option<bool> compute_facet_infos(const std::vector<facet>& facets, facet_query_t& facet_query,
                                      const uint32_t facet_query_num_typos,
@@ -1263,7 +1266,8 @@ public:
     GeoPolygonIndex* get_geopolygon_index(const std::string& field_name) const;
 
     Option<bool> get_related_ids_with_lock(const std::string& field_name,
-                                           const std::vector<uint32_t>& seq_id_vec, std::vector<uint32_t>& related_ids) const;
+                                           const std::vector<uint32_t>& seq_id_vec, std::vector<uint32_t>& related_ids,
+                                           bool keep_multiplicity = false) const;
 
     Option<bool> do_facets_with_lock(std::vector<facet> & facets, facet_query_t & facet_query,
                                      bool estimate_facets, size_t facet_sample_percent,

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -4874,14 +4874,14 @@ Option<bool> Collection::get_filter_ids_with_lock(const std::string& filter_quer
 }
 
 Option<bool> Collection::get_related_ids_with_lock(const std::string& field_name, const std::vector<uint32_t>& seq_id_vec,
-                                                   std::vector<uint32_t>& result) const {
+                                                   std::vector<uint32_t>& result, bool keep_multiplicity) const {
     std::shared_lock lock(mutex);
-    return get_related_ids(field_name, seq_id_vec, result);
+    return get_related_ids(field_name, seq_id_vec, result, keep_multiplicity);
 }
 
 Option<bool> Collection::get_related_ids(const std::string& ref_field_name, const std::vector<uint32_t>& seq_id_vec,
-                                         std::vector<uint32_t>& result) const {
-    return index->get_related_ids_with_lock(ref_field_name, seq_id_vec, result);
+                                         std::vector<uint32_t>& result, bool keep_multiplicity) const {
+    return index->get_related_ids_with_lock(ref_field_name, seq_id_vec, result, keep_multiplicity);
 }
 
 Option<bool> Collection::get_object_array_related_id_with_lock(const std::string& ref_field_name,
@@ -7940,8 +7940,25 @@ Option<bool> Collection::parse_facet(const std::string& facet_field, std::vector
             ref_collection_name = ref_collection->name;
         }
 
+        auto close_paren_pos = facet_field.rfind(')');
+        if (close_paren_pos == std::string::npos || close_paren_pos < open_paren_pos) {
+            return Option<bool>(400, error_message + "missing closing `)` in `" + facet_field + "`.");
+        }
+
+        // Optional trailing modifier: `$other(field):weighted`
+        bool weighted = false;
+        if (close_paren_pos + 1 < facet_field.size()) {
+            std::string suffix = facet_field.substr(close_paren_pos + 1);
+            if (suffix == ":weighted") {
+                weighted = true;
+            } else {
+                return Option<bool>(400, error_message + "unknown modifier `" + suffix +
+                                         "` (supported: `:weighted`).");
+            }
+        }
+
         std::string ref_facet_expression = facet_field.substr(open_paren_pos + 1,
-                                                              facet_field.size() - open_paren_pos - 2);
+                                                              close_paren_pos - open_paren_pos - 1);
         std::vector<std::string> ref_facet_strings;
         StringUtils::split_facet(ref_facet_expression, ref_facet_strings);
 
@@ -7956,6 +7973,7 @@ Option<bool> Collection::parse_facet(const std::string& facet_field, std::vector
         for (auto& ref_facet: ref_facets) {
             ref_facet.reference_collection_name = ref_collection_name;
             ref_facet.reference_collection_alias_name = ref_alias_collection_name;
+            ref_facet.weighted = weighted;
             ref_facet.orig_index = facets.size();
             facets.emplace_back(std::move(ref_facet));
         }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -4561,7 +4561,8 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                                           this_facet.is_range_query, this_facet.is_sort_by_alpha,
                                           this_facet.sort_order, this_facet.sort_field,
                                           this_facet.reference_collection_name,
-                                          this_facet.reference_collection_alias_name);
+                                          this_facet.reference_collection_alias_name,
+                                          this_facet.weighted);
                 num_value_facets++;
                 continue;
             }
@@ -4571,7 +4572,8 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                                               this_facet.facet_range_map, this_facet.is_range_query,
                                               this_facet.is_sort_by_alpha, this_facet.sort_order, this_facet.sort_field,
                                               this_facet.reference_collection_name,
-                                              this_facet.reference_collection_alias_name);
+                                              this_facet.reference_collection_alias_name,
+                                              this_facet.weighted);
             }
         }
 
@@ -4817,7 +4819,8 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
 void Index::get_reference_facet_ids(const uint32_t* all_result_ids, const size_t& all_result_ids_len,
                                     const std::string& collection_name, Collection const *const ref_collection,
                                     filter_result_iterator_t& fit,
-                                    std::unordered_map<std::string, reference_filter_result_t>& reference_facet_ids) const {
+                                    std::unordered_map<std::string, reference_filter_result_t>& reference_facet_ids,
+                                    bool keep_child_multiplicity) const {
 
     auto const& ref_collection_name = ref_collection->get_name();
     reference_facet_ids[ref_collection_name] = reference_filter_result_t();
@@ -4874,7 +4877,7 @@ void Index::get_reference_facet_ids(const uint32_t* all_result_ids, const size_t
                 continue;
             }
 
-            get_related_ids(reference_field_name, all_result_ids[i], ref_doc_ids);
+            get_related_ids(reference_field_name, all_result_ids[i], ref_doc_ids, keep_child_multiplicity);
         } else if (joined_coll_has_reference) {
             auto& cm = CollectionManager::get_instance();
             auto joined_collection = cm.get_collection(joined_coll_having_reference);
@@ -4894,13 +4897,20 @@ void Index::get_reference_facet_ids(const uint32_t* all_result_ids, const size_t
 
             joined_collection->get_related_ids_with_lock(reference_field_name,
                                                          std::vector<uint32_t>(ref_result.docs, ref_result.docs + ref_result.count),
-                                                         ref_doc_ids);
+                                                         ref_doc_ids, keep_child_multiplicity);
         }
     }
 
     fit.reset();
     gfx::timsort(ref_doc_ids.begin(), ref_doc_ids.end());
-    ref_doc_ids.erase(unique(ref_doc_ids.begin(), ref_doc_ids.end()), ref_doc_ids.end());
+    if (!keep_child_multiplicity) {
+        // Default behavior: collapse to one entry per parent doc, so facet
+        // stats are computed once per matching parent.
+        ref_doc_ids.erase(unique(ref_doc_ids.begin(), ref_doc_ids.end()), ref_doc_ids.end());
+    }
+    // When keep_child_multiplicity is true, duplicates are preserved (sorted)
+    // so the downstream facet loop iterates each parent N times (once per
+    // matching child reference), naturally multiplying stats.sum and counts.
 
     auto& result = reference_facet_ids[ref_collection_name];
     result.count = ref_doc_ids.size();
@@ -6584,7 +6594,8 @@ Option<bool> Index::compute_facet_infos(const std::vector<facet>& facets, facet_
 
             if (reference_facet_ids.count(ref_collection_name) == 0) {
                 get_reference_facet_ids(all_result_ids, all_result_ids_len, collection->get_name(),
-                                        ref_collection.get(), fit, reference_facet_ids);
+                                        ref_collection.get(), fit, reference_facet_ids,
+                                        a_facet.weighted);
             }
 
             if (reference_facet_ids.at(ref_collection_name).count == 0) {
@@ -6624,7 +6635,10 @@ Option<bool> Index::compute_facet_infos(const std::vector<facet>& facets, facet_
         bool facet_value_index_exists = facet_index_v4->has_value_index(facet_field.name);
 
         //as we use sort index for range facets with hash based index, sort index should be present
-        if(facet_index_type == exhaustive || group_limit != 0) {
+        // Weighted reference facets require the exhaustive hash-based path: the value
+        // index intersection collapses duplicate doc_ids, which would defeat the
+        // child-multiplicity preserved in get_reference_facet_ids.
+        if(facet_index_type == exhaustive || group_limit != 0 || a_facet.weighted) {
             facet_infos[findex].use_value_index = false;
         }
         else if(facet_value_index_exists) {
@@ -8634,13 +8648,13 @@ int64_t Index::reference_string_sort_score(const string &field_name,  const std:
 }
 
 Option<bool> Index::get_related_ids_with_lock(const std::string& field_name, const std::vector<uint32_t>& seq_id_vec,
-                                              std::vector<uint32_t>& related_ids) const {
+                                              std::vector<uint32_t>& related_ids, bool keep_multiplicity) const {
     std::shared_lock lock(mutex);
-    return get_related_ids(field_name, seq_id_vec, related_ids);
+    return get_related_ids(field_name, seq_id_vec, related_ids, keep_multiplicity);
 }
 
 Option<bool> Index::get_related_ids(const std::string& field_name, const std::vector<uint32_t>& seq_id_vec,
-                                    std::vector<uint32_t>& related_ids) const {
+                                    std::vector<uint32_t>& related_ids, bool keep_multiplicity) const {
     auto const& collection_name = get_collection_name();
     auto const reference_helper_field_name = field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX;
     auto search_schema_it = search_schema.find(reference_helper_field_name);
@@ -8706,15 +8720,17 @@ Option<bool> Index::get_related_ids(const std::string& field_name, const std::ve
     }
 
     gfx::timsort(related_ids.begin(), related_ids.end());
-    related_ids.erase(unique(related_ids.begin(), related_ids.end()), related_ids.end());
+    if (!keep_multiplicity) {
+        related_ids.erase(unique(related_ids.begin(), related_ids.end()), related_ids.end());
+    }
 
     return Option<bool>(true);
 }
 
 Option<bool> Index::get_related_ids(const std::string& field_name, const uint32_t& seq_id,
-                                    std::vector<uint32_t>& result) const {
+                                    std::vector<uint32_t>& result, bool keep_multiplicity) const {
     const std::vector<uint32_t> seq_ids_vec{seq_id};
-    return get_related_ids(field_name, seq_ids_vec, result);
+    return get_related_ids(field_name, seq_ids_vec, result, keep_multiplicity);
 }
 
 Option<bool> Index::get_object_array_related_id(const std::string& collection_name,

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -424,6 +424,14 @@ size_t StringUtils::split_facet(const std::string &s, std::vector<std::string> &
                 return 0;
             }
 
+            // Absorb optional trailing modifier after `)` (e.g. ":weighted"),
+            // so it is forwarded to parse_facet instead of being silently dropped.
+            if (index < current_str.size() && current_str[index] == ':') {
+                while (index < current_str.size() && current_str[index] != ',') {
+                    index++;
+                }
+            }
+
             temp = delim = current_str.substr(0, index);
             subend = substart + delim.size();
 

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -11170,6 +11170,105 @@ TEST_F(CollectionJoinTest, FacetByReference) {
     ASSERT_EQ("73.5", res_obj["facet_counts"][0]["counts"][3]["value"].get<std::string>());
 }
 
+TEST_F(CollectionJoinTest, FacetByReferenceWeightedAggregation) {
+    // The `:weighted` modifier on a reference facet multiplies stats by the
+    // number of child rows referencing each parent, instead of the default
+    // behavior that deduplicates child rows to one count per parent.
+    //
+    // Setup:
+    //   Pop A (estimatedValue_usd=1000) referenced by 3 FolderItems in folder F1.
+    //   Pop B (estimatedValue_usd=500)  referenced by 1 FolderItem  in folder F1.
+    //   1 extra FolderItem in F_other (must not affect F1 results).
+
+    auto schema_pops_json = R"({
+            "name": "Pops",
+            "fields": [
+                {"name": "name", "type": "string"},
+                {"name": "estimatedValue_usd", "type": "int32", "facet": true}
+            ]
+        })"_json;
+    std::vector<nlohmann::json> pops = {
+            R"({ "id": "A", "name": "Alpha", "estimatedValue_usd": 1000 })"_json,
+            R"({ "id": "B", "name": "Beta",  "estimatedValue_usd": 500  })"_json
+    };
+    auto pops_create_op = collectionManager.create_collection(schema_pops_json);
+    ASSERT_TRUE(pops_create_op.ok());
+    for (auto const& json : pops) {
+        auto add_op = pops_create_op.get()->add(json.dump());
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    auto schema_fi_json = R"({
+            "name": "FolderItems",
+            "fields": [
+                {"name": "folderId", "type": "string", "facet": true},
+                {"name": "itemId", "type": "string", "reference": "Pops.id"}
+            ]
+        })"_json;
+    std::vector<nlohmann::json> folderItems = {
+            R"({ "id": "fi_1", "folderId": "F1", "itemId": "A" })"_json,
+            R"({ "id": "fi_2", "folderId": "F1", "itemId": "A" })"_json,
+            R"({ "id": "fi_3", "folderId": "F1", "itemId": "A" })"_json,
+            R"({ "id": "fi_B", "folderId": "F1", "itemId": "B" })"_json,
+            R"({ "id": "fi_other", "folderId": "F_other", "itemId": "A" })"_json
+    };
+    auto fi_create_op = collectionManager.create_collection(schema_fi_json);
+    ASSERT_TRUE(fi_create_op.ok());
+    for (auto const& json : folderItems) {
+        auto add_op = fi_create_op.get()->add(json.dump());
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    // --- Default behavior: parent-dedup (regression guard) ---
+    std::map<std::string, std::string> req_params = {
+            {"collection", "FolderItems"},
+            {"q", "*"},
+            {"query_by", "folderId"},
+            {"filter_by", "folderId:=F1"},
+            {"facet_by", "$Pops(estimatedValue_usd)"},
+            {"per_page", "0"}
+    };
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    nlohmann::json res = nlohmann::json::parse(json_res);
+    ASSERT_EQ(4, res["found"]);
+    ASSERT_EQ(1500, res["facet_counts"][0]["stats"]["sum"].get<int>());
+    ASSERT_EQ(2, res["facet_counts"][0]["counts"].size());
+    // Both A and B appear once each.
+    for (auto const& c : res["facet_counts"][0]["counts"]) {
+        ASSERT_EQ(1, c["count"].get<int>());
+    }
+
+    // --- Weighted behavior: child-multiplicity ---
+    req_params["facet_by"] = "$Pops(estimatedValue_usd):weighted";
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    res = nlohmann::json::parse(json_res);
+    ASSERT_EQ(4, res["found"]);
+    // sum = 3 * 1000 + 1 * 500 = 3500
+    ASSERT_EQ(3500, res["facet_counts"][0]["stats"]["sum"].get<int>());
+    ASSERT_EQ(2, res["facet_counts"][0]["counts"].size());
+    // Value 1000 must appear 3 times (one per FolderItem), value 500 once.
+    int count_for_1000 = 0, count_for_500 = 0;
+    for (auto const& c : res["facet_counts"][0]["counts"]) {
+        if (c["value"].get<std::string>() == "1000") count_for_1000 = c["count"].get<int>();
+        if (c["value"].get<std::string>() == "500")  count_for_500  = c["count"].get<int>();
+    }
+    ASSERT_EQ(3, count_for_1000);
+    ASSERT_EQ(1, count_for_500);
+
+    // --- Unknown modifier rejected ---
+    req_params["facet_by"] = "$Pops(estimatedValue_usd):garbage";
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_FALSE(search_op.ok());
+    ASSERT_NE(std::string::npos, search_op.error().find("unknown modifier"));
+}
+
 TEST_F(CollectionJoinTest, GroupByWithVectorQueryDoesNotLeakReferenceFacets) {
     auto schema_json =
             R"({


### PR DESCRIPTION
## Summary

Adds an opt-in `:weighted` modifier to `facet_by` for reference facets so each child reference weights the parent's value in `stats.sum` and counts (instead of the current default that collapses duplicates to one entry per parent).

```
facet_by=$other_collection(field):weighted
```

Default behavior is unchanged.

## Motivation

When a parent collection has many child references (cart items, folder items, collection duplicates), faceting on a parent field via a join currently sums the parent's value only once, regardless of how many child rows reference it. There is no built-in way to obtain a child-weighted aggregate from a single search.

Related discussion: #1706, #2761, #2861.

## Behavior

| Query | Default | `:weighted` |
|-------|---------|------------|
| 3 child rows referencing parent A (value=1000) + 1 child row referencing parent B (value=500) | sum=1500, count(1000)=1, count(500)=1 | sum=3500, count(1000)=3, count(500)=1 |

## Implementation

- `Index::get_reference_facet_ids` accepts `bool keep_child_multiplicity` and skips the final `erase(unique(...))` on `ref_doc_ids` when true.
- `Index::get_related_ids` / `get_related_ids_with_lock` accept a matching `bool keep_multiplicity` and skip their internal dedup so duplicates accumulate correctly across child docs.
- `use_value_index` is forced to `false` for weighted facets (the value-index intersection path collapses duplicates, defeating the multiplicity).
- `StringUtils::split_facet` was dropping any suffix after `)` for `$ref` facets; it now forwards an optional `:modifier` so it reaches `Collection::parse_facet`, which rejects unknown modifiers.
- The `weighted` bool is propagated through every `emplace_back` that rebuilds facets for batching (top_k, value, thread batches), so the flag survives the parallel facet path.

## Test plan

- [x] New regression test `CollectionJoinTest.FacetByReferenceWeightedAggregation` covering:
  - default dedup behavior (sum=1500)
  - weighted multiplicity (sum=3500, count distribution)
  - unknown-modifier rejection
- [x] `CollectionJoinTest.FacetBy*` — 3/3 pass (existing + new)
- [x] `CollectionFacetingTest.*` — 49/49 pass (incl. `FacetByReferenceWithJoinFilter`)
- [x] `FacetIndexTest.*` + `StringUtilsTest.*` — 21/21 pass
- [x] Manual JS harness reproducing the original use case (folder with duplicate items) sees `sum=1000*3 + 500=3500` with `:weighted`, `sum=1500` without

Total: 74 tests passing locally on a Linux arm64 build, zero regressions on the relevant suites.

This PR is opened as **draft** to validate CI before requesting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)