### PR TITLE
fix: remove stemmed tokens from index on document delete and update

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -7555,7 +7555,9 @@ void Index::remove_field(uint32_t seq_id, nlohmann::json& document, const std::s
     // Go through all the field names and find the keys+values so that they can be removed from in-memory index
     if(search_field.type == field_types::STRING_ARRAY || search_field.type == field_types::STRING) {
         std::vector<std::string> tokens;
-        tokenize_string_field(document, search_field, tokens, search_field.locale, symbols_to_index, token_separators);
+        const auto& field_symbols = search_field.symbols_to_index.empty() ? symbols_to_index : search_field.symbols_to_index;
+        const auto& field_separators = search_field.token_separators.empty() ? token_separators : search_field.token_separators;
+        tokenize_string_field(document, search_field, tokens, search_field.locale, field_symbols, field_separators);
 
         for(size_t i = 0; i < tokens.size(); i++) {
             const auto& token = tokens[i];

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1379,8 +1379,8 @@ void Index::tokenize_string_array(const std::vector<std::string>& strings,
                 continue;
             }
 
-            if(token.size() > 100) {
-                token.erase(100);
+            if(token.size() > a_field.truncate_len && a_field.truncate_len > 0) {
+                token.erase(a_field.truncate_len);
             }
 
             token_to_offsets[token].push_back(token_index + 1);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -7781,11 +7781,20 @@ void Index::tokenize_string_field(const nlohmann::json& document, const field& s
     const std::string& field_name = search_field.name;
 
     if(search_field.type == field_types::STRING) {
-        Tokenizer(document[field_name], true, false, locale, symbols_to_index, token_separators).tokenize(tokens);
+        Tokenizer(document[field_name], true, false, locale, symbols_to_index, token_separators,
+                  search_field.get_stemmer()).tokenize(tokens);
     } else if(search_field.type == field_types::STRING_ARRAY) {
         const std::vector<std::string>& values = document[field_name].get<std::vector<std::string>>();
         for(const std::string & value: values) {
-            Tokenizer(value, true, false, locale, symbols_to_index, token_separators).tokenize(tokens);
+            Tokenizer(value, true, false, locale, symbols_to_index, token_separators,
+                      search_field.get_stemmer()).tokenize(tokens);
+        }
+    }
+
+    // indexing truncates tokens before inserting, removal must match
+    for(auto& token: tokens) {
+        if(token.size() > search_field.truncate_len && search_field.truncate_len > 0) {
+            token.erase(search_field.truncate_len);
         }
     }
 }

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <chrono>
 #include <collection_manager.h>
+#include <posting.h>
 #include "collection.h"
 #include "synonym_index.h"
 #include "synonym_index_manager.h"
@@ -3728,6 +3729,143 @@ TEST_F(CollectionSpecificMoreTest, StemmingWithDroppingTokens) {
     ASSERT_EQ("gardening supply", search_res["hits"][1]["document"]["content"].get<std::string>());
 }
 
+TEST_F(CollectionSpecificMoreTest, StemmingRemoveDocLeavesNoStalePostings) {
+    nlohmann::json schema = R"({
+        "name": "stem_remove",
+        "fields": [
+            {"name": "title", "type": "string", "stem": true}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    Collection* coll = create_op.get();
+
+    ASSERT_TRUE(coll->add(R"({"id": "0", "title": "Blue Jeans"})"_json.dump()).ok());
+    ASSERT_TRUE(coll->add(R"({"id": "1", "title": "Red Jeans"})"_json.dump()).ok());
+    ASSERT_TRUE(coll->add(R"({"id": "2", "title": "Denim Jean"})"_json.dump()).ok());
+
+    auto res = coll->search("jeans", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+    ASSERT_EQ(3, res["found"].get<size_t>());
+    ASSERT_EQ(3, res["hits"].size());
+
+    ASSERT_TRUE(coll->remove("1").ok());
+
+    // "jeans" is indexed under its stem "jean", so removal must clean that posting list
+    std::string stem_token = "jean";
+    art_leaf* leaf = const_cast<Index*>(coll->_get_index())->get_token_leaf(
+            "title", (const unsigned char*) stem_token.c_str(), stem_token.size() + 1);
+    ASSERT_NE(nullptr, leaf);
+    ASSERT_EQ(2, posting_t::num_ids(leaf->values));
+
+    res = coll->search("jeans", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+    ASSERT_EQ(2, res["found"].get<size_t>());
+    ASSERT_EQ(2, res["hits"].size());
+
+    // control: raw token already equals its stem
+    ASSERT_TRUE(coll->remove("2").ok());
+
+    res = coll->search("jeans", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+    ASSERT_EQ(1, res["found"].get<size_t>());
+    ASSERT_EQ(1, res["hits"].size());
+    ASSERT_EQ("0", res["hits"][0]["document"]["id"].get<std::string>());
+}
+
+TEST_F(CollectionSpecificMoreTest, StemmingUpdateDocLeavesNoStalePostings) {
+    nlohmann::json schema = R"({
+        "name": "stem_update",
+        "fields": [
+            {"name": "title", "type": "string", "stem": true}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    Collection* coll = create_op.get();
+
+    ASSERT_TRUE(coll->add(R"({"id": "0", "title": "running shoes"})"_json.dump()).ok());
+
+    auto res = coll->search("run", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+    ASSERT_EQ(1, res["found"].get<size_t>());
+
+    ASSERT_TRUE(coll->add(R"({"id": "0", "title": "walking shoes"})"_json.dump(), UPDATE).ok());
+
+    res = coll->search("run", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+    ASSERT_EQ(0, res["found"].get<size_t>());
+    ASSERT_EQ(0, res["hits"].size());
+
+    res = coll->search("walk", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+    ASSERT_EQ(1, res["found"].get<size_t>());
+    ASSERT_EQ(1, res["hits"].size());
+}
+
+TEST_F(CollectionSpecificMoreTest, StemmingRemoveDocArrayFieldLeavesNoStalePostings) {
+    nlohmann::json schema = R"({
+        "name": "stem_remove_arr",
+        "fields": [
+            {"name": "tags", "type": "string[]", "stem": true}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    Collection* coll = create_op.get();
+
+    ASSERT_TRUE(coll->add(R"({"id": "0", "tags": ["blue jeans"]})"_json.dump()).ok());
+    ASSERT_TRUE(coll->add(R"({"id": "1", "tags": ["red jeans"]})"_json.dump()).ok());
+
+    auto res = coll->search("jeans", {"tags"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+    ASSERT_EQ(2, res["found"].get<size_t>());
+
+    ASSERT_TRUE(coll->remove("1").ok());
+
+    std::string stem_token = "jean";
+    art_leaf* leaf = const_cast<Index*>(coll->_get_index())->get_token_leaf(
+            "tags", (const unsigned char*) stem_token.c_str(), stem_token.size() + 1);
+    ASSERT_NE(nullptr, leaf);
+    ASSERT_EQ(1, posting_t::num_ids(leaf->values));
+
+    res = coll->search("jeans", {"tags"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+    ASSERT_EQ(1, res["found"].get<size_t>());
+    ASSERT_EQ(1, res["hits"].size());
+    ASSERT_EQ("0", res["hits"][0]["document"]["id"].get<std::string>());
+}
+
+TEST_F(CollectionSpecificMoreTest, StemmingDictionaryRemoveDocLeavesNoStalePostings) {
+    std::vector<std::string> json_lines;
+    json_lines.push_back("{\"word\": \"trousers\", \"root\": \"pant\"}");
+    ASSERT_TRUE(stemmerManager.upsert_stemming_dictionary("stale_posting_stems", json_lines).ok());
+
+    nlohmann::json schema = R"({
+        "name": "stem_remove_dict",
+        "fields": [
+            {"name": "title", "type": "string", "stem_dictionary": "stale_posting_stems"}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    Collection* coll = create_op.get();
+
+    ASSERT_TRUE(coll->add(R"({"id": "0", "title": "blue trousers"})"_json.dump()).ok());
+    ASSERT_TRUE(coll->add(R"({"id": "1", "title": "red trousers"})"_json.dump()).ok());
+
+    auto res = coll->search("pant", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+    ASSERT_EQ(2, res["found"].get<size_t>());
+
+    ASSERT_TRUE(coll->remove("1").ok());
+
+    std::string root_token = "pant";
+    art_leaf* leaf = const_cast<Index*>(coll->_get_index())->get_token_leaf(
+            "title", (const unsigned char*) root_token.c_str(), root_token.size() + 1);
+    ASSERT_NE(nullptr, leaf);
+    ASSERT_EQ(1, posting_t::num_ids(leaf->values));
+
+    res = coll->search("pant", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+    ASSERT_EQ(1, res["found"].get<size_t>());
+    ASSERT_EQ(1, res["hits"].size());
+    ASSERT_EQ("0", res["hits"][0]["document"]["id"].get<std::string>());
+}
 
 TEST_F(CollectionSpecificMoreTest, CustomStemmingDictionaryOverridesDeEnLocale) {
     nlohmann::json schema = R"({

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -3867,6 +3867,74 @@ TEST_F(CollectionSpecificMoreTest, StemmingDictionaryRemoveDocLeavesNoStalePosti
     ASSERT_EQ("0", res["hits"][0]["document"]["id"].get<std::string>());
 }
 
+TEST_F(CollectionSpecificMoreTest, FieldLevelSymbolsToIndexRemoveDocLeavesNoStalePostings) {
+    nlohmann::json schema = R"({
+        "name": "field_symbols_remove",
+        "fields": [
+            {"name": "title", "type": "string", "symbols_to_index": ["-"]}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    Collection* coll = create_op.get();
+
+    ASSERT_TRUE(coll->add(R"({"id": "0", "title": "t-shirt blue"})"_json.dump()).ok());
+    ASSERT_TRUE(coll->add(R"({"id": "1", "title": "t-shirt red"})"_json.dump()).ok());
+
+    auto res = coll->search("t-shirt", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+    ASSERT_EQ(2, res["found"].get<size_t>());
+
+    ASSERT_TRUE(coll->remove("1").ok());
+
+    // removal must tokenize with the field-level symbols, else it computes "tshirt"
+    // and misses the "t-shirt" leaf
+    std::string token = "t-shirt";
+    art_leaf* leaf = const_cast<Index*>(coll->_get_index())->get_token_leaf(
+            "title", (const unsigned char*) token.c_str(), token.size() + 1);
+    ASSERT_NE(nullptr, leaf);
+    ASSERT_EQ(1, posting_t::num_ids(leaf->values));
+
+    res = coll->search("t-shirt", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+    ASSERT_EQ(1, res["found"].get<size_t>());
+    ASSERT_EQ(1, res["hits"].size());
+    ASSERT_EQ("0", res["hits"][0]["document"]["id"].get<std::string>());
+}
+
+TEST_F(CollectionSpecificMoreTest, FieldLevelTokenSeparatorsRemoveDocLeavesNoStalePostings) {
+    nlohmann::json schema = R"({
+        "name": "field_separators_remove",
+        "fields": [
+            {"name": "tags", "type": "string[]", "token_separators": ["-"]}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    Collection* coll = create_op.get();
+
+    ASSERT_TRUE(coll->add(R"({"id": "0", "tags": ["space-ship alpha"]})"_json.dump()).ok());
+    ASSERT_TRUE(coll->add(R"({"id": "1", "tags": ["space-ship beta"]})"_json.dump()).ok());
+
+    auto res = coll->search("space", {"tags"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+    ASSERT_EQ(2, res["found"].get<size_t>());
+
+    ASSERT_TRUE(coll->remove("1").ok());
+
+    // removal must split on the field-level separator, else it computes "spaceship"
+    // and leaves "space"/"ship" postings stale
+    std::string token = "space";
+    art_leaf* leaf = const_cast<Index*>(coll->_get_index())->get_token_leaf(
+            "tags", (const unsigned char*) token.c_str(), token.size() + 1);
+    ASSERT_NE(nullptr, leaf);
+    ASSERT_EQ(1, posting_t::num_ids(leaf->values));
+
+    res = coll->search("space", {"tags"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+    ASSERT_EQ(1, res["found"].get<size_t>());
+    ASSERT_EQ(1, res["hits"].size());
+    ASSERT_EQ("0", res["hits"][0]["document"]["id"].get<std::string>());
+}
+
 TEST_F(CollectionSpecificMoreTest, CustomStemmingDictionaryOverridesDeEnLocale) {
     nlohmann::json schema = R"({
         "name": "custom_stemming_test",


### PR DESCRIPTION
## Change Summary


- pass `field::get_stemmer()` to the `Tokenizer` in `Index::tokenize_string_field` so the removal path computes the stemmed tokens indexing actually inserted, instead of raw tokens that miss the ART leaves and leave stale seq_ids behind, inflating `found` and truncating the results page at the phantom hit
- truncate removal tokens to `truncate_len` in `tokenize_string_field`, mirroring the indexing side so tokens longer than the limit are also cleaned up
- honor per-field `truncate_len` in `Index::tokenize_string_array` instead of the hardcoded 100, aligning string arrays with the scalar path
- add regression tests covering delete and update with `stem: true`, a stemmed `string[]` field, and a custom `stem_dictionary`, asserting posting list counts via `get_token_leaf`

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
