### PR TITLE
fix: apply rule stemming consistently in curation evaluation

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -5073,11 +5073,20 @@ void Collection::process_filter_sort_curations(std::vector<const curation_t*>& f
       symbols.push_back('.');
 
       const auto& separators = query_token_separators.empty() ? token_separators : query_token_separators;
-      const bool use_search_field_stemmer = !curation.rule.dynamic_query && !curation.rule.dynamic_filter;
+      const bool is_static = !curation.rule.dynamic_query && !curation.rule.dynamic_filter;
+
+      // a rule with stem enabled normalizes its query with the rule's own stemmer, regardless of
+      // whether the searched fields have stemming. otherwise a static rule "tops" stays "tops"
+      // here and fails to match a singular "top" query even though the include path already did.
+      std::shared_ptr<Stemmer> effective_stemmer = is_static ? stemmer : nullptr;
+      if(is_static && curation.rule.stem) {
+          effective_stemmer = StemmerManager::get_instance().get_stemmer(curation.rule.locale,
+                                                                         curation.rule.stemming_dictionary);
+      }
 
       std::vector<std::string> tokens;
       Tokenizer tokenizer(curation.rule.query, true, false, query_locale, symbols, separators,
-                          use_search_field_stemmer ? stemmer : nullptr, true);
+                          effective_stemmer, true);
       tokenizer.tokenize(tokens);
       auto query_normalized = StringUtils::join(tokens, " ");
       size_t i = 0;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2963,6 +2963,24 @@ bool Index::static_filter_query_eval(const curation_t* curation,
                                      std::unique_ptr<filter_node_t>& filter_tree_root,
                                      const bool& validate_field_names) const {
     std::string query = StringUtils::join(tokens, " ");
+
+    // when the rule has stem enabled, stem the query tokens with the rule's own stemmer so the match
+    // is consistent regardless of field stemming. curation_normalized_query is already rule-stemmed by
+    // the caller and the query side must be stemmed the same way, otherwise a rule "tops" stemmed to
+    // "top" would match "pink top" but not "pink tops".
+    if (curation->rule.stem) {
+        auto rule_stemmer = StemmerManager::get_instance().get_stemmer(curation->rule.locale,
+                                                                       curation->rule.stemming_dictionary);
+        if (rule_stemmer != nullptr) {
+            std::vector<std::string> stemmed_tokens;
+            stemmed_tokens.reserve(tokens.size());
+            for (const auto& tok : tokens) {
+                stemmed_tokens.push_back(rule_stemmer->stem(tok));
+            }
+            query = StringUtils::join(stemmed_tokens, " ");
+        }
+    }
+
     bool tag_matched = (!curation->rule.tags.empty() && curation->rule.filter_by.empty() &&
                          curation->rule.query.empty());
 

--- a/test/collection_curation_test.cpp
+++ b/test/collection_curation_test.cpp
@@ -6724,3 +6724,145 @@ TEST_F(CollectionCurationTest, FilterCurationsWithSemanticOnlySearch) {
     const auto second_id = results["hits"][1]["document"]["id"].get<std::string>();
     ASSERT_TRUE((first_id == "1" && second_id == "3") || (first_id == "3" && second_id == "1"));
 }
+
+// A contains rule with stem enabled must apply filter_by for both the plural query
+// that matches the rule token verbatim ("pink tops") and the singular query that
+// matches only via stemming ("pink top"). Fields have no stemming and only the rule
+// does, so docs match "pink top" literally.
+TEST_F(CollectionCurationTest, ContainsRuleStemmedMatchAppliesFilterBy) {
+    auto& ov_manager = CurationIndexManager::get_instance();
+
+    nlohmann::json schema = R"({
+          "name": "products_stem_filter",
+          "fields": [
+              {"name": "title", "type": "string", "stem": false},
+              {"name": "category_l2", "type": "string"},
+              {"name": "target_demographic", "type": "string"},
+              {"name": "gender", "type": "string"}
+          ]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+    Collection* coll1 = op.get();
+    coll1->set_curation_sets({"index"});
+
+    // adult women's tops, kept by filter_by
+    ASSERT_TRUE(coll1->add(R"({"id":"1","title":"Pink Summer Top","category_l2":"tops","target_demographic":"Adult","gender":"female"})").ok());
+    ASSERT_TRUE(coll1->add(R"({"id":"2","title":"Pink Casual Top","category_l2":"tops","target_demographic":"Adult","gender":"female"})").ok());
+    // kids item, must be excluded by filter_by
+    ASSERT_TRUE(coll1->add(R"({"id":"3","title":"Pink Kids Top","category_l2":"girls clothing","target_demographic":"Teen","gender":"female"})").ok());
+
+    // contains rule on "tops" with stemming, scoped to adult women's tops
+    nlohmann::json curation_json = R"OVR(
+        {
+          "id": "contains-tops",
+          "rule": {
+              "query": "tops",
+              "match": "contains",
+              "stem": true
+          },
+          "filter_curated_hits": true,
+          "remove_matched_tokens": false,
+          "stop_processing": true,
+          "filter_by": "category_l2:=`tops` && target_demographic:=`Adult` && gender:=`female`"
+        }
+    )OVR"_json;
+
+    curation_t ov;
+    auto parse_op = curation_t::parse(curation_json, "contains-tops", ov);
+    ASSERT_TRUE(parse_op.ok());
+    ov_manager.upsert_curation_item("index", curation_json);
+
+    // plural matches the rule token verbatim
+    auto res_op = coll1->search("pink tops", {"title"}, "", {}, {}, {0});
+    ASSERT_TRUE(res_op.ok());
+    auto results = res_op.get();
+    ASSERT_EQ(2, results["found"].get<size_t>());
+    for (const auto& hit : results["hits"]) {
+        ASSERT_NE("3", hit["document"]["id"].get<std::string>()) << "kids item leaked into 'pink tops'";
+    }
+
+    // singular matches the rule only via stemming, filter_by must still apply
+    results.clear();
+    res_op = coll1->search("pink top", {"title"}, "", {}, {}, {0});
+    ASSERT_TRUE(res_op.ok());
+    results = res_op.get();
+    ASSERT_EQ(2, results["found"].get<size_t>()) << "stemmed rule match dropped filter_by";
+    for (const auto& hit : results["hits"]) {
+        ASSERT_NE("3", hit["document"]["id"].get<std::string>()) << "kids item leaked into 'pink top'";
+    }
+}
+
+// Same as above but the plural is resolved through a stemming dictionary
+// (people to person) instead of the built-in stemmer. Both the singular and plural
+// queries must apply the rule filter_by.
+TEST_F(CollectionCurationTest, ContainsRuleDictionaryStemmedMatchAppliesFilterBy) {
+    auto& ov_manager = CurationIndexManager::get_instance();
+
+    nlohmann::json schema = R"({
+          "name": "products_dict_stem_filter",
+          "fields": [
+              {"name": "title", "type": "string", "stem": false},
+              {"name": "category_l2", "type": "string"},
+              {"name": "target_demographic", "type": "string"}
+          ]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+    Collection* coll1 = op.get();
+    coll1->set_curation_sets({"index"});
+
+    // maps the plural "people" to "person"
+    std::vector<std::string> json_lines;
+    json_lines.push_back("{\"word\": \"people\", \"root\":\"person\"}");
+    ASSERT_TRUE(stemmerManager.upsert_stemming_dictionary("people_set", json_lines).ok());
+
+    // each title holds both literal forms so both queries match every doc with field
+    // stemming off, leaving filter_by as the only thing that drops the kids item
+    ASSERT_TRUE(coll1->add(R"({"id":"1","title":"People Person Tee","category_l2":"tops","target_demographic":"Adult"})").ok());
+    ASSERT_TRUE(coll1->add(R"({"id":"2","title":"Person People Hoodie","category_l2":"tops","target_demographic":"Adult"})").ok());
+    // kids item, must be excluded by filter_by
+    ASSERT_TRUE(coll1->add(R"({"id":"3","title":"People Person Onesie","category_l2":"girls clothing","target_demographic":"Teen"})").ok());
+
+    nlohmann::json curation_json = R"OVR(
+        {
+          "id": "contains-people",
+          "rule": {
+              "query": "people",
+              "match": "contains",
+              "stem": true,
+              "stemming_dictionary": "people_set"
+          },
+          "filter_curated_hits": true,
+          "remove_matched_tokens": false,
+          "stop_processing": true,
+          "filter_by": "category_l2:=`tops` && target_demographic:=`Adult`"
+        }
+    )OVR"_json;
+
+    curation_t ov;
+    auto parse_op = curation_t::parse(curation_json, "contains-people", ov);
+    ASSERT_TRUE(parse_op.ok());
+    ov_manager.upsert_curation_item("index", curation_json);
+
+    // plural matches the rule token verbatim
+    auto res_op = coll1->search("people", {"title"}, "", {}, {}, {0});
+    ASSERT_TRUE(res_op.ok());
+    auto results = res_op.get();
+    ASSERT_EQ(2, results["found"].get<size_t>());
+    for (const auto& hit : results["hits"]) {
+        ASSERT_NE("3", hit["document"]["id"].get<std::string>()) << "kids item leaked into 'people'";
+    }
+
+    // singular matches only through the dictionary, filter_by must still apply
+    results.clear();
+    res_op = coll1->search("person", {"title"}, "", {}, {}, {0});
+    ASSERT_TRUE(res_op.ok());
+    results = res_op.get();
+    ASSERT_EQ(2, results["found"].get<size_t>()) << "dictionary-stemmed rule match dropped filter_by";
+    for (const auto& hit : results["hits"]) {
+        ASSERT_NE("3", hit["document"]["id"].get<std::string>()) << "kids item leaked into 'person'";
+    }
+}


### PR DESCRIPTION
## Change Summary
- use rule's stemmer when tokenizing curation rules with stemming enabled
- stem query tokens in `static_filter_query_eval` to match rule stemming
- add tests verifying `filter_by` applies for both direct and stemmed rule matches

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
