### PR TITLE
fix: validate user_id for log analytics events

### DIFF
--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -856,9 +856,20 @@ int HttpServer::process_request(const std::shared_ptr<http_req>& request, const 
     thread_pool->enqueue([rpath, message_dispatcher, request, response]() {
         // call the API handler
         //LOG(INFO) << "Wait for response " << response.get() << ", action: " << rpath->_get_action();
-        (rpath->handler)(request, response);
+        bool should_dispatch = !rpath->async_res;
+        try {
+            (rpath->handler)(request, response);
+        } catch(const std::exception& e) {
+            // log the raw error but return a fixed message to avoid leaking implementation details
+            LOG(ERROR) << "Handler for " << rpath->action << " threw an exception.";
+            LOG(ERROR) << "Raw error: " << e.what();
+            response->set_500("Internal server error.");
+            response->final = true;
+            // async handlers won't stream a response after throwing, so dispatch here
+            should_dispatch = true;
+        }
 
-        if(!rpath->async_res) {
+        if(should_dispatch) {
             // lifecycle of non async res will be owned by stream responder
             auto req_res = new async_req_res_t(request, response, true);
             message_dispatcher->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, req_res);

--- a/src/search_analytics.cpp
+++ b/src/search_analytics.cpp
@@ -104,7 +104,7 @@ Option<bool> SearchAnalytics::add_event(const std::string& client_ip, const nloh
       data["q"].get<std::string>(),
       event_type,
       data.contains("timestamp") ? data["timestamp"].get<uint64_t>() : uint64_t(now_ts_useconds),
-      data["user_id"].get<std::string>(),
+      data.contains("user_id") ? data["user_id"].get<std::string>() : "",
       data.contains("filter_by") ? data["filter_by"].get<std::string>() : "",
       data.contains("analytics_tag") ? data["analytics_tag"].get<std::string>() : ""
     };
@@ -123,6 +123,9 @@ Option<bool> SearchAnalytics::add_event(const std::string& client_ip, const nloh
     const auto& log_event_it = search_log_events.find(event_name);
     if(log_event_it == search_log_events.end()) {
       return Option<bool>(400, "Rule does not exist");
+    }
+    if(!data.contains("user_id") || !data["user_id"].is_string()) {
+      return Option<bool>(400, "'user_id' should be a string and is required");
     }
     const auto& meta_fields = search_rules.find(event_name)->second.meta_fields;
     search_log_events[event_name].push_back(search_event_t{

--- a/test/analytics_manager_test.cpp
+++ b/test/analytics_manager_test.cpp
@@ -724,6 +724,107 @@ TEST_F(AnalyticsManagerTest, PopularQueries) {
   }
 }
 
+TEST_F(AnalyticsManagerTest, PopularQueriesMissingUserId) {
+  nlohmann::json products_schema = R"({
+      "name": "products",
+      "fields": [
+        {"name": "company_name", "type": "string" },
+        {"name": "num_employees", "type": "int32" },
+        {"name": "country", "type": "string", "facet": true }
+      ],
+      "default_sorting_field": "num_employees"
+  })"_json;
+
+  nlohmann::json queries_schema = R"({
+      "name": "queries",
+      "fields": [
+          {"name": "q", "type": "string"},
+          {"name": "count", "type": "int32"}
+      ]
+  })"_json;
+
+  auto coll_create_op = collectionManager.create_collection(products_schema);
+  ASSERT_TRUE(coll_create_op.ok());
+
+  auto queries_coll_create_op = collectionManager.create_collection(queries_schema);
+  ASSERT_TRUE(queries_coll_create_op.ok());
+
+  nlohmann::json rule = R"({
+    "name": "popular_no_user",
+    "type": "popular_queries",
+    "collection": "products",
+    "event_type": "search",
+    "params": {
+      "destination_collection": "queries",
+      "capture_search_requests": false,
+      "meta_fields": ["analytics_tag"],
+      "limit": 1000
+    }
+  })"_json;
+
+  auto create_op = analyticsManager.create_rule(rule, false, true, true);
+  ASSERT_TRUE(create_op.ok());
+
+  // user_id is optional for counter rules: event is accepted and counted
+  auto add_event_op = analyticsManager.add_external_event("127.0.0.1", R"({
+    "name": "popular_no_user",
+    "data": {
+      "q": "hola",
+      "analytics_tag": "tag1"
+    }
+  })"_json);
+  ASSERT_TRUE(add_event_op.ok());
+
+  auto get_counter_op = search_analytics.get_search_counter_events();
+  ASSERT_EQ(get_counter_op["popular_no_user"].query_counts.size(), 1);
+  for(auto& [key, value] : get_counter_op["popular_no_user"].query_counts) {
+    ASSERT_EQ(key.query, "hola");
+    ASSERT_EQ(key.user_id, "");
+    ASSERT_EQ(value, 1);
+  }
+}
+
+TEST_F(AnalyticsManagerTest, LogEventMissingUserIdReturns400) {
+  nlohmann::json products_schema = R"({
+      "name": "products",
+      "fields": [
+        {"name": "company_name", "type": "string" },
+        {"name": "num_employees", "type": "int32" },
+        {"name": "country", "type": "string", "facet": true }
+      ],
+      "default_sorting_field": "num_employees"
+  })"_json;
+
+  auto coll_create_op = collectionManager.create_collection(products_schema);
+  ASSERT_TRUE(coll_create_op.ok());
+
+  nlohmann::json log_rule = R"({
+    "name": "log_no_user",
+    "type": "log",
+    "collection": "products",
+    "event_type": "search",
+    "params": {
+      "capture_search_requests": false,
+      "meta_fields": ["analytics_tag"]
+    }
+  })"_json;
+
+  auto create_op = analyticsManager.create_rule(log_rule, false, true, true);
+  ASSERT_TRUE(create_op.ok());
+
+  // user_id is required for log rules: event is rejected with a 400 instead of hanging
+  auto add_event_op = analyticsManager.add_external_event("127.0.0.1", R"({
+    "name": "log_no_user",
+    "data": {
+      "q": "hola",
+      "analytics_tag": "tag1"
+    }
+  })"_json);
+  ASSERT_FALSE(add_event_op.ok());
+  ASSERT_EQ(add_event_op.code(), 400);
+  ASSERT_EQ(add_event_op.error(), "'user_id' should be a string and is required");
+}
+
 TEST_F(AnalyticsManagerTest, MetaFieldsGenerateUniqueIDs) {
   nlohmann::json products_schema = R"({
       "name": "products_meta_id",


### PR DESCRIPTION
## Change Summary
- reject log rules missing `user_id` with a 400 instead of hanging
- keep counter rules accepting missing `user_id` with empty user id


<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
