### PR TITLE
fix: validate query vector dimensions on hybrid (non-wildcard) search

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -9213,19 +9213,19 @@ Option<bool> Collection::parse_and_validate_vector_query(const std::string& vect
         }
     }
 
-    if(is_wildcard_query) {
-        if(vector_query.values.empty() && !vector_query.query_doc_given) {
-            // for usability we will treat this as non-vector query
-            vector_query.field_name.clear();
-            if(vector_query.k != 0) {
-                per_page = std::min(per_page, vector_query.k);
-            }
+    if(is_wildcard_query && vector_query.values.empty() && !vector_query.query_doc_given) {
+        // for usability we will treat this as non-vector query
+        vector_query.field_name.clear();
+        if(vector_query.k != 0) {
+            per_page = std::min(per_page, vector_query.k);
         }
+    }
 
-        else if(vector_field_it.value().num_dim != vector_query.values.size()) {
-            return Option<bool>(400, "Query field `" + vector_query.field_name + "` must have " +
-                                                std::to_string(vector_field_it.value().num_dim) + " dimensions.");
-        }
+    // validate query vector dimensions on every path that reaches the search (incl. hybrid/non-wildcard),
+    // otherwise an under/over-sized client vector is read against the field's num_dim in the distance function
+    else if(vector_field_it.value().num_dim != vector_query.values.size()) {
+        return Option<bool>(400, "Query field `" + vector_query.field_name + "` must have " +
+                                            std::to_string(vector_field_it.value().num_dim) + " dimensions.");
     }
 
     return Option<bool>(true);

--- a/test/collection_vector_search_test.cpp
+++ b/test/collection_vector_search_test.cpp
@@ -175,6 +175,18 @@ TEST_F(CollectionVectorTest, BasicVectorQuerying) {
     ASSERT_FALSE(res_op.ok());
     ASSERT_EQ("Query field `vec` must have 4 dimensions.", res_op.error());
 
+    // wrong dimensions must also be rejected on a hybrid (non-wildcard) query, not just wildcard
+    res_op = coll1->search("title", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, Index::DROP_TOKENS_THRESHOLD,
+                                          spp::sparse_hash_set<std::string>(),
+                                          spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                          "", 10, {}, {}, {}, 0,
+                                          "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7, fallback,
+                                          4, {off}, 32767, 32767, 2,
+                                          false, true, "vec:([0.96826, 0.94, 0.39557])");
+
+    ASSERT_FALSE(res_op.ok());
+    ASSERT_EQ("Query field `vec` must have 4 dimensions.", res_op.error());
+
     // validate bad vector query field name
     res_op = coll1->search("*", {}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, Index::DROP_TOKENS_THRESHOLD,
                                           spp::sparse_hash_set<std::string>(),


### PR DESCRIPTION
## Problem

`Collection::parse_and_validate_vector_query` (`src/collection.cpp`) validates that a client-supplied query vector has the same number of floats as the target field's `num_dim`, but that check is nested inside `if(is_wildcard_query)`:

```cpp
if(is_wildcard_query) {
    if(vector_query.values.empty() && !vector_query.query_doc_given) {
        // treat as non-vector query
        ...
    }
    else if(vector_field_it.value().num_dim != vector_query.values.size()) {
        return Option<bool>(400, "Query field `" + ... + "` must have ... dimensions.");
    }
}
return Option<bool>(true);
```

So the dimension check only runs for wildcard queries (`q=*`). A **hybrid** search (a real text query plus a `vector_query`) skips it entirely. `VectorQueryOps::parse_vector_query_str` does not check the dimension either, so an under or oversized query vector is accepted and passed to `Index::search`.

On the non-wildcard path the mismatched vector reaches the distance functions in `src/index.cpp` (`process_results_bruteforce`, `process_results_hnsw_index`, and the rerank in `compute_aux_scores`), for example:

```cpp
std::vector<float> normalized_q(vector_query.values.size());   // sized to the client vector
hnsw_index_t::normalize_vector(vector_query.values, normalized_q);
... space->get_dist_func()(normalized_q.data(), values.data(), &field_vector_index->num_dim);
... vecdex->searchKnnCloserFirst(normalized_q.data(), k, ...);
```

The hnswlib distance function reads `num_dim` floats from the query buffer, but that buffer only holds `values.size()` floats. When `values.size() < num_dim` this is an out-of-bounds read past the query allocation. It is uncaught and can crash the server (SIGSEGV) on a request that carries a valid `documents:search` key.

## Reproduction

A collection with a text field and a vector field (`num_dim = N`), at least one indexed document, then a hybrid search whose vector has fewer than `N` floats:

```
q=<any term>&query_by=<text field>&vector_query=<vec field>:([1, 2, 3], k:10)
```

with `N` much larger than 3 (e.g. a 768-dim embedding field). The wildcard form (`q=*` with the same short vector) is already rejected with a `must have N dimensions` error; the hybrid form is not.

## Fix

Hoist the `num_dim != values.size()` check out of the `if(is_wildcard_query)` block so it runs on every path that reaches the search, while preserving the wildcard usability behavior of treating an empty vector as a non-vector query:

```cpp
if(is_wildcard_query && vector_query.values.empty() && !vector_query.query_doc_given) {
    // for usability we will treat this as non-vector query
    ...
}
else if(vector_field_it.value().num_dim != vector_query.values.size()) {
    return Option<bool>(400, "Query field `" + ... + "` must have ... dimensions.");
}
```

Legitimate queries are unaffected: the auto-embedding (`queries`) path always produces a `num_dim`-sized vector, an `id`-provided vector is dimension-checked as before, and a correctly sized hybrid vector still passes. Under and oversized vectors on the hybrid path now return the same `400 must have N dimensions` error the wildcard path already returns, before the vector reaches the distance function.

## Testing

Added a regression case to `CollectionVectorTest.BasicVectorQuerying` that issues a hybrid (non-wildcard) search with an undersized vector and asserts the `400 must have N dimensions` response, mirroring the existing wildcard assertion a few lines above.
