### PR TITLE
Skip remote model endpoint validation on collection load (#2988)

### DIFF
--- a/include/embedder_manager.h
+++ b/include/embedder_manager.h
@@ -84,6 +84,7 @@ public:
     Option<bool> validate_and_init_remote_model(const nlohmann::json& model_config, size_t& num_dims);
     Option<bool> validate_and_init_local_model(const nlohmann::json& model_config, size_t& num_dims);
     Option<bool> validate_and_init_model(const nlohmann::json& model_config, size_t& num_dims);
+    Option<bool> init_remote_model_without_validation(const nlohmann::json& model_config, size_t num_dims);
 
     Option<bool> update_remote_model_apikey(const nlohmann::json& model_config, const std::string& new_apikey, size_t num_dims = 0);
 
@@ -105,4 +106,3 @@ private:
 
     bool is_model_public(const std::string& model_name);
 };
-

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -2025,6 +2025,15 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
                             }
                         }
 
+                        if(embedding_op.embedding.size() != vector_field_it.value().num_dim) {
+                            return Option<bool>(400, "The embedding model returned " +
+                                                     std::to_string(embedding_op.embedding.size()) +
+                                                     " dimensions, but the field `" +
+                                                     sort_field_std.vector_query.query.field_name + "` expects " +
+                                                     std::to_string(vector_field_it.value().num_dim) +
+                                                     " dimensions. Was the remote embedding model changed?");
+                        }
+
                         embeddings.emplace_back(embedding_op.embedding);
                     }
 
@@ -2905,6 +2914,12 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
                     }
                 }
                 std::vector<float> embedding = embedding_op.embedding;
+                if(embedding.size() != search_field.num_dim) {
+                    return Option<bool>(400, "The embedding model returned " + std::to_string(embedding.size()) +
+                                             " dimensions, but the field `" + search_field.name + "` expects " +
+                                             std::to_string(search_field.num_dim) + " dimensions. Was the remote "
+                                             "embedding model changed?");
+                }
                 // params could have been set for an embed field, so we take a backup and restore
                 vector_query.values = embedding;
                 vector_query.field_name = field_name;
@@ -9210,9 +9225,16 @@ Option<bool> Collection::parse_and_validate_vector_query(const std::string& vect
                 }
             }
 
+            if(embedding_op.embedding.size() != vector_field_it.value().num_dim) {
+                return Option<bool>(400, "The embedding model returned " + std::to_string(embedding_op.embedding.size()) +
+                                         " dimensions, but the field `" + vector_query.field_name + "` expects " +
+                                         std::to_string(vector_field_it.value().num_dim) +
+                                         " dimensions. Was the remote embedding model changed?");
+            }
+
             embeddings.emplace_back(embedding_op.embedding);
         }
-        
+
         if(vector_query.query_weights.empty()) {
             // get average of all embeddings
             std::vector<float> avg_embedding(vector_field_it.value().num_dim, 0);

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -239,9 +239,12 @@ Option<Collection*> CollectionManager::init_collection(const nlohmann::json & co
             size_t num_dim = field_obj[fields::num_dim];
             auto& model_config = field_obj[fields::embed][fields::model_config];
 
-            auto res = EmbedderManager::get_instance().validate_and_init_model(model_config, num_dim);
+            const std::string& model_name = model_config["model_name"].get<std::string>();
+            auto& embedder_manager = EmbedderManager::get_instance();
+            auto res = num_dim > 0 && EmbedderManager::is_remote_model(model_name) ?
+                       embedder_manager.init_remote_model_without_validation(model_config, num_dim) :
+                       embedder_manager.validate_and_init_model(model_config, num_dim);
             if(!res.ok()) {
-                const std::string& model_name = model_config["model_name"].get<std::string>();
                 LOG(ERROR) << "Error initializing model: " << model_name << ", error: " << res.error();
                 continue;
             }

--- a/src/embedder_manager.cpp
+++ b/src/embedder_manager.cpp
@@ -69,6 +69,22 @@ Option<bool> EmbedderManager::validate_and_init_remote_model(const nlohmann::jso
     return Option<bool>(true);
 }
 
+Option<bool> EmbedderManager::init_remote_model_without_validation(const nlohmann::json& model_config,
+                                                                   size_t num_dims) {
+    try {
+        std::unique_lock<std::mutex> lock(text_embedders_mutex);
+        const auto& model_key = RemoteEmbedder::get_model_key(model_config, num_dims);
+        auto text_embedder_it = text_embedders.find(model_key);
+        if(text_embedder_it == text_embedders.end()) {
+            text_embedders.emplace(model_key, std::make_shared<TextEmbedder>(model_config, num_dims, true));
+        }
+    } catch(const std::exception& e) {
+        return Option<bool>(400, "Error initializing remote model: " + std::string(e.what()));
+    }
+
+    return Option<bool>(true);
+}
+
 Option<bool> EmbedderManager::update_remote_model_apikey(const nlohmann::json &model_config, const std::string& new_apikey, size_t num_dims) {
     std::unique_lock<std::mutex> lock(text_embedders_mutex);
     const auto& model_key = RemoteEmbedder::get_model_key(model_config, num_dims);

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -1104,12 +1104,13 @@ TEST_F(CollectionManagerTest, RestoreAutoSchemaDocsOnRestart) {
 }
 
 TEST_F(CollectionManagerTest, RestoreRemoteEmbeddingFieldWithoutEndpointValidation) {
-    auto create_op = collectionManager.create_collection(R"({
+    nlohmann::json coll_json = R"({
         "name": "coll_embed",
         "fields": [
             {"name": "title", "type": "string"}
         ]
-    })"_json);
+    })"_json;
+    auto create_op = collectionManager.create_collection(coll_json);
     ASSERT_TRUE(create_op.ok());
 
     std::string collection_meta_json;

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <collection_manager.h>
 #include "analytics_manager.h"
+#include "embedder_manager.h"
 #include "string_utils.h"
 #include "collection.h"
 #include "synonym_index.h"
@@ -87,6 +88,7 @@ protected:
             CurationIndexManager::get_instance().dispose();
             delete store;
         }
