### PR TITLE
fix(collection): prevent wildcard drop from removing explicitly declared fields

### DIFF
--- a/include/field.h
+++ b/include/field.h
@@ -90,6 +90,8 @@ namespace fields {
     
     static const std::string hnsw_params = "hnsw_params";
     static const std::string track_missing_values = "track_missing_values";
+
+    static const std::string from_dynamic = "from_dynamic";
 }
 
 enum vector_distance_type_t {
@@ -152,6 +154,9 @@ struct field {
     bool stem = false;
     std::string stem_dictionary = "";
     std::shared_ptr<Stemmer> stemmer;
+
+    // name of the dynamic pattern that materialized this field, empty when declared explicitly
+    std::string from_dynamic;
   
     nlohmann::json hnsw_params;
 
@@ -167,10 +172,11 @@ struct field {
           const bool store = true, const bool stem = false, const std::string& stem_dictionary = "", const nlohmann::json hnsw_params = nlohmann::json(),
           const bool async_reference = false, const nlohmann::json& token_separators = {}, const nlohmann::json& symbols_to_index = {},
           const bool cascade_delete = true, const uint32_t truncate_len = 100,
-          const bool track_missing_values = false) :
+          const bool track_missing_values = false, const std::string& from_dynamic = "") :
             name(name), type(type), facet(facet), optional(optional), index(index), locale(locale),
             nested(nested), nested_array(nested_array), num_dim(num_dim), vec_dist(vec_dist), reference(reference),
             embed(embed), range_index(range_index), track_missing_values(track_missing_values), store(store), truncate_len(truncate_len), stem(stem), stem_dictionary(stem_dictionary),
+            from_dynamic(from_dynamic),
             hnsw_params(hnsw_params), is_async_reference(async_reference), cascade_delete(cascade_delete) {
 
         set_computed_defaults(sort, infix);
@@ -420,7 +426,8 @@ struct field {
                      json[fields::symbols_to_index].get<nlohmann::json>(),
                      json[fields::cascade_delete].get<bool>(),
                      json[fields::truncate_len].get<uint32_t>(),
-                     json[fields::track_missing_values].get<bool>());
+                     json[fields::track_missing_values].get<bool>(),
+                     json[fields::from_dynamic].get<std::string>());
     }
 
     static Option<bool> fields_to_json_fields(const std::vector<field> & fields,

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -449,6 +449,8 @@ nlohmann::json Collection::get_summary_json() const {
         field_json[fields::stem_dictionary] = coll_field.stem_dictionary;
         field_json[fields::track_missing_values] = coll_field.track_missing_values;
 
+        field_json[fields::from_dynamic] = coll_field.from_dynamic;
+
         if(coll_field.range_index) {
             field_json[fields::range_index] = coll_field.range_index;
         }
@@ -7709,6 +7711,7 @@ Option<bool> Collection::detect_new_fields(nlohmann::json& document,
 
                     new_field = dynamic_field;
                     new_field.name = fname;
+                    new_field.from_dynamic = dynamic_field.name;
                     found_dynamic_field = true;
 
                     if(kv->is_object() && dynamic_field.name.find(".*") == kv.key().size()) {

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -7298,12 +7298,11 @@ Option<bool> Collection::validate_alter_payload(nlohmann::json& schema_changes,
             // NOTE: fields with type "auto" or "string*" will exist in both `search_schema` and `dynamic_fields`
             if(found_dyn_field) {
                 del_fields.push_back(dyn_field_it->second);
-                // we will also have to resolve the actual field names which match the dynamic field pattern
+                // only drop fields materialized by this exact pattern, leaving explicit declarations intact
+                const std::string& pattern = dyn_field_it->first;
                 for(auto& a_field: search_schema) {
-                    if(std::regex_match(a_field.name, std::regex(dyn_field_it->first))) {
+                    if(a_field.from_dynamic == pattern) {
                         del_fields.push_back(a_field);
-                        // if schema contains explicit fields that match dynamic field that're going to be removed,
-                        // we will have to remove them from the schema so that validation can occur properly
                         updated_search_schema.erase(a_field.name);
                     }
                 }

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -72,6 +72,9 @@ void field::add_default_json_values(nlohmann::json& json) {
     if (json.count(fields::track_missing_values) == 0) {
         json[fields::track_missing_values] = false;
     }
+    if (json.count(fields::from_dynamic) == 0) {
+        json[fields::from_dynamic] = "";
+    }
     if (json.count(fields::store) == 0) {
         json[fields::store] = true;
     }
@@ -609,6 +612,7 @@ bool field::flatten_obj(nlohmann::json& doc, nlohmann::json& value, bool has_arr
         flattened_field.optional = true;
         flattened_field.nested = true;
         flattened_field.nested_array = has_obj_array;
+        flattened_field.from_dynamic = found_dynamic_field ? dyn_field.name : "";
         int sort_op = flattened_field.sort ? 1 : -1;
         int infix_op = flattened_field.infix ? 1 : -1;
         flattened_field.set_computed_defaults(sort_op, infix_op);
@@ -936,6 +940,7 @@ nlohmann::json field::field_to_json_field(const struct field& field) {
     field_val[fields::range_index] = field.range_index;
     field_val[fields::track_missing_values] = field.track_missing_values;
     field_val[fields::stem_dictionary] = field.stem_dictionary;
+    field_val[fields::from_dynamic] = field.from_dynamic;
 
     if(field.embed.count(fields::from) != 0) {
         field_val[fields::embed] = field.embed;

--- a/test/collection_schema_change_test.cpp
+++ b/test/collection_schema_change_test.cpp
@@ -2154,3 +2154,64 @@ TEST_F(CollectionSchemaChangeTest, DropObjectFieldWithSimilarPrefix) {
     ASSERT_EQ(1, schema_map.count("attributes_filter"));
     ASSERT_EQ(1, schema_map.count("attributes_nested_string"));
 }
+
+TEST_F(CollectionSchemaChangeTest, DropNestedWildcardDoesNotRemoveSiblingsOrSharedPrefix) {
+    // dropping a wildcard nested field must only remove the pattern and its materialized children
+    nlohmann::json schema = R"({
+        "name": "coll1",
+        "enable_nested_fields": true,
+        "fields": [
+            {"name": "facetAttributes",            "type": "object",   "facet": false, "optional": true},
+            {"name": "facetAttributes.*",          "type": "string[]", "facet": true,  "optional": true},
+            {"name": "facetAttributes.menuBusca",  "type": "string[]", "facet": true,  "optional": true},
+            {"name": "facetAttributesList",        "type": "object",   "facet": false, "optional": true},
+            {"name": "facetAttributesList.key",    "type": "string",   "facet": true,  "optional": true},
+            {"name": "facetAttributesList.value",  "type": "string",   "facet": true,  "optional": true},
+            {"name": "name",                       "type": "string"}
+        ]
+    })"_json;
+
+    Collection* coll = collectionManager.create_collection(schema).get();
+    ASSERT_TRUE(coll != nullptr);
+
+    nlohmann::json doc;
+    doc["id"] = "a";
+    doc["name"] = "alpha";
+    doc["facetAttributes"] = nlohmann::json::object();
+    doc["facetAttributes"]["menuBusca"] = {"m1"};
+    doc["facetAttributes"]["cor"] = {"red"};
+    doc["facetAttributesList"] = nlohmann::json::object();
+    doc["facetAttributesList"]["key"] = "k";
+    doc["facetAttributesList"]["value"] = "v";
+    ASSERT_TRUE(coll->add(doc.dump()).ok());
+
+    auto schema_map = coll->get_schema();
+    ASSERT_EQ(1, schema_map.count("facetAttributes"));
+    ASSERT_EQ(1, schema_map.count("facetAttributes.menuBusca"));
+    ASSERT_EQ(1, schema_map.count("facetAttributes.cor"));
+    ASSERT_EQ(1, schema_map.count("facetAttributesList"));
+    ASSERT_EQ(1, schema_map.count("facetAttributesList.key"));
+    ASSERT_EQ(1, schema_map.count("facetAttributesList.value"));
+    ASSERT_EQ(1, coll->get_dynamic_fields().count("facetAttributes.*"));
+
+    auto schema_changes = R"({
+        "fields": [
+            {"name": "facetAttributes.*", "drop": true}
+        ]
+    })"_json;
+
+    auto alter_op = coll->alter(schema_changes);
+    ASSERT_TRUE(alter_op.ok());
+
+    schema_map = coll->get_schema();
+
+    ASSERT_EQ(0, coll->get_dynamic_fields().count("facetAttributes.*"));
+    ASSERT_EQ(0, schema_map.count("facetAttributes.cor"));
+
+    ASSERT_EQ(1, schema_map.count("facetAttributes"));
+    ASSERT_EQ(1, schema_map.count("facetAttributes.menuBusca"));
+    ASSERT_EQ(1, schema_map.count("facetAttributesList"));
+    ASSERT_EQ(1, schema_map.count("facetAttributesList.key"));
+    ASSERT_EQ(1, schema_map.count("facetAttributesList.value"));
+    ASSERT_EQ(1, schema_map.count("name"));
+}


### PR DESCRIPTION
## Change Summary

- add `from_dynamic` field to the `field` struct to record the dynamic pattern that materialized it, empty for explicitly declared fields
- serialize and deserialize `from_dynamic` via JSON; stamp it in `detect_new_fields` and `flatten_obj`
- replace regex-based materialized-field resolution in `validate_alter_payload` with an exact `from_dynamic == pattern` check
- add test asserting that dropping `facetAttributes.*` removes only its materialized children and leaves sibling objects, explicit sub-fields, and shared-prefix collections intact
- #2946 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
