### PR TITLE
Rebind reference field to the new swapped collection alias.

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -525,6 +525,7 @@ private:
 
     std::string get_seq_id_key(uint32_t seq_id) const;
 
+public:
     struct async_reference_backfill_update_t {
         uint32_t seq_id;
         nlohmann::json old_doc;
@@ -533,6 +534,11 @@ private:
 
     using async_reference_backfill_update_map_t = std::map<uint32_t, async_reference_backfill_update_t>;
 
+    Option<bool> apply_staged_async_reference_updates(Collection* referencing_coll,
+                                                      const std::string& referencing_collection_name,
+                                                      async_reference_backfill_update_map_t& staged_updates);
+
+private:
     Option<bool> stage_async_reference_update(Collection* referencing_coll,
                                               const std::string& referencing_collection_name,
                                               const std::string& referencing_field_name,
@@ -540,10 +546,6 @@ private:
                                               const std::set<std::string>& filter_values,
                                               const uint32_t ref_seq_id,
                                               async_reference_backfill_update_map_t& staged_updates);
-
-    Option<bool> apply_staged_async_reference_updates(Collection* referencing_coll,
-                                                      const std::string& referencing_collection_name,
-                                                      async_reference_backfill_update_map_t& staged_updates);
 
     static bool handle_highlight_text(std::string& text, const bool& normalise, const field& search_field,
                                       const bool& is_arr_obj_ele,
@@ -833,7 +835,8 @@ private:
     Option<bool> async_reference_helper_backfill(const std::string& referenced_field_name,
                                                  Collection* referencing_coll,
                                                  const std::string& referencing_field_name,
-                                                 const bool apply_updates);
+                                                 const bool apply_updates,
+                                                 async_reference_backfill_update_map_t* staged_updates);
 
     // Called to reset the reference helper fields to sentinel value when a referenced document fails to index.
     static void reset_referencing_documents(const spp::sparse_hash_map<std::string, std::set<reference_pair_t>>& found_async_referenced_ins,
@@ -1321,13 +1324,10 @@ public:
                                                    const uint32_t ref_seq_id, const std::string& field_name,
                                                    const bool apply_updates = true);
 
-    Option<bool> backfill_async_reference_helpers(const std::string& referenced_field_name,
-                                                  Collection* referencing_coll,
-                                                  const std::string& referencing_field_name);
-
-    Option<bool> validate_async_reference_helper_backfill(const std::string& referenced_field_name,
-                                                          Collection* referencing_coll,
-                                                          const std::string& referencing_field_name);
+    Option<bool> stage_async_reference_helper_backfill(const std::string& referenced_field_name,
+                                                       Collection* referencing_coll,
+                                                       const std::string& referencing_field_name,
+                                                       async_reference_backfill_update_map_t& staged_updates);
 
     Option<uint32_t> get_sort_index_value_with_lock(const std::string& field_name, const uint32_t& seq_id) const;
 

--- a/include/collection.h
+++ b/include/collection.h
@@ -1266,12 +1266,12 @@ public:
     // Return a copy of the referenced field in the referencing collection to avoid schema lookups in the future. The
     // tradeoff is that we have to make sure any changes during collection alter operation are passed to the referencing
     // collection.
-    [[nodiscard]] std::set<update_reference_info_t> add_referenced_ins(std::map<std::string, reference_info_t>& ref_infos);
+    std::set<update_reference_info_t> add_referenced_ins(std::map<std::string, reference_info_t>& ref_infos);
 
-    [[nodiscard]] std::set<update_reference_info_t> add_referenced_in(const std::string& collection_name,
-                                                                      const std::string& field_name, const bool& is_async,
-                                                                      const std::string& referenced_field_name,
-                                                                      field& referenced_field);
+    std::set<update_reference_info_t> add_referenced_in(const std::string& collection_name,
+                                                        const std::string& field_name, const bool& is_async,
+                                                        const std::string& referenced_field_name,
+                                                        field& referenced_field);
 
     [[nodiscard]] std::set<update_reference_info_t> validate_referenced_in(const std::string& collection_name,
                                                                            const std::string& field_name,

--- a/include/collection.h
+++ b/include/collection.h
@@ -525,6 +525,26 @@ private:
 
     std::string get_seq_id_key(uint32_t seq_id) const;
 
+    struct async_reference_backfill_update_t {
+        uint32_t seq_id;
+        nlohmann::json old_doc;
+        nlohmann::json new_doc;
+    };
+
+    using async_reference_backfill_update_map_t = std::map<uint32_t, async_reference_backfill_update_t>;
+
+    Option<bool> stage_async_reference_update(Collection* referencing_coll,
+                                              const std::string& referencing_collection_name,
+                                              const std::string& referencing_field_name,
+                                              const std::string& filter,
+                                              const std::set<std::string>& filter_values,
+                                              const uint32_t ref_seq_id,
+                                              async_reference_backfill_update_map_t& staged_updates);
+
+    Option<bool> apply_staged_async_reference_updates(Collection* referencing_coll,
+                                                      const std::string& referencing_collection_name,
+                                                      async_reference_backfill_update_map_t& staged_updates);
+
     static bool handle_highlight_text(std::string& text, const bool& normalise, const field& search_field,
                                       const bool& is_arr_obj_ele,
                                       const std::vector<char>& symbols_to_index, const std::vector<char>& token_separators,

--- a/include/collection.h
+++ b/include/collection.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include <unordered_map>
+#include <map>
 #include <thread>
 #include <memory>
 #include <atomic>
@@ -528,8 +529,8 @@ private:
 public:
     struct async_reference_backfill_update_t {
         uint32_t seq_id;
-        nlohmann::json old_doc;
-        nlohmann::json new_doc;
+        std::map<std::string, nlohmann::json> old_helper_fields;
+        std::map<std::string, nlohmann::json> new_helper_fields;
     };
 
     using async_reference_backfill_update_map_t = std::map<uint32_t, async_reference_backfill_update_t>;

--- a/include/collection.h
+++ b/include/collection.h
@@ -528,9 +528,15 @@ private:
 
 public:
     struct async_reference_backfill_update_t {
+        struct expected_reference_field_t {
+            std::string name;
+            nlohmann::json value;
+        };
+
         uint32_t seq_id;
         std::map<std::string, nlohmann::json> old_helper_fields;
         std::map<std::string, nlohmann::json> new_helper_fields;
+        std::map<std::string, expected_reference_field_t> expected_reference_fields;
     };
 
     using async_reference_backfill_update_map_t = std::map<uint32_t, async_reference_backfill_update_t>;

--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -71,6 +71,10 @@ private:
     Option<bool> resolve_deferred_references_for_symlink(const std::string& symlink_name,
                                                          const std::string& collection_name);
 
+    Option<bool> rebind_references_for_symlink_target_swap(const std::string& symlink_name,
+                                                           const std::string& old_collection_name,
+                                                           const std::string& new_collection_name);
+
 public:
     static constexpr const size_t DEFAULT_NUM_MEMORY_SHARDS = 4;
 

--- a/include/collection_manager.h
+++ b/include/collection_manager.h
@@ -2,6 +2,9 @@
 
 #include <iostream>
 #include <string>
+#ifdef TEST_BUILD
+#include <functional>
+#endif
 #include <sparsepp.h>
 #include "store.h"
 #include "field.h"
@@ -11,6 +14,10 @@
 #include "batched_indexer.h"
 
 const std::string ERROR_could_not_locate_document_in_store = "Could not locate the JSON document for sequence ID: ";
+
+#ifdef TEST_BUILD
+extern std::function<Option<bool>()> collection_manager_before_async_reference_backfill_apply;
+#endif
 
 // Singleton, for managing meta information of all collections and house keeping
 class CollectionManager {
@@ -108,7 +115,7 @@ public:
     Option<Collection*> clone_collection(const std::string& existing_name, const nlohmann::json& req_json,
                                          const bool copy_documents = false);
 
-    void add_to_collections(Collection* collection);
+    std::shared_ptr<Collection> add_to_collections(Collection* collection);
 
     Option<std::vector<std::shared_ptr<Collection>>> get_collections(uint32_t limit = 0, uint32_t offset = 0,
                                                      const std::vector<std::string>& api_key_collections = {}) const;

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -370,6 +370,215 @@ Option<bool> Collection::validate_async_reference_helper_backfill(const std::str
     return async_reference_helper_backfill(referenced_field_name, referencing_coll, referencing_field_name, false);
 }
 
+Option<bool> Collection::stage_async_reference_update(Collection* referencing_coll,
+                                                      const std::string& referencing_collection_name,
+                                                      const std::string& referencing_field_name,
+                                                      const std::string& filter,
+                                                      const std::set<std::string>& filter_values,
+                                                      const uint32_t ref_seq_id,
+                                                      async_reference_backfill_update_map_t& staged_updates) {
+    field referencing_field;
+    {
+        std::shared_lock lock(referencing_coll->mutex);
+
+        auto ref_field_it = referencing_coll->search_schema.find(referencing_field_name);
+        if (ref_field_it == referencing_coll->search_schema.end()) {
+            return Option<bool>(400, "Could not find field `" + referencing_field_name + "` in the schema.");
+        }
+        referencing_field = ref_field_it.value();
+    }
+
+    filter_result_t filter_result;
+    auto filter_op = referencing_coll->get_filter_ids_with_lock(filter, filter_result, false);
+    if (!filter_op.ok()) {
+        return filter_op;
+    }
+    if (filter_result.count == 0) {
+        return Option<bool>(true);
+    }
+
+    for (uint32_t i = 0; i < filter_result.count; i++) {
+        auto const& referencing_seq_id = filter_result.docs[i];
+
+        nlohmann::json existing_document;
+        auto staged_update_it = staged_updates.find(referencing_seq_id);
+        if (staged_update_it == staged_updates.end()) {
+            auto get_doc_op = referencing_coll->get_document_from_store(referencing_coll->get_seq_id_key(referencing_seq_id),
+                                                                        existing_document);
+            if (!get_doc_op.ok()) {
+                if (get_doc_op.code() == 404) {
+                    LOG(ERROR) << "`" << referencing_collection_name << "` collection: Sequence ID `" <<
+                               referencing_seq_id << "` exists, but document is missing.";
+                    continue;
+                }
+
+                LOG(ERROR) << "`" << referencing_collection_name << "` collection: " << get_doc_op.error();
+                continue;
+            }
+        } else {
+            existing_document = staged_update_it->second.new_doc;
+        }
+
+        auto const id = existing_document["id"].get<std::string>();
+        auto const reference_helper_field_name = referencing_field_name + fields::REFERENCE_HELPER_FIELD_SUFFIX;
+
+        if (referencing_field.is_singular()) {
+            if (staged_update_it == staged_updates.end()) {
+                auto update = async_reference_backfill_update_t{referencing_seq_id, existing_document,
+                                                                existing_document};
+                staged_update_it = staged_updates.emplace(referencing_seq_id, std::move(update)).first;
+            }
+
+            staged_update_it->second.new_doc[reference_helper_field_name] = ref_seq_id;
+            continue;
+        }
+
+        if (!existing_document.contains(referencing_field_name) || !existing_document[referencing_field_name].is_array()) {
+            return Option<bool>(400, "Expected document `id: " + id + "` to have `" += referencing_field_name +
+                                     "` array field that is `" += get_field_value(existing_document, referencing_field_name) +
+                                     "` instead.");
+        } else if (!existing_document.contains(reference_helper_field_name) ||
+                   !existing_document[reference_helper_field_name].is_array()) {
+            return Option<bool>(400, "Expected document `id: " + id + "` to have `" += reference_helper_field_name +
+                                     "` array field that is `" += get_field_value(existing_document, referencing_field_name) +
+                                     "` instead.");
+        } else if (existing_document[referencing_field_name].size() != existing_document[reference_helper_field_name].size()) {
+            return Option<bool>(400, "Expected document `id: " + id + "` to have equal count of elements in `" +=
+                                     referencing_field_name + ": " += get_field_value(existing_document, referencing_field_name) +
+                                     "` field and `" += reference_helper_field_name + ": " +=
+                                     get_field_value(existing_document, reference_helper_field_name) + "` field.");
+        }
+
+        auto should_update = false;
+        nlohmann::json helper_field = existing_document[reference_helper_field_name];
+        for (uint32_t j = 0; j < existing_document[referencing_field_name].size(); j++) {
+            auto const& ref_value = get_array_field_value(existing_document, referencing_field_name, j);
+            if (filter_values.count(ref_value) == 0) {
+                continue;
+            }
+
+            should_update = true;
+            helper_field[j] = ref_seq_id;
+        }
+
+        if (!should_update) {
+            continue;
+        }
+
+        if (staged_update_it == staged_updates.end()) {
+            auto update = async_reference_backfill_update_t{referencing_seq_id, existing_document,
+                                                            existing_document};
+            staged_update_it = staged_updates.emplace(referencing_seq_id, std::move(update)).first;
+        }
+        staged_update_it->second.new_doc[reference_helper_field_name] = std::move(helper_field);
+    }
+
+    return Option<bool>(true);
+}
+
+Option<bool> Collection::apply_staged_async_reference_updates(Collection* referencing_coll,
+                                                              const std::string& referencing_collection_name,
+                                                              async_reference_backfill_update_map_t& staged_updates) {
+    if (staged_updates.empty()) {
+        return Option<bool>(true);
+    }
+
+    std::vector<index_record> index_records;
+    index_records.reserve(staged_updates.size());
+    size_t document_index = 0;
+    for (const auto& staged_update_item: staged_updates) {
+        const auto& staged_update = staged_update_item.second;
+        index_record record(document_index++, staged_update.seq_id, staged_update.new_doc,
+                            index_operation_t::UPDATE, DIRTY_VALUES::COERCE_OR_REJECT);
+        record.old_doc = staged_update.old_doc;
+        record.is_update = true;
+        index_records.emplace_back(std::move(record));
+    }
+
+    std::shared_lock alter_shlock(referencing_coll->alter_mutex);
+    {
+        std::shared_lock schema_lock(referencing_coll->mutex);
+        Index::batch_validate_and_preprocess(referencing_coll->index, index_records,
+                                             referencing_coll->default_sorting_field,
+                                             referencing_coll->search_schema,
+                                             referencing_coll->embedding_fields,
+                                             referencing_coll->fallback_field_type,
+                                             referencing_coll->token_separators,
+                                             referencing_coll->symbols_to_index,
+                                             true);
+    }
+
+    std::unordered_set<std::string> dummy_set;
+    {
+        std::unique_lock index_lock(referencing_coll->mutex);
+        Index::batch_memory_index(referencing_coll->index, index_records, referencing_coll->default_sorting_field,
+                                  referencing_coll->search_schema, referencing_coll->embedding_fields,
+                                  referencing_coll->fallback_field_type, referencing_coll->token_separators,
+                                  referencing_coll->symbols_to_index, dummy_set);
+    }
+
+    auto rollback_indexed_updates = [&]() {
+        for (auto& record: index_records) {
+            if (!record.indexed.ok()) {
+                continue;
+            }
+
+            auto new_doc = record.new_doc;
+            referencing_coll->remove_document(new_doc, record.seq_id, false, false);
+
+            auto old_doc_for_index = record.old_doc;
+            auto restore_index_op = referencing_coll->index_in_memory(old_doc_for_index, record.seq_id,
+                                                                      record.operation, record.dirty_values);
+            if (!restore_index_op.ok()) {
+                LOG(ERROR) << "Failed to restore async reference helper backfill index state for document `" <<
+                           record.old_doc.value("id", "") << "` in collection `" << referencing_collection_name <<
+                           "`: " << restore_index_op.error();
+            }
+
+            auto old_doc_for_store = record.old_doc;
+            remove_flat_fields(old_doc_for_store);
+            for (auto& f: referencing_coll->fields) {
+                if(!f.store) {
+                    old_doc_for_store.erase(f.name);
+                }
+            }
+
+            const std::string& serialized_json = old_doc_for_store.dump(-1, ' ', false,
+                                                                        nlohmann::detail::error_handler_t::ignore);
+            if (!referencing_coll->store->insert(referencing_coll->get_seq_id_key(record.seq_id), serialized_json)) {
+                LOG(ERROR) << "Failed to restore async reference helper backfill store state for document `" <<
+                           record.old_doc.value("id", "") << "` in collection `" << referencing_collection_name << "`.";
+            }
+        }
+    };
+
+    for (const auto& record: index_records) {
+        if (!record.indexed.ok()) {
+            rollback_indexed_updates();
+            return Option<bool>(record.indexed.code(), record.indexed.error());
+        }
+    }
+
+    for (auto& record: index_records) {
+        auto new_doc_for_store = record.new_doc;
+        remove_flat_fields(new_doc_for_store);
+        for (auto& f: referencing_coll->fields) {
+            if(!f.store) {
+                new_doc_for_store.erase(f.name);
+            }
+        }
+
+        const std::string& serialized_json = new_doc_for_store.dump(-1, ' ', false,
+                                                                    nlohmann::detail::error_handler_t::ignore);
+        if (!referencing_coll->store->insert(referencing_coll->get_seq_id_key(record.seq_id), serialized_json)) {
+            rollback_indexed_updates();
+            return Option<bool>(500, "Could not write async reference helper backfill to on-disk storage.");
+        }
+    }
+
+    return Option<bool>(true);
+}
+
 Option<bool> Collection::async_reference_helper_backfill(const std::string& referenced_field_name,
                                                          Collection* referencing_coll,
                                                          const std::string& referencing_field_name,
@@ -392,6 +601,9 @@ Option<bool> Collection::async_reference_helper_backfill(const std::string& refe
         referenced_field = it.value();
     }
     const auto referenced_field_type = referenced_field.get_single_field_type();
+
+    async_reference_backfill_update_map_t staged_updates;
+
     const auto seq_id_prefix = get_seq_id_collection_prefix();
     std::string iter_upper_bound_key = seq_id_prefix + "`";
     auto iter_upper_bound = std::make_unique<rocksdb::Slice>(iter_upper_bound_key);
@@ -494,11 +706,24 @@ Option<bool> Collection::async_reference_helper_backfill(const std::string& refe
 
         auto ref_filter = referencing_field_name + ":= ";
         ref_filter += ref_filter_value;
-        auto update_op = referencing_coll->update_async_references_with_lock(name, ref_filter, values, seq_id,
-                                                                             referencing_field_name, apply_updates);
+        auto update_op = apply_updates ?
+                         stage_async_reference_update(referencing_coll, referencing_collection_name,
+                                                      referencing_field_name, ref_filter, values, seq_id,
+                                                      staged_updates) :
+                         referencing_coll->update_async_references_with_lock(name, ref_filter, values, seq_id,
+                                                                             referencing_field_name, false);
         if (!update_op.ok()) {
             return Option<bool>(400, "Error while updating async reference field `" + referencing_field_name +
                                      "` of collection `" + referencing_collection_name + "`: " + update_op.error());
+        }
+    }
+
+    if (apply_updates) {
+        auto apply_op = apply_staged_async_reference_updates(referencing_coll, referencing_collection_name,
+                                                             staged_updates);
+        if (!apply_op.ok()) {
+            return Option<bool>(400, "Error while updating async reference field `" + referencing_field_name +
+                                     "` of collection `" + referencing_collection_name + "`: " + apply_op.error());
         }
     }
 

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -358,16 +358,13 @@ Option<bool> Collection::update_async_references_with_lock(const std::string& re
     return Option<bool>(true);
 }
 
-Option<bool> Collection::backfill_async_reference_helpers(const std::string& referenced_field_name,
-                                                          Collection* referencing_coll,
-                                                          const std::string& referencing_field_name) {
-    return async_reference_helper_backfill(referenced_field_name, referencing_coll, referencing_field_name, true);
-}
-
-Option<bool> Collection::validate_async_reference_helper_backfill(const std::string& referenced_field_name,
-                                                                  Collection* referencing_coll,
-                                                                  const std::string& referencing_field_name) {
-    return async_reference_helper_backfill(referenced_field_name, referencing_coll, referencing_field_name, false);
+Option<bool> Collection::stage_async_reference_helper_backfill(
+        const std::string& referenced_field_name,
+        Collection* referencing_coll,
+        const std::string& referencing_field_name,
+        async_reference_backfill_update_map_t& staged_updates) {
+    return async_reference_helper_backfill(referenced_field_name, referencing_coll, referencing_field_name, true,
+                                           &staged_updates);
 }
 
 Option<bool> Collection::stage_async_reference_update(Collection* referencing_coll,
@@ -582,7 +579,8 @@ Option<bool> Collection::apply_staged_async_reference_updates(Collection* refere
 Option<bool> Collection::async_reference_helper_backfill(const std::string& referenced_field_name,
                                                          Collection* referencing_coll,
                                                          const std::string& referencing_field_name,
-                                                         const bool apply_updates) {
+                                                         const bool apply_updates,
+                                                         async_reference_backfill_update_map_t* staged_updates) {
     if (referencing_coll == nullptr) {
         return Option<bool>(true);
     }
@@ -602,7 +600,8 @@ Option<bool> Collection::async_reference_helper_backfill(const std::string& refe
     }
     const auto referenced_field_type = referenced_field.get_single_field_type();
 
-    async_reference_backfill_update_map_t staged_updates;
+    async_reference_backfill_update_map_t local_staged_updates;
+    auto& pending_staged_updates = staged_updates == nullptr ? local_staged_updates : *staged_updates;
 
     const auto seq_id_prefix = get_seq_id_collection_prefix();
     std::string iter_upper_bound_key = seq_id_prefix + "`";
@@ -709,7 +708,7 @@ Option<bool> Collection::async_reference_helper_backfill(const std::string& refe
         auto update_op = apply_updates ?
                          stage_async_reference_update(referencing_coll, referencing_collection_name,
                                                       referencing_field_name, ref_filter, values, seq_id,
-                                                      staged_updates) :
+                                                      pending_staged_updates) :
                          referencing_coll->update_async_references_with_lock(name, ref_filter, values, seq_id,
                                                                              referencing_field_name, false);
         if (!update_op.ok()) {
@@ -718,9 +717,9 @@ Option<bool> Collection::async_reference_helper_backfill(const std::string& refe
         }
     }
 
-    if (apply_updates) {
+    if (apply_updates && staged_updates == nullptr) {
         auto apply_op = apply_staged_async_reference_updates(referencing_coll, referencing_collection_name,
-                                                             staged_updates);
+                                                             pending_staged_updates);
         if (!apply_op.ok()) {
             return Option<bool>(400, "Error while updating async reference field `" + referencing_field_name +
                                      "` of collection `" + referencing_collection_name + "`: " + apply_op.error());

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -432,6 +432,11 @@ Option<bool> Collection::stage_async_reference_update(Collection* referencing_co
                         existing_document.contains(reference_helper_field_name) ?
                         existing_document[reference_helper_field_name] : nlohmann::json(nullptr);
             }
+            staged_update_it->second.expected_reference_fields[reference_helper_field_name] = {
+                    referencing_field_name,
+                    existing_document.contains(referencing_field_name) ?
+                    existing_document[referencing_field_name] : nlohmann::json(nullptr)
+            };
             staged_update_it->second.new_helper_fields[reference_helper_field_name] = ref_seq_id;
             continue;
         }
@@ -478,6 +483,11 @@ Option<bool> Collection::stage_async_reference_update(Collection* referencing_co
                     existing_document.contains(reference_helper_field_name) ?
                     existing_document[reference_helper_field_name] : nlohmann::json(nullptr);
         }
+        staged_update_it->second.expected_reference_fields[reference_helper_field_name] = {
+                referencing_field_name,
+                existing_document.contains(referencing_field_name) ?
+                existing_document[referencing_field_name] : nlohmann::json(nullptr)
+        };
         staged_update_it->second.new_helper_fields[reference_helper_field_name] = std::move(helper_field);
     }
 
@@ -518,7 +528,22 @@ Option<bool> Collection::apply_staged_async_reference_updates(Collection* refere
         nlohmann::json update_document;
         update_document["id"] = existing_document["id"].get<std::string>();
         for (const auto& helper_field: staged_update.new_helper_fields) {
+            auto expected_reference_it = staged_update.expected_reference_fields.find(helper_field.first);
+            if (expected_reference_it != staged_update.expected_reference_fields.end()) {
+                const auto& expected_reference = expected_reference_it->second;
+                const auto current_reference_value = existing_document.contains(expected_reference.name) ?
+                                                     existing_document[expected_reference.name] :
+                                                     nlohmann::json(nullptr);
+                if (current_reference_value != expected_reference.value) {
+                    continue;
+                }
+            }
+
             update_document[helper_field.first] = helper_field.second;
+        }
+
+        if (update_document.size() == 1) {
+            continue;
         }
 
         index_record record(document_index++, staged_update.seq_id, update_document,

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -399,21 +399,23 @@ Option<bool> Collection::stage_async_reference_update(Collection* referencing_co
 
         nlohmann::json existing_document;
         auto staged_update_it = staged_updates.find(referencing_seq_id);
-        if (staged_update_it == staged_updates.end()) {
-            auto get_doc_op = referencing_coll->get_document_from_store(referencing_coll->get_seq_id_key(referencing_seq_id),
-                                                                        existing_document);
-            if (!get_doc_op.ok()) {
-                if (get_doc_op.code() == 404) {
-                    LOG(ERROR) << "`" << referencing_collection_name << "` collection: Sequence ID `" <<
-                               referencing_seq_id << "` exists, but document is missing.";
-                    continue;
-                }
-
-                LOG(ERROR) << "`" << referencing_collection_name << "` collection: " << get_doc_op.error();
+        auto get_doc_op = referencing_coll->get_document_from_store(referencing_coll->get_seq_id_key(referencing_seq_id),
+                                                                    existing_document);
+        if (!get_doc_op.ok()) {
+            if (get_doc_op.code() == 404) {
+                LOG(ERROR) << "`" << referencing_collection_name << "` collection: Sequence ID `" <<
+                           referencing_seq_id << "` exists, but document is missing.";
                 continue;
             }
-        } else {
-            existing_document = staged_update_it->second.new_doc;
+
+            LOG(ERROR) << "`" << referencing_collection_name << "` collection: " << get_doc_op.error();
+            continue;
+        }
+
+        if (staged_update_it != staged_updates.end()) {
+            for (const auto& helper_field: staged_update_it->second.new_helper_fields) {
+                existing_document[helper_field.first] = helper_field.second;
+            }
         }
 
         auto const id = existing_document["id"].get<std::string>();
@@ -421,12 +423,16 @@ Option<bool> Collection::stage_async_reference_update(Collection* referencing_co
 
         if (referencing_field.is_singular()) {
             if (staged_update_it == staged_updates.end()) {
-                auto update = async_reference_backfill_update_t{referencing_seq_id, existing_document,
-                                                                existing_document};
+                auto update = async_reference_backfill_update_t{referencing_seq_id, {}, {}};
                 staged_update_it = staged_updates.emplace(referencing_seq_id, std::move(update)).first;
             }
 
-            staged_update_it->second.new_doc[reference_helper_field_name] = ref_seq_id;
+            if (staged_update_it->second.old_helper_fields.count(reference_helper_field_name) == 0) {
+                staged_update_it->second.old_helper_fields[reference_helper_field_name] =
+                        existing_document.contains(reference_helper_field_name) ?
+                        existing_document[reference_helper_field_name] : nlohmann::json(nullptr);
+            }
+            staged_update_it->second.new_helper_fields[reference_helper_field_name] = ref_seq_id;
             continue;
         }
 
@@ -463,11 +469,16 @@ Option<bool> Collection::stage_async_reference_update(Collection* referencing_co
         }
 
         if (staged_update_it == staged_updates.end()) {
-            auto update = async_reference_backfill_update_t{referencing_seq_id, existing_document,
-                                                            existing_document};
+            auto update = async_reference_backfill_update_t{referencing_seq_id, {}, {}};
             staged_update_it = staged_updates.emplace(referencing_seq_id, std::move(update)).first;
         }
-        staged_update_it->second.new_doc[reference_helper_field_name] = std::move(helper_field);
+
+        if (staged_update_it->second.old_helper_fields.count(reference_helper_field_name) == 0) {
+            staged_update_it->second.old_helper_fields[reference_helper_field_name] =
+                    existing_document.contains(reference_helper_field_name) ?
+                    existing_document[reference_helper_field_name] : nlohmann::json(nullptr);
+        }
+        staged_update_it->second.new_helper_fields[reference_helper_field_name] = std::move(helper_field);
     }
 
     return Option<bool>(true);
@@ -485,11 +496,40 @@ Option<bool> Collection::apply_staged_async_reference_updates(Collection* refere
     size_t document_index = 0;
     for (const auto& staged_update_item: staged_updates) {
         const auto& staged_update = staged_update_item.second;
-        index_record record(document_index++, staged_update.seq_id, staged_update.new_doc,
+
+        nlohmann::json existing_document;
+        auto get_doc_op = referencing_coll->get_document_from_store(
+                referencing_coll->get_seq_id_key(staged_update.seq_id), existing_document);
+        if (!get_doc_op.ok()) {
+            if (get_doc_op.code() == 404) {
+                LOG(ERROR) << "`" << referencing_collection_name << "` collection: Sequence ID `" <<
+                           staged_update.seq_id << "` exists, but document is missing.";
+                continue;
+            }
+
+            return Option<bool>(get_doc_op.code(), get_doc_op.error());
+        }
+
+        if (!existing_document.contains("id")) {
+            return Option<bool>(400, "`" + referencing_collection_name + "` collection: Sequence ID `" +
+                                     std::to_string(staged_update.seq_id) + "` document is missing `id` field.");
+        }
+
+        nlohmann::json update_document;
+        update_document["id"] = existing_document["id"].get<std::string>();
+        for (const auto& helper_field: staged_update.new_helper_fields) {
+            update_document[helper_field.first] = helper_field.second;
+        }
+
+        index_record record(document_index++, staged_update.seq_id, update_document,
                             index_operation_t::UPDATE, DIRTY_VALUES::COERCE_OR_REJECT);
-        record.old_doc = staged_update.old_doc;
+        record.old_doc = std::move(existing_document);
         record.is_update = true;
         index_records.emplace_back(std::move(record));
+    }
+
+    if (index_records.empty()) {
+        return Option<bool>(true);
     }
 
     std::shared_lock alter_shlock(referencing_coll->alter_mutex);

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1427,6 +1427,30 @@ Option<bool> CollectionManager::rebind_references_for_symlink_target_swap(const 
 
     }
 
+    std::vector<const symlink_ref_rebind_t*> applied_rebinds;
+    applied_rebinds.reserve(rebind_plan.size());
+    auto rollback_applied_rebinds = [&]() {
+        for (auto it = applied_rebinds.rbegin(); it != applied_rebinds.rend(); ++it) {
+            const auto& rebind = **it;
+
+            new_coll->remove_referenced_in(rebind.ref_info.collection, rebind.ref_info.field,
+                                           rebind.ref_info.is_async, rebind.ref_info.referenced_field_name);
+
+            if (old_coll != nullptr) {
+                field referenced_field = rebind.ref_info.referenced_field;
+                old_coll->add_referenced_in(rebind.ref_info.collection, rebind.ref_info.field,
+                                            rebind.ref_info.is_async, rebind.ref_info.referenced_field_name,
+                                            referenced_field);
+            }
+
+            for (const auto& update_ref_info: rebind.update_ref_infos) {
+                rebind.referencing_coll->update_reference_info_with_lock(update_ref_info.field,
+                                                                         old_collection_name,
+                                                                         rebind.ref_info.referenced_field);
+            }
+        }
+    };
+
     for (const auto& rebind: rebind_plan) {
         if (old_coll != nullptr) {
             old_coll->remove_referenced_in(rebind.ref_info.collection, rebind.ref_info.field,
@@ -1434,12 +1458,9 @@ Option<bool> CollectionManager::rebind_references_for_symlink_target_swap(const 
         }
 
         field referenced_field = rebind.ref_info.referenced_field;
-        auto added_update_ref_infos = new_coll->add_referenced_in(rebind.ref_info.collection,
-                                                                  rebind.ref_info.field,
-                                                                  rebind.ref_info.is_async,
-                                                                  rebind.ref_info.referenced_field_name,
-                                                                  referenced_field);
-        (void) added_update_ref_infos;
+        new_coll->add_referenced_in(rebind.ref_info.collection, rebind.ref_info.field, rebind.ref_info.is_async,
+                                    rebind.ref_info.referenced_field_name, referenced_field);
+        applied_rebinds.emplace_back(&rebind);
 
         for (const auto& update_ref_info: rebind.update_ref_infos) {
             rebind.referencing_coll->update_reference_info_with_lock(update_ref_info.field,
@@ -1451,6 +1472,7 @@ Option<bool> CollectionManager::rebind_references_for_symlink_target_swap(const 
                                                                               rebind.referencing_coll.get(),
                                                                               update_ref_info.field);
                 if (!backfill_op.ok()) {
+                    rollback_applied_rebinds();
                     return backfill_op;
                 }
             }

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1103,7 +1103,13 @@ Option<bool> CollectionManager::upsert_symlink(const std::string & symlink_name,
     lock.unlock();
 
     auto resolve_op = resolve_deferred_references_for_symlink(symlink_name, collection_name);
-    if (!resolve_op.ok()) {
+    Option<bool> reference_update_op = resolve_op;
+    if (reference_update_op.ok() && had_existing_symlink && existing_collection_name != collection_name) {
+        reference_update_op = rebind_references_for_symlink_target_swap(symlink_name, existing_collection_name,
+                                                                        collection_name);
+    }
+
+    if (!reference_update_op.ok()) {
         lock.lock();
         if (had_existing_symlink) {
             if (!store->insert(get_symlink_key(symlink_name), existing_collection_name)) {
@@ -1119,7 +1125,7 @@ Option<bool> CollectionManager::upsert_symlink(const std::string & symlink_name,
         lock.unlock();
     }
 
-    return resolve_op;
+    return reference_update_op;
 }
 
 Option<bool> CollectionManager::validate_deferred_references_for_symlink(const std::string& symlink_name,
@@ -1283,6 +1289,148 @@ Option<bool> CollectionManager::resolve_deferred_references_for_symlink(const st
         persist_referenced_ins();
         u_lock.unlock();
     }
+
+    return Option<bool>(true);
+}
+
+Option<bool> CollectionManager::rebind_references_for_symlink_target_swap(const std::string& symlink_name,
+                                                                          const std::string& old_collection_name,
+                                                                          const std::string& new_collection_name) {
+    std::map<std::string, reference_info_t> old_ref_infos;
+    {
+        std::shared_lock lock(mutex);
+        auto ref_infos_it = referenced_ins.find(old_collection_name);
+        if (ref_infos_it != referenced_ins.end()) {
+            old_ref_infos = ref_infos_it->second;
+        }
+    }
+
+    if (old_ref_infos.empty()) {
+        return Option<bool>(true);
+    }
+
+    auto old_coll = get_collection(old_collection_name);
+    auto new_coll = get_collection(new_collection_name);
+    if (new_coll == nullptr) {
+        return Option<bool>(true);
+    }
+
+    auto resolved_new_collection_name = new_coll->get_name();
+    if (old_collection_name == resolved_new_collection_name) {
+        return Option<bool>(true);
+    }
+
+    struct symlink_ref_rebind_t {
+        reference_info_t ref_info;
+        std::shared_ptr<Collection> referencing_coll;
+        std::set<update_reference_info_t> update_ref_infos;
+    };
+
+    std::vector<symlink_ref_rebind_t> rebind_plan;
+    rebind_plan.reserve(old_ref_infos.size());
+
+    const auto alias_reference_prefix = symlink_name + ".";
+    for (const auto& item: old_ref_infos) {
+        const auto& old_ref_info = item.second;
+        auto referencing_coll = get_collection(old_ref_info.collection);
+        if (referencing_coll == nullptr) {
+            continue;
+        }
+
+        auto schema = referencing_coll->get_schema();
+        auto schema_it = schema.find(old_ref_info.field);
+        if (schema_it == schema.end()) {
+            continue;
+        }
+
+        const auto& original_reference = schema_it.value().reference;
+        if (original_reference.rfind(alias_reference_prefix, 0) != 0) {
+            continue;
+        }
+
+        auto original_referenced_field_name = original_reference.substr(alias_reference_prefix.size());
+        if (original_referenced_field_name != old_ref_info.referenced_field_name) {
+            continue;
+        }
+
+        symlink_ref_rebind_t rebind;
+        rebind.ref_info = old_ref_info;
+        rebind.referencing_coll = referencing_coll;
+        rebind.update_ref_infos = new_coll->validate_referenced_in(rebind.ref_info.collection,
+                                                                   rebind.ref_info.field,
+                                                                   rebind.ref_info.referenced_field_name,
+                                                                   rebind.ref_info.referenced_field);
+        if (rebind.update_ref_infos.empty()) {
+            return Option<bool>(400, "Referenced field `" + rebind.ref_info.referenced_field_name +
+                                     "` not found in the collection `" + resolved_new_collection_name + "`.");
+        }
+
+        if (rebind.update_ref_infos.begin()->is_mutual_reference) {
+            auto info = is_referenced_in_with_lock(rebind.ref_info.collection, resolved_new_collection_name);
+            auto referenced_field = info.ok() ? info.get().field : rebind.update_ref_infos.begin()->field;
+            return Option<bool>(400, "Collections having reference to each other are not allowed. `" +
+                                     rebind.ref_info.collection + "` collection is referenced by `" +
+                                     resolved_new_collection_name + "` collection's `" + referenced_field + "` field.");
+        }
+
+        if (rebind.ref_info.is_async) {
+            auto validate_backfill_op = new_coll->validate_async_reference_helper_backfill(
+                    rebind.ref_info.referenced_field_name, rebind.referencing_coll.get(), rebind.ref_info.field);
+            if (!validate_backfill_op.ok()) {
+                return validate_backfill_op;
+            }
+        }
+
+        rebind_plan.emplace_back(std::move(rebind));
+    }
+
+    if (rebind_plan.empty()) {
+        return Option<bool>(true);
+    }
+
+    for (const auto& rebind: rebind_plan) {
+        if (old_coll != nullptr) {
+            old_coll->remove_referenced_in(rebind.ref_info.collection, rebind.ref_info.field,
+                                           rebind.ref_info.is_async, rebind.ref_info.referenced_field_name);
+        }
+
+        field referenced_field = rebind.ref_info.referenced_field;
+        auto added_update_ref_infos = new_coll->add_referenced_in(rebind.ref_info.collection,
+                                                                  rebind.ref_info.field,
+                                                                  rebind.ref_info.is_async,
+                                                                  rebind.ref_info.referenced_field_name,
+                                                                  referenced_field);
+        (void) added_update_ref_infos;
+
+        for (const auto& update_ref_info: rebind.update_ref_infos) {
+            rebind.referencing_coll->update_reference_info_with_lock(update_ref_info.field,
+                                                                     resolved_new_collection_name,
+                                                                     update_ref_info.referenced_field);
+
+            if (rebind.ref_info.is_async) {
+                auto backfill_op = new_coll->backfill_async_reference_helpers(update_ref_info.referenced_field.name,
+                                                                              rebind.referencing_coll.get(),
+                                                                              update_ref_info.field);
+                if (!backfill_op.ok()) {
+                    return backfill_op;
+                }
+            }
+        }
+    }
+
+    std::unique_lock lock(mutex);
+    for (const auto& rebind: rebind_plan) {
+        auto old_ref_infos_it = referenced_ins.find(old_collection_name);
+        if (old_ref_infos_it != referenced_ins.end()) {
+            old_ref_infos_it->second.erase(rebind.ref_info.collection);
+            if (old_ref_infos_it->second.empty()) {
+                referenced_ins.erase(old_ref_infos_it);
+            }
+        }
+
+        referenced_ins[resolved_new_collection_name][rebind.ref_info.collection] = rebind.ref_info;
+    }
+    persist_referenced_ins();
 
     return Option<bool>(true);
 }

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -847,6 +847,20 @@ bool CollectionManager::auth_key_matches(const string& req_auth_key, const strin
     return auth_manager.authenticate(action, collection_keys, params, embedded_params_vec);
 }
 
+struct referenced_in_replay_t {
+    std::map<std::string, reference_info_t>* ref_info_map;
+    std::set<update_reference_info_t> update_ref_infos;
+};
+
+struct deferred_ref_resolution_t {
+    std::string symlink_name;
+    std::string referenced_collection_name;
+    reference_info_t ref_info;
+    std::shared_ptr<Collection> referencing_coll;
+    std::shared_ptr<Collection> referenced_coll;
+    std::set<update_reference_info_t> update_ref_infos;
+};
+
 Option<Collection*> CollectionManager::create_collection(const std::string& name,
                                                          const size_t num_memory_shards,
                                                          const std::vector<field> & fields,
@@ -969,12 +983,8 @@ Option<Collection*> CollectionManager::create_collection(const std::string& name
         }
     }
 
-    struct referenced_in_replay_t {
-        std::map<std::string, reference_info_t>* ref_info_map;
-        std::set<update_reference_info_t> update_ref_infos;
-    };
-
     std::vector<referenced_in_replay_t> referenced_in_replay_plan;
+    std::vector<deferred_ref_resolution_t> deferred_ref_resolution_plan;
     std::vector<staged_async_reference_backfill_t> staged_backfills;
 
     for(auto& ref_info_map: ref_info_maps) {
@@ -1006,6 +1016,66 @@ Option<Collection*> CollectionManager::create_collection(const std::string& name
         referenced_in_replay_plan.emplace_back(std::move(replay));
     }
 
+    for (const auto& symlink_name: deferred_ref_symlinks) {
+        std::map<std::string, reference_info_t> deferred_ref_infos;
+        {
+            std::shared_lock ref_lock(mutex);
+            auto ref_infos_it = referenced_ins.find(symlink_name);
+            if (ref_infos_it != referenced_ins.end()) {
+                deferred_ref_infos = ref_infos_it->second;
+            }
+        }
+
+        for (const auto& item: deferred_ref_infos) {
+            deferred_ref_resolution_t resolution;
+            resolution.symlink_name = symlink_name;
+            resolution.referenced_collection_name = name;
+            resolution.ref_info = item.second;
+            resolution.referencing_coll = get_collection(resolution.ref_info.collection);
+            resolution.referenced_coll = get_collection(resolution.referenced_collection_name);
+
+            if (resolution.referenced_coll != nullptr) {
+                resolution.referenced_collection_name = resolution.referenced_coll->get_name();
+                resolution.update_ref_infos = resolution.referenced_coll->validate_referenced_in(
+                        resolution.ref_info.collection, resolution.ref_info.field,
+                        resolution.ref_info.referenced_field_name, resolution.ref_info.referenced_field);
+                if (resolution.update_ref_infos.empty()) {
+                    rollback_new_collection();
+                    return Option<Collection*>(400, "Referenced field `" + resolution.ref_info.referenced_field_name +
+                                                    "` not found in the collection `" +
+                                                    resolution.referenced_collection_name + "`.");
+                }
+
+                if (resolution.update_ref_infos.begin()->is_mutual_reference) {
+                    auto info = is_referenced_in_with_lock(resolution.ref_info.collection,
+                                                           resolution.referenced_collection_name);
+                    auto referenced_field = info.ok() ? info.get().field : resolution.update_ref_infos.begin()->field;
+                    rollback_new_collection();
+                    return Option<Collection*>(400, "Collections having reference to each other are not allowed. `" +
+                                                    resolution.ref_info.collection + "` collection is referenced by `" +=
+                                                    resolution.referenced_collection_name + "` collection's `" +=
+                                                    referenced_field + "` field.");
+                }
+            }
+
+            if (resolution.ref_info.is_async && resolution.referencing_coll != nullptr &&
+                resolution.referenced_coll != nullptr) {
+                for (const auto& update_ref_info: resolution.update_ref_infos) {
+                    auto stage_op = stage_async_reference_helper_backfill(resolution.referenced_coll.get(),
+                                                                          resolution.referencing_coll.get(),
+                                                                          update_ref_info.referenced_field.name,
+                                                                          update_ref_info.field, staged_backfills);
+                    if (!stage_op.ok()) {
+                        rollback_new_collection();
+                        return Option<Collection*>(stage_op.code(), stage_op.error());
+                    }
+                }
+            }
+
+            deferred_ref_resolution_plan.emplace_back(std::move(resolution));
+        }
+    }
+
     auto apply_backfills_op = apply_staged_async_reference_helper_backfills(staged_backfills);
     if (!apply_backfills_op.ok()) {
         rollback_new_collection();
@@ -1026,12 +1096,56 @@ Option<Collection*> CollectionManager::create_collection(const std::string& name
         }
     }
 
-    for (const auto& symlink_name: deferred_ref_symlinks) {
-        auto resolve_op = resolve_deferred_references_for_symlink(symlink_name, name);
-        if (!resolve_op.ok()) {
-            rollback_new_collection();
-            return Option<Collection*>(resolve_op.code(), resolve_op.error());
+    std::set<std::string> resolved_ref_symlinks;
+    std::unique_lock u_lock(mutex, std::defer_lock);
+    for (const auto& resolution: deferred_ref_resolution_plan) {
+        if (resolution.referenced_coll != nullptr) {
+            field referenced_field = resolution.ref_info.referenced_field;
+            resolution.referenced_coll->add_referenced_in(resolution.ref_info.collection, resolution.ref_info.field,
+                                                          resolution.ref_info.is_async,
+                                                          resolution.ref_info.referenced_field_name,
+                                                          referenced_field);
         }
+
+        u_lock.lock();
+        auto it = referenced_ins.find(resolution.referenced_collection_name);
+        if (it == referenced_ins.end()) {
+            referenced_ins[resolution.referenced_collection_name] = {
+                    {resolution.ref_info.collection, resolution.ref_info}};
+        } else {
+            referenced_ins[resolution.referenced_collection_name].insert({
+                    resolution.ref_info.collection, resolution.ref_info});
+        }
+        resolved_ref_symlinks.insert(resolution.symlink_name);
+        u_lock.unlock();
+
+        if (resolution.referencing_coll == nullptr) {
+            continue;
+        }
+
+        if (resolution.update_ref_infos.empty()) {
+            resolution.referencing_coll->update_reference_info_with_lock(resolution.ref_info.field,
+                                                                         resolution.referenced_collection_name,
+                                                                         field{});
+            continue;
+        }
+
+        for (const auto& update_ref_info: resolution.update_ref_infos) {
+            resolution.referencing_coll->update_reference_info_with_lock(update_ref_info.field,
+                                                                         resolution.referenced_collection_name,
+                                                                         update_ref_info.referenced_field);
+        }
+    }
+
+    if (!resolved_ref_symlinks.empty()) {
+        u_lock.lock();
+        for (const auto& symlink_name: resolved_ref_symlinks) {
+            if (name != symlink_name) {
+                referenced_ins.erase(symlink_name);
+            }
+        }
+        persist_referenced_ins();
+        u_lock.unlock();
     }
 
     return Option<Collection*>(new_collection);

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -20,6 +20,90 @@
 
 constexpr const size_t CollectionManager::DEFAULT_NUM_MEMORY_SHARDS;
 
+struct staged_async_reference_backfill_t {
+    Collection* referenced_coll = nullptr;
+    Collection* referencing_coll = nullptr;
+    std::string referencing_collection_name;
+    Collection::async_reference_backfill_update_map_t updates;
+};
+
+Option<bool> stage_async_reference_helper_backfill(
+        Collection* referenced_coll,
+        Collection* referencing_coll,
+        const std::string& referenced_field_name,
+        const std::string& referencing_field_name,
+        std::vector<staged_async_reference_backfill_t>& staged_backfills) {
+    if (referenced_coll == nullptr || referencing_coll == nullptr) {
+        return Option<bool>(true);
+    }
+
+    staged_async_reference_backfill_t staged_backfill;
+    staged_backfill.referenced_coll = referenced_coll;
+    staged_backfill.referencing_coll = referencing_coll;
+    staged_backfill.referencing_collection_name = referencing_coll->get_name();
+
+    auto stage_op = referenced_coll->stage_async_reference_helper_backfill(referenced_field_name, referencing_coll,
+                                                                           referencing_field_name,
+                                                                           staged_backfill.updates);
+    if (!stage_op.ok()) {
+        return stage_op;
+    }
+
+    if (!staged_backfill.updates.empty()) {
+        staged_backfills.emplace_back(std::move(staged_backfill));
+    }
+
+    return Option<bool>(true);
+}
+
+Collection::async_reference_backfill_update_map_t reverse_async_reference_helper_backfill(
+        const Collection::async_reference_backfill_update_map_t& updates) {
+    Collection::async_reference_backfill_update_map_t reversed_updates;
+    for (const auto& update_item: updates) {
+        const auto& update = update_item.second;
+        reversed_updates.emplace(update_item.first, Collection::async_reference_backfill_update_t{
+                update.seq_id, update.new_doc, update.old_doc});
+    }
+
+    return reversed_updates;
+}
+
+void rollback_applied_async_reference_helper_backfills(
+        const std::vector<staged_async_reference_backfill_t>& staged_backfills,
+        const std::vector<size_t>& applied_backfill_indices) {
+    for (auto it = applied_backfill_indices.rbegin(); it != applied_backfill_indices.rend(); ++it) {
+        const auto& staged_backfill = staged_backfills[*it];
+        auto reversed_updates = reverse_async_reference_helper_backfill(staged_backfill.updates);
+        auto rollback_op = staged_backfill.referenced_coll->apply_staged_async_reference_updates(
+                staged_backfill.referencing_coll, staged_backfill.referencing_collection_name, reversed_updates);
+        if (!rollback_op.ok()) {
+            LOG(ERROR) << "Failed to rollback async reference helper backfill for collection `"
+                       << staged_backfill.referencing_collection_name << "`: " << rollback_op.error();
+        }
+    }
+}
+
+Option<bool> apply_staged_async_reference_helper_backfills(
+        std::vector<staged_async_reference_backfill_t>& staged_backfills) {
+    std::vector<size_t> applied_backfill_indices;
+    applied_backfill_indices.reserve(staged_backfills.size());
+
+    for (size_t i = 0; i < staged_backfills.size(); i++) {
+        auto& staged_backfill = staged_backfills[i];
+        auto apply_op = staged_backfill.referenced_coll->apply_staged_async_reference_updates(
+                staged_backfill.referencing_coll, staged_backfill.referencing_collection_name,
+                staged_backfill.updates);
+        if (!apply_op.ok()) {
+            rollback_applied_async_reference_helper_backfills(staged_backfills, applied_backfill_indices);
+            return apply_op;
+        }
+
+        applied_backfill_indices.push_back(i);
+    }
+
+    return Option<bool>(true);
+}
+
 CollectionManager::CollectionManager() {
 
 }
@@ -885,23 +969,56 @@ Option<Collection*> CollectionManager::create_collection(const std::string& name
         }
     }
 
+    struct referenced_in_replay_t {
+        std::map<std::string, reference_info_t>* ref_info_map;
+        std::set<update_reference_info_t> update_ref_infos;
+    };
+
+    std::vector<referenced_in_replay_t> referenced_in_replay_plan;
+    std::vector<staged_async_reference_backfill_t> staged_backfills;
+
     for(auto& ref_info_map: ref_info_maps) {
-        const auto& update_ref_infos = new_collection->add_referenced_ins(ref_info_map);
-        for (auto& update_ref_info: update_ref_infos) {
+        referenced_in_replay_t replay{&ref_info_map, {}};
+        for (auto& ref_info_item: ref_info_map) {
+            auto& ref_info = ref_info_item.second;
+            auto update_ref_infos = new_collection->validate_referenced_in(ref_info.collection, ref_info.field,
+                                                                           ref_info.referenced_field_name,
+                                                                           ref_info.referenced_field);
+            replay.update_ref_infos.insert(update_ref_infos.begin(), update_ref_infos.end());
+        }
+
+        for (auto& update_ref_info: replay.update_ref_infos) {
+            auto coll = get_collection_unsafe(update_ref_info.collection);
+            if(coll) {
+                const auto ref_info_it = ref_info_map.find(update_ref_info.collection);
+                if (ref_info_it != ref_info_map.end() && ref_info_it->second.is_async) {
+                    auto stage_op = stage_async_reference_helper_backfill(new_collection, coll.get(),
+                                                                          update_ref_info.referenced_field.name,
+                                                                          update_ref_info.field, staged_backfills);
+                    if (!stage_op.ok()) {
+                        rollback_new_collection();
+                        return Option<Collection*>(stage_op.code(), stage_op.error());
+                    }
+                }
+            }
+        }
+
+        referenced_in_replay_plan.emplace_back(std::move(replay));
+    }
+
+    auto apply_backfills_op = apply_staged_async_reference_helper_backfills(staged_backfills);
+    if (!apply_backfills_op.ok()) {
+        rollback_new_collection();
+        return Option<Collection*>(apply_backfills_op.code(), apply_backfills_op.error());
+    }
+
+    for(auto& replay: referenced_in_replay_plan) {
+        new_collection->add_referenced_ins(*replay.ref_info_map);
+        for (auto& update_ref_info: replay.update_ref_infos) {
             auto coll = get_collection_unsafe(update_ref_info.collection);
             if(coll) {
                 coll->update_reference_info_with_lock(update_ref_info.field, new_collection->get_name(),
                                                       update_ref_info.referenced_field);
-
-                const auto ref_info_it = ref_info_map.find(update_ref_info.collection);
-                if (ref_info_it != ref_info_map.end() && ref_info_it->second.is_async) {
-                    auto backfill_op = new_collection->backfill_async_reference_helpers(
-                            update_ref_info.referenced_field.name, coll.get(), update_ref_info.field);
-                    if (!backfill_op.ok()) {
-                        rollback_new_collection();
-                        return Option<Collection*>(backfill_op.code(), backfill_op.error());
-                    }
-                }
 
                 // We do not erase from `referenced_ins` here, because if a referenced collection is dropped and
                 // created again, the referenced field won't be updated in referencing collection.
@@ -1233,17 +1350,30 @@ Option<bool> CollectionManager::resolve_deferred_references_for_symlink(const st
             }
         }
 
-        if (resolution.ref_info.is_async && resolution.referencing_coll != nullptr &&
-            resolution.referenced_coll != nullptr) {
-            auto validate_backfill_op = resolution.referenced_coll->validate_async_reference_helper_backfill(
-                    resolution.ref_info.referenced_field_name, resolution.referencing_coll.get(),
-                    resolution.ref_info.field);
-            if (!validate_backfill_op.ok()) {
-                return validate_backfill_op;
-            }
+        resolution_plan.emplace_back(std::move(resolution));
+    }
+
+    std::vector<staged_async_reference_backfill_t> staged_backfills;
+    for (const auto& resolution: resolution_plan) {
+        if (!resolution.ref_info.is_async || resolution.referencing_coll == nullptr ||
+            resolution.referenced_coll == nullptr) {
+            continue;
         }
 
-        resolution_plan.emplace_back(std::move(resolution));
+        for (const auto& update_ref_info: resolution.update_ref_infos) {
+            auto stage_op = stage_async_reference_helper_backfill(resolution.referenced_coll.get(),
+                                                                  resolution.referencing_coll.get(),
+                                                                  update_ref_info.referenced_field.name,
+                                                                  update_ref_info.field, staged_backfills);
+            if (!stage_op.ok()) {
+                return stage_op;
+            }
+        }
+    }
+
+    auto apply_backfills_op = apply_staged_async_reference_helper_backfills(staged_backfills);
+    if (!apply_backfills_op.ok()) {
+        return apply_backfills_op;
     }
 
     std::unique_lock u_lock(mutex, std::defer_lock);
@@ -1283,14 +1413,6 @@ Option<bool> CollectionManager::resolve_deferred_references_for_symlink(const st
             resolution.referencing_coll->update_reference_info_with_lock(update_ref_info.field,
                                                                          resolution.referenced_collection_name,
                                                                          update_ref_info.referenced_field);
-
-            if (resolution.ref_info.is_async && resolution.referenced_coll != nullptr) {
-                auto backfill_op = resolution.referenced_coll->backfill_async_reference_helpers(
-                        update_ref_info.referenced_field.name, resolution.referencing_coll.get(), update_ref_info.field);
-                if (!backfill_op.ok()) {
-                    return backfill_op;
-                }
-            }
         }
     }
 
@@ -1416,19 +1538,11 @@ Option<bool> CollectionManager::rebind_references_for_symlink_target_swap(const 
                                      rebind.ref_info.collection + "` collection is referenced by `" +
                                      resolved_new_collection_name + "` collection's `" + referenced_field + "` field.");
         }
-
-        if (rebind.ref_info.is_async) {
-            auto validate_backfill_op = new_coll->validate_async_reference_helper_backfill(
-                    rebind.ref_info.referenced_field_name, rebind.referencing_coll.get(), rebind.ref_info.field);
-            if (!validate_backfill_op.ok()) {
-                return validate_backfill_op;
-            }
-        }
-
     }
 
     std::vector<const symlink_ref_rebind_t*> applied_rebinds;
     applied_rebinds.reserve(rebind_plan.size());
+    std::vector<staged_async_reference_backfill_t> staged_backfills;
     auto rollback_applied_rebinds = [&]() {
         for (auto it = applied_rebinds.rbegin(); it != applied_rebinds.rend(); ++it) {
             const auto& rebind = **it;
@@ -1466,17 +1580,29 @@ Option<bool> CollectionManager::rebind_references_for_symlink_target_swap(const 
             rebind.referencing_coll->update_reference_info_with_lock(update_ref_info.field,
                                                                      resolved_new_collection_name,
                                                                      update_ref_info.referenced_field);
+        }
+    }
 
-            if (rebind.ref_info.is_async) {
-                auto backfill_op = new_coll->backfill_async_reference_helpers(update_ref_info.referenced_field.name,
-                                                                              rebind.referencing_coll.get(),
-                                                                              update_ref_info.field);
-                if (!backfill_op.ok()) {
-                    rollback_applied_rebinds();
-                    return backfill_op;
-                }
+    for (const auto& rebind: rebind_plan) {
+        if (!rebind.ref_info.is_async) {
+            continue;
+        }
+
+        for (const auto& update_ref_info: rebind.update_ref_infos) {
+            auto stage_op = stage_async_reference_helper_backfill(new_coll.get(), rebind.referencing_coll.get(),
+                                                                  update_ref_info.referenced_field.name,
+                                                                  update_ref_info.field, staged_backfills);
+            if (!stage_op.ok()) {
+                rollback_applied_rebinds();
+                return stage_op;
             }
         }
+    }
+
+    auto apply_backfills_op = apply_staged_async_reference_helper_backfills(staged_backfills);
+    if (!apply_backfills_op.ok()) {
+        rollback_applied_rebinds();
+        return apply_backfills_op;
     }
 
     std::unique_lock lock(mutex);

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -66,7 +66,7 @@ Collection::async_reference_backfill_update_map_t reverse_async_reference_helper
     for (const auto& update_item: updates) {
         const auto& update = update_item.second;
         reversed_updates.emplace(update_item.first, Collection::async_reference_backfill_update_t{
-                update.seq_id, update.new_helper_fields, update.old_helper_fields});
+                update.seq_id, update.new_helper_fields, update.old_helper_fields, update.expected_reference_fields});
     }
 
     return reversed_updates;

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -62,7 +62,7 @@ Collection::async_reference_backfill_update_map_t reverse_async_reference_helper
     for (const auto& update_item: updates) {
         const auto& update = update_item.second;
         reversed_updates.emplace(update_item.first, Collection::async_reference_backfill_update_t{
-                update.seq_id, update.new_doc, update.old_doc});
+                update.seq_id, update.new_helper_fields, update.old_helper_fields});
     }
 
     return reversed_updates;

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -892,6 +892,17 @@ Option<Collection*> CollectionManager::create_collection(const std::string& name
             if(coll) {
                 coll->update_reference_info_with_lock(update_ref_info.field, new_collection->get_name(),
                                                       update_ref_info.referenced_field);
+
+                const auto ref_info_it = ref_info_map.find(update_ref_info.collection);
+                if (ref_info_it != ref_info_map.end() && ref_info_it->second.is_async) {
+                    auto backfill_op = new_collection->backfill_async_reference_helpers(
+                            update_ref_info.referenced_field.name, coll.get(), update_ref_info.field);
+                    if (!backfill_op.ok()) {
+                        rollback_new_collection();
+                        return Option<Collection*>(backfill_op.code(), backfill_op.error());
+                    }
+                }
+
                 // We do not erase from `referenced_ins` here, because if a referenced collection is dropped and
                 // created again, the referenced field won't be updated in referencing collection.
             }
@@ -1309,17 +1320,6 @@ Option<bool> CollectionManager::rebind_references_for_symlink_target_swap(const 
         return Option<bool>(true);
     }
 
-    auto old_coll = get_collection(old_collection_name);
-    auto new_coll = get_collection(new_collection_name);
-    if (new_coll == nullptr) {
-        return Option<bool>(true);
-    }
-
-    auto resolved_new_collection_name = new_coll->get_name();
-    if (old_collection_name == resolved_new_collection_name) {
-        return Option<bool>(true);
-    }
-
     struct symlink_ref_rebind_t {
         reference_info_t ref_info;
         std::shared_ptr<Collection> referencing_coll;
@@ -1356,6 +1356,50 @@ Option<bool> CollectionManager::rebind_references_for_symlink_target_swap(const 
         symlink_ref_rebind_t rebind;
         rebind.ref_info = old_ref_info;
         rebind.referencing_coll = referencing_coll;
+        rebind_plan.emplace_back(std::move(rebind));
+    }
+
+    if (rebind_plan.empty()) {
+        return Option<bool>(true);
+    }
+
+    auto old_coll = get_collection(old_collection_name);
+    auto new_coll = get_collection(new_collection_name);
+    if (new_coll == nullptr) {
+        for (const auto& rebind: rebind_plan) {
+            if (old_coll != nullptr) {
+                old_coll->remove_referenced_in(rebind.ref_info.collection, rebind.ref_info.field,
+                                               rebind.ref_info.is_async, rebind.ref_info.referenced_field_name);
+            }
+
+            rebind.referencing_coll->update_reference_info_with_lock(rebind.ref_info.field, new_collection_name, field{});
+        }
+
+        std::unique_lock lock(mutex);
+        for (const auto& rebind: rebind_plan) {
+            auto old_ref_infos_it = referenced_ins.find(old_collection_name);
+            if (old_ref_infos_it != referenced_ins.end()) {
+                old_ref_infos_it->second.erase(rebind.ref_info.collection);
+                if (old_ref_infos_it->second.empty()) {
+                    referenced_ins.erase(old_ref_infos_it);
+                }
+            }
+
+            auto deferred_ref_info = rebind.ref_info;
+            deferred_ref_info.referenced_field = field{};
+            referenced_ins[new_collection_name][deferred_ref_info.collection] = std::move(deferred_ref_info);
+        }
+        persist_referenced_ins();
+
+        return Option<bool>(true);
+    }
+
+    auto resolved_new_collection_name = new_coll->get_name();
+    if (old_collection_name == resolved_new_collection_name) {
+        return Option<bool>(true);
+    }
+
+    for (auto& rebind: rebind_plan) {
         rebind.update_ref_infos = new_coll->validate_referenced_in(rebind.ref_info.collection,
                                                                    rebind.ref_info.field,
                                                                    rebind.ref_info.referenced_field_name,
@@ -1381,11 +1425,6 @@ Option<bool> CollectionManager::rebind_references_for_symlink_target_swap(const 
             }
         }
 
-        rebind_plan.emplace_back(std::move(rebind));
-    }
-
-    if (rebind_plan.empty()) {
-        return Option<bool>(true);
     }
 
     for (const auto& rebind: rebind_plan) {

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -20,16 +20,20 @@
 
 constexpr const size_t CollectionManager::DEFAULT_NUM_MEMORY_SHARDS;
 
+#ifdef TEST_BUILD
+std::function<Option<bool>()> collection_manager_before_async_reference_backfill_apply = nullptr;
+#endif
+
 struct staged_async_reference_backfill_t {
-    Collection* referenced_coll = nullptr;
-    Collection* referencing_coll = nullptr;
+    std::shared_ptr<Collection> referenced_coll;
+    std::shared_ptr<Collection> referencing_coll;
     std::string referencing_collection_name;
     Collection::async_reference_backfill_update_map_t updates;
 };
 
 Option<bool> stage_async_reference_helper_backfill(
-        Collection* referenced_coll,
-        Collection* referencing_coll,
+        std::shared_ptr<Collection> referenced_coll,
+        std::shared_ptr<Collection> referencing_coll,
         const std::string& referenced_field_name,
         const std::string& referencing_field_name,
         std::vector<staged_async_reference_backfill_t>& staged_backfills) {
@@ -38,13 +42,13 @@ Option<bool> stage_async_reference_helper_backfill(
     }
 
     staged_async_reference_backfill_t staged_backfill;
-    staged_backfill.referenced_coll = referenced_coll;
-    staged_backfill.referencing_coll = referencing_coll;
     staged_backfill.referencing_collection_name = referencing_coll->get_name();
+    staged_backfill.referenced_coll = std::move(referenced_coll);
+    staged_backfill.referencing_coll = std::move(referencing_coll);
 
-    auto stage_op = referenced_coll->stage_async_reference_helper_backfill(referenced_field_name, referencing_coll,
-                                                                           referencing_field_name,
-                                                                           staged_backfill.updates);
+    auto stage_op = staged_backfill.referenced_coll->stage_async_reference_helper_backfill(
+            referenced_field_name, staged_backfill.referencing_coll.get(), referencing_field_name,
+            staged_backfill.updates);
     if (!stage_op.ok()) {
         return stage_op;
     }
@@ -75,7 +79,7 @@ void rollback_applied_async_reference_helper_backfills(
         const auto& staged_backfill = staged_backfills[*it];
         auto reversed_updates = reverse_async_reference_helper_backfill(staged_backfill.updates);
         auto rollback_op = staged_backfill.referenced_coll->apply_staged_async_reference_updates(
-                staged_backfill.referencing_coll, staged_backfill.referencing_collection_name, reversed_updates);
+                staged_backfill.referencing_coll.get(), staged_backfill.referencing_collection_name, reversed_updates);
         if (!rollback_op.ok()) {
             LOG(ERROR) << "Failed to rollback async reference helper backfill for collection `"
                        << staged_backfill.referencing_collection_name << "`: " << rollback_op.error();
@@ -85,13 +89,22 @@ void rollback_applied_async_reference_helper_backfills(
 
 Option<bool> apply_staged_async_reference_helper_backfills(
         std::vector<staged_async_reference_backfill_t>& staged_backfills) {
+#ifdef TEST_BUILD
+    if (collection_manager_before_async_reference_backfill_apply != nullptr) {
+        auto hook_op = collection_manager_before_async_reference_backfill_apply();
+        if (!hook_op.ok()) {
+            return hook_op;
+        }
+    }
+#endif
+
     std::vector<size_t> applied_backfill_indices;
     applied_backfill_indices.reserve(staged_backfills.size());
 
     for (size_t i = 0; i < staged_backfills.size(); i++) {
         auto& staged_backfill = staged_backfills[i];
         auto apply_op = staged_backfill.referenced_coll->apply_staged_async_reference_updates(
-                staged_backfill.referencing_coll, staged_backfill.referencing_collection_name,
+                staged_backfill.referencing_coll.get(), staged_backfill.referencing_collection_name,
                 staged_backfill.updates);
         if (!apply_op.ok()) {
             rollback_applied_async_reference_helper_backfills(staged_backfills, applied_backfill_indices);
@@ -386,12 +399,13 @@ Option<Collection*> CollectionManager::init_collection(const nlohmann::json & co
     return Option<Collection*>(collection);
 }
 
-void CollectionManager::add_to_collections(Collection* collection) {
+std::shared_ptr<Collection> CollectionManager::add_to_collections(Collection* collection) {
     const std::string& collection_name = collection->get_name();
     const uint32_t collection_id = collection->get_collection_id();
     std::unique_lock lock(mutex);
-    collections.emplace(collection_name, collection);
+    auto emplace_result = collections.emplace(collection_name, collection);
     collection_id_names.emplace(collection_id, collection_name);
+    return emplace_result.first->second;
 }
 
 void CollectionManager::init(Store *store, ThreadPool* thread_pool,
@@ -949,7 +963,7 @@ Option<Collection*> CollectionManager::create_collection(const std::string& name
     }
 
     auto new_collection = collection_op.get();
-    add_to_collections(new_collection);
+    auto new_collection_shared = add_to_collections(new_collection);
     lock.lock();
 
     std::vector<std::map<std::string, reference_info_t>> ref_info_maps;
@@ -1002,7 +1016,7 @@ Option<Collection*> CollectionManager::create_collection(const std::string& name
             if(coll) {
                 const auto ref_info_it = ref_info_map.find(update_ref_info.collection);
                 if (ref_info_it != ref_info_map.end() && ref_info_it->second.is_async) {
-                    auto stage_op = stage_async_reference_helper_backfill(new_collection, coll.get(),
+                    auto stage_op = stage_async_reference_helper_backfill(new_collection_shared, coll,
                                                                           update_ref_info.referenced_field.name,
                                                                           update_ref_info.field, staged_backfills);
                     if (!stage_op.ok()) {
@@ -1061,8 +1075,8 @@ Option<Collection*> CollectionManager::create_collection(const std::string& name
             if (resolution.ref_info.is_async && resolution.referencing_coll != nullptr &&
                 resolution.referenced_coll != nullptr) {
                 for (const auto& update_ref_info: resolution.update_ref_infos) {
-                    auto stage_op = stage_async_reference_helper_backfill(resolution.referenced_coll.get(),
-                                                                          resolution.referencing_coll.get(),
+                    auto stage_op = stage_async_reference_helper_backfill(resolution.referenced_coll,
+                                                                          resolution.referencing_coll,
                                                                           update_ref_info.referenced_field.name,
                                                                           update_ref_info.field, staged_backfills);
                     if (!stage_op.ok()) {
@@ -1475,8 +1489,8 @@ Option<bool> CollectionManager::resolve_deferred_references_for_symlink(const st
         }
 
         for (const auto& update_ref_info: resolution.update_ref_infos) {
-            auto stage_op = stage_async_reference_helper_backfill(resolution.referenced_coll.get(),
-                                                                  resolution.referencing_coll.get(),
+            auto stage_op = stage_async_reference_helper_backfill(resolution.referenced_coll,
+                                                                  resolution.referencing_coll,
                                                                   update_ref_info.referenced_field.name,
                                                                   update_ref_info.field, staged_backfills);
             if (!stage_op.ok()) {
@@ -1703,7 +1717,7 @@ Option<bool> CollectionManager::rebind_references_for_symlink_target_swap(const 
         }
 
         for (const auto& update_ref_info: rebind.update_ref_infos) {
-            auto stage_op = stage_async_reference_helper_backfill(new_coll.get(), rebind.referencing_coll.get(),
+            auto stage_op = stage_async_reference_helper_backfill(new_coll, rebind.referencing_coll,
                                                                   update_ref_info.referenced_field.name,
                                                                   update_ref_info.field, staged_backfills);
             if (!stage_op.ok()) {

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -11035,6 +11035,75 @@ TEST_F(CollectionJoinTest, StagedAsyncReferenceBackfillDoesNotOverwriteChildUpda
     ASSERT_EQ(0, child_doc["parent_id_sequence_id"].get<uint32_t>());
 }
 
+TEST_F(CollectionJoinTest, CreateTimeAsyncBackfillRetainsReferencingCollectionUntilApply) {
+    const std::string parent_collection_name = "create_backfill_lifetime_parent";
+    const std::string child_collection_name = "create_backfill_lifetime_child";
+
+    auto schema_json =
+            R"({
+                "fields": [
+                    {"name": "parent_id", "type": "string", "reference": "create_backfill_lifetime_parent.id", "async_reference": true},
+                    {"name": "note", "type": "string"}
+                ]
+            })"_json;
+    schema_json["name"] = child_collection_name;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto child = collection_create_op.get();
+
+    auto add_op = child->add(R"({"id":"child-1","parent_id":"parent-1","note":"before parent"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    auto child_doc = child->get("child-1").get();
+    ASSERT_EQ(Join::reference_helper_sentinel_value, child_doc["parent_id_sequence_id"]);
+
+    std::weak_ptr<Collection> child_weak = collectionManager.get_collection(child_collection_name);
+
+    const auto future_collection_id = collectionManager.get_next_collection_id();
+    const auto future_parent_seq_id = 0;
+    const auto future_parent_seq_id_key = std::to_string(future_collection_id) + "_" +
+                                          std::string(Collection::SEQ_ID_PREFIX) + "_" +
+                                          StringUtils::serialize_uint32_t(future_parent_seq_id);
+    ASSERT_TRUE(store->insert(future_parent_seq_id_key, R"({"id":"parent-1","name":"Parent One"})"));
+
+    bool hook_ran = false;
+    collection_manager_before_async_reference_backfill_apply = [&]() {
+        if (hook_ran) {
+            return Option<bool>(true);
+        }
+        hook_ran = true;
+
+        auto drop_op = collectionManager.drop_collection(child_collection_name);
+        if (!drop_op.ok()) {
+            return Option<bool>(drop_op.code(), drop_op.error());
+        }
+
+        if (child_weak.expired()) {
+            return Option<bool>(500, "Staged async reference backfill did not retain the referencing collection.");
+        }
+
+        return Option<bool>(true);
+    };
+
+    struct reset_backfill_hook_t {
+        ~reset_backfill_hook_t() {
+            collection_manager_before_async_reference_backfill_apply = nullptr;
+        }
+    } reset_backfill_hook;
+
+    schema_json =
+            R"({
+                "fields": [
+                    {"name": "name", "type": "string"}
+                ]
+            })"_json;
+    schema_json["name"] = parent_collection_name;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    ASSERT_TRUE(hook_ran);
+    ASSERT_EQ(nullptr, collectionManager.get_collection(child_collection_name));
+}
+
 TEST_F(CollectionJoinTest, AsyncRefFieldExistingAliasReferenceResolvesWhenTargetCollectionIsCreated) {
     const std::string parent_alias_name = "bookings_existing_alias";
     const std::string parent_collection_name = "production.bookings_existing_alias";

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -10264,6 +10264,135 @@ TEST_F(CollectionJoinTest, FailedAliasTargetSwapAsyncBackfillRestoresReferenceOw
     ASSERT_EQ("id", ref_fields.begin()->second.referenced_field.name);
 }
 
+TEST_F(CollectionJoinTest, FailedAliasTargetSwapAsyncBackfillDoesNotLeaveNewTargetHelperIds) {
+    const std::string parent_alias_name = "authors_partial_backfill_alias";
+    const std::string parent_v1_collection_name = "authors_partial_backfill_v1";
+    const std::string parent_v2_collection_name = "authors_partial_backfill_v2";
+    const std::string child_collection_name = "books_referencing_authors_partial_backfill_alias";
+    const std::string reference_field_name = "author_ids";
+
+    auto schema_json =
+            R"({
+                "fields": [
+                    {"name": "name", "type": "string", "facet": true}
+                ]
+            })"_json;
+    schema_json["name"] = parent_v1_collection_name;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto parent_v1 = collection_create_op.get();
+
+    auto add_op = parent_v1->add(R"({"id":"author-1","name":"Author One v1"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+    auto parent_v1_author_1_seq_id_op = parent_v1->doc_id_to_seq_id("author-1");
+    ASSERT_TRUE(parent_v1_author_1_seq_id_op.ok()) << parent_v1_author_1_seq_id_op.error();
+
+    add_op = parent_v1->add(R"({"id":"author-2","name":"Author Two v1"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+    auto parent_v1_author_2_seq_id_op = parent_v1->doc_id_to_seq_id("author-2");
+    ASSERT_TRUE(parent_v1_author_2_seq_id_op.ok()) << parent_v1_author_2_seq_id_op.error();
+
+    auto upsert_op = collectionManager.upsert_symlink(parent_alias_name, parent_v1_collection_name);
+    ASSERT_TRUE(upsert_op.ok()) << upsert_op.error();
+
+    schema_json =
+            R"({
+                "fields": [
+                    {"name": "author_ids", "type": "string[]", "reference": "authors_partial_backfill_alias.id", "async_reference": true},
+                    {"name": "title", "type": "string"}
+                ]
+            })"_json;
+    schema_json["name"] = child_collection_name;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto child = collection_create_op.get();
+
+    add_op = child->add(R"({"id":"book-1","author_ids":["author-1"],"title":"First Alias Book"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    add_op = child->add(R"({"id":"book-2","author_ids":["author-2"],"title":"Second Alias Book"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    auto book_1_doc = child->get("book-1").get();
+    ASSERT_EQ(1, book_1_doc["author_ids_sequence_id"].size());
+    ASSERT_EQ(parent_v1_author_1_seq_id_op.get(), book_1_doc["author_ids_sequence_id"][0]);
+
+    auto book_2_doc = child->get("book-2").get();
+    ASSERT_EQ(1, book_2_doc["author_ids_sequence_id"].size());
+    ASSERT_EQ(parent_v1_author_2_seq_id_op.get(), book_2_doc["author_ids_sequence_id"][0]);
+
+    schema_json =
+            R"({
+                "fields": [
+                    {"name": "name", "type": "string", "facet": true}
+                ]
+            })"_json;
+    schema_json["name"] = parent_v2_collection_name;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto parent_v2 = collection_create_op.get();
+
+    add_op = parent_v2->add(R"({"id":"dummy-before-author-1","name":"Dummy Before Author One"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    add_op = parent_v2->add(R"({"id":"author-1","name":"Author One v2"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+    auto parent_v2_author_1_seq_id_op = parent_v2->doc_id_to_seq_id("author-1");
+    ASSERT_TRUE(parent_v2_author_1_seq_id_op.ok()) << parent_v2_author_1_seq_id_op.error();
+    ASSERT_NE(parent_v1_author_1_seq_id_op.get(), parent_v2_author_1_seq_id_op.get());
+
+    for (size_t i = 0; i < 5000; i++) {
+        nlohmann::json doc;
+        doc["id"] = "dummy-" + std::to_string(i);
+        doc["name"] = "Dummy " + std::to_string(i);
+        add_op = parent_v2->add(doc.dump());
+        ASSERT_TRUE(add_op.ok()) << add_op.error();
+    }
+
+    add_op = parent_v2->add(R"({"id":"author-2","name":"Author Two v2"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    std::atomic<bool> stop_corruptor{false};
+    std::atomic<bool> corruption_done{false};
+    std::thread corruptor([&]() {
+        while (!stop_corruptor.load() && !corruption_done.load()) {
+            auto ref_fields = child->get_reference_fields();
+            auto ref_field_it = ref_fields.find(reference_field_name);
+            if (ref_field_it != ref_fields.end() && ref_field_it->second.collection == parent_v2_collection_name) {
+                auto child_seq_id_op = child->doc_id_to_seq_id("book-2");
+                if (child_seq_id_op.ok()) {
+                    auto stored_doc = child->get("book-2").get();
+                    stored_doc["author_ids_sequence_id"] = Join::reference_helper_sentinel_value;
+                    auto child_seq_id_key = child->get_seq_id_collection_prefix() + "_" +
+                                            StringUtils::serialize_uint32_t(child_seq_id_op.get());
+                    store->insert(child_seq_id_key, stored_doc.dump());
+                    corruption_done.store(true);
+                }
+                break;
+            }
+
+            std::this_thread::yield();
+        }
+    });
+
+    upsert_op = collectionManager.upsert_symlink(parent_alias_name, parent_v2_collection_name);
+    stop_corruptor.store(true);
+    corruptor.join();
+
+    ASSERT_TRUE(corruption_done.load()) << "Test did not reach the async backfill failure window.";
+    ASSERT_FALSE(upsert_op.ok());
+    ASSERT_NE(std::string::npos, upsert_op.error().find("author_ids_sequence_id"));
+
+    auto alias_op = collectionManager.resolve_symlink(parent_alias_name);
+    ASSERT_TRUE(alias_op.ok()) << alias_op.error();
+    ASSERT_EQ(parent_v1_collection_name, alias_op.get());
+
+    book_1_doc = child->get("book-1").get();
+    ASSERT_EQ(1, book_1_doc["author_ids_sequence_id"].size());
+    ASSERT_EQ(parent_v1_author_1_seq_id_op.get(), book_1_doc["author_ids_sequence_id"][0]);
+    ASSERT_NE(parent_v2_author_1_seq_id_op.get(), book_1_doc["author_ids_sequence_id"][0]);
+}
+
 TEST_F(CollectionJoinTest, AsyncRefFieldAliasTargetSwapToFutureCollectionRebindsAliasReferencesOnly) {
     const std::string parent_alias_name = "authors_alias";
     const std::string parent_v1_collection_name = "authors_v1";

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -11551,6 +11551,102 @@ TEST_F(CollectionJoinTest, FailedTargetCollectionCreateForExistingAliasRollsBack
     ASSERT_EQ(parent_collection_name, ref_fields.begin()->second.collection);
 }
 
+TEST_F(CollectionJoinTest, FailedTargetCollectionCreateRollsBackDirectAsyncBackfillAndMetadata) {
+    const std::string parent_alias_name = "parent_alias_create_rollback_missing_field";
+    const std::string parent_collection_name = "parent_collection_create_rollback";
+    const std::string direct_child_collection_name = "child_direct_referencing_create_rollback_parent";
+    const std::string alias_child_collection_name = "child_alias_referencing_create_rollback_parent";
+
+    auto schema_json =
+            R"({
+                "fields": [
+                    {"name": "parent_id", "type": "string", "reference": "parent_collection_create_rollback.id", "async_reference": true},
+                    {"name": "note", "type": "string"}
+                ]
+            })"_json;
+    schema_json["name"] = direct_child_collection_name;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto direct_child = collection_create_op.get();
+
+    auto add_op = direct_child->add(R"({"id":"direct-child-1","parent_id":"parent-1","note":"direct"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    auto direct_child_doc = direct_child->get("direct-child-1").get();
+    ASSERT_EQ("parent_id_sequence_id", direct_child_doc[".ref"][0]);
+    ASSERT_EQ(Join::reference_helper_sentinel_value, direct_child_doc["parent_id_sequence_id"]);
+
+    auto direct_ref_fields = direct_child->get_reference_fields();
+    ASSERT_EQ(1, direct_ref_fields.size());
+    ASSERT_EQ(parent_collection_name, direct_ref_fields.begin()->second.collection);
+    ASSERT_TRUE(direct_ref_fields.begin()->second.referenced_field.name.empty());
+
+    auto upsert_op = collectionManager.upsert_symlink(parent_alias_name, parent_collection_name);
+    ASSERT_TRUE(upsert_op.ok()) << upsert_op.error();
+
+    schema_json =
+            R"({
+                "fields": [
+                    {"name": "missing_code", "type": "string", "reference": "parent_alias_create_rollback_missing_field.missing_code", "async_reference": true},
+                    {"name": "note", "type": "string"}
+                ]
+            })"_json;
+    schema_json["name"] = alias_child_collection_name;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto alias_child = collection_create_op.get();
+
+    auto referenced_ins = collectionManager._get_referenced_ins();
+    ASSERT_EQ(1, referenced_ins.count(parent_collection_name));
+    ASSERT_EQ(1, referenced_ins.at(parent_collection_name).count(direct_child_collection_name));
+    ASSERT_EQ(1, referenced_ins.count(parent_alias_name));
+    ASSERT_EQ(1, referenced_ins.at(parent_alias_name).count(alias_child_collection_name));
+
+    const auto future_collection_id = collectionManager.get_next_collection_id();
+    const auto future_parent_seq_id = 0;
+    const auto future_parent_seq_id_key = std::to_string(future_collection_id) + "_" +
+                                          std::string(Collection::SEQ_ID_PREFIX) + "_" +
+                                          StringUtils::serialize_uint32_t(future_parent_seq_id);
+    ASSERT_TRUE(store->insert(future_parent_seq_id_key, R"({"id":"parent-1","name":"Parent One"})"));
+
+    schema_json =
+            R"({
+                "fields": [
+                    {"name": "name", "type": "string", "facet": true}
+                ]
+            })"_json;
+    schema_json["name"] = parent_collection_name;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_FALSE(collection_create_op.ok());
+    ASSERT_EQ("Referenced field `missing_code` not found in the collection `" + parent_collection_name + "`.",
+              collection_create_op.error());
+
+    ASSERT_EQ(nullptr, collectionManager.get_collection(parent_collection_name));
+    ASSERT_EQ(nullptr, collectionManager.get_collection(parent_alias_name));
+    ASSERT_FALSE(store->contains(Collection::get_meta_key(parent_collection_name)));
+    ASSERT_FALSE(store->contains(Collection::get_next_seq_id_key(parent_collection_name)));
+    ASSERT_FALSE(store->contains(future_parent_seq_id_key));
+
+    referenced_ins = collectionManager._get_referenced_ins();
+    ASSERT_EQ(1, referenced_ins.count(parent_collection_name));
+    ASSERT_EQ(1, referenced_ins.at(parent_collection_name).count(direct_child_collection_name));
+    ASSERT_EQ(1, referenced_ins.count(parent_alias_name));
+    ASSERT_EQ(1, referenced_ins.at(parent_alias_name).count(alias_child_collection_name));
+
+    direct_ref_fields = direct_child->get_reference_fields();
+    ASSERT_EQ(1, direct_ref_fields.size());
+    ASSERT_EQ(parent_collection_name, direct_ref_fields.begin()->second.collection);
+    ASSERT_TRUE(direct_ref_fields.begin()->second.referenced_field.name.empty());
+
+    direct_child_doc = direct_child->get("direct-child-1").get();
+    ASSERT_EQ(Join::reference_helper_sentinel_value, direct_child_doc["parent_id_sequence_id"]);
+
+    auto alias_ref_fields = alias_child->get_reference_fields();
+    ASSERT_EQ(1, alias_ref_fields.size());
+    ASSERT_EQ(parent_alias_name, alias_ref_fields.begin()->second.collection);
+    ASSERT_TRUE(alias_ref_fields.begin()->second.referenced_field.name.empty());
+}
+
 TEST_F(CollectionJoinTest, AsyncRefFieldAliasReferenceWithoutPersistedReferencedIns) {
     auto schema_json =
             R"({
@@ -11628,18 +11724,18 @@ TEST_F(CollectionJoinTest, AsyncRefFieldAliasReferenceWithoutPersistedReferenced
                                                                          "production.booking-payments");
     ASSERT_TRUE(referenced_in_op.ok()) << referenced_in_op.error();
     auto referenced_in = referenced_in_op.get();
-    EXPECT_EQ("bookingId", referenced_in.field);
-    EXPECT_EQ("id", referenced_in.referenced_field_name);
-    EXPECT_TRUE(referenced_in.is_async);
+    ASSERT_EQ("bookingId", referenced_in.field);
+    ASSERT_EQ("id", referenced_in.referenced_field_name);
+    ASSERT_TRUE(referenced_in.is_async);
 
     auto reloaded_bookings = collectionManager.get_collection("production.bookings");
     ASSERT_NE(nullptr, reloaded_bookings);
     auto async_refs = reloaded_bookings->get_async_referenced_ins();
-    EXPECT_EQ(1, async_refs.size());
-    EXPECT_EQ(1, async_refs.count("id"));
-    EXPECT_EQ(0, async_refs.count(""));
+    ASSERT_EQ(1, async_refs.size());
+    ASSERT_EQ(1, async_refs.count("id"));
+    ASSERT_EQ(0, async_refs.count(""));
     if (async_refs.count("id") == 1) {
-        EXPECT_EQ(1, async_refs.at("id").count(reference_pair_t("production.booking-payments", "bookingId")));
+        ASSERT_EQ(1, async_refs.at("id").count(reference_pair_t("production.booking-payments", "bookingId")));
     }
 
     run_join_query(collectionManager, "after restart without $REFERENCED_INS key in store");

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <fstream>
 #include <algorithm>
+#include <thread>
 #include <collection_manager.h>
 #include "collection.h"
 #include <join.h>
@@ -10139,6 +10140,128 @@ TEST_F(CollectionJoinTest, AsyncRefFieldReverseJoinSurvivesAliasTargetSwap) {
 
     child_doc = child->get("inc-1").get();
     ASSERT_EQ(parent_v2_seq_id_op.get(), child_doc["variant_pack_uuid_sequence_id"].get<uint32_t>());
+}
+
+TEST_F(CollectionJoinTest, FailedAliasTargetSwapAsyncBackfillRestoresReferenceOwnership) {
+    const std::string parent_alias_name = "authors_rollback_alias";
+    const std::string parent_v1_collection_name = "authors_rollback_v1";
+    const std::string parent_v2_collection_name = "authors_rollback_v2";
+    const std::string child_collection_name = "books_referencing_authors_rollback_alias";
+    const std::string reference_field_name = "author_ids";
+
+    auto schema_json =
+            R"({
+                "fields": [
+                    {"name": "name", "type": "string", "facet": true}
+                ]
+            })"_json;
+    schema_json["name"] = parent_v1_collection_name;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto parent_v1 = collection_create_op.get();
+
+    auto add_op = parent_v1->add(R"({"id":"author-1","name":"Enid Blyton"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+    auto parent_v1_seq_id_op = parent_v1->doc_id_to_seq_id("author-1");
+    ASSERT_TRUE(parent_v1_seq_id_op.ok()) << parent_v1_seq_id_op.error();
+
+    auto upsert_op = collectionManager.upsert_symlink(parent_alias_name, parent_v1_collection_name);
+    ASSERT_TRUE(upsert_op.ok()) << upsert_op.error();
+
+    schema_json =
+            R"({
+                "fields": [
+                    {"name": "author_ids", "type": "string[]", "reference": "authors_rollback_alias.id", "async_reference": true},
+                    {"name": "title", "type": "string"}
+                ]
+            })"_json;
+    schema_json["name"] = child_collection_name;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto child = collection_create_op.get();
+
+    add_op = child->add(R"({"id":"book-1","author_ids":["author-1"],"title":"Alias Book"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    auto child_doc = child->get("book-1").get();
+    ASSERT_EQ(1, child_doc["author_ids_sequence_id"].size());
+    ASSERT_EQ(parent_v1_seq_id_op.get(), child_doc["author_ids_sequence_id"][0]);
+
+    schema_json =
+            R"({
+                "fields": [
+                    {"name": "name", "type": "string", "facet": true}
+                ]
+            })"_json;
+    schema_json["name"] = parent_v2_collection_name;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto parent_v2 = collection_create_op.get();
+
+    for (size_t i = 0; i < 5000; i++) {
+        nlohmann::json doc;
+        doc["id"] = "dummy-" + std::to_string(i);
+        doc["name"] = "Dummy " + std::to_string(i);
+        add_op = parent_v2->add(doc.dump());
+        ASSERT_TRUE(add_op.ok()) << add_op.error();
+    }
+
+    add_op = parent_v2->add(R"({"id":"author-1","name":"Enid Blyton v2"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    std::atomic<bool> stop_corruptor{false};
+    std::atomic<bool> corruption_done{false};
+    std::thread corruptor([&]() {
+        while (!stop_corruptor.load() && !corruption_done.load()) {
+            auto ref_fields = child->get_reference_fields();
+            auto ref_field_it = ref_fields.find(reference_field_name);
+            if (ref_field_it != ref_fields.end() && ref_field_it->second.collection == parent_v2_collection_name) {
+                auto child_seq_id_op = child->doc_id_to_seq_id("book-1");
+                if (child_seq_id_op.ok()) {
+                    auto stored_doc = child->get("book-1").get();
+                    stored_doc["author_ids_sequence_id"] = Join::reference_helper_sentinel_value;
+                    auto child_seq_id_key = child->get_seq_id_collection_prefix() + "_" +
+                                            StringUtils::serialize_uint32_t(child_seq_id_op.get());
+                    store->insert(child_seq_id_key, stored_doc.dump());
+                    corruption_done.store(true);
+                }
+                break;
+            }
+
+            std::this_thread::yield();
+        }
+    });
+
+    upsert_op = collectionManager.upsert_symlink(parent_alias_name, parent_v2_collection_name);
+    stop_corruptor.store(true);
+    corruptor.join();
+
+    ASSERT_TRUE(corruption_done.load()) << "Test did not reach the post-mutation async backfill window.";
+    ASSERT_FALSE(upsert_op.ok());
+    ASSERT_NE(std::string::npos, upsert_op.error().find("author_ids_sequence_id"));
+
+    auto alias_op = collectionManager.resolve_symlink(parent_alias_name);
+    ASSERT_TRUE(alias_op.ok()) << alias_op.error();
+    ASSERT_EQ(parent_v1_collection_name, alias_op.get());
+
+    auto referenced_ins = collectionManager._get_referenced_ins();
+    ASSERT_EQ(1, referenced_ins.count(parent_v1_collection_name));
+    ASSERT_EQ(1, referenced_ins.at(parent_v1_collection_name).count(child_collection_name));
+    ASSERT_EQ(0, referenced_ins.count(parent_v2_collection_name));
+
+    auto parent_v1_async_refs = parent_v1->get_async_referenced_ins();
+    ASSERT_EQ(1, parent_v1_async_refs.size());
+    ASSERT_EQ(1, parent_v1_async_refs.count("id"));
+    ASSERT_EQ(1, parent_v1_async_refs.at("id").count(reference_pair_t(child_collection_name, reference_field_name)));
+
+    auto parent_v2_async_refs = parent_v2->get_async_referenced_ins();
+    ASSERT_TRUE(parent_v2_async_refs.empty());
+
+    auto ref_fields = child->get_reference_fields();
+    ASSERT_EQ(1, ref_fields.size());
+    ASSERT_EQ(parent_v1_collection_name, ref_fields.begin()->second.collection);
+    ASSERT_EQ("id", ref_fields.begin()->second.field);
+    ASSERT_EQ("id", ref_fields.begin()->second.referenced_field.name);
 }
 
 TEST_F(CollectionJoinTest, AsyncRefFieldAliasTargetSwapToFutureCollectionRebindsAliasReferencesOnly) {

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -10141,6 +10141,142 @@ TEST_F(CollectionJoinTest, AsyncRefFieldReverseJoinSurvivesAliasTargetSwap) {
     ASSERT_EQ(parent_v2_seq_id_op.get(), child_doc["variant_pack_uuid_sequence_id"].get<uint32_t>());
 }
 
+TEST_F(CollectionJoinTest, AsyncRefFieldAliasTargetSwapToFutureCollectionRebindsAliasReferencesOnly) {
+    const std::string parent_alias_name = "authors_alias";
+    const std::string parent_v1_collection_name = "authors_v1";
+    const std::string parent_v2_collection_name = "authors_v2";
+    const std::string child_collection_referencing_alias_name = "books_referencing_authors_alias";
+    const std::string child_collection_referencing_parent_v1_name = "books_referencing_authors_v1";
+
+    auto schema_json =
+            R"({
+                "fields": [
+                    {"name": "name", "type": "string", "facet": true}
+                ]
+            })"_json;
+    schema_json["name"] = parent_v1_collection_name;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto parent_v1 = collection_create_op.get();
+
+    auto add_op = parent_v1->add(R"({"id":"author-1","name":"Enid Blyton"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+    auto parent_v1_seq_id_op = parent_v1->doc_id_to_seq_id("author-1");
+    ASSERT_TRUE(parent_v1_seq_id_op.ok()) << parent_v1_seq_id_op.error();
+
+    auto upsert_op = collectionManager.upsert_symlink(parent_alias_name, parent_v1_collection_name);
+    ASSERT_TRUE(upsert_op.ok()) << upsert_op.error();
+
+    schema_json =
+            R"({
+                "fields": [
+                    {"name": "author_id", "type": "string", "reference": "authors_alias.id", "async_reference": true},
+                    {"name": "title", "type": "string"}
+                ]
+            })"_json;
+    schema_json["name"] = child_collection_referencing_alias_name;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto alias_child = collection_create_op.get();
+
+    schema_json =
+            R"({
+                "fields": [
+                    {"name": "author_id", "type": "string", "reference": "authors_v1.id", "async_reference": true},
+                    {"name": "title", "type": "string"}
+                ]
+            })"_json;
+    schema_json["name"] = child_collection_referencing_parent_v1_name;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto direct_child = collection_create_op.get();
+
+    add_op = alias_child->add(R"({"id":"alias-book-1","author_id":"author-1","title":"Alias Book"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+    add_op = direct_child->add(R"({"id":"direct-book-1","author_id":"author-1","title":"Direct Book"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    auto alias_child_doc = alias_child->get("alias-book-1").get();
+    ASSERT_EQ(parent_v1_seq_id_op.get(), alias_child_doc["author_id_sequence_id"]);
+    auto direct_child_doc = direct_child->get("direct-book-1").get();
+    ASSERT_EQ(parent_v1_seq_id_op.get(), direct_child_doc["author_id_sequence_id"]);
+
+    auto referenced_ins = collectionManager._get_referenced_ins();
+    ASSERT_EQ(1, referenced_ins.count(parent_v1_collection_name));
+    ASSERT_EQ(1, referenced_ins.at(parent_v1_collection_name).count(child_collection_referencing_alias_name));
+    ASSERT_EQ(1, referenced_ins.at(parent_v1_collection_name).count(child_collection_referencing_parent_v1_name));
+
+    // Update alias to point at Parent V2 collection.
+    upsert_op = collectionManager.upsert_symlink(parent_alias_name, parent_v2_collection_name);
+    ASSERT_TRUE(upsert_op.ok()) << upsert_op.error();
+
+    referenced_ins = collectionManager._get_referenced_ins();
+    ASSERT_EQ(1, referenced_ins.count(parent_v1_collection_name));
+    ASSERT_EQ(0, referenced_ins.at(parent_v1_collection_name).count(child_collection_referencing_alias_name));
+    ASSERT_EQ(1, referenced_ins.at(parent_v1_collection_name).count(child_collection_referencing_parent_v1_name));
+    ASSERT_EQ(0, referenced_ins.count(parent_alias_name));
+    ASSERT_EQ(1, referenced_ins.count(parent_v2_collection_name));
+    ASSERT_EQ(1, referenced_ins.at(parent_v2_collection_name).count(child_collection_referencing_alias_name));
+    ASSERT_EQ(0, referenced_ins.at(parent_v2_collection_name).count(child_collection_referencing_parent_v1_name));
+
+    schema_json =
+            R"({
+                "fields": [
+                    {"name": "name", "type": "string", "facet": true}
+                ]
+            })"_json;
+    schema_json["name"] = parent_v2_collection_name;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto parent_v2 = collection_create_op.get();
+
+    add_op = parent_v2->add(R"({"id":"dummy","name":"Placeholder"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+    add_op = parent_v2->add(R"({"id":"author-1","name":"Enid Blyton v2"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+    auto parent_v2_seq_id_op = parent_v2->doc_id_to_seq_id("author-1");
+    ASSERT_TRUE(parent_v2_seq_id_op.ok()) << parent_v2_seq_id_op.error();
+    ASSERT_NE(parent_v1_seq_id_op.get(), parent_v2_seq_id_op.get());
+
+    referenced_ins = collectionManager._get_referenced_ins();
+    ASSERT_EQ(1, referenced_ins.count(parent_v1_collection_name));
+    ASSERT_EQ(1, referenced_ins.at(parent_v1_collection_name).count(child_collection_referencing_parent_v1_name));
+    ASSERT_EQ(0, referenced_ins.at(parent_v1_collection_name).count(child_collection_referencing_alias_name));
+    ASSERT_EQ(1, referenced_ins.count(parent_v2_collection_name));
+    ASSERT_EQ(1, referenced_ins.at(parent_v2_collection_name).count(child_collection_referencing_alias_name));
+    ASSERT_EQ(0, referenced_ins.at(parent_v2_collection_name).count(child_collection_referencing_parent_v1_name));
+    ASSERT_EQ(0, referenced_ins.count(parent_alias_name));
+
+    auto parent_v1_async_refs = parent_v1->get_async_referenced_ins();
+    ASSERT_EQ(1, parent_v1_async_refs.size());
+    ASSERT_EQ(1, parent_v1_async_refs.count("id"));
+    ASSERT_EQ(0, parent_v1_async_refs.at("id").count(reference_pair_t(child_collection_referencing_alias_name, "author_id")));
+    ASSERT_EQ(1, parent_v1_async_refs.at("id").count(reference_pair_t(child_collection_referencing_parent_v1_name, "author_id")));
+
+    auto parent_v2_async_refs = parent_v2->get_async_referenced_ins();
+    ASSERT_EQ(1, parent_v2_async_refs.size());
+    ASSERT_EQ(1, parent_v2_async_refs.count("id"));
+    ASSERT_EQ(1, parent_v2_async_refs.at("id").count(reference_pair_t(child_collection_referencing_alias_name, "author_id")));
+    ASSERT_EQ(0, parent_v2_async_refs.at("id").count(reference_pair_t(child_collection_referencing_parent_v1_name, "author_id")));
+
+    auto alias_ref_fields = alias_child->get_reference_fields();
+    ASSERT_EQ(1, alias_ref_fields.size());
+    ASSERT_EQ(parent_v2_collection_name, alias_ref_fields.begin()->second.collection);
+    ASSERT_EQ("id", alias_ref_fields.begin()->second.field);
+    ASSERT_EQ("id", alias_ref_fields.begin()->second.referenced_field.name);
+
+    auto direct_ref_fields = direct_child->get_reference_fields();
+    ASSERT_EQ(1, direct_ref_fields.size());
+    ASSERT_EQ(parent_v1_collection_name, direct_ref_fields.begin()->second.collection);
+    ASSERT_EQ("id", direct_ref_fields.begin()->second.field);
+    ASSERT_EQ("id", direct_ref_fields.begin()->second.referenced_field.name);
+
+    alias_child_doc = alias_child->get("alias-book-1").get();
+    ASSERT_EQ(parent_v2_seq_id_op.get(), alias_child_doc["author_id_sequence_id"]);
+    direct_child_doc = direct_child->get("direct-book-1").get();
+    ASSERT_EQ(parent_v1_seq_id_op.get(), direct_child_doc["author_id_sequence_id"]);
+}
+
 TEST_F(CollectionJoinTest, AsyncRefFieldDeferredAliasReference) {
     auto schema_json =
             R"({

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -11035,6 +11035,141 @@ TEST_F(CollectionJoinTest, StagedAsyncReferenceBackfillDoesNotOverwriteChildUpda
     ASSERT_EQ(0, child_doc["parent_id_sequence_id"].get<uint32_t>());
 }
 
+TEST_F(CollectionJoinTest, StagedAsyncReferenceBackfillDoesNotOverwriteReferenceFieldUpdateBetweenStageAndApply) {
+    const std::string parent_collection_name = "staged_backfill_reference_update_parent";
+    const std::string child_collection_name = "staged_backfill_reference_update_child";
+
+    auto schema_json =
+            R"({
+                "fields": [
+                    {"name": "name", "type": "string"}
+                ]
+            })"_json;
+    schema_json["name"] = parent_collection_name;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto parent = collection_create_op.get();
+
+    auto add_op = parent->add(R"({"id":"parent-1","name":"Parent One"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+    add_op = parent->add(R"({"id":"parent-2","name":"Parent Two"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    auto parent_1_seq_id_op = parent->doc_id_to_seq_id("parent-1");
+    ASSERT_TRUE(parent_1_seq_id_op.ok()) << parent_1_seq_id_op.error();
+    auto parent_2_seq_id_op = parent->doc_id_to_seq_id("parent-2");
+    ASSERT_TRUE(parent_2_seq_id_op.ok()) << parent_2_seq_id_op.error();
+
+    schema_json =
+            R"({
+                "fields": [
+                    {"name": "parent_id", "type": "string", "reference": "staged_backfill_reference_update_parent.id", "async_reference": true},
+                    {"name": "note", "type": "string"}
+                ]
+            })"_json;
+    schema_json["name"] = child_collection_name;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto child = collection_create_op.get();
+
+    add_op = child->add(R"({"id":"child-1","parent_id":"parent-1","note":"before stage"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    auto child_doc = child->get("child-1").get();
+    ASSERT_EQ(parent_1_seq_id_op.get(), child_doc["parent_id_sequence_id"].get<uint32_t>());
+
+    Collection::async_reference_backfill_update_map_t staged_updates;
+    auto stage_op = parent->stage_async_reference_helper_backfill("id", child, "parent_id", staged_updates);
+    ASSERT_TRUE(stage_op.ok()) << stage_op.error();
+    ASSERT_EQ(1, staged_updates.size());
+
+    std::string dirty_values = "REJECT";
+    auto update_op = child->update_matching_filter("id:=child-1", R"({"parent_id":"parent-2"})", dirty_values);
+    ASSERT_TRUE(update_op.ok()) << update_op.error();
+    ASSERT_EQ(1, update_op.get()["num_updated"].get<size_t>());
+
+    child_doc = child->get("child-1").get();
+    ASSERT_EQ("parent-2", child_doc["parent_id"].get<std::string>());
+    ASSERT_EQ(parent_2_seq_id_op.get(), child_doc["parent_id_sequence_id"].get<uint32_t>());
+
+    auto apply_op = parent->apply_staged_async_reference_updates(child, child_collection_name, staged_updates);
+    ASSERT_TRUE(apply_op.ok()) << apply_op.error();
+
+    child_doc = child->get("child-1").get();
+    ASSERT_EQ("parent-2", child_doc["parent_id"].get<std::string>());
+    ASSERT_EQ(parent_2_seq_id_op.get(), child_doc["parent_id_sequence_id"].get<uint32_t>());
+}
+
+TEST_F(CollectionJoinTest, StagedAsyncReferenceBackfillDoesNotOverwriteReferenceArrayUpdateBetweenStageAndApply) {
+    const std::string parent_collection_name = "staged_backfill_reference_array_update_parent";
+    const std::string child_collection_name = "staged_backfill_reference_array_update_child";
+
+    auto schema_json =
+            R"({
+                "fields": [
+                    {"name": "name", "type": "string"}
+                ]
+            })"_json;
+    schema_json["name"] = parent_collection_name;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto parent = collection_create_op.get();
+
+    auto add_op = parent->add(R"({"id":"author-1","name":"Author One"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+    add_op = parent->add(R"({"id":"author-2","name":"Author Two"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    auto author_1_seq_id_op = parent->doc_id_to_seq_id("author-1");
+    ASSERT_TRUE(author_1_seq_id_op.ok()) << author_1_seq_id_op.error();
+    auto author_2_seq_id_op = parent->doc_id_to_seq_id("author-2");
+    ASSERT_TRUE(author_2_seq_id_op.ok()) << author_2_seq_id_op.error();
+
+    schema_json =
+            R"({
+                "fields": [
+                    {"name": "author_ids", "type": "string[]", "reference": "staged_backfill_reference_array_update_parent.id", "async_reference": true},
+                    {"name": "title", "type": "string"}
+                ]
+            })"_json;
+    schema_json["name"] = child_collection_name;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto child = collection_create_op.get();
+
+    add_op = child->add(R"({"id":"book-1","author_ids":["author-1"],"title":"Before stage"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    auto child_doc = child->get("book-1").get();
+    ASSERT_EQ(1, child_doc["author_ids_sequence_id"].size());
+    ASSERT_EQ(author_1_seq_id_op.get(), child_doc["author_ids_sequence_id"][0].get<uint32_t>());
+
+    Collection::async_reference_backfill_update_map_t staged_updates;
+    auto stage_op = parent->stage_async_reference_helper_backfill("id", child, "author_ids", staged_updates);
+    ASSERT_TRUE(stage_op.ok()) << stage_op.error();
+    ASSERT_EQ(1, staged_updates.size());
+
+    std::string dirty_values = "REJECT";
+    auto update_op = child->update_matching_filter("id:=book-1", R"({"author_ids":["author-2"]})", dirty_values);
+    ASSERT_TRUE(update_op.ok()) << update_op.error();
+    ASSERT_EQ(1, update_op.get()["num_updated"].get<size_t>());
+
+    child_doc = child->get("book-1").get();
+    ASSERT_EQ(1, child_doc["author_ids"].size());
+    ASSERT_EQ("author-2", child_doc["author_ids"][0].get<std::string>());
+    ASSERT_EQ(1, child_doc["author_ids_sequence_id"].size());
+    ASSERT_EQ(author_2_seq_id_op.get(), child_doc["author_ids_sequence_id"][0].get<uint32_t>());
+
+    auto apply_op = parent->apply_staged_async_reference_updates(child, child_collection_name, staged_updates);
+    ASSERT_TRUE(apply_op.ok()) << apply_op.error();
+
+    child_doc = child->get("book-1").get();
+    ASSERT_EQ(1, child_doc["author_ids"].size());
+    ASSERT_EQ("author-2", child_doc["author_ids"][0].get<std::string>());
+    ASSERT_EQ(1, child_doc["author_ids_sequence_id"].size());
+    ASSERT_EQ(author_2_seq_id_op.get(), child_doc["author_ids_sequence_id"][0].get<uint32_t>());
+}
+
 TEST_F(CollectionJoinTest, CreateTimeAsyncBackfillRetainsReferencingCollectionUntilApply) {
     const std::string parent_collection_name = "create_backfill_lifetime_parent";
     const std::string child_collection_name = "create_backfill_lifetime_child";

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -10393,6 +10393,156 @@ TEST_F(CollectionJoinTest, FailedAliasTargetSwapAsyncBackfillDoesNotLeaveNewTarg
     ASSERT_NE(parent_v2_author_1_seq_id_op.get(), book_1_doc["author_ids_sequence_id"][0]);
 }
 
+TEST_F(CollectionJoinTest, FailedAliasTargetSwapAsyncBackfillRollbackRestoresPreviouslyBackfilledChildren) {
+    const std::string parent_alias_name = "authors_multi_backfill_alias";
+    const std::string parent_v1_collection_name = "authors_multi_backfill_v1";
+    const std::string parent_v2_collection_name = "authors_multi_backfill_v2";
+    const std::string first_child_collection_name = "a_books_referencing_authors_multi_backfill_alias";
+    const std::string second_child_collection_name = "b_books_referencing_authors_multi_backfill_alias";
+    const std::string reference_field_name = "author_ids";
+
+    auto schema_json =
+            R"({
+                "fields": [
+                    {"name": "name", "type": "string", "facet": true}
+                ]
+            })"_json;
+    schema_json["name"] = parent_v1_collection_name;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto parent_v1 = collection_create_op.get();
+
+    auto add_op = parent_v1->add(R"({"id":"author-1","name":"Author One v1"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+    auto parent_v1_author_1_seq_id_op = parent_v1->doc_id_to_seq_id("author-1");
+    ASSERT_TRUE(parent_v1_author_1_seq_id_op.ok()) << parent_v1_author_1_seq_id_op.error();
+
+    add_op = parent_v1->add(R"({"id":"author-2","name":"Author Two v1"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+    auto parent_v1_author_2_seq_id_op = parent_v1->doc_id_to_seq_id("author-2");
+    ASSERT_TRUE(parent_v1_author_2_seq_id_op.ok()) << parent_v1_author_2_seq_id_op.error();
+
+    auto upsert_op = collectionManager.upsert_symlink(parent_alias_name, parent_v1_collection_name);
+    ASSERT_TRUE(upsert_op.ok()) << upsert_op.error();
+
+    schema_json =
+            R"({
+                "fields": [
+                    {"name": "author_ids", "type": "string[]", "reference": "authors_multi_backfill_alias.id", "async_reference": true},
+                    {"name": "title", "type": "string"}
+                ]
+            })"_json;
+    schema_json["name"] = first_child_collection_name;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto first_child = collection_create_op.get();
+
+    schema_json =
+            R"({
+                "fields": [
+                    {"name": "author_ids", "type": "string[]", "reference": "authors_multi_backfill_alias.id", "async_reference": true},
+                    {"name": "title", "type": "string"}
+                ]
+            })"_json;
+    schema_json["name"] = second_child_collection_name;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto second_child = collection_create_op.get();
+
+    add_op = first_child->add(R"({"id":"book-a","author_ids":["author-1"],"title":"First Alias Book"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    add_op = second_child->add(R"({"id":"book-b","author_ids":["author-2"],"title":"Second Alias Book"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    auto first_child_doc = first_child->get("book-a").get();
+    ASSERT_EQ(1, first_child_doc["author_ids_sequence_id"].size());
+    ASSERT_EQ(parent_v1_author_1_seq_id_op.get(), first_child_doc["author_ids_sequence_id"][0]);
+
+    auto second_child_doc = second_child->get("book-b").get();
+    ASSERT_EQ(1, second_child_doc["author_ids_sequence_id"].size());
+    ASSERT_EQ(parent_v1_author_2_seq_id_op.get(), second_child_doc["author_ids_sequence_id"][0]);
+
+    schema_json =
+            R"({
+                "fields": [
+                    {"name": "name", "type": "string", "facet": true}
+                ]
+            })"_json;
+    schema_json["name"] = parent_v2_collection_name;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto parent_v2 = collection_create_op.get();
+
+    add_op = parent_v2->add(R"({"id":"dummy-before-author-1","name":"Dummy Before Author One"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    add_op = parent_v2->add(R"({"id":"author-1","name":"Author One v2"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+    auto parent_v2_author_1_seq_id_op = parent_v2->doc_id_to_seq_id("author-1");
+    ASSERT_TRUE(parent_v2_author_1_seq_id_op.ok()) << parent_v2_author_1_seq_id_op.error();
+    ASSERT_NE(parent_v1_author_1_seq_id_op.get(), parent_v2_author_1_seq_id_op.get());
+
+    for (size_t i = 0; i < 5000; i++) {
+        nlohmann::json doc;
+        doc["id"] = "dummy-" + std::to_string(i);
+        doc["name"] = "Dummy " + std::to_string(i);
+        add_op = parent_v2->add(doc.dump());
+        ASSERT_TRUE(add_op.ok()) << add_op.error();
+    }
+
+    add_op = parent_v2->add(R"({"id":"author-2","name":"Author Two v2"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    std::atomic<bool> stop_corruptor{false};
+    std::atomic<bool> corruption_done{false};
+    std::thread corruptor([&]() {
+        while (!stop_corruptor.load() && !corruption_done.load()) {
+            auto ref_fields = second_child->get_reference_fields();
+            auto ref_field_it = ref_fields.find(reference_field_name);
+            if (ref_field_it != ref_fields.end() && ref_field_it->second.collection == parent_v2_collection_name) {
+                auto child_seq_id_op = second_child->doc_id_to_seq_id("book-b");
+                if (child_seq_id_op.ok()) {
+                    auto stored_doc = second_child->get("book-b").get();
+                    stored_doc["author_ids_sequence_id"] = Join::reference_helper_sentinel_value;
+                    auto child_seq_id_key = second_child->get_seq_id_collection_prefix() + "_" +
+                                            StringUtils::serialize_uint32_t(child_seq_id_op.get());
+                    store->insert(child_seq_id_key, stored_doc.dump());
+                    corruption_done.store(true);
+                }
+                break;
+            }
+
+            std::this_thread::yield();
+        }
+    });
+
+    upsert_op = collectionManager.upsert_symlink(parent_alias_name, parent_v2_collection_name);
+    stop_corruptor.store(true);
+    corruptor.join();
+
+    ASSERT_TRUE(corruption_done.load()) << "Test did not reach the second child async backfill failure window.";
+    ASSERT_FALSE(upsert_op.ok());
+    ASSERT_NE(std::string::npos, upsert_op.error().find("author_ids_sequence_id"));
+
+    auto alias_op = collectionManager.resolve_symlink(parent_alias_name);
+    ASSERT_TRUE(alias_op.ok()) << alias_op.error();
+    ASSERT_EQ(parent_v1_collection_name, alias_op.get());
+
+    auto first_child_ref_fields = first_child->get_reference_fields();
+    ASSERT_EQ(1, first_child_ref_fields.size());
+    ASSERT_EQ(parent_v1_collection_name, first_child_ref_fields.begin()->second.collection);
+
+    auto second_child_ref_fields = second_child->get_reference_fields();
+    ASSERT_EQ(1, second_child_ref_fields.size());
+    ASSERT_EQ(parent_v1_collection_name, second_child_ref_fields.begin()->second.collection);
+
+    first_child_doc = first_child->get("book-a").get();
+    ASSERT_EQ(1, first_child_doc["author_ids_sequence_id"].size());
+    ASSERT_EQ(parent_v1_author_1_seq_id_op.get(), first_child_doc["author_ids_sequence_id"][0]);
+    ASSERT_NE(parent_v2_author_1_seq_id_op.get(), first_child_doc["author_ids_sequence_id"][0]);
+}
+
 TEST_F(CollectionJoinTest, AsyncRefFieldAliasTargetSwapToFutureCollectionRebindsAliasReferencesOnly) {
     const std::string parent_alias_name = "authors_alias";
     const std::string parent_v1_collection_name = "authors_v1";

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -9981,6 +9981,166 @@ TEST_F(CollectionJoinTest, AsyncRefFieldAliasReference) {
     run_join_query("after restart");
 }
 
+TEST_F(CollectionJoinTest, AsyncRefFieldReverseJoinSurvivesAliasTargetSwap) {
+    const std::string parent_alias_name = "postgresql";
+    const std::string parent_v1_collection_name = "postgresql_v1";
+    const std::string parent_v2_collection_name = "postgresql_v2";
+    const std::string child_collection_name = "include";
+
+    auto create_parent_collection = [&](const std::string& collection_name,
+                                        const std::string& matching_doc_id,
+                                        bool add_dummy_first,
+                                        Collection*& parent) {
+        nlohmann::json schema_json;
+        schema_json["name"] = collection_name;
+        schema_json["fields"] = nlohmann::json::array({
+                {{"name", "variant_pack_uuid"}, {"type", "string"}, {"facet", true}},
+                {{"name", "display_name"}, {"type", "string"}}
+        });
+
+        auto collection_create_op = collectionManager.create_collection(schema_json);
+        ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+        parent = collection_create_op.get();
+
+        if (add_dummy_first) {
+            auto add_op = parent->add(R"({
+                "id": "dummy-v2",
+                "variant_pack_uuid": "dummy",
+                "display_name": "placeholder"
+            })");
+            ASSERT_TRUE(add_op.ok()) << add_op.error();
+        }
+
+        nlohmann::json matching_doc;
+        matching_doc["id"] = matching_doc_id;
+        matching_doc["variant_pack_uuid"] = "vp-11";
+        matching_doc["display_name"] = "coconut water";
+        auto add_op = parent->add(matching_doc.dump());
+        ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+        add_op = parent->add(R"({
+            "id": "vp-12",
+            "variant_pack_uuid": "vp-12",
+            "display_name": "coconut milk"
+        })");
+        ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    };
+
+    Collection* parent_v1 = nullptr;
+    create_parent_collection(parent_v1_collection_name, "vp-11-v1", false, parent_v1);
+    ASSERT_NE(nullptr, parent_v1);
+    auto upsert_op = collectionManager.upsert_symlink(parent_alias_name, parent_v1_collection_name);
+    ASSERT_TRUE(upsert_op.ok()) << upsert_op.error();
+
+    nlohmann::json child_schema;
+    child_schema["name"] = child_collection_name;
+    child_schema["fields"] = nlohmann::json::array({
+            {{"name", "variant_pack_uuid"},
+             {"type", "string"},
+             {"facet", true},
+             {"reference", parent_alias_name + ".variant_pack_uuid"},
+             {"async_reference", true}},
+            {{"name", "restaurant_uuid"}, {"type", "string"}, {"facet", true}}
+    });
+
+    auto collection_create_op = collectionManager.create_collection(child_schema);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto child = collection_create_op.get();
+
+    auto add_op = child->add(R"({
+        "id": "inc-1",
+        "variant_pack_uuid": "vp-11",
+        "restaurant_uuid": "r1"
+    })");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    add_op = child->add(R"({
+        "id": "inc-2",
+        "variant_pack_uuid": "vp-12",
+        "restaurant_uuid": "r2"
+    })");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    auto run_reverse_join_query = [&](const std::string& stage,
+                                      const std::string& expected_doc_id) -> ::testing::AssertionResult {
+        std::map<std::string, std::string> req_params = {
+                {"collection", parent_alias_name},
+                {"q", "water"},
+                {"query_by", "display_name"},
+                {"filter_by", "$include(restaurant_uuid:=`r1`)"}
+        };
+        nlohmann::json embedded_params;
+        std::string json_res;
+        auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+
+        auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+        if (!search_op.ok()) {
+            return ::testing::AssertionFailure() << stage << ": " << search_op.error();
+        }
+
+        auto res_obj = nlohmann::json::parse(json_res);
+        if (res_obj["found"].get<size_t>() != 1 || res_obj["hits"].size() != 1) {
+            return ::testing::AssertionFailure() << stage << ": " << json_res;
+        }
+
+        auto actual_doc_id = res_obj["hits"][0]["document"]["id"].get<std::string>();
+        if (actual_doc_id != expected_doc_id) {
+            return ::testing::AssertionFailure() << stage << ": expected " << expected_doc_id
+                                                 << ", got " << actual_doc_id << ". Response: " << json_res;
+        }
+
+        return ::testing::AssertionSuccess();
+    };
+
+    ASSERT_TRUE(run_reverse_join_query("before alias swap", "vp-11-v1"));
+
+    auto parent_v1_seq_id_op = parent_v1->doc_id_to_seq_id("vp-11-v1");
+    ASSERT_TRUE(parent_v1_seq_id_op.ok()) << parent_v1_seq_id_op.error();
+    auto child_doc = child->get("inc-1").get();
+    ASSERT_EQ(parent_v1_seq_id_op.get(), child_doc["variant_pack_uuid_sequence_id"].get<uint32_t>());
+
+    Collection* parent_v2 = nullptr;
+    create_parent_collection(parent_v2_collection_name, "vp-11-v2", true, parent_v2);
+    ASSERT_NE(nullptr, parent_v2);
+    auto parent_v2_seq_id_op = parent_v2->doc_id_to_seq_id("vp-11-v2");
+    ASSERT_TRUE(parent_v2_seq_id_op.ok()) << parent_v2_seq_id_op.error();
+    ASSERT_NE(parent_v1_seq_id_op.get(), parent_v2_seq_id_op.get());
+
+    upsert_op = collectionManager.upsert_symlink(parent_alias_name, parent_v2_collection_name);
+    ASSERT_TRUE(upsert_op.ok()) << upsert_op.error();
+
+    ASSERT_TRUE(run_reverse_join_query("after alias swap", "vp-11-v2"));
+
+    auto referenced_in_op = collectionManager.is_referenced_in_with_lock(parent_v2_collection_name,
+                                                                         child_collection_name);
+    ASSERT_TRUE(referenced_in_op.ok()) << referenced_in_op.error();
+    ASSERT_EQ("variant_pack_uuid", referenced_in_op.get().field);
+    ASSERT_EQ("variant_pack_uuid", referenced_in_op.get().referenced_field_name);
+
+    auto async_refs = parent_v2->get_async_referenced_ins();
+    ASSERT_EQ(1, async_refs.size());
+    ASSERT_EQ(1, async_refs.count("variant_pack_uuid"));
+    ASSERT_EQ(1, async_refs.at("variant_pack_uuid").count(reference_pair_t(child_collection_name,
+                                                                            "variant_pack_uuid")));
+
+    auto old_async_refs = parent_v1->get_async_referenced_ins();
+    ASSERT_TRUE(old_async_refs.empty());
+    auto old_referenced_in_op = collectionManager.is_referenced_in_with_lock(parent_v1_collection_name,
+                                                                             child_collection_name);
+    ASSERT_FALSE(old_referenced_in_op.ok());
+
+    auto ref_fields = child->get_reference_fields();
+    ASSERT_EQ(1, ref_fields.size());
+    ASSERT_EQ(parent_v2_collection_name, ref_fields.begin()->second.collection);
+    ASSERT_EQ("variant_pack_uuid", ref_fields.begin()->second.field);
+    ASSERT_EQ("variant_pack_uuid", ref_fields.begin()->second.referenced_field.name);
+
+    child_doc = child->get("inc-1").get();
+    ASSERT_EQ(parent_v2_seq_id_op.get(), child_doc["variant_pack_uuid_sequence_id"].get<uint32_t>());
+}
+
 TEST_F(CollectionJoinTest, AsyncRefFieldDeferredAliasReference) {
     auto schema_json =
             R"({

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -10981,6 +10981,60 @@ TEST_F(CollectionJoinTest, AsyncRefFieldDeferredAliasReferenceBackfillsIdReferen
     ASSERT_EQ("booking-11", res_obj["hits"][0]["document"]["bookingId"].get<std::string>());
 }
 
+TEST_F(CollectionJoinTest, StagedAsyncReferenceBackfillDoesNotOverwriteChildUpdateBetweenStageAndApply) {
+    const std::string parent_collection_name = "staged_backfill_parent";
+    const std::string child_collection_name = "staged_backfill_child";
+
+    auto schema_json =
+            R"({
+                "fields": [
+                    {"name": "name", "type": "string"}
+                ]
+            })"_json;
+    schema_json["name"] = parent_collection_name;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto parent = collection_create_op.get();
+
+    auto add_op = parent->add(R"({"id":"parent-1","name":"Parent One"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    schema_json =
+            R"({
+                "fields": [
+                    {"name": "parent_id", "type": "string", "reference": "staged_backfill_parent.id", "async_reference": true},
+                    {"name": "note", "type": "string"}
+                ]
+            })"_json;
+    schema_json["name"] = child_collection_name;
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok()) << collection_create_op.error();
+    auto child = collection_create_op.get();
+
+    add_op = child->add(R"({"id":"child-1","parent_id":"parent-1","note":"before stage"})");
+    ASSERT_TRUE(add_op.ok()) << add_op.error();
+
+    Collection::async_reference_backfill_update_map_t staged_updates;
+    auto stage_op = parent->stage_async_reference_helper_backfill("id", child, "parent_id", staged_updates);
+    ASSERT_TRUE(stage_op.ok()) << stage_op.error();
+    ASSERT_EQ(1, staged_updates.size());
+
+    std::string dirty_values = "REJECT";
+    auto update_op = child->update_matching_filter("id:=child-1", R"({"note":"updated after stage"})", dirty_values);
+    ASSERT_TRUE(update_op.ok()) << update_op.error();
+    ASSERT_EQ(1, update_op.get()["num_updated"].get<size_t>());
+
+    auto child_doc = child->get("child-1").get();
+    ASSERT_EQ("updated after stage", child_doc["note"].get<std::string>());
+
+    auto apply_op = parent->apply_staged_async_reference_updates(child, child_collection_name, staged_updates);
+    ASSERT_TRUE(apply_op.ok()) << apply_op.error();
+
+    child_doc = child->get("child-1").get();
+    ASSERT_EQ("updated after stage", child_doc["note"].get<std::string>());
+    ASSERT_EQ(0, child_doc["parent_id_sequence_id"].get<uint32_t>());
+}
+
 TEST_F(CollectionJoinTest, AsyncRefFieldExistingAliasReferenceResolvesWhenTargetCollectionIsCreated) {
     const std::string parent_alias_name = "bookings_existing_alias";
     const std::string parent_collection_name = "production.bookings_existing_alias";


### PR DESCRIPTION
## Change Summary
Harden async reference handling when aliases are created, resolved, or retargeted. Introduce staged async-reference backfills so helper-field updates can be validated before metadata is mutated, then applied with rollback support if any child collection update fails.
  
  - Rebind alias-based reference fields when an alias target is swapped, including future-target aliases.
  - Resolve deferred alias references when the target collection is later created.
  - Stage async reference helper backfills before applying them, so partial failures can be rolled back.
  - Preserve collection lifetime during staged backfills by retaining shared_ptr<Collection> handles.
  - Apply helper-field-only patches against the current child document to avoid overwriting concurrent document updates.
  - Add regression coverage for alias target swap rollback, create-time deferred reference resolution, stale staged backfills, and dropped referencing collections during backfill.



## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
