### PR TITLE
build: bump snowball to v3.1.1 for Czech stemmer support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -342,7 +342,7 @@ new_git_repository(
     name= "snowball",
     build_file = "//bazel:snowball.BUILD",
     # Pin snowball to the latest known-good upstream commit.
-    commit = "2c40f9d8d93faa141e2a8ab640e404b815726c25",
+    commit = "cd195b51e948a902a4312f023f4a14392516a543",
     remote = "https://github.com/snowballstem/snowball.git"
 )
 


### PR DESCRIPTION
The snowball dependency is pinned to commit 2c40f9d8 (2026-04-22), which was the last known-good commit at the time of #2889. The Czech stemmer was merged into snowball one day later (2026-04-23, snowballstem/snowball commit 5d93b6ee), so the current pin excludes it.

Closes #2887

## Change Summary
<!--- Described your changes here -->
- Bump the pin to v3.1.1 (commit cd195b51, 2026-06-03), the latest stable snowball release, which includes the Czech stemmer. 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
