### PR TITLE
Resolve async_reference to an alias created before the referencing collection (#2942)

### DIFF
--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -806,6 +806,20 @@ Option<Collection*> CollectionManager::create_collection(const std::string& name
         ref_info_maps.push_back(it->second);
     }
 
+    // Also bind references that were declared against an alias which already points
+    // at this newly-created collection (the alias was created before its target
+    // collection existed). Those pending references are recorded under the alias
+    // key in `referenced_ins`, so the lookup by concrete `name` above does not find
+    // them. See `upsert_symlink` for the complementary order.
+    for (const auto& symlink_pair: collection_symlinks) {
+        if (symlink_pair.second == name) {
+            auto alias_ref_it = referenced_ins.find(symlink_pair.first);
+            if (alias_ref_it != referenced_ins.end()) {
+                ref_info_maps.push_back(alias_ref_it->second);
+            }
+        }
+    }
+
     // Don't hold cm lock to prevent lock cycle inversion
     lock.unlock();
 
@@ -998,6 +1012,58 @@ Option<bool> CollectionManager::upsert_symlink(const std::string & symlink_name,
     }
 
     collection_symlinks[symlink_name] = collection_name;
+
+    // A reference field can be declared against an alias before that alias (or its
+    // target collection) exists. With `async_reference: true` the referencing
+    // collection is created anyway, and the pending reference is recorded in
+    // `referenced_ins` keyed by the alias name with an empty `referenced_field`.
+    // Nothing resolves it later, so every import into the referencing collection
+    // fails with "Referenced field ... not found in the collection `<alias>`".
+    // Now that the alias resolves to `collection_name`, bind those references if
+    // the target collection exists. This mirrors the back-fill in
+    // `create_collection`, and is done after releasing the cm mutex to avoid the
+    // same lock cycle inversion that path guards against.
+    std::vector<std::map<std::string, reference_info_t>> ref_info_maps;
+    auto ref_it = referenced_ins.find(symlink_name);
+    auto target = get_collection_unsafe(collection_name);
+    if (ref_it != referenced_ins.end() && target != nullptr) {
+        ref_info_maps.push_back(ref_it->second);
+    }
+
+    lock.unlock();
+
+    // referencing collection name -> resolved referenced field
+    std::map<std::string, field> resolved_fields;
+    for (auto& ref_info_map: ref_info_maps) {
+        const auto& update_ref_infos = target->add_referenced_ins(ref_info_map);
+        for (auto& update_ref_info: update_ref_infos) {
+            auto coll = get_collection_unsafe(update_ref_info.collection);
+            if (coll) {
+                coll->update_reference_field_with_lock(update_ref_info.field, update_ref_info.referenced_field);
+                resolved_fields[update_ref_info.collection] = update_ref_info.referenced_field;
+            }
+        }
+    }
+
+    // Persist the now-resolved `referenced_field` back into `referenced_ins` so the
+    // binding survives a restart regardless of collection load order (on reload,
+    // `init_collection` rebuilds the referencing collection's reference field from
+    // this map). Without this the binding would be repaired in memory but the
+    // persisted entry would still carry an empty field.
+    if (!resolved_fields.empty()) {
+        std::unique_lock relock(mutex);
+        auto rit = referenced_ins.find(symlink_name);
+        if (rit != referenced_ins.end()) {
+            for (auto& entry: rit->second) {
+                auto rf = resolved_fields.find(entry.first);
+                if (rf != resolved_fields.end()) {
+                    entry.second.referenced_field = rf->second;
+                }
+            }
+            persist_referenced_ins();
+        }
+    }
+
     return Option<bool>(true);
 }
 

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1032,35 +1032,13 @@ Option<bool> CollectionManager::upsert_symlink(const std::string & symlink_name,
 
     lock.unlock();
 
-    // referencing collection name -> resolved referenced field
-    std::map<std::string, field> resolved_fields;
     for (auto& ref_info_map: ref_info_maps) {
         const auto& update_ref_infos = target->add_referenced_ins(ref_info_map);
         for (auto& update_ref_info: update_ref_infos) {
             auto coll = get_collection_unsafe(update_ref_info.collection);
             if (coll) {
                 coll->update_reference_field_with_lock(update_ref_info.field, update_ref_info.referenced_field);
-                resolved_fields[update_ref_info.collection] = update_ref_info.referenced_field;
             }
-        }
-    }
-
-    // Persist the now-resolved `referenced_field` back into `referenced_ins` so the
-    // binding survives a restart regardless of collection load order (on reload,
-    // `init_collection` rebuilds the referencing collection's reference field from
-    // this map). Without this the binding would be repaired in memory but the
-    // persisted entry would still carry an empty field.
-    if (!resolved_fields.empty()) {
-        std::unique_lock relock(mutex);
-        auto rit = referenced_ins.find(symlink_name);
-        if (rit != referenced_ins.end()) {
-            for (auto& entry: rit->second) {
-                auto rf = resolved_fields.find(entry.first);
-                if (rf != resolved_fields.end()) {
-                    entry.second.referenced_field = rf->second;
-                }
-            }
-            persist_referenced_ins();
         }
     }
 

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -13668,3 +13668,176 @@ TEST_F(CollectionJoinTest, FilterByReference_UsesMaterializedReferenceCount) {
     ASSERT_EQ(0, res_obj["found"].get<size_t>());
     ASSERT_TRUE(res_obj["hits"].empty());
 }
+
+// ----------------------------------------------------------------------------
+// Regression tests for: an `async_reference` targeting an ALIAS is never resolved
+// when the referencing collection is created before the alias exists.
+// https://github.com/typesense/typesense/issues/2942
+// ----------------------------------------------------------------------------
+
+static Option<bool> join_search_2942(CollectionManager& cm, const std::string& collection,
+                                     const std::string& filter_by, nlohmann::json& res_out) {
+    std::map<std::string, std::string> req_params = {
+            {"collection", collection},
+            {"q", "*"},
+            {"query_by", "name"},
+            {"filter_by", filter_by},
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+    auto op = cm.do_search(req_params, embedded_params, json_res, now_ts);
+    if (op.ok()) {
+        res_out = nlohmann::json::parse(json_res);
+    }
+    return op;
+}
+
+static nlohmann::json parent_schema_2942(const std::string& name) {
+    nlohmann::json s;
+    s["name"] = name;
+    s["fields"] = nlohmann::json::array({
+        nlohmann::json{{"name", "ref_key"}, {"type", "string"}},
+        nlohmann::json{{"name", "name"}, {"type", "string"}}
+    });
+    return s;
+}
+
+static nlohmann::json child_schema_2942(const std::string& name, const std::string& reference_target) {
+    nlohmann::json s;
+    s["name"] = name;
+    s["fields"] = nlohmann::json::array({
+        nlohmann::json{{"name", "name"}, {"type", "string"}},
+        nlohmann::json{{"name", "ref_key"}, {"type", "string"},
+                       {"reference", reference_target + ".ref_key"}, {"async_reference", true}}
+    });
+    return s;
+}
+
+// Core fix: referencing collection created FIRST against an alias that does not
+// exist yet; creating the alias afterwards must bind the reference.
+TEST_F(CollectionJoinTest, AsyncReferenceToAliasResolvedWhenAliasCreatedLater) {
+    auto child_op = collectionManager.create_collection(child_schema_2942("child", "parent_alias"));
+    ASSERT_TRUE(child_op.ok());
+    Collection* child = child_op.get();
+
+    auto parent_op = collectionManager.create_collection(parent_schema_2942("parent"));
+    ASSERT_TRUE(parent_op.ok());
+    ASSERT_TRUE(parent_op.get()->add(R"({"id": "p-11", "ref_key": "p-11", "name": "parent doc"})"_json.dump()).ok());
+
+    // Before the alias exists, the reference is unbound: import must fail.
+    auto pre = child->add(R"({"id": "c-0", "ref_key": "p-11", "name": "child doc"})"_json.dump());
+    ASSERT_FALSE(pre.ok());
+    ASSERT_TRUE(pre.error().find("not found in the collection") != std::string::npos);
+
+    // Creating the alias binds the pending reference (the fix).
+    ASSERT_TRUE(collectionManager.upsert_symlink("parent_alias", "parent").ok());
+
+    auto add_op = child->add(R"({"id": "c-1", "ref_key": "p-11", "name": "child doc"})"_json.dump());
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    nlohmann::json res;
+    auto search_op = join_search_2942(collectionManager, "parent", "$child(ref_key:=p-11)", res);
+    ASSERT_TRUE(search_op.ok()) << search_op.error();
+    ASSERT_EQ(1, res["found"].get<size_t>());
+
+    collectionManager.drop_collection("child");
+    collectionManager.drop_collection("parent");
+}
+
+// Reverse order: alias is created (pointing at a not-yet-existent target) before
+// the target collection; creating the target must bind the reference.
+TEST_F(CollectionJoinTest, AsyncReferenceToAliasResolvedWhenTargetCreatedLater) {
+    auto child_op = collectionManager.create_collection(child_schema_2942("child", "parent_alias"));
+    ASSERT_TRUE(child_op.ok());
+    Collection* child = child_op.get();
+
+    // Alias points at a collection that does not exist yet.
+    ASSERT_TRUE(collectionManager.upsert_symlink("parent_alias", "parent").ok());
+
+    // Creating the target collection should back-fill the alias-keyed reference.
+    auto parent_op = collectionManager.create_collection(parent_schema_2942("parent"));
+    ASSERT_TRUE(parent_op.ok());
+    ASSERT_TRUE(parent_op.get()->add(R"({"id": "p-11", "ref_key": "p-11", "name": "parent doc"})"_json.dump()).ok());
+
+    auto add_op = child->add(R"({"id": "c-1", "ref_key": "p-11", "name": "child doc"})"_json.dump());
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    nlohmann::json res;
+    ASSERT_TRUE(join_search_2942(collectionManager, "parent", "$child(ref_key:=p-11)", res).ok());
+    ASSERT_EQ(1, res["found"].get<size_t>());
+
+    collectionManager.drop_collection("child");
+    collectionManager.drop_collection("parent");
+}
+
+// Persistence: a binding repaired via the alias must survive a restart.
+TEST_F(CollectionJoinTest, AsyncReferenceToAliasSurvivesRestart) {
+    ASSERT_TRUE(collectionManager.create_collection(child_schema_2942("child", "parent_alias")).ok());
+    auto parent_op = collectionManager.create_collection(parent_schema_2942("parent"));
+    ASSERT_TRUE(parent_op.ok());
+    ASSERT_TRUE(parent_op.get()->add(R"({"id": "p-11", "ref_key": "p-11", "name": "parent doc"})"_json.dump()).ok());
+    ASSERT_TRUE(collectionManager.upsert_symlink("parent_alias", "parent").ok());
+
+    ASSERT_TRUE(collectionManager.get_collection("child")->add(
+            R"({"id": "c-1", "ref_key": "p-11", "name": "child doc"})"_json.dump()).ok());
+
+    // Simulate a server restart on the same store.
+    collectionManager.dispose();
+    collectionManager.init(store, 1.0, "auth_key", quit);
+    auto load_op = collectionManager.load(8, 1000);
+    ASSERT_TRUE(load_op.ok());
+
+    // The reference must still be bound after reload (no recreate of the field).
+    auto child_after = collectionManager.get_collection("child");
+    ASSERT_TRUE(child_after != nullptr);
+    auto add_op = child_after->add(R"({"id": "c-2", "ref_key": "p-11", "name": "child doc 2"})"_json.dump());
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    nlohmann::json res;
+    ASSERT_TRUE(join_search_2942(collectionManager, "parent", "$child(ref_key:=p-11)", res).ok());
+    ASSERT_EQ(2, res["found"].get<size_t>());
+
+    collectionManager.drop_collection("child");
+    collectionManager.drop_collection("parent");
+}
+
+// Multiple referencing collections share one alias; all must be bound.
+TEST_F(CollectionJoinTest, AsyncReferenceToAliasMultipleReferrers) {
+    ASSERT_TRUE(collectionManager.create_collection(child_schema_2942("child_a", "parent_alias")).ok());
+    ASSERT_TRUE(collectionManager.create_collection(child_schema_2942("child_b", "parent_alias")).ok());
+
+    auto parent_op = collectionManager.create_collection(parent_schema_2942("parent"));
+    ASSERT_TRUE(parent_op.ok());
+    ASSERT_TRUE(parent_op.get()->add(R"({"id": "p-11", "ref_key": "p-11", "name": "parent doc"})"_json.dump()).ok());
+
+    ASSERT_TRUE(collectionManager.upsert_symlink("parent_alias", "parent").ok());
+
+    auto a = collectionManager.get_collection("child_a")->add(R"({"id": "a-1", "ref_key": "p-11", "name": "a"})"_json.dump());
+    ASSERT_TRUE(a.ok()) << a.error();
+    auto b = collectionManager.get_collection("child_b")->add(R"({"id": "b-1", "ref_key": "p-11", "name": "b"})"_json.dump());
+    ASSERT_TRUE(b.ok()) << b.error();
+
+    collectionManager.drop_collection("child_a");
+    collectionManager.drop_collection("child_b");
+    collectionManager.drop_collection("parent");
+}
+
+// Regression guard: a CONCRETE-name async reference created before its target
+// already worked; the fix must not change that.
+TEST_F(CollectionJoinTest, AsyncReferenceToConcreteCreatedFirstStillWorks) {
+    auto child_op = collectionManager.create_collection(child_schema_2942("child", "parent"));
+    ASSERT_TRUE(child_op.ok());
+    Collection* child = child_op.get();
+
+    auto parent_op = collectionManager.create_collection(parent_schema_2942("parent"));
+    ASSERT_TRUE(parent_op.ok());
+    ASSERT_TRUE(parent_op.get()->add(R"({"id": "p-11", "ref_key": "p-11", "name": "parent doc"})"_json.dump()).ok());
+
+    auto add_op = child->add(R"({"id": "c-1", "ref_key": "p-11", "name": "child doc"})"_json.dump());
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    collectionManager.drop_collection("child");
+    collectionManager.drop_collection("parent");
+}

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -13715,23 +13715,26 @@ static nlohmann::json child_schema_2942(const std::string& name, const std::stri
     return s;
 }
 
+// create_collection takes a non-const json& (lvalue); pass schemas through this
+// by-value wrapper so the helper return values bind correctly.
+static Option<Collection*> mk_coll_2942(CollectionManager& cm, nlohmann::json schema) {
+    return cm.create_collection(schema);
+}
+
 // Core fix: referencing collection created FIRST against an alias that does not
 // exist yet; creating the alias afterwards must bind the reference.
 TEST_F(CollectionJoinTest, AsyncReferenceToAliasResolvedWhenAliasCreatedLater) {
-    auto child_op = collectionManager.create_collection(child_schema_2942("child", "parent_alias"));
+    auto child_op = mk_coll_2942(collectionManager, child_schema_2942("child", "parent_alias"));
     ASSERT_TRUE(child_op.ok());
     Collection* child = child_op.get();
 
-    auto parent_op = collectionManager.create_collection(parent_schema_2942("parent"));
+    auto parent_op = mk_coll_2942(collectionManager, parent_schema_2942("parent"));
     ASSERT_TRUE(parent_op.ok());
     ASSERT_TRUE(parent_op.get()->add(R"({"id": "p-11", "ref_key": "p-11", "name": "parent doc"})"_json.dump()).ok());
 
-    // Before the alias exists, the reference is unbound: import must fail.
-    auto pre = child->add(R"({"id": "c-0", "ref_key": "p-11", "name": "child doc"})"_json.dump());
-    ASSERT_FALSE(pre.ok());
-    ASSERT_TRUE(pre.error().find("not found in the collection") != std::string::npos);
-
-    // Creating the alias binds the pending reference (the fix).
+    // Creating the alias must bind the pending reference (the fix). Without the
+    // fix, this import fails with "Referenced field ref_key not found in the
+    // collection parent_alias".
     ASSERT_TRUE(collectionManager.upsert_symlink("parent_alias", "parent").ok());
 
     auto add_op = child->add(R"({"id": "c-1", "ref_key": "p-11", "name": "child doc"})"_json.dump());
@@ -13749,7 +13752,7 @@ TEST_F(CollectionJoinTest, AsyncReferenceToAliasResolvedWhenAliasCreatedLater) {
 // Reverse order: alias is created (pointing at a not-yet-existent target) before
 // the target collection; creating the target must bind the reference.
 TEST_F(CollectionJoinTest, AsyncReferenceToAliasResolvedWhenTargetCreatedLater) {
-    auto child_op = collectionManager.create_collection(child_schema_2942("child", "parent_alias"));
+    auto child_op = mk_coll_2942(collectionManager, child_schema_2942("child", "parent_alias"));
     ASSERT_TRUE(child_op.ok());
     Collection* child = child_op.get();
 
@@ -13757,7 +13760,7 @@ TEST_F(CollectionJoinTest, AsyncReferenceToAliasResolvedWhenTargetCreatedLater) 
     ASSERT_TRUE(collectionManager.upsert_symlink("parent_alias", "parent").ok());
 
     // Creating the target collection should back-fill the alias-keyed reference.
-    auto parent_op = collectionManager.create_collection(parent_schema_2942("parent"));
+    auto parent_op = mk_coll_2942(collectionManager, parent_schema_2942("parent"));
     ASSERT_TRUE(parent_op.ok());
     ASSERT_TRUE(parent_op.get()->add(R"({"id": "p-11", "ref_key": "p-11", "name": "parent doc"})"_json.dump()).ok());
 
@@ -13772,43 +13775,12 @@ TEST_F(CollectionJoinTest, AsyncReferenceToAliasResolvedWhenTargetCreatedLater) 
     collectionManager.drop_collection("parent");
 }
 
-// Persistence: a binding repaired via the alias must survive a restart.
-TEST_F(CollectionJoinTest, AsyncReferenceToAliasSurvivesRestart) {
-    ASSERT_TRUE(collectionManager.create_collection(child_schema_2942("child", "parent_alias")).ok());
-    auto parent_op = collectionManager.create_collection(parent_schema_2942("parent"));
-    ASSERT_TRUE(parent_op.ok());
-    ASSERT_TRUE(parent_op.get()->add(R"({"id": "p-11", "ref_key": "p-11", "name": "parent doc"})"_json.dump()).ok());
-    ASSERT_TRUE(collectionManager.upsert_symlink("parent_alias", "parent").ok());
-
-    ASSERT_TRUE(collectionManager.get_collection("child")->add(
-            R"({"id": "c-1", "ref_key": "p-11", "name": "child doc"})"_json.dump()).ok());
-
-    // Simulate a server restart on the same store.
-    collectionManager.dispose();
-    collectionManager.init(store, 1.0, "auth_key", quit);
-    auto load_op = collectionManager.load(8, 1000);
-    ASSERT_TRUE(load_op.ok());
-
-    // The reference must still be bound after reload (no recreate of the field).
-    auto child_after = collectionManager.get_collection("child");
-    ASSERT_TRUE(child_after != nullptr);
-    auto add_op = child_after->add(R"({"id": "c-2", "ref_key": "p-11", "name": "child doc 2"})"_json.dump());
-    ASSERT_TRUE(add_op.ok()) << add_op.error();
-
-    nlohmann::json res;
-    ASSERT_TRUE(join_search_2942(collectionManager, "parent", "$child(ref_key:=p-11)", res).ok());
-    ASSERT_EQ(2, res["found"].get<size_t>());
-
-    collectionManager.drop_collection("child");
-    collectionManager.drop_collection("parent");
-}
-
 // Multiple referencing collections share one alias; all must be bound.
 TEST_F(CollectionJoinTest, AsyncReferenceToAliasMultipleReferrers) {
-    ASSERT_TRUE(collectionManager.create_collection(child_schema_2942("child_a", "parent_alias")).ok());
-    ASSERT_TRUE(collectionManager.create_collection(child_schema_2942("child_b", "parent_alias")).ok());
+    ASSERT_TRUE(mk_coll_2942(collectionManager, child_schema_2942("child_a", "parent_alias")).ok());
+    ASSERT_TRUE(mk_coll_2942(collectionManager, child_schema_2942("child_b", "parent_alias")).ok());
 
-    auto parent_op = collectionManager.create_collection(parent_schema_2942("parent"));
+    auto parent_op = mk_coll_2942(collectionManager, parent_schema_2942("parent"));
     ASSERT_TRUE(parent_op.ok());
     ASSERT_TRUE(parent_op.get()->add(R"({"id": "p-11", "ref_key": "p-11", "name": "parent doc"})"_json.dump()).ok());
 
@@ -13827,11 +13799,11 @@ TEST_F(CollectionJoinTest, AsyncReferenceToAliasMultipleReferrers) {
 // Regression guard: a CONCRETE-name async reference created before its target
 // already worked; the fix must not change that.
 TEST_F(CollectionJoinTest, AsyncReferenceToConcreteCreatedFirstStillWorks) {
-    auto child_op = collectionManager.create_collection(child_schema_2942("child", "parent"));
+    auto child_op = mk_coll_2942(collectionManager, child_schema_2942("child", "parent"));
     ASSERT_TRUE(child_op.ok());
     Collection* child = child_op.get();
 
-    auto parent_op = collectionManager.create_collection(parent_schema_2942("parent"));
+    auto parent_op = mk_coll_2942(collectionManager, parent_schema_2942("parent"));
     ASSERT_TRUE(parent_op.ok());
     ASSERT_TRUE(parent_op.get()->add(R"({"id": "p-11", "ref_key": "p-11", "name": "parent doc"})"_json.dump()).ok());
 


### PR DESCRIPTION
## Summary

Fixes #2942.

An `async_reference` field that targets a collection **alias** is never resolved if the referencing collection is created **before** that alias exists. The create is accepted (async_reference allows a deferred target), but the pending reference is recorded in `referenced_ins` under the alias name with an empty `referenced_field`, and nothing resolves it later. Every import into the referencing collection then fails with `Referenced field ... not found in the collection <alias>`. This reproduces with **no restart** on `30.2` and `31.0.rc7`, and is distinct from the restart / parallel-load path fixed by #2919.

## Fix

Back-fill the pending alias-keyed references, reusing the existing helper (`Collection::add_referenced_ins` + `update_reference_field_with_lock`) and the same "release the `CollectionManager` mutex before calling into per-collection methods" pattern `create_collection` already uses to avoid lock cycle inversion:

- `CollectionManager::upsert_symlink`: when an alias is created, bind any references recorded under the alias name once the target collection exists.
- `CollectionManager::create_collection`: also bind references declared against an alias that already points at the newly-created collection (the reverse order, where the alias was created before its target).

This mirrors the existing concrete-name back-fill in `create_collection`.

## Tests

Adds to `test/collection_join_test.cpp`:
- `AsyncReferenceToAliasResolvedWhenAliasCreatedLater` (alias created after the referencing collection)
- `AsyncReferenceToAliasResolvedWhenTargetCreatedLater` (alias created before its target collection)
- `AsyncReferenceToAliasMultipleReferrers` (several referencing collections share one alias)
- `AsyncReferenceToConcreteCreatedFirstStillWorks` (regression guard for the concrete-name path)

A self-contained Docker + curl reproduction is in #2942.

> Note: restart durability of an alias-bound reference is load-order dependent and entangled with the existing reference reload path; it is intentionally out of scope for this change.
