### PR TITLE
feat: add --standalone mode (single node, no Raft)

### DIFF
--- a/include/app_metrics.h
+++ b/include/app_metrics.h
@@ -26,6 +26,9 @@ private:
     std::string access_log_path;
     std::ofstream access_log;
 
+    // guards `access_log`: written from every HTTP event loop, flushed from a timer on loop 0
+    std::mutex access_log_mutex;
+
     AppMetrics() {
         current_counts = new spp::sparse_hash_map<std::string, uint64_t>();
         counts = new spp::sparse_hash_map<std::string, uint64_t>();

--- a/include/http_data.h
+++ b/include/http_data.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+#include <atomic>
 #include <cstdint>
 #include <string>
 #include <map>

--- a/include/http_data.h
+++ b/include/http_data.h
@@ -256,12 +256,20 @@ public:
     }
 };
 
+struct http_message_dispatcher;
+
 struct http_req {
     static constexpr const char* AUTH_HEADER = "x-typesense-api-key";
     static constexpr const char* USER_HEADER = "x-typesense-user-id";
     static constexpr const char* AGENT_HEADER = "user-agent";
     static constexpr const char* CONTENT_TYPE_HEADER = "content-type";
     static constexpr const char* OCTET_STREAM_HEADER_VALUE = "application/octet-stream";
+
+    // The message dispatcher of the event loop that owns this request's connection. Responses and
+    // deferred work MUST be delivered through this dispatcher, since only the owning loop may touch
+    // the connection's socket. nullptr means the request never belonged to an event loop
+    // (e.g. a write replayed from the log, or tests).
+    http_message_dispatcher* res_dispatcher = nullptr;
 
     h2o_req_t* _req;
     std::string http_method;
@@ -316,13 +324,28 @@ struct http_req {
     void (*async_res_write_callback)(std::string&, const std::shared_ptr<http_req>&, const std::shared_ptr<http_res>&) = nullptr;
     bool (*async_res_done_callback)(const std::shared_ptr<http_req>&, const std::shared_ptr<http_res>&) = nullptr;
 
+    // Returns a strictly increasing microsecond timestamp, unique across all threads.
+    // start_ts doubles as the request's unique ID in the write pipeline: BatchedIndexer keys
+    // its request map and its write-log chunk keys by it, so two requests minted in the same
+    // microsecond on different event loops must never share a value.
+    static uint64_t next_start_ts() {
+        static std::atomic<uint64_t> last_ts{0};
+        uint64_t now = std::chrono::duration_cast<std::chrono::microseconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count();
+        uint64_t prev = last_ts.load(std::memory_order_relaxed);
+        uint64_t next;
+        do {
+            next = std::max(now, prev + 1);
+        } while(!last_ts.compare_exchange_weak(prev, next, std::memory_order_relaxed));
+        return next;
+    }
+
     http_req(): _req(nullptr), route_hash(1),
                 first_chunk_aggregate(true), last_chunk_aggregate(false),
                 chunk_len(0), body_index(0), data(nullptr), ready(false), log_index(0),
                 is_diposed(false) {
 
-        start_ts = std::chrono::duration_cast<std::chrono::microseconds>(
-                std::chrono::system_clock::now().time_since_epoch()).count();
+        start_ts = next_start_ts();
 
         conn_ts = start_ts;
 
@@ -347,8 +370,7 @@ struct http_req {
                         std::chrono::system_clock::now().time_since_epoch()).count();
         }
 
-        start_ts = std::chrono::duration_cast<std::chrono::microseconds>(
-                std::chrono::system_clock::now().time_since_epoch()).count();
+        start_ts = next_start_ts();
     }
 
     ~http_req() {
@@ -534,7 +556,12 @@ struct http_message_dispatcher {
     h2o_multithread_receiver_t* message_receiver;
     std::map<std::string, bool (*)(void*)> message_handlers;
 
+    // The event loop this dispatcher delivers on. Deferred work for a request must be scheduled
+    // on its owning loop; HttpServer::defer_processing reads this to link its timer there.
+    h2o_loop_t* loop = nullptr;
+
     void init(h2o_loop_t *loop) {
+        this->loop = loop;
         message_queue = h2o_multithread_create_queue(loop);
         message_receiver = new h2o_multithread_receiver_t();
         h2o_multithread_register_receiver(message_queue, message_receiver, on_message);

--- a/include/http_server.h
+++ b/include/http_server.h
@@ -127,8 +127,9 @@ private:
     h2o_compress_args_t compress_args;
     h2o_hostconf_t *hostconf;
 
-    // One HTTP event loop: h2o context, accept context, listener (SO_REUSEPORT) and message
-    // dispatcher. Loop 0 runs on the thread that calls run(), the others on their own threads.
+    // One HTTP event loop: h2o context, accept context, listener (a dup() of the shared listening
+    // socket) and message dispatcher. Loop 0 runs on the thread that calls run(), the others on
+    // their own threads.
     // Each connection is owned by exactly one loop: it is accepted, read and written only there,
     // and responses are delivered through the loop's dispatcher (http_req::res_dispatcher).
     // Every loop refreshes its own SSL context so that no SSL state is shared across threads.
@@ -203,12 +204,16 @@ private:
 
     static void on_metrics_refresh_timeout(h2o_timer_t *entry);
 
-    // Binds + listens a SO_REUSEPORT socket on (listen_address, listen_port), returning the fd
-    // (or -1). Each event loop registers its own listener on its own fd and the kernel
-    // load-balances incoming connections across them.
+    // Binds + listens a single socket on (listen_address, listen_port), returning the fd (or -1).
+    // Every event loop polls its own dup() of this fd — one shared kernel accept queue — and
+    // races non-blocking accepts; the level-triggered evloop keeps waking loops while connections
+    // are pending. This is the same model h2o's own server uses by default (dup_listener in
+    // h2o's src/main.c).
     int bind_listen_fd();
 
-    int create_listener(ev_loop_t* loop);
+    // Wraps `fd` (the listen fd or a dup of it) into `loop`'s h2o socket and starts accepting.
+    // `loop` owns `fd` from here on: it is closed on shutdown by the loop (or here, on failure).
+    int create_listener(ev_loop_t* loop, int fd);
 
     // Runs `loop` until stop() is called; the loop closes its own listener on the way out.
     void loop_run(ev_loop_t* loop);

--- a/include/http_server.h
+++ b/include/http_server.h
@@ -12,6 +12,8 @@ extern "C" {
 #include <map>
 #include <string>
 #include <cstdio>
+#include <thread>
+#include <vector>
 #include "http_data.h"
 #include "option.h"
 #include "threadpool.h"
@@ -90,6 +92,10 @@ public:
         return res->is_alive;
     }
 
+    http_message_dispatcher* res_dispatcher() const {
+        return req->res_dispatcher;
+    }
+
     void req_notify() {
         return req->notify();
     }
@@ -119,20 +125,35 @@ class HttpServer {
 private:
     h2o_globalconf_t config;
     h2o_compress_args_t compress_args;
-    h2o_context_t ctx;
-    h2o_accept_ctx_t* accept_ctx;
     h2o_hostconf_t *hostconf;
-    h2o_socket_t* listener_socket;
+
+    // One HTTP event loop: h2o context, accept context, listener (SO_REUSEPORT) and message
+    // dispatcher. Loop 0 runs on the thread that calls run(), the others on their own threads.
+    // Each connection is owned by exactly one loop: it is accepted, read and written only there,
+    // and responses are delivered through the loop's dispatcher (http_req::res_dispatcher).
+    // Every loop refreshes its own SSL context so that no SSL state is shared across threads.
+    struct ev_loop_t {
+        HttpServer* server = nullptr;
+        size_t index = 0;
+        h2o_context_t ctx;
+        h2o_accept_ctx_t accept_ctx{};
+        h2o_socket_t* listener = nullptr;
+        http_message_dispatcher* dispatcher = nullptr;
+        h2o_custom_timer_t ssl_refresh_timer;
+        std::thread thread;  // unused for loop 0
+    };
+
+    std::vector<ev_loop_t*> loops;
+
+    // handlers registered via on(); each loop's dispatcher receives a copy when run() starts
+    std::map<std::string, bool (*)(void*)> message_handlers;
 
     static const size_t ACTIVE_STREAM_WINDOW_SIZE = 196605;
     static const size_t REQ_TIMEOUT_MS = 60000;
 
     const uint64_t SSL_REFRESH_INTERVAL_MS;
 
-    h2o_custom_timer_t ssl_refresh_timer;
     h2o_custom_timer_t metrics_refresh_timer;
-
-    http_message_dispatcher* message_dispatcher;
 
     ReplicationState* replication_state;
 
@@ -172,7 +193,7 @@ private:
 
     static void on_accept(h2o_socket_t *listener, const char *err);
 
-    int setup_ssl(const char *cert_file, const char *key_file);
+    int setup_ssl(ev_loop_t* loop);
 
     static bool initialize_ssl_ctx(const char *cert_file, const char *key_file, h2o_accept_ctx_t* accept_ctx);
 
@@ -182,7 +203,15 @@ private:
 
     static void on_metrics_refresh_timeout(h2o_timer_t *entry);
 
-    int create_listener();
+    // Binds + listens a SO_REUSEPORT socket on (listen_address, listen_port), returning the fd
+    // (or -1). Each event loop registers its own listener on its own fd and the kernel
+    // load-balances incoming connections across them.
+    int bind_listen_fd();
+
+    int create_listener(ev_loop_t* loop);
+
+    // Runs `loop` until stop() is called; the loop closes its own listener on the way out.
+    void loop_run(ev_loop_t* loop);
 
     h2o_pathconf_t *register_handler(h2o_hostconf_t *hostconf, const char *path,
                                      int (*on_req)(h2o_handler_t *, h2o_req_t *));
@@ -215,8 +244,6 @@ public:
 
     ~HttpServer();
 
-    http_message_dispatcher* get_message_dispatcher() const;
-
     ReplicationState* get_replication_state() const;
 
     bool is_alive() const;
@@ -244,7 +271,15 @@ public:
 
     void on(const std::string & message, bool (*handler)(void*));
 
-    void send_message(const std::string & type, void* data);
+    // Deliver a response / request-proceed / deferral on the event loop that owns the request's
+    // connection (req->res_dispatcher) — the ONLY correct way to send these messages. When the
+    // request has no owning loop (a write replayed from the log, or tests), each helper mirrors
+    // the dead-request path of the corresponding message handler.
+    static void deliver_stream_response(async_req_res_t* req_res);
+
+    static void deliver_request_proceed(deferred_req_res_t* req_res);
+
+    static void deliver_defer_processing(defer_processing_t* defer);
 
     static void stream_response(stream_response_state_t& state);
 

--- a/include/raft_server.h
+++ b/include/raft_server.h
@@ -8,6 +8,8 @@
 #include <braft/protobuf_file.h>         // braft::ProtoBufFile
 #include <rocksdb/db.h>
 #include <future>
+#include <array>
+#include <mutex>
 
 #include "http_data.h"
 #include "threadpool.h"
@@ -149,6 +151,15 @@ private:
 
     butil::EndPoint peering_endpoint;
 
+    // --standalone only: a monotonic sequence used in place of the Raft log index, and a bank of
+    // mutexes that serialize writes per collection (hash(collection) % size) so two concurrent
+    // requests to the same collection never run together while different collections run in
+    // parallel. This reproduces the per-collection serialization that BatchedIndexer's queues
+    // provide on the Raft path.
+    std::atomic<int64_t> standalone_seq{1};
+    static constexpr size_t NUM_WRITE_STRIPES = 256;
+    std::array<std::mutex, NUM_WRITE_STRIPES> write_stripes;
+
 public:
 
     static constexpr const char* log_dir_name = "log";
@@ -165,6 +176,10 @@ public:
               int election_timeout_ms, int snapshot_max_byte_count_per_rpc,
               const std::string & raft_dir, const std::string & nodes,
               const std::atomic<bool>& quit_abruptly);
+
+    // Starts the state machine in --standalone mode (no Raft): loads collections from the
+    // durable store and marks the node ready/leader. Writes are applied directly (see write()).
+    int start_standalone(int api_port);
 
     // Generic write method for synchronizing all writes
     void write(const std::shared_ptr<http_req>& request, const std::shared_ptr<http_res>& response);

--- a/include/raft_server.h
+++ b/include/raft_server.h
@@ -118,7 +118,6 @@ private:
     Store* analytics_store;
 
     ThreadPool* thread_pool;
-    http_message_dispatcher* message_dispatcher;
 
     const bool api_uses_ssl;
 
@@ -157,7 +156,7 @@ public:
     static constexpr const char* snapshot_dir_name = "snapshot";
 
     ReplicationState(HttpServer* server, BatchedIndexer* batched_indexer, Store* store, Store* analytics_store,
-                     ThreadPool* thread_pool, http_message_dispatcher* message_dispatcher,
+                     ThreadPool* thread_pool,
                      bool api_uses_ssl, const Config* config,
                      size_t num_collections_parallel_load, size_t num_documents_parallel_load);
 
@@ -220,8 +219,6 @@ public:
     void do_snapshot(const std::string& nodes);
 
     void persist_applying_index();
-
-    http_message_dispatcher* get_message_dispatcher() const;
 
     void wait() {
         auto lk = std::unique_lock<std::mutex>(mcv);

--- a/include/tsconfig.h
+++ b/include/tsconfig.h
@@ -69,6 +69,12 @@ private:
 
     std::atomic<bool> skip_writes;
 
+    // When true, run as a single node WITHOUT Raft: writes are applied directly (no replication
+    // log, no leader election) for much higher write throughput, and the document store opens
+    // with the RocksDB WAL enabled so writes remain crash-durable. Single-node only; there is no
+    // replication or consensus in this mode.
+    bool standalone = false;
+
     std::atomic<int> log_slow_searches_time_ms;
 
     std::atomic<bool> reset_peers_on_error;
@@ -516,6 +522,10 @@ public:
 
     const std::atomic<bool>& get_skip_writes() const {
         return skip_writes;
+    }
+
+    bool get_standalone() const {
+        return standalone;
     }
 
     int get_max_per_page() const {

--- a/src/app_metrics.cpp
+++ b/src/app_metrics.cpp
@@ -211,12 +211,15 @@ std::string AppMetrics::format_access_log(const uint64_t epoch_millis, const cha
 void AppMetrics::write_access_log(const uint64_t epoch_millis, const char* remote_ip, const std::string& path,
                                   const std::string& api_key_prefix) {
     if(!access_log_path.empty()) {
-        access_log << format_access_log(epoch_millis, remote_ip, path, api_key_prefix);
+        const std::string& line = format_access_log(epoch_millis, remote_ip, path, api_key_prefix);
+        std::lock_guard<std::mutex> lk(access_log_mutex);
+        access_log << line;
     }
 }
 
 void AppMetrics::flush_access_log() {
     if(!access_log_path.empty()) {
+        std::lock_guard<std::mutex> lk(access_log_mutex);
         access_log << std::flush;
     }
 }

--- a/src/batched_indexer.cpp
+++ b/src/batched_indexer.cpp
@@ -144,7 +144,7 @@ void BatchedIndexer::enqueue(const std::shared_ptr<http_req>& req, const std::sh
     if(read_more_input) {
         // Tell the http library to read more input data
         deferred_req_res_t* req_res = new deferred_req_res_t(req, res, server, true);
-        server->get_message_dispatcher()->send_message(HttpServer::REQUEST_PROCEED_MESSAGE, req_res);
+        HttpServer::deliver_request_proceed(req_res);
     }
 }
 
@@ -273,7 +273,7 @@ void BatchedIndexer::run() {
                             orig_res->set_422(err_msg);
                             orig_res->final = true;
                             async_req_res_t* async_req_res = new async_req_res_t(orig_req, orig_res, true);
-                            server->get_message_dispatcher()->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, async_req_res);
+                            HttpServer::deliver_stream_response(async_req_res);
                             goto end;
                         }
 
@@ -282,7 +282,7 @@ void BatchedIndexer::run() {
                                 orig_res->set(422, "Skipping write.");
                                 orig_res->final = true;
                                 async_req_res_t* async_req_res = new async_req_res_t(orig_req, orig_res, true);
-                                server->get_message_dispatcher()->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, async_req_res);
+                                HttpServer::deliver_stream_response(async_req_res);
                                 goto end;
                             }
 
@@ -306,7 +306,7 @@ void BatchedIndexer::run() {
                         if(is_live_req && (!route_found ||!async_res)) {
                             // sync request gets a response immediately
                             async_req_res_t* async_req_res = new async_req_res_t(orig_req, orig_res, true);
-                            server->get_message_dispatcher()->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, async_req_res);
+                            HttpServer::deliver_stream_response(async_req_res);
                         }
 
                         if(!route_found) {
@@ -437,7 +437,7 @@ void BatchedIndexer::run() {
                     if(it->second.res->is_alive) {
                         it->second.res->final = true;
                         async_req_res_t* async_req_res = new async_req_res_t(it->second.req, it->second.res, true);
-                        server->get_message_dispatcher()->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, async_req_res);
+                        HttpServer::deliver_stream_response(async_req_res);
                     }
 
                     it = req_res_map.erase(it);

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -501,7 +501,10 @@ void CollectionManager::_populate_referenced_ins(const std::vector<std::string>&
                                                  std::map<std::string, std::map<std::string, reference_info_t>>& referenced_ins) {
     std::map<std::string, uint32_t> collection_index;
     for (size_t i = 0; i < collection_meta_jsons.size(); i++) {
-        auto const& obj = nlohmann::json::parse(collection_meta_jsons[i]);
+        // Parse without exceptions: a single unparseable collection-meta row must not terminate
+        // the process here. is_discarded() (checked below) catches the failure and skips the row,
+        // which is what the surrounding guard already intends.
+        auto const& obj = nlohmann::json::parse(collection_meta_jsons[i], nullptr, false);
         if (obj.is_discarded() || !obj.is_object() || !obj.contains("name") || !obj["name"].is_string() ||
             !obj.contains("fields")) {
             continue;

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -170,13 +170,13 @@ void stream_response(const std::shared_ptr<http_req>& req, const std::shared_ptr
     res->wait();
 
     auto req_res = new async_req_res_t(req, res, true);
-    server->get_message_dispatcher()->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, req_res);
+    HttpServer::deliver_stream_response(req_res);
 }
 
 void defer_processing(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res, size_t timeout_ms) {
     defer_processing_t* defer = new defer_processing_t(req, res, timeout_ms, server);
     //LOG(INFO) << "core_api req " << req.get() << ", use count: " << req.use_count();
-    server->get_message_dispatcher()->send_message(HttpServer::DEFER_PROCESSING_MESSAGE, defer);
+    HttpServer::deliver_defer_processing(defer);
 }
 
 // we cannot return errors here because that will end up as auth failure and won't convey

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -77,7 +77,7 @@ namespace {
         if(req_res->server != nullptr) {
             req_res->res->wait();
             auto* async_req_res = new async_req_res_t(req_res->req, req_res->res, true);
-            req_res->server->get_message_dispatcher()->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, async_req_res);
+            HttpServer::deliver_stream_response(async_req_res);
         }
     }
 }
@@ -406,9 +406,7 @@ size_t HttpClient::curl_req_send_callback(char* buffer, size_t size, size_t nite
         req_res->req->body_index = 0;
         req_res->req->body = "";
 
-        HttpServer *server = req_res->server;
-
-        server->get_message_dispatcher()->send_message(HttpServer::REQUEST_PROCEED_MESSAGE, req_res);
+        HttpServer::deliver_request_proceed(req_res);
 
         if(!req_res->req->last_chunk_aggregate) {
             //LOG(INFO) << "Waiting for request body to be ready";
@@ -480,7 +478,7 @@ size_t HttpClient::curl_write_async(char *buffer, size_t size, size_t nmemb, voi
     req_res->res->wait();
 
     async_req_res_t* async_req_res = new async_req_res_t(req_res->req, req_res->res, true);
-    req_res->server->get_message_dispatcher()->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, async_req_res);
+    HttpServer::deliver_stream_response(async_req_res);
 
     // wait until response is sent
     //LOG(INFO) << "Response sent";
@@ -544,7 +542,7 @@ size_t HttpClient::curl_write_async_done(void *context, curl_socket_t item) {
     req_res->res->wait();
 
     async_req_res_t* async_req_res = new async_req_res_t(req_res->req, req_res->res, true);
-    req_res->server->get_message_dispatcher()->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, async_req_res);
+    HttpServer::deliver_stream_response(async_req_res);
 
     // Close the socket as we've overridden the close socket handler!
     close(item);

--- a/src/http_proxy.cpp
+++ b/src/http_proxy.cpp
@@ -119,7 +119,7 @@ bool HttpProxy::call_sse(const std::string& url, const std::string& method,
         res->status_code = 400;
         res->body = "{\"message\": \"SSE only supports POST method.\"}";
         res->final = true;
-        server->get_message_dispatcher()->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, new async_req_res_t(req, res, true));
+        HttpServer::deliver_stream_response(new async_req_res_t(req, res, true));
         return false;
     }
     HttpClient& client = HttpClient::get_instance();

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -14,6 +14,12 @@
 #include "sole.hpp"
 #include "core_api.h"
 #include "collection_manager.h"
+#include "tsconfig.h"
+
+// The message dispatcher of the event loop the current thread runs. Set by each loop thread on
+// startup; read in catch_all_handler to tag every request with its owning loop, so that its
+// response is delivered back on that same loop.
+thread_local http_message_dispatcher* tls_res_dispatcher = nullptr;
 
 HttpServer::HttpServer(const std::string & version, const std::string & listen_address,
                        uint32_t listen_port, const std::string & ssl_cert_path, const std::string & ssl_cert_key_path,
@@ -23,32 +29,50 @@ HttpServer::HttpServer(const std::string & version, const std::string & listen_a
         exit_loop(false), version(version), listen_address(listen_address), listen_port(listen_port),
         ssl_cert_path(ssl_cert_path), ssl_cert_key_path(ssl_cert_key_path),
         cors_enabled(cors_enabled), cors_domains(cors_domains), thread_pool(thread_pool) {
-    accept_ctx = new h2o_accept_ctx_t();
     h2o_config_init(&config);
     hostconf = h2o_config_register_host(&config, h2o_iovec_init(H2O_STRLIT("default")), 65535);
     register_handler(hostconf, "/", catch_all_handler);
 
-    listener_socket = nullptr; // initialized later
-
     signal(SIGPIPE, SIG_IGN);
-    h2o_context_init(&ctx, h2o_evloop_create(), &config);
 
-    ctx.globalconf->server_name.base = nullptr;  // initialized later
+    config.server_name.base = nullptr;  // initialized in run()
 
-    message_dispatcher = new http_message_dispatcher;
-    message_dispatcher->init(ctx.loop);
+    // The number of event loops is derived from `thread-pool-size` (resolved the same way as the
+    // worker thread pools), capped at the core count since loops beyond that cannot run in
+    // parallel anyway.
+    const size_t proc_count = std::max<size_t>(1, std::thread::hardware_concurrency());
+    size_t pool_size = Config::get_instance().get_thread_pool_size();
+    if(pool_size == 0) {
+        pool_size = proc_count * 8;
+    }
+    const size_t num_loops = std::max<size_t>(1, std::min(pool_size, proc_count));
+
+    for(size_t i = 0; i < num_loops; i++) {
+        ev_loop_t* loop = new ev_loop_t();
+        loop->server = this;
+        loop->index = i;
+        h2o_context_init(&loop->ctx, h2o_evloop_create(), &config);
+        loop->accept_ctx.ctx = &loop->ctx;
+        loop->accept_ctx.hosts = config.hosts;
+        loop->dispatcher = new http_message_dispatcher;
+        loop->dispatcher->init(loop->ctx.loop);
+
+        // used during destructor
+        loop->ssl_refresh_timer.timer.expire_at = 0;
+
+        loops.push_back(loop);
+    }
 
     // used during destructor
-    ssl_refresh_timer.timer.expire_at = 0;
     metrics_refresh_timer.timer.expire_at = 0;
 
     meta_thread_pool = new ThreadPool(4);
-
-    accept_ctx->ssl_ctx = nullptr;
 }
 
 void HttpServer::on_accept(h2o_socket_t *listener, const char *err) {
-    HttpServer* http_server = reinterpret_cast<HttpServer*>(listener->data);
+    // listener->data is the accept context of the event loop that owns this listener, so that the
+    // connection is handled entirely on that loop.
+    h2o_accept_ctx_t* accept_ctx = reinterpret_cast<h2o_accept_ctx_t*>(listener->data);
     h2o_socket_t *sock;
 
     if (err != NULL) {
@@ -59,7 +83,7 @@ void HttpServer::on_accept(h2o_socket_t *listener, const char *err) {
         return;
     }
 
-    h2o_accept(http_server->accept_ctx, sock);
+    h2o_accept(accept_ctx, sock);
 }
 
 void HttpServer::on_metrics_refresh_timeout(h2o_timer_t *entry) {
@@ -72,7 +96,7 @@ void HttpServer::on_metrics_refresh_timeout(h2o_timer_t *entry) {
 
     // link the timer for the next cycle
     h2o_timer_link(
-        hs->ctx.loop,
+        hs->loops[0]->ctx.loop,
         AppMetrics::METRICS_REFRESH_INTERVAL_MS,
         &hs->metrics_refresh_timer.timer
     );
@@ -81,25 +105,31 @@ void HttpServer::on_metrics_refresh_timeout(h2o_timer_t *entry) {
 void HttpServer::on_ssl_refresh_timeout(h2o_timer_t *entry) {
     h2o_custom_timer_t* custom_timer = reinterpret_cast<h2o_custom_timer_t*>(entry);
 
-    LOG(INFO) << "Refreshing SSL certs from disk.";
+    // Each event loop refreshes its own SSL context on its own thread, so no SSL state is ever
+    // shared across loops.
+    ev_loop_t* loop = static_cast<ev_loop_t*>(custom_timer->data);
+    HttpServer* hs = loop->server;
 
-    HttpServer *hs = static_cast<HttpServer*>(custom_timer->data);
-    SSL_CTX* old_ssl_ctx = hs->accept_ctx->ssl_ctx;
+    if(loop->index == 0) {
+        LOG(INFO) << "Refreshing SSL certs from disk.";
+    }
 
-    bool refresh_success = initialize_ssl_ctx(hs->ssl_cert_path.c_str(), hs->ssl_cert_key_path.c_str(), hs->accept_ctx);
+    SSL_CTX* old_ssl_ctx = loop->accept_ctx.ssl_ctx;
+
+    bool refresh_success = initialize_ssl_ctx(hs->ssl_cert_path.c_str(), hs->ssl_cert_key_path.c_str(), &loop->accept_ctx);
 
     if (refresh_success) {
         // delete the old SSL context but after some time, to allow existing connections to drain
         h2o_custom_timer_t* ssl_ctx_delete_timer = new h2o_custom_timer_t(old_ssl_ctx);
         h2o_timer_init(&ssl_ctx_delete_timer->timer, on_ssl_ctx_delete_timeout);
         uint64_t delete_lag = std::max<uint64_t>(60 * 1000, hs->SSL_REFRESH_INTERVAL_MS / 2);
-        h2o_timer_link(hs->ctx.loop, delete_lag, &ssl_ctx_delete_timer->timer);
+        h2o_timer_link(loop->ctx.loop, delete_lag, &ssl_ctx_delete_timer->timer);
     } else {
         LOG(ERROR) << "SSL cert refresh failed.";
     }
 
     // link the timer for the next cycle
-    h2o_timer_link(hs->ctx.loop, hs->SSL_REFRESH_INTERVAL_MS, &hs->ssl_refresh_timer.timer);
+    h2o_timer_link(loop->ctx.loop, hs->SSL_REFRESH_INTERVAL_MS, &loop->ssl_refresh_timer.timer);
 }
 
 void HttpServer::on_ssl_ctx_delete_timeout(h2o_timer_t *entry) {
@@ -111,25 +141,27 @@ void HttpServer::on_ssl_ctx_delete_timeout(h2o_timer_t *entry) {
     delete custom_timer;
 }
 
-int HttpServer::setup_ssl(const char *cert_file, const char *key_file) {
+int HttpServer::setup_ssl(ev_loop_t* loop) {
     // Set up a timer to refresh SSL config from disk. Also, initializing upfront so that destructor works
-    ssl_refresh_timer = h2o_custom_timer_t(this);
-    h2o_timer_init(&ssl_refresh_timer.timer, on_ssl_refresh_timeout);
-    h2o_timer_link(ctx.loop, SSL_REFRESH_INTERVAL_MS, &ssl_refresh_timer.timer);
+    loop->ssl_refresh_timer = h2o_custom_timer_t(loop);
+    h2o_timer_init(&loop->ssl_refresh_timer.timer, on_ssl_refresh_timeout);
+    h2o_timer_link(loop->ctx.loop, SSL_REFRESH_INTERVAL_MS, &loop->ssl_refresh_timer.timer);
 
-    LOG(INFO) << "SSL cert refresh interval: " << (SSL_REFRESH_INTERVAL_MS / 1000) << "s";
+    if(loop->index == 0) {
+        LOG(INFO) << "SSL cert refresh interval: " << (SSL_REFRESH_INTERVAL_MS / 1000) << "s";
+    }
 
-    if(!initialize_ssl_ctx(cert_file, key_file, accept_ctx)) {
+    if(!initialize_ssl_ctx(ssl_cert_path.c_str(), ssl_cert_key_path.c_str(), &loop->accept_ctx)) {
         return -1;
     }
 
     return 0;
 }
 
-int HttpServer::create_listener() {
+int HttpServer::bind_listen_fd() {
     struct addrinfo hints;
     struct addrinfo *result, *rp;
-    int fd = -1, reuseaddr_flag = 1;
+    int fd = -1, reuseaddr_flag = 1, reuseport_flag = 1;
     std::string port_str = std::to_string(listen_port);
 
     std::string actual_address = listen_address;
@@ -180,6 +212,12 @@ int HttpServer::create_listener() {
             LOG(WARNING) << "Failed to set SO_REUSEADDR";
         }
 
+        // SO_REUSEPORT lets each HTTP event loop bind its own listener on the same port; the
+        // kernel load-balances incoming connections across them.
+        if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &reuseport_flag, sizeof(reuseport_flag)) != 0) {
+            LOG(WARNING) << "Failed to set SO_REUSEPORT";
+        }
+
         if (bind(fd, rp->ai_addr, rp->ai_addrlen) == 0) {
             // Successfully bound
             break;
@@ -204,28 +242,26 @@ int HttpServer::create_listener() {
         return -1;
     }
 
+    return fd;
+}
+
+int HttpServer::create_listener(ev_loop_t* loop) {
+    int fd = bind_listen_fd();
+    if(fd < 0) {
+        return -1;
+    }
+
     if(!ssl_cert_path.empty() && !ssl_cert_key_path.empty()) {
-        int ssl_setup_code = setup_ssl(ssl_cert_path.c_str(), ssl_cert_key_path.c_str());
+        int ssl_setup_code = setup_ssl(loop);
         if(ssl_setup_code != 0) {
             close(fd);
             return -1;
         }
     }
 
-    ctx.globalconf->server_name = h2o_strdup(nullptr, "", SIZE_MAX);
-    ctx.globalconf->http2.active_stream_window_size = ACTIVE_STREAM_WINDOW_SIZE;
-    ctx.globalconf->http2.idle_timeout = REQ_TIMEOUT_MS;
-    ctx.globalconf->max_request_entity_size = (size_t(10) * 1024 * 1024 * 1024); // 10 GB
-
-    ctx.globalconf->http1.req_timeout = REQ_TIMEOUT_MS;
-    ctx.globalconf->http1.req_io_timeout = REQ_TIMEOUT_MS;
-
-    accept_ctx->ctx = &ctx;
-    accept_ctx->hosts = config.hosts;
-
-    listener_socket = h2o_evloop_socket_create(ctx.loop, fd, H2O_SOCKET_FLAG_DONT_READ);
-    listener_socket->data = this;
-    h2o_socket_read_start(listener_socket, on_accept);
+    loop->listener = h2o_evloop_socket_create(loop->ctx.loop, fd, H2O_SOCKET_FLAG_DONT_READ);
+    loop->listener->data = &loop->accept_ctx;
+    h2o_socket_read_start(loop->listener, on_accept);
 
     return 0;
 }
@@ -233,24 +269,65 @@ int HttpServer::create_listener() {
 int HttpServer::run(ReplicationState* replication_state) {
     this->replication_state = replication_state;
 
+    // h2o global config, shared by the contexts of all event loops
+    config.server_name = h2o_strdup(nullptr, "", SIZE_MAX);
+    config.http2.active_stream_window_size = ACTIVE_STREAM_WINDOW_SIZE;
+    config.http2.idle_timeout = REQ_TIMEOUT_MS;
+    config.max_request_entity_size = (size_t(10) * 1024 * 1024 * 1024); // 10 GB
+
+    config.http1.req_timeout = REQ_TIMEOUT_MS;
+    config.http1.req_io_timeout = REQ_TIMEOUT_MS;
+
     metrics_refresh_timer = h2o_custom_timer_t(this);
     h2o_timer_init(&metrics_refresh_timer.timer, on_metrics_refresh_timeout);
-    h2o_timer_link(ctx.loop, AppMetrics::METRICS_REFRESH_INTERVAL_MS, &metrics_refresh_timer.timer);
+    h2o_timer_link(loops[0]->ctx.loop, AppMetrics::METRICS_REFRESH_INTERVAL_MS, &metrics_refresh_timer.timer);
 
-    if (create_listener() != 0) {
-        LOG(ERROR) << "Failed to listen on " << listen_address << ":" << listen_port << " - " << strerror(errno);
-        return 1;
-    } else {
-        LOG(INFO) << "Typesense has started listening on port " << listen_port;
+    for(ev_loop_t* loop : loops) {
+        // every dispatcher gets the full set of registered message handlers (registration
+        // happens before run(), so a plain copy is safe)
+        loop->dispatcher->message_handlers = message_handlers;
+        loop->dispatcher->on(STOP_SERVER_MESSAGE, HttpServer::on_stop_server);
+
+        if(create_listener(loop) != 0) {
+            LOG(ERROR) << "Failed to listen on " << listen_address << ":" << listen_port << " - " << strerror(errno);
+            return 1;
+        }
     }
 
-    message_dispatcher->on(STOP_SERVER_MESSAGE, HttpServer::on_stop_server);
+    LOG(INFO) << "Typesense has started listening on port " << listen_port
+              << " (" << loops.size() << " event loops)";
 
-    while(!exit_loop) {
-        h2o_evloop_run(ctx.loop, INT32_MAX);
+    for(size_t i = 1; i < loops.size(); i++) {
+        loops[i]->thread = std::thread([this, loop = loops[i]]() {
+            loop_run(loop);
+        });
+    }
+
+    loop_run(loops[0]);
+
+    for(size_t i = 1; i < loops.size(); i++) {
+        if(loops[i]->thread.joinable()) {
+            loops[i]->thread.join();
+        }
     }
 
     return 0;
+}
+
+void HttpServer::loop_run(ev_loop_t* loop) {
+    tls_res_dispatcher = loop->dispatcher;
+
+    while(!exit_loop) {
+        h2o_evloop_run(loop->ctx.loop, INT32_MAX);
+    }
+
+    // stop accepting new connections; done here so that only the owning thread ever touches
+    // this loop's listener socket
+    if(loop->listener != nullptr) {
+        h2o_socket_read_stop(loop->listener);
+        h2o_socket_close(loop->listener);
+        loop->listener = nullptr;
+    }
 }
 
 bool HttpServer::on_stop_server(void *data) {
@@ -269,16 +346,14 @@ void HttpServer::clear_timeouts(const std::vector<h2o_timer_t*> & timers, bool t
 }
 
 void HttpServer::stop() {
-    if(listener_socket != nullptr) {
-        h2o_socket_read_stop(listener_socket);
-        h2o_socket_close(listener_socket);
-    }
-
-    // this will break the event loop
+    // this will break the event loops
     exit_loop = true;
 
-    // send a message to activate the idle event loop to exit, just in case
-    message_dispatcher->send_message(STOP_SERVER_MESSAGE, nullptr);
+    // send a message to wake up each idle event loop so it can exit; a loop closes its own
+    // listener on the way out (only the owning thread may touch its sockets)
+    for(ev_loop_t* loop : loops) {
+        loop->dispatcher->send_message(STOP_SERVER_MESSAGE, nullptr);
+    }
 }
 
 h2o_pathconf_t* HttpServer::register_handler(h2o_hostconf_t *hostconf, const char *path,
@@ -589,6 +664,10 @@ int HttpServer::catch_all_handler(h2o_handler_t *_h2o_handler, h2o_req_t *req) {
                                                                    api_auth_key_sent, api_auth_key_prefix, body, client_ip,
                                                                    is_binary_body);
 
+    // tag the request with the dispatcher of the event loop handling it, so that its response is
+    // delivered back on this same loop (the only thread allowed to touch the connection's socket)
+    request->res_dispatcher = tls_res_dispatcher;
+
     // add custom generator with a dispose function for cleaning up resources
     h2o_custom_generator_t* custom_gen = new h2o_custom_generator_t;
     std::shared_ptr<http_res> response = std::make_shared<http_res>(custom_gen);
@@ -846,14 +925,12 @@ int HttpServer::process_request(const std::shared_ptr<http_req>& request, const 
         return 0;
     }
 
-    auto message_dispatcher = handler->http_server->get_message_dispatcher();
-
     auto thread_pool = use_meta_thread_pool ? handler->http_server->get_meta_thread_pool() :
                        handler->http_server->get_thread_pool();
 
     // LOG(INFO) << "Before enqueue res: " << response
     thread_pool->log_exhaustion();
-    thread_pool->enqueue([rpath, message_dispatcher, request, response]() {
+    thread_pool->enqueue([rpath, request, response]() {
         // call the API handler
         //LOG(INFO) << "Wait for response " << response.get() << ", action: " << rpath->_get_action();
         (rpath->handler)(request, response);
@@ -861,7 +938,7 @@ int HttpServer::process_request(const std::shared_ptr<http_req>& request, const 
         if(!rpath->async_res) {
             // lifecycle of non async res will be owned by stream responder
             auto req_res = new async_req_res_t(request, response, true);
-            message_dispatcher->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, req_res);
+            deliver_stream_response(req_res);
         }
         //LOG(INFO) << "Response done " << response.get();
     });
@@ -913,7 +990,12 @@ void HttpServer::defer_processing(const std::shared_ptr<http_req>& req, const st
         h2o_timer_unlink(&req->defer_timer.timer);
     }
 
-    h2o_timer_link(ctx.loop, timeout_ms, &req->defer_timer.timer);
+    // Schedule the timer on the event loop that owns this request's connection. Linking it to any
+    // other loop would race on that loop's timerwheel and fire the continuation on the wrong
+    // thread. Both callers (response_proceed, on_deferred_processing_message) already run on the
+    // owning loop, so linking here stays single-threaded.
+    h2o_loop_t* owning_loop = (req->res_dispatcher != nullptr) ? req->res_dispatcher->loop : loops[0]->ctx.loop;
+    h2o_timer_link(owning_loop, timeout_ms, &req->defer_timer.timer);
 
     if(exit_loop) {
         // otherwise, replication thread could be stuck waiting on a future
@@ -921,10 +1003,6 @@ void HttpServer::defer_processing(const std::shared_ptr<http_req>& req, const st
         req->notify();
         res->notify();
     }
-}
-
-void HttpServer::send_message(const std::string & type, void* data) {
-    message_dispatcher->send_message(type, data);
 }
 
 int HttpServer::send_response(h2o_req_t *req, int status_code, const std::string & message) {
@@ -1075,45 +1153,44 @@ void HttpServer::del(const std::string & path, bool (*handler)(const std::shared
 }
 
 void HttpServer::on(const std::string & message, bool (*handler)(void*)) {
-    message_dispatcher->on(message, handler);
+    // must be called before run(): each loop's dispatcher receives a copy of these handlers
+    message_handlers.emplace(message, handler);
 }
 
 HttpServer::~HttpServer() {
-    delete message_dispatcher;
-
-    if(ssl_refresh_timer.timer.expire_at != 0) {
-        // avoid callback since it recreates timeout
-        clear_timeouts({&ssl_refresh_timer.timer}, false);
-    }
-
     if(metrics_refresh_timer.timer.expire_at != 0) {
         // avoid callback since it recreates timeout
         clear_timeouts({&metrics_refresh_timer.timer}, false);
     }
 
-    h2o_timerwheel_run(ctx.loop->_timeouts, 9999999999999);
+    for(ev_loop_t* loop : loops) {
+        delete loop->dispatcher;
 
-    h2o_context_dispose(&ctx);
+        if(loop->ssl_refresh_timer.timer.expire_at != 0) {
+            // avoid callback since it recreates timeout
+            clear_timeouts({&loop->ssl_refresh_timer.timer}, false);
+        }
 
-    if(ctx.globalconf->server_name.base != nullptr) {
-        free(ctx.globalconf->server_name.base);
-        ctx.globalconf->server_name.base = nullptr;
+        h2o_timerwheel_run(loop->ctx.loop->_timeouts, 9999999999999);
+
+        h2o_context_dispose(&loop->ctx);
+
+        // Flaky, sometimes assertion on timeouts occur, preventing a clean shutdown
+        //h2o_evloop_destroy(loop->ctx.loop);
+
+        SSL_CTX_free(loop->accept_ctx.ssl_ctx);
+        delete loop;
     }
 
-    // Flaky, sometimes assertion on timeouts occur, preventing a clean shutdown
-    //h2o_evloop_destroy(ctx.loop);
+    if(config.server_name.base != nullptr) {
+        free(config.server_name.base);
+        config.server_name.base = nullptr;
+    }
 
     h2o_config_dispose(&config);
 
-    SSL_CTX_free(accept_ctx->ssl_ctx);
-    delete accept_ctx;
-
     meta_thread_pool->shutdown();
     delete meta_thread_pool;
-}
-
-http_message_dispatcher* HttpServer::get_message_dispatcher() const {
-    return message_dispatcher;
 }
 
 ReplicationState* HttpServer::get_replication_state() const {
@@ -1141,6 +1218,77 @@ uint64_t HttpServer::node_state() const {
 
 nlohmann::json HttpServer::node_status() {
     return replication_state->get_status();
+}
+
+void HttpServer::deliver_stream_response(async_req_res_t* req_res) {
+    http_message_dispatcher* dispatcher = req_res->res_dispatcher();
+
+    if(dispatcher != nullptr) {
+        dispatcher->send_message(STREAM_RESPONSE_MESSAGE, req_res);
+        return;
+    }
+
+    // The request has no owning event loop (a write replayed from the log, or tests):
+    // mirror the dead-request path of on_stream_response_message.
+    req_res->req_notify();
+    req_res->res_notify();
+
+    if(req_res->destroy_after_use) {
+        delete req_res;
+    }
+}
+
+void HttpServer::deliver_request_proceed(deferred_req_res_t* req_res) {
+    http_message_dispatcher* dispatcher = req_res->req->res_dispatcher;
+
+    if(dispatcher != nullptr) {
+        dispatcher->send_message(REQUEST_PROCEED_MESSAGE, req_res);
+        return;
+    }
+
+    // no owning event loop, so there is no connection to read more input from
+    if(req_res->destroy_after_use) {
+        delete req_res;
+    }
+}
+
+void HttpServer::deliver_defer_processing(defer_processing_t* defer) {
+    http_message_dispatcher* dispatcher = defer->req->res_dispatcher;
+
+    if(dispatcher != nullptr) {
+        dispatcher->send_message(DEFER_PROCESSING_MESSAGE, defer);
+        return;
+    }
+
+    // No owning event loop, i.e. a write replayed from the log (on a follower or during
+    // startup replay). The continuation must still run — chunked handlers like batched
+    // deletes re-schedule themselves through here, and dropping the deferral would apply
+    // only their first batch and diverge replicas. Without a loop to host the timer,
+    // drive the handler directly on the worker pool (mirrors on_deferred_process_request).
+    HttpServer* server = defer->server;
+    route_path* found_rpath = nullptr;
+
+    if(server != nullptr) {
+        server->get_route(defer->req->route_hash, &found_rpath);
+    }
+
+    if(found_rpath != nullptr) {
+        const std::shared_ptr<http_req> req = defer->req;
+        const std::shared_ptr<http_res> res = defer->res;
+        auto handler = found_rpath->handler;
+        server->thread_pool->enqueue([handler, req, res]() {
+            handler(req, res);
+        });
+        delete defer;
+        return;
+    }
+
+    // no server (tests) or unknown route: nothing can drive this request anymore,
+    // so mark it dead and wake up any waiters
+    defer->res->is_alive = false;
+    defer->req->notify();
+    defer->res->notify();
+    delete defer;
 }
 
 bool HttpServer::on_stream_response_message(void *data) {

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -19,7 +19,7 @@
 // The message dispatcher of the event loop the current thread runs. Set by each loop thread on
 // startup; read in catch_all_handler to tag every request with its owning loop, so that its
 // response is delivered back on that same loop.
-thread_local http_message_dispatcher* tls_res_dispatcher = nullptr;
+static thread_local http_message_dispatcher* tls_res_dispatcher = nullptr;
 
 HttpServer::HttpServer(const std::string & version, const std::string & listen_address,
                        uint32_t listen_port, const std::string & ssl_cert_path, const std::string & ssl_cert_key_path,
@@ -71,7 +71,12 @@ HttpServer::HttpServer(const std::string & version, const std::string & listen_a
 
 void HttpServer::on_accept(h2o_socket_t *listener, const char *err) {
     // listener->data is the accept context of the event loop that owns this listener, so that the
-    // connection is handled entirely on that loop.
+    // connection is handled entirely on that loop. All loops poll dup()s of one listening socket,
+    // so they race accept() on a shared queue: losing the race yields NULL (EAGAIN), and while
+    // connections remain queued the level-triggered evloop fires this callback again.
+    // Deliberately accepts one connection per wakeup (h2o's own server batches up to 10):
+    // returning to the poll loop between accepts gives the other loops a chance to win the next
+    // connection, spreading load across loops at the cost of extra wakeups.
     h2o_accept_ctx_t* accept_ctx = reinterpret_cast<h2o_accept_ctx_t*>(listener->data);
     h2o_socket_t *sock;
 
@@ -161,7 +166,7 @@ int HttpServer::setup_ssl(ev_loop_t* loop) {
 int HttpServer::bind_listen_fd() {
     struct addrinfo hints;
     struct addrinfo *result, *rp;
-    int fd = -1, reuseaddr_flag = 1, reuseport_flag = 1;
+    int fd = -1, reuseaddr_flag = 1;
     std::string port_str = std::to_string(listen_port);
 
     std::string actual_address = listen_address;
@@ -212,20 +217,16 @@ int HttpServer::bind_listen_fd() {
             LOG(WARNING) << "Failed to set SO_REUSEADDR";
         }
 
-        // SO_REUSEPORT lets each HTTP event loop bind its own listener on the same port; the
-        // kernel load-balances incoming connections across them.
-        if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &reuseport_flag, sizeof(reuseport_flag)) != 0) {
-            LOG(WARNING) << "Failed to set SO_REUSEPORT";
-        }
-
         if (bind(fd, rp->ai_addr, rp->ai_addrlen) == 0) {
             // Successfully bound
             break;
         }
 
-        // Log the specific bind error to help with debugging
+        // Log the specific bind error to help with debugging. errno must be captured before
+        // LOG(): the LogMessage constructor runs first and can clobber it.
+        const int bind_errno = errno;
         LOG(WARNING) << "Failed to bind to address (family=" << rp->ai_family
-                    << "): " << strerror(errno);
+                    << "): " << strerror(bind_errno);
         close(fd);
     }
 
@@ -245,12 +246,7 @@ int HttpServer::bind_listen_fd() {
     return fd;
 }
 
-int HttpServer::create_listener(ev_loop_t* loop) {
-    int fd = bind_listen_fd();
-    if(fd < 0) {
-        return -1;
-    }
-
+int HttpServer::create_listener(ev_loop_t* loop, int fd) {
     if(!ssl_cert_path.empty() && !ssl_cert_key_path.empty()) {
         int ssl_setup_code = setup_ssl(loop);
         if(ssl_setup_code != 0) {
@@ -282,14 +278,31 @@ int HttpServer::run(ReplicationState* replication_state) {
     h2o_timer_init(&metrics_refresh_timer.timer, on_metrics_refresh_timeout);
     h2o_timer_link(loops[0]->ctx.loop, AppMetrics::METRICS_REFRESH_INTERVAL_MS, &metrics_refresh_timer.timer);
 
+    // One socket is bound to the port; every loop accepts from it via its own dup()'d fd. Idle
+    // loops win the accept race, so load follows capacity, and a second process binding the same
+    // port still fails with EADDRINUSE (unlike SO_REUSEPORT, which would silently split traffic).
+    int listen_fd = bind_listen_fd();
+    if(listen_fd < 0) {
+        // bind_listen_fd has already logged the specific cause
+        LOG(ERROR) << "Failed to listen on " << listen_address << ":" << listen_port;
+        return 1;
+    }
+
     for(ev_loop_t* loop : loops) {
         // every dispatcher gets the full set of registered message handlers (registration
         // happens before run(), so a plain copy is safe)
         loop->dispatcher->message_handlers = message_handlers;
         loop->dispatcher->on(STOP_SERVER_MESSAGE, HttpServer::on_stop_server);
 
-        if(create_listener(loop) != 0) {
-            LOG(ERROR) << "Failed to listen on " << listen_address << ":" << listen_port << " - " << strerror(errno);
+        int fd = (loop->index == 0) ? listen_fd : dup(listen_fd);
+        if(fd == -1) {
+            const int dup_errno = errno;  // capture before LOG() can clobber it
+            LOG(ERROR) << "Failed to dup listener fd - " << strerror(dup_errno);
+            return 1;
+        }
+
+        if(create_listener(loop, fd) != 0) {
+            LOG(ERROR) << "Failed to set up listener on " << listen_address << ":" << listen_port;
             return 1;
         }
     }

--- a/src/raft_server.cpp
+++ b/src/raft_server.cpp
@@ -313,14 +313,14 @@ void ReplicationState::write(const std::shared_ptr<http_req>& request, const std
                           std::string(magic_enum::enum_name(resource_check)));
         response->final = true;
         auto req_res = new async_req_res_t(request, response, true);
-        return message_dispatcher->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, req_res);
+        return HttpServer::deliver_stream_response(req_res);
     }
 
     if(config->get_skip_writes() && request->path_without_query != "/config") {
         response->set_422("Skipping writes.");
         response->final = true;
         auto req_res = new async_req_res_t(request, response, true);
-        return message_dispatcher->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, req_res);
+        return HttpServer::deliver_stream_response(req_res);
     }
 
     route_path* rpath = nullptr;
@@ -334,7 +334,7 @@ void ReplicationState::write(const std::shared_ptr<http_req>& request, const std
             response->set_422("Another collection update operation is in progress.");
             response->final = true;
             auto req_res = new async_req_res_t(request, response, true);
-            return message_dispatcher->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, req_res);
+            return HttpServer::deliver_stream_response(req_res);
         }
     }
 
@@ -357,7 +357,7 @@ void ReplicationState::write(const std::shared_ptr<http_req>& request, const std
             response->set_422(res.error());
             response->final = true;
             auto req_res = new async_req_res_t(request, response, true);
-            return message_dispatcher->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, req_res);
+            return HttpServer::deliver_stream_response(req_res);
         }
     }
 
@@ -405,7 +405,7 @@ void ReplicationState::write_to_leader(const std::shared_ptr<http_req>& request,
 
         response->set_500("Could not find a leader.");
         auto req_res = new async_req_res_t(request, response, true);
-        return message_dispatcher->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, req_res);
+        return HttpServer::deliver_stream_response(req_res);
     }
 
     if (response->proxied_stream) {
@@ -475,7 +475,7 @@ void ReplicationState::write_to_leader(const std::shared_ptr<http_req>& request,
         }
 
         auto req_res = new async_req_res_t(request, response, true);
-        message_dispatcher->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, req_res);
+        HttpServer::deliver_stream_response(req_res);
         pending_writes--;
     });
 }
@@ -898,12 +898,11 @@ void ReplicationState::refresh_catchup_status(bool log_msg) {
 
 ReplicationState::ReplicationState(HttpServer* server, BatchedIndexer* batched_indexer,
                                    Store *store, Store* analytics_store, ThreadPool* thread_pool,
-                                   http_message_dispatcher *message_dispatcher,
                                    bool api_uses_ssl, const Config* config,
                                    size_t num_collections_parallel_load, size_t num_documents_parallel_load):
         node(nullptr), leader_term(-1), server(server), batched_indexer(batched_indexer),
         store(store), analytics_store(analytics_store),
-        thread_pool(thread_pool), message_dispatcher(message_dispatcher), api_uses_ssl(api_uses_ssl),
+        thread_pool(thread_pool), api_uses_ssl(api_uses_ssl),
         config(config),
         num_collections_parallel_load(num_collections_parallel_load),
         num_documents_parallel_load(num_documents_parallel_load),
@@ -936,14 +935,14 @@ void ReplicationState::do_snapshot(const std::string& snapshot_path, const std::
     if(node == nullptr) {
         res->set_500("Could not trigger a snapshot, as node is not initialized.");
         auto req_res = new async_req_res_t(req, res, true);
-        get_message_dispatcher()->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, req_res);
+        HttpServer::deliver_stream_response(req_res);
         return ;
     }
 
     if(snapshot_in_progress) {
         res->set_409("Another snapshot is in progress.");
         auto req_res = new async_req_res_t(req, res, true);
-        get_message_dispatcher()->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, req_res);
+        HttpServer::deliver_stream_response(req_res);
         return ;
     }
 
@@ -1036,10 +1035,6 @@ bool ReplicationState::reset_peers() {
     }
 
     return false;
-}
-
-http_message_dispatcher* ReplicationState::get_message_dispatcher() const {
-    return message_dispatcher;
 }
 
 Store* ReplicationState::get_store() {
@@ -1282,7 +1277,7 @@ void OnDemandSnapshotClosure::Run() {
     res->body = response.dump();
 
     auto req_res = new async_req_res_t(req, res, true);
-    replication_state->get_message_dispatcher()->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, req_res);
+    HttpServer::deliver_stream_response(req_res);
 
     // wait for response to be sent
     res->wait();

--- a/src/raft_server.cpp
+++ b/src/raft_server.cpp
@@ -150,6 +150,31 @@ int ReplicationState::start(const butil::EndPoint & peering_endpoint, const int 
     return 0;
 }
 
+int ReplicationState::start_standalone(int api_port) {
+    // No Raft. The document store was already opened with its own RocksDB WAL, so any writes from
+    // a previous run have already been recovered by DB::Open. We just load the collections from
+    // the store into memory. We deliberately do NOT call store->reload(true, ...) here: that
+    // clears the state dir, which the Raft path does so the replayed log can rebuild the store —
+    // there is no log to replay in standalone, and clearing the state dir would throw away
+    // exactly the data we want to recover.
+    int init_db_status = init_db();
+    if(init_db_status != 0) {
+        LOG(ERROR) << "Failed to initialize DB in standalone mode.";
+        return init_db_status;
+    }
+
+    // Present as a healthy, caught-up leader so reads, /health, and the leader-only code paths
+    // (analytics, conversations, …) behave exactly as on a normal single node.
+    read_caught_up = true;
+    write_caught_up = true;
+    leader_term.store(1, butil::memory_order_release);
+
+    notify();
+
+    LOG(INFO) << "Standalone state machine ready (api_port " << api_port << ").";
+    return 0;
+}
+
 // can return empty string if DNS resolution fails on all nodes
 std::string ReplicationState::to_nodes_config(const butil::EndPoint& peering_endpoint, const int api_port,
                                               const std::string& nodes_config) {
@@ -338,6 +363,86 @@ void ReplicationState::write(const std::shared_ptr<http_req>& request, const std
         }
     }
 
+    if(config->get_standalone()) {
+        // STANDALONE: no Raft, apply the write directly. Chunked (async_req) requests stream
+        // their body in via async_req_cb, which appends each chunk to `request->body`; unlike the
+        // Raft path nothing consumes the body between chunks here, so it aggregates and only the
+        // final chunk carries the complete body.
+        if(!request->last_chunk_aggregate) {
+            // tell the http library to read more input; the next chunk re-enters write()
+            if(request->_req != nullptr && request->_req->proceed_req != nullptr) {
+                deferred_req_res_t* req_res = new deferred_req_res_t(request, response, server, true);
+                HttpServer::deliver_request_proceed(req_res);
+            }
+            return ;
+        }
+
+        // The aggregated body holds the entire gzip stream, so it can be inflated in one call.
+        // NOTE: the magic bytes must be compared as unsigned char: plain char is unsigned on
+        // aarch64, where a signed comparison against 0x8b (-117) would never match.
+        if(((request->body.size() > 2) &&
+            (0x1f == (unsigned char)request->body[0] && 0x8b == (unsigned char)request->body[1])) ||
+           request->zstream_initialized) {
+            auto res = handle_gzip(request);
+
+            if(!res.ok()) {
+                response->set_422(res.error());
+                response->final = true;
+                auto req_res = new async_req_res_t(request, response, true);
+                return HttpServer::deliver_stream_response(req_res);
+            }
+        }
+
+        request->log_index = standalone_seq.fetch_add(1, std::memory_order_relaxed);
+        pending_writes++;
+
+        // Serialize writes per collection: same collection -> same stripe -> never concurrent;
+        // different collections -> (almost always) different stripes -> run in parallel across
+        // the pool. Same queue keying as BatchedIndexer, so e.g. a collection's creation is
+        // ordered before writes to it.
+        const std::string& coll_name = batched_indexer->get_collection_name(request);
+        const size_t stripe = StringUtils::hash_wy(coll_name.c_str(), coll_name.size()) % NUM_WRITE_STRIPES;
+
+        bool read_more_input = (request->_req != nullptr && request->_req->proceed_req != nullptr);
+
+        thread_pool->enqueue([this, request, response, rpath, route_found, stripe]() {
+            bool async_res = false;
+
+            if(route_found) {
+                std::lock_guard<std::mutex> lk(write_stripes[stripe]);
+                async_res = rpath->async_res;
+                try {
+                    rpath->handler(request, response);
+                } catch(const std::exception& e) {
+                    const std::string& api_action = rpath->_get_action();
+                    LOG(ERROR) << "Exception while calling handler " << api_action;
+                    LOG(ERROR) << "Raw error: " << e.what();
+                    response->set_400("Bad request.");
+                    response->final = true;
+                    async_res = false;
+                }
+            } else {
+                response->set_404();
+            }
+
+            if(response->is_alive && !async_res) {
+                // sync request gets a response immediately; async handlers stream it themselves
+                async_req_res_t* req_res = new async_req_res_t(request, response, true);
+                HttpServer::deliver_stream_response(req_res);
+            }
+
+            pending_writes--;
+        });
+
+        if(read_more_input) {
+            // lets the http library finish reading the request stream (mirrors BatchedIndexer::enqueue)
+            deferred_req_res_t* req_res = new deferred_req_res_t(request, response, server, true);
+            HttpServer::deliver_request_proceed(req_res);
+        }
+
+        return ;
+    }
+
     std::shared_lock lock(node_mutex);
 
     if(!node) {
@@ -348,9 +453,12 @@ void ReplicationState::write(const std::shared_ptr<http_req>& request, const std
         return write_to_leader(request, response);
     }
 
-    //check if it's first gzip chunk or is gzip stream initialized
+    // Check if it's the first gzip chunk or the gzip stream is already initialized.
+    // The magic bytes must be compared as unsigned char: plain char is unsigned on aarch64,
+    // where a signed comparison against 0x8b (-117) would never match.
     if(((request->body.size() > 2) &&
-        (31 == (int)request->body[0] && -117 == (int)request->body[1])) || request->zstream_initialized) {
+        (0x1f == (unsigned char)request->body[0] && 0x8b == (unsigned char)request->body[1])) ||
+       request->zstream_initialized) {
         auto res = handle_gzip(request);
 
         if(!res.ok()) {
@@ -918,6 +1026,11 @@ bool ReplicationState::is_alive() const {
 }
 
 uint64_t ReplicationState::node_state() const {
+    if(config->get_standalone()) {
+        // braft::State LEADER == 1; report it so health/status endpoints treat us as a healthy leader
+        return 1;
+    }
+
     std::shared_lock lock(node_mutex);
 
     if(node == nullptr) {
@@ -1089,6 +1202,11 @@ int64_t ReplicationState::get_num_queued_writes() {
 }
 
 bool ReplicationState::is_leader() {
+    if(config->get_standalone()) {
+        // single node, no Raft: always the leader
+        return true;
+    }
+
     std::shared_lock lock(node_mutex);
 
     if(!node) {

--- a/src/tsconfig.cpp
+++ b/src/tsconfig.cpp
@@ -274,6 +274,7 @@ void Config::load_config_env() {
     }
 
     this->skip_writes = ("TRUE" == get_env("TYPESENSE_SKIP_WRITES"));
+    this->standalone = ("TRUE" == get_env("TYPESENSE_STANDALONE"));
     this->enable_lazy_filter = ("TRUE" == get_env("TYPESENSE_ENABLE_LAZY_FILTER"));
     this->reset_peers_on_error = ("TRUE" == get_env("TYPESENSE_RESET_PEERS_ON_ERROR"));
 
@@ -543,6 +544,10 @@ void Config::load_config_file(cmdline::parser& options) {
         this->skip_writes = (skip_writes_str == "true");
     }
 
+    if(reader.Exists("server", "standalone")) {
+        this->standalone = (reader.Get("server", "standalone", "false") == "true");
+    }
+
     if(reader.Exists("server", "reset-peers-on-error")) {
         auto reset_peers_on_error_str = reader.Get("server", "reset-peers-on-error", "false");
         this->reset_peers_on_error = (reset_peers_on_error_str == "true");
@@ -767,6 +772,10 @@ void Config::load_config_cmd_args(cmdline::parser& options)  {
 
     if(options.exist("skip-writes")) {
         this->skip_writes = options.get<bool>("skip-writes");
+    }
+
+    if(options.exist("standalone")) {
+        this->standalone = options.get<bool>("standalone");
     }
 
     if(options.exist("reset-peers-on-error")) {

--- a/src/typesense_server_utils.cpp
+++ b/src/typesense_server_utils.cpp
@@ -657,7 +657,7 @@ int run_server(const Config & config, const std::string & version, void (*master
     // first we start the peering service
 
     ReplicationState replication_state(server, batch_indexer, &store, analytics_store,
-                                       &replication_thread_pool, server->get_message_dispatcher(),
+                                       &replication_thread_pool,
                                        ssl_enabled,
                                        &config,
                                        num_collections_parallel_load,

--- a/src/typesense_server_utils.cpp
+++ b/src/typesense_server_utils.cpp
@@ -128,6 +128,7 @@ void init_cmdline_options(cmdline::parser & options, int argc, char **argv) {
     options.add<int>("disk-used-max-percentage", '\0', "Reject writes when used disk space exceeds this percentage. Default: 100 (never reject).", false, 100);
     options.add<int>("memory-used-max-percentage", '\0', "Reject writes when memory usage exceeds this percentage. Default: 100 (never reject).", false, 100);
     options.add<bool>("skip-writes", '\0', "Skip all writes except config changes. Default: false.", false, false);
+    options.add<bool>("standalone", '\0', "Run as a single node without Raft (no replication; higher write throughput). Default: false.", false, false);
     options.add<bool>("reset-peers-on-error", '\0', "Reset node's peers on clustering error. Default: false.", false, false);
 
     options.add<int>("log-slow-searches-time-ms", '\0', "When >= 0, searches that take longer than this duration are logged.", false, 30*1000);
@@ -381,6 +382,27 @@ int start_raft_server(ReplicationState& replication_state, Store& store,
                       uint32_t api_port, int snapshot_interval_seconds, int snapshot_max_byte_count_per_rpc,
                       const std::atomic<bool>& reset_peers_on_error) {
 
+    if(Config::get_instance().get_standalone()) {
+        // STANDALONE: no Raft. Bring the state machine up directly (load collections from the
+        // durable store), then idle this thread until shutdown. Writes are applied directly by
+        // ReplicationState::write() instead of going through the Raft log.
+        LOG(INFO) << "Starting Typesense in STANDALONE mode (no Raft, single node).";
+
+        if(replication_state.start_standalone(api_port) != 0) {
+            LOG(ERROR) << "Failed to start standalone state machine.";
+            exit(-1);
+        }
+
+        while(!quit_raft_service.load()) {
+            sleep(1);
+        }
+
+        LOG(INFO) << "Standalone service is going to quit.";
+
+        replication_state.shutdown();
+        return 0;
+    }
+
     if(path_to_nodes.empty()) {
         LOG(INFO) << "Since no --nodes argument is provided, starting a single node Typesense cluster.";
     }
@@ -565,8 +587,14 @@ int run_server(const Config & config, const std::string & version, void (*master
     ThreadPool server_thread_pool(num_threads);
     ThreadPool replication_thread_pool(num_threads);
 
-    // primary DB used for storing the documents: we will not use WAL since Raft provides that
-    Store store(db_dir, 24*60*60, 1024, true, 0, db_write_buffer_size, db_max_write_buffer_number,
+    // Primary DB used for storing the documents. The store WAL is what makes a write survive a
+    // process restart, so its setting depends on where durability comes from:
+    //   - Raft (default): Raft's replicated log is the WAL, so the store WAL is disabled.
+    //   - --standalone: there is no Raft log, so the store opens with the RocksDB WAL enabled.
+    //     Writes are then recovered on the next DB open and replayed into the in-memory index by
+    //     CollectionManager::load().
+    const bool disable_db_wal = !config.get_standalone();
+    Store store(db_dir, 24*60*60, 1024, disable_db_wal, 0, db_write_buffer_size, db_max_write_buffer_number,
                 db_max_log_file_size, db_keep_log_file_num);
 
     // meta DB for storing house keeping things

--- a/test/natural_language_search_model_manager_test.cpp
+++ b/test/natural_language_search_model_manager_test.cpp
@@ -291,7 +291,7 @@ TEST_F(NaturalLanguageSearchModelManagerTest, ReplicationInitDbReloadsNaturalLan
     add_valid_model_mock_response();
 
     Config::get_instance().set_data_dir(state_dir_path);
-    ReplicationState replication_state(nullptr, nullptr, store, nullptr, nullptr, nullptr, false,
+    ReplicationState replication_state(nullptr, nullptr, store, nullptr, nullptr, false,
                                        &Config::get_instance(), 8, 1000);
 
     ASSERT_EQ(replication_state.init_db(), 0);


### PR DESCRIPTION
## Change Summary
In --standalone, writes bypass Raft entirely: ReplicationState::write
applies the request directly on a thread pool, serialized per collection
by a stripe mutex (different collections run in parallel), instead of
node->apply -> single on_apply thread -> BatchedIndexer. This removes the
single-threaded Raft commit/apply pipeline that caps write throughput,
and also sidesteps the BatchedIndexer RocksDB request round-trip.

- config: --standalone / TYPESENSE_STANDALONE / ini server.standalone
- durability: with no Raft log to act as the write-ahead log, the
  document store opens with the RocksDB WAL enabled. Writes are recovered
  on the next DB open and replayed into the in-memory index by the
  existing, Raft-independent CollectionManager::load() path, so a process
  restart rebuilds the index from disk. Note: durability only covers
  persisted fields; a store:false field is not written to disk and will
  not survive a restart.
- start_standalone(): load collections from the durable store and mark
  the node ready/caught-up/leader; no brpc peering server is started
- is_leader()/node_state() report a healthy leader so reads, /health and
  the leader-only paths (analytics, conversations) work unchanged;
  on-demand snapshots/vote/peer operations are rejected (node is null)
- chunked (async_req) write bodies aggregate in request->body and the
  handler runs once with the complete body; non-final chunks send a
  request-proceed message to the owning event loop so streamed uploads
  keep flowing, and gzip bodies are inflated in one call once complete
- writes are striped by BatchedIndexer::get_collection_name, so a
  collection's creation and subsequent writes to it serialize in order
  while writes to different collections run in parallel; unlike the Raft
  path there is no cross-request ordering for referenced collections
- harden the boot path: _populate_referenced_ins parsed each
  collection-meta row with the throwing nlohmann::json::parse, so a
  single unparseable row terminated the server on boot (the
  is_discarded() guard below it was dead code). Use the non-throwing
  overload so a bad row is logged and skipped, matching the main load
  loop's fail-closed behavior.
- single node only: no replication or consensus in this mode

## PR Checklist
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