+        EmbedderManager::get_instance().delete_all_text_embedders();
         analyticsManager.stop();
         delete analytic_store;
     }
@@ -1099,6 +1101,62 @@ TEST_F(CollectionManagerTest, RestoreAutoSchemaDocsOnRestart) {
 
     collectionManager.drop_collection("coll1");
     collectionManager2.drop_collection("coll1");
+}
+
+TEST_F(CollectionManagerTest, RestoreRemoteEmbeddingFieldWithoutEndpointValidation) {
+    auto create_op = collectionManager.create_collection(R"({
+        "name": "coll_embed",
+        "fields": [
+            {"name": "title", "type": "string"}
+        ]
+    })"_json);
+    ASSERT_TRUE(create_op.ok());
+
+    std::string collection_meta_json;
+    ASSERT_EQ(StoreStatus::FOUND, store->get(Collection::get_meta_key("coll_embed"), collection_meta_json));
+    auto collection_meta = nlohmann::json::parse(collection_meta_json);
+
+    const nlohmann::json embedding_field = R"({
+        "name": "embedding",
+        "type": "float[]",
+        "facet": false,
+        "optional": true,
+        "index": true,
+        "num_dim": 4,
+        "embed": {
+            "from": ["title"],
+            "model_config": {
+                "model_name": "openai/unreachable-model",
+                "api_key": "dummy-key",
+                "url": "http://localhost:1"
+            }
+        }
+    })"_json;
+
+    collection_meta[Collection::COLLECTION_SEARCH_FIELDS_KEY].push_back(embedding_field);
+    ASSERT_TRUE(store->insert(Collection::get_meta_key("coll_embed"), collection_meta.dump()));
+
+    collectionManager.dispose();
+    delete store;
+    store = new Store("/tmp/typesense_test/coll_manager_test_db");
+    collectionManager.init(store, 1.0, "auth_key", quit);
+
+    auto load_op = collectionManager.load(8, 1000);
+    ASSERT_TRUE(load_op.ok());
+
+    auto restored_collection = collectionManager.get_collection("coll_embed").get();
+    ASSERT_NE(nullptr, restored_collection);
+    ASSERT_EQ(1, restored_collection->get_schema().count("embedding"));
+    ASSERT_EQ(1, restored_collection->get_embedding_fields().count("embedding"));
+    ASSERT_EQ(4, restored_collection->get_embedding_fields().at("embedding").num_dim);
+
+    const auto& model_config = embedding_field["embed"]["model_config"];
+    auto embedder_op = EmbedderManager::get_instance().get_text_embedder(model_config, 4);
+    ASSERT_TRUE(embedder_op.ok());
+    ASSERT_TRUE(embedder_op.get()->is_remote());
+    ASSERT_EQ(4, embedder_op.get()->get_num_dim());
+
+    collectionManager.drop_collection("coll_embed");
 }
 
 TEST_F(CollectionManagerTest, RestorePresetsOnRestart) {


### PR DESCRIPTION
Fixes #2988.

A restart while a remote embedding endpoint was unreachable silently dropped auto-embedding fields from the persisted schema, because `init_collection` treated any `validate_and_init_model` failure as fatal for the field.

**Approach**: when a remote model's dimensions are already persisted (`num_dim > 0`), skip endpoint validation entirely during load and register the embedder directly via a new `EmbedderManager::init_remote_model_without_validation`. The load-time validation is only a liveness ping, it guarantees nothing a moment later, and the embedder it constructs is identical to the one registered without it (`has_custom_dims` evaluates to `num_dims > 0` on this path either way). Endpoint problems now surface on the first embedding request instead; a malformed persisted config still fails embedder construction (caught, logged) and drops the field as before. Local models and fields with unknown dims keep the validating path.

**Second commit:** query-time guards that reject embeddings whose size does not match the field's `num_dim` (e.g. the model behind a fixed URL was swapped), in all three places query embeddings are consumed, instead of feeding mismatched vectors to the vector index.

