### PR TITLE
Fix async-reference replay stalls and harden batched indexer snapshot recovery.

### DIFF
--- a/include/batched_indexer.h
+++ b/include/batched_indexer.h
@@ -117,7 +117,7 @@ private:
     void update_coll_to_references_after_request(const std::shared_ptr<http_req>& req,
                                                  const std::string& coll_name);
 
-    void add_reference_request_with_lock(refq_entry&& ref);
+    void add_reference_request(refq_entry&& ref);
 
     size_t process_reference_queue_with_lock(uint64_t completed_request_id);
 

--- a/include/batched_indexer.h
+++ b/include/batched_indexer.h
@@ -10,6 +10,8 @@
 
 class BatchedIndexer {
 private:
+    friend class ReplicationState;
+
     struct req_res_t {
         uint64_t start_ts;
         std::string prev_req_body;  // used to handle partial JSON documents caused by chunking
@@ -80,6 +82,7 @@ private:
 
     std::atomic<bool> quit;
     std::shared_mutex pause_mutex;
+    std::shared_mutex lifecycle_mutex;
 
     // Used to skip over a bad raft log entry which previously triggered a crash
     const static int64_t UNSET_SKIP_INDEX = -9999;
@@ -120,6 +123,12 @@ private:
     void add_reference_request(refq_entry&& ref);
 
     size_t process_reference_queue_with_lock(uint64_t completed_request_id);
+
+    // The caller must hold `lifecycle_mutex` exclusively.
+    void clear_state_unlocked();
+
+    // The caller must hold `lifecycle_mutex` exclusively.
+    void load_state_unlocked(const nlohmann::json& state);
 
 public:
 

--- a/include/batched_indexer.h
+++ b/include/batched_indexer.h
@@ -61,8 +61,10 @@ private:
     std::vector<std::deque<uint64_t>> queues;
 
     std::unordered_map<std::string, std::unordered_set<std::string>> coll_to_references;
-    await_t refq_wait;
     std::list<refq_entry> reference_q;
+    std::unordered_map<uint64_t, std::list<refq_entry>::iterator> reference_q_by_request;
+    std::unordered_map<uint64_t, std::vector<uint64_t>> reference_waiters;
+    std::unordered_map<std::string, uint64_t> collection_request_tails;
 
     /* Variables to be serialized on snapshot                  /
     --------------------------------------------------------- */
@@ -100,16 +102,24 @@ private:
 
     static std::string get_req_suffix_key(uint64_t req_id);
 
+    static bool is_request_earlier(uint64_t lhs_latest_chunk_log_index, uint64_t lhs_last_updated,
+                                   uint64_t lhs_req_id, uint64_t rhs_latest_chunk_log_index,
+                                   uint64_t rhs_last_updated, uint64_t rhs_req_id);
+
     std::unordered_set<uint64_t> get_requests_to_wait_on_with_lock(uint64_t req_id,
                                                                    const std::string& coll_name);
 
-    std::unordered_set<uint64_t> get_requests_to_wait_on(uint64_t req_id,
-                                                         const std::string& coll_name);
+    std::unordered_set<uint64_t> get_requests_to_wait_on(uint64_t req_id, const std::string& coll_name,
+                                                         bool use_order_fallback = false);
 
     void update_coll_to_references(const std::shared_ptr<http_req>& req, const std::string& coll_name);
 
     void update_coll_to_references_after_request(const std::shared_ptr<http_req>& req,
                                                  const std::string& coll_name);
+
+    void add_reference_request_with_lock(refq_entry&& ref);
+
+    size_t process_reference_queue_with_lock(uint64_t completed_request_id);
 
 public:
 

--- a/include/batched_indexer.h
+++ b/include/batched_indexer.h
@@ -125,7 +125,7 @@ private:
     size_t process_reference_queue_with_lock(uint64_t completed_request_id);
 
     // The caller must hold `lifecycle_mutex` exclusively.
-    void clear_state_unlocked();
+    void clear_state_unlocked(bool cancel_live_requests = true);
 
     // The caller must hold `lifecycle_mutex` exclusively.
     void load_state_unlocked(const nlohmann::json& state);

--- a/include/raft_server.h
+++ b/include/raft_server.h
@@ -129,6 +129,8 @@ private:
 
     std::atomic<bool> read_caught_up;
     std::atomic<bool> write_caught_up;
+    mutable std::shared_mutex snapshot_load_mutex;
+    std::atomic<bool> snapshot_load_blocks_readiness;
 
     std::string raft_dir_path;
 
@@ -188,11 +190,11 @@ public:
     }
 
     bool is_read_caught_up() const {
-        return read_caught_up;
+        return !snapshot_load_blocks_readiness && read_caught_up;
     }
 
     bool is_write_caught_up() const {
-        return write_caught_up;
+        return !snapshot_load_blocks_readiness && write_caught_up;
     }
 
     bool is_alive() const;

--- a/include/raft_server.h
+++ b/include/raft_server.h
@@ -284,6 +284,12 @@ private:
 
     int on_snapshot_load(braft::SnapshotReader* reader);
 
+    int restore_batched_indexer_state(StoreStatus status, const std::string& state,
+                                      bool batched_indexer_workers_paused);
+
+    // The caller must hold the batched indexer's lifecycle mutex exclusively when one is configured.
+    int fail_snapshot_load_unlocked(int status);
+
     void on_leader_start(int64_t term) {
         leader_term.store(term, butil::memory_order_release);
         LOG(INFO) << "Node becomes leader, term: " << term;

--- a/include/raft_server.h
+++ b/include/raft_server.h
@@ -202,7 +202,7 @@ public:
     // Shut this node down.
     void shutdown();
 
-    int init_db();
+    int init_db(bool batched_indexer_workers_paused = false);
 
     Store* get_store();
 

--- a/src/batched_indexer.cpp
+++ b/src/batched_indexer.cpp
@@ -541,7 +541,7 @@ void BatchedIndexer::persist_applying_index() {
 void BatchedIndexer::serialize_state(nlohmann::json& state) {
     // requires external synchronization!
     state["queued_writes"] = queued_writes.load();
-    state["req_res_map"] = nlohmann::json();
+    state["req_res_map"] = nlohmann::json::object();
 
     size_t num_reqs_stored = 0;
     std::unique_lock lk(mutex);

--- a/src/batched_indexer.cpp
+++ b/src/batched_indexer.cpp
@@ -53,6 +53,8 @@ std::string get_ref_coll_names(const std::string& body, std::unordered_set<std::
 }
 
 void BatchedIndexer::enqueue(const std::shared_ptr<http_req>& req, const std::shared_ptr<http_res>& res) {
+    std::shared_lock lifecycle_lock(lifecycle_mutex);
+
     // Called by the raft write thread: goal is to quickly send the request to a queue and move on
     // NOTE: it's ok to access `req` and `res` in this function without synchronization
     // because the read thread for *this* request is paused now and resumes only messaged at the end
@@ -213,6 +215,19 @@ void BatchedIndexer::run() {
                     break;
                 }
 
+                // Do not hold a queue mutex while waiting for snapshot installation to finish: the installer needs
+                // every queue mutex in order to replace the queues. Recheck after acquiring the lifecycle lock,
+                // because installation may have replaced the entry that originally woke this worker.
+                qlk.unlock();
+                std::shared_lock lifecycle_lock(lifecycle_mutex);
+                qlk.lock();
+                if(quit) {
+                    break;
+                }
+                if(queue.empty()) {
+                    continue;
+                }
+
                 uint64_t req_id = queue.front();
                 queue.pop_front();
                 qlk.unlock();
@@ -365,6 +380,7 @@ void BatchedIndexer::run() {
                 std::chrono::high_resolution_clock::now() - last_gc_run).count();
 
         if(seconds_elapsed > GC_INTERVAL_SECONDS) {
+            std::shared_lock lifecycle_lock(lifecycle_mutex);
 
             std::unique_lock lk(mutex);
             LOG(INFO) << "Running GC for aborted requests, req map size: " << req_res_map.size()
@@ -567,7 +583,28 @@ void BatchedIndexer::serialize_state(nlohmann::json& state) {
     LOG(INFO) << "Serialized " << num_reqs_stored << " in-flight requests for snapshot.";
 }
 
+void BatchedIndexer::clear_state_unlocked() {
+    for (size_t queue_id = 0; queue_id < num_threads; queue_id++) {
+        std::unique_lock qlk(qmutuxes[queue_id].mcv);
+        queues[queue_id].clear();
+    }
+
+    std::unique_lock lk(mutex);
+    req_res_map.clear();
+    coll_to_references.clear();
+    reference_q.clear();
+    reference_q_by_request.clear();
+    reference_waiters.clear();
+    collection_request_tails.clear();
+    queued_writes = 0;
+}
+
 void BatchedIndexer::load_state(const nlohmann::json& state) {
+    std::unique_lock lifecycle_lock(lifecycle_mutex);
+    load_state_unlocked(state);
+}
+
+void BatchedIndexer::load_state_unlocked(const nlohmann::json& state) {
     // `queued_writes` is a denormalized counter that must always equal the sum of the unprocessed chunks
     // across the *complete* requests in `req_res_map`. Restoring it verbatim from the snapshot let a drifted
     // value survive forever: e.g. a value that counted writes whose request entries were already gone would
@@ -577,14 +614,7 @@ void BatchedIndexer::load_state(const nlohmann::json& state) {
     // not counted at enqueue time either, and will be counted by enqueue() when the raft log is replayed.
     const int64_t persisted_queued_writes = state.contains("queued_writes") ?
                                                 state["queued_writes"].get<int64_t>() : 0;
-    queued_writes = 0;
-    {
-        std::unique_lock lk(mutex);
-        reference_q.clear();
-        reference_q_by_request.clear();
-        reference_waiters.clear();
-        collection_request_tails.clear();
-    }
+    clear_state_unlocked();
 
     // Tracked alongside `queued_writes` purely for the post-load sanity check below: by the time we log, the
     // restored queues have been notified and a worker may have already decremented the live counter, so we

--- a/src/batched_indexer.cpp
+++ b/src/batched_indexer.cpp
@@ -583,20 +583,50 @@ void BatchedIndexer::serialize_state(nlohmann::json& state) {
     LOG(INFO) << "Serialized " << num_reqs_stored << " in-flight requests for snapshot.";
 }
 
-void BatchedIndexer::clear_state_unlocked() {
+void BatchedIndexer::clear_state_unlocked(const bool cancel_live_requests) {
     for (size_t queue_id = 0; queue_id < num_threads; queue_id++) {
         std::unique_lock qlk(qmutuxes[queue_id].mcv);
         queues[queue_id].clear();
     }
 
-    std::unique_lock lk(mutex);
-    req_res_map.clear();
-    coll_to_references.clear();
-    reference_q.clear();
-    reference_q_by_request.clear();
-    reference_waiters.clear();
-    collection_request_tails.clear();
-    queued_writes = 0;
+    std::vector<std::pair<std::shared_ptr<http_req>, std::shared_ptr<http_res>>> displaced_live_requests;
+    {
+        std::unique_lock lk(mutex);
+        if(cancel_live_requests) {
+            for (const auto& [request_id, req_res] : req_res_map) {
+                if(req_res.res != nullptr && req_res.res->is_alive) {
+                    displaced_live_requests.emplace_back(req_res.req, req_res.res);
+                }
+            }
+        }
+
+        req_res_map.clear();
+        coll_to_references.clear();
+        reference_q.clear();
+        reference_q_by_request.clear();
+        reference_waiters.clear();
+        collection_request_tails.clear();
+        queued_writes = 0;
+    }
+
+    for (const auto& [req, res] : displaced_live_requests) {
+        {
+            std::unique_lock response_lock(res->mres);
+            if(!res->is_alive) {
+                continue;
+            }
+            res->set_503("Request cancelled while installing a Raft snapshot.");
+            res->final = true;
+        }
+
+        if(server != nullptr) {
+            auto* async_req_res = new async_req_res_t(req, res, true);
+            server->get_message_dispatcher()->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, async_req_res);
+        } else {
+            req->notify();
+            res->notify();
+        }
+    }
 }
 
 void BatchedIndexer::load_state(const nlohmann::json& state) {

--- a/src/batched_indexer.cpp
+++ b/src/batched_indexer.cpp
@@ -594,6 +594,8 @@ void BatchedIndexer::load_state(const nlohmann::json& state) {
     size_t num_reqs_restored = 0;
     std::set<uint64_t> queue_ids;
     std::unordered_set<uint64_t> reference_q_start_ts;
+    std::unordered_map<std::string, uint64_t> persisted_collection_tails;
+    std::unordered_map<std::string, uint64_t> reconstructed_collection_tails;
 
     if(state.contains("reference_q")) {
         for(const auto& item: state["reference_q"].items()) {
@@ -647,6 +649,47 @@ void BatchedIndexer::load_state(const nlohmann::json& state) {
         num_reqs_restored++;
     }
 
+    if (state.contains("collection_request_tails")) {
+        std::unique_lock lk(mutex);
+        for (const auto& item : state["collection_request_tails"].items()) {
+            const auto request_id = item.value().get<uint64_t>();
+            if (req_res_map.count(request_id) != 0) {
+                persisted_collection_tails[item.key()] = request_id;
+            }
+        }
+    }
+
+    {
+        std::unique_lock lk(mutex);
+        // The main queues are restored in logical request order below. Start each legacy collection chain at the
+        // logical tail of the requests that are already eligible for those queues. Requests still in `reference_q`
+        // are deliberately excluded: regardless of logical order, they will be appended only after their
+        // dependencies complete. A valid persisted tail remains authoritative; only missing collections need this
+        // reconstruction.
+        for (const auto& [request_id, req_res] : req_res_map) {
+            if (!req_res.is_complete || reference_q_start_ts.count(request_id) != 0) {
+                continue;
+            }
+
+            const auto& coll_name = get_collection_name(req_res.req);
+            if (coll_name.empty() || persisted_collection_tails.count(coll_name) != 0) {
+                continue;
+            }
+
+            const auto tail_it = reconstructed_collection_tails.find(coll_name);
+            if (tail_it == reconstructed_collection_tails.end()) {
+                reconstructed_collection_tails[coll_name] = request_id;
+                continue;
+            }
+
+            const auto& existing_tail = req_res_map.at(tail_it->second);
+            if (is_request_earlier(existing_tail.latest_chunk_log_index, existing_tail.last_updated, tail_it->second,
+                                   req_res.latest_chunk_log_index, req_res.last_updated, request_id)) {
+                tail_it->second = request_id;
+            }
+        }
+    }
+
     if(state.contains("reference_q")) {
         std::unique_lock lk(mutex);
 
@@ -668,6 +711,33 @@ void BatchedIndexer::load_state(const nlohmann::json& state) {
                     dependencies.insert(dependency_id);
                 }
             }
+        }
+
+        // Legacy snapshots did not record the physical collection tails. Extend each missing collection's
+        // reconstructed main-queue tail through its blocked entries in persisted `reference_q` order. This captures
+        // topology-gap states where a logically newer request already bypassed an older blocked request: the blocked
+        // request will be appended after that main-queue request, so it(not the logical maximum) is the next tail.
+        //
+        // Add these edges before reducing dependency frontiers so the synthetic chain also proves that older
+        // same-collection dependencies are transitively covered and the migrated state stays bounded.
+        for (const auto& item : state["reference_q"].items()) {
+            const nlohmann::json& ref_entry = item.value();
+            const auto request_id = ref_entry["start_ts"].get<uint64_t>();
+            const auto request_it = req_res_map.find(request_id);
+            if (request_it == req_res_map.end() || !request_it->second.is_complete) {
+                continue;
+            }
+
+            const auto& coll_name = get_collection_name(request_it->second.req);
+            if (coll_name.empty() || persisted_collection_tails.count(coll_name) != 0) {
+                continue;
+            }
+
+            const auto tail_it = reconstructed_collection_tails.find(coll_name);
+            if (tail_it != reconstructed_collection_tails.end() && tail_it->second != request_id) {
+                persisted_dependencies[request_id].insert(tail_it->second);
+            }
+            reconstructed_collection_tails[coll_name] = request_id;
         }
 
         for(const auto& item: state["reference_q"].items()) {
@@ -728,6 +798,13 @@ void BatchedIndexer::load_state(const nlohmann::json& state) {
                     const std::string& coll_name = get_collection_name(req);
                     ref.waiting_on_requests = get_requests_to_wait_on(ref.start_ts, coll_name, true);
                 }
+
+                // Snapshots old enough to omit dependency sets still need the reconstructed same-collection chain.
+                const auto reconstructed_dependencies_it = persisted_dependencies.find(ref.start_ts);
+                if (reconstructed_dependencies_it != persisted_dependencies.end()) {
+                    ref.waiting_on_requests.insert(reconstructed_dependencies_it->second.begin(),
+                                                   reconstructed_dependencies_it->second.end());
+                }
             }
             if (ref.waiting_on_requests.empty()) {
                 queue_ids.insert(ref.queue_id);
@@ -741,41 +818,9 @@ void BatchedIndexer::load_state(const nlohmann::json& state) {
 
     {
         std::unique_lock lk(mutex);
-        if (state.contains("collection_request_tails")) {
-            for (const auto& item : state["collection_request_tails"].items()) {
-                const auto request_id = item.value().get<uint64_t>();
-                if (req_res_map.count(request_id) != 0) {
-                    collection_request_tails[item.key()] = request_id;
-                }
-            }
-        }
-
-        // Older snapshots did not persist collection tails. Reconstruct any missing collection in the same total
-        // order used by the main queues below, without overwriting authoritative tails from a newer snapshot.
-        std::unordered_map<std::string, uint64_t> reconstructed_tails;
-        for (const auto& [request_id, req_res] : req_res_map) {
-            if (!req_res.is_complete) {
-                continue;
-            }
-
-            const auto& coll_name = get_collection_name(req_res.req);
-            if (coll_name.empty() || collection_request_tails.count(coll_name) != 0) {
-                continue;
-            }
-
-            const auto tail_it = reconstructed_tails.find(coll_name);
-            if (tail_it == reconstructed_tails.end()) {
-                reconstructed_tails[coll_name] = request_id;
-                continue;
-            }
-
-            const auto& existing_tail = req_res_map.at(tail_it->second);
-            if (is_request_earlier(existing_tail.latest_chunk_log_index, existing_tail.last_updated, tail_it->second,
-                                   req_res.latest_chunk_log_index, req_res.last_updated, request_id)) {
-                tail_it->second = request_id;
-            }
-        }
-        collection_request_tails.insert(reconstructed_tails.begin(), reconstructed_tails.end());
+        collection_request_tails = std::move(persisted_collection_tails);
+        collection_request_tails.insert(reconstructed_collection_tails.begin(),
+                                        reconstructed_collection_tails.end());
     }
 
     std::unordered_map<uint64_t, std::pair<uint64_t, uint64_t>> restored_request_order;

--- a/src/batched_indexer.cpp
+++ b/src/batched_indexer.cpp
@@ -743,6 +743,43 @@ void BatchedIndexer::load_state_unlocked(const nlohmann::json& state) {
             }
         }
 
+        // Requests restored directly to a worker queue are serialized by that queue even though legacy snapshots do
+        // not record explicit dependency edges between them. Record their reconstructed FIFO rank so a legacy
+        // dependency closure can be reduced to the latest dependency that is actually present in that closure.
+        // Choosing only the collection's overall logical tail would be incorrect when the current request precedes
+        // later entries from the same collection.
+        std::unordered_map<uint64_t, size_t> main_queue_ranks;
+        std::unordered_map<std::string, std::vector<uint64_t>> main_queue_requests_by_collection;
+        for (const auto& [request_id, req_res] : req_res_map) {
+            if (!req_res.is_complete || reference_q_start_ts.count(request_id) != 0) {
+                continue;
+            }
+            main_queue_requests_by_collection[get_collection_name(req_res.req)].push_back(request_id);
+        }
+
+        for (auto& [coll_name, request_ids] : main_queue_requests_by_collection) {
+            std::sort(request_ids.begin(), request_ids.end(), [this](const uint64_t lhs, const uint64_t rhs) {
+                const auto& lhs_req_res = req_res_map.at(lhs);
+                const auto& rhs_req_res = req_res_map.at(rhs);
+                return is_request_earlier(lhs_req_res.latest_chunk_log_index, lhs_req_res.last_updated, lhs,
+                                          rhs_req_res.latest_chunk_log_index, rhs_req_res.last_updated, rhs);
+            });
+
+            const auto persisted_tail_it = persisted_collection_tails.find(coll_name);
+            if (persisted_tail_it != persisted_collection_tails.end()) {
+                const auto tail_it = std::find(request_ids.begin(), request_ids.end(), persisted_tail_it->second);
+                if (tail_it != request_ids.end()) {
+                    const auto tail_request_id = *tail_it;
+                    request_ids.erase(tail_it);
+                    request_ids.push_back(tail_request_id);
+                }
+            }
+
+            for (size_t rank = 0; rank < request_ids.size(); rank++) {
+                main_queue_ranks[request_ids[rank]] = rank;
+            }
+        }
+
         // Legacy snapshots did not record the physical collection tails. Extend each missing collection's
         // reconstructed main-queue tail through its blocked entries in persisted `reference_q` order. This captures
         // topology-gap states where a logically newer request already bypassed an older blocked request: the blocked
@@ -777,6 +814,8 @@ void BatchedIndexer::load_state_unlocked(const nlohmann::json& state) {
                 // Legacy snapshots can contain the transitive closure of every earlier related request. Reduce each
                 // collection to its independent dependency frontier. Unlike choosing the logically latest request,
                 // this keeps multiple same-collection dependencies when none is proven to cover another.
+                std::unordered_map<std::string, std::unordered_set<uint64_t>> dependency_candidates;
+                std::unordered_map<std::string, uint64_t> latest_main_queue_dependencies;
                 std::unordered_map<std::string, std::unordered_set<uint64_t>> dependency_frontiers;
                 const auto restored_dependencies_it =
                     persisted_dependencies.find(ref_entry["start_ts"].get<uint64_t>());
@@ -784,7 +823,26 @@ void BatchedIndexer::load_state_unlocked(const nlohmann::json& state) {
                     for (const auto dependency_id : restored_dependencies_it->second) {
                         const auto& dependency_collection =
                             get_collection_name(req_res_map.at(dependency_id).req);
-                        auto& frontier = dependency_frontiers[dependency_collection];
+                        const auto rank_it = main_queue_ranks.find(dependency_id);
+                        if (rank_it != main_queue_ranks.end()) {
+                            const auto selected_it = latest_main_queue_dependencies.find(dependency_collection);
+                            if (selected_it == latest_main_queue_dependencies.end() ||
+                                main_queue_ranks.at(selected_it->second) < rank_it->second) {
+                                latest_main_queue_dependencies[dependency_collection] = dependency_id;
+                            }
+                        } else {
+                            dependency_candidates[dependency_collection].insert(dependency_id);
+                        }
+                    }
+                }
+
+                for (const auto& [dependency_collection, dependency_id] : latest_main_queue_dependencies) {
+                    dependency_candidates[dependency_collection].insert(dependency_id);
+                }
+
+                for (const auto& [dependency_collection, candidates] : dependency_candidates) {
+                    auto& frontier = dependency_frontiers[dependency_collection];
+                    for (const auto dependency_id : candidates) {
                         bool is_covered = false;
                         for (const auto frontier_dependency_id : frontier) {
                             const auto frontier_dependencies_it =

--- a/src/batched_indexer.cpp
+++ b/src/batched_indexer.cpp
@@ -119,7 +119,7 @@ void BatchedIndexer::enqueue(const std::shared_ptr<http_req>& req, const std::sh
                 } else {
                     refq_entry ref(queue_id, req->start_ts);
                     ref.waiting_on_requests = std::move(wait_on_request_ids);
-                    add_reference_request_with_lock(std::move(ref));
+                    add_reference_request(std::move(ref));
                 }
             }
 
@@ -432,7 +432,7 @@ void BatchedIndexer::run() {
     delete thread_pool;
 }
 
-void BatchedIndexer::add_reference_request_with_lock(refq_entry&& ref) {
+void BatchedIndexer::add_reference_request(refq_entry&& ref) {
     const auto request_id = ref.start_ts;
     reference_q.emplace_back(std::move(ref));
     const auto reference_q_it = std::prev(reference_q.end());
@@ -734,7 +734,7 @@ void BatchedIndexer::load_state(const nlohmann::json& state) {
                 std::unique_lock qlk(qmutuxes[ref.queue_id].mcv);
                 queues[ref.queue_id].emplace_back(ref.start_ts);
             } else {
-                add_reference_request_with_lock(std::move(ref));
+                add_reference_request(std::move(ref));
             }
         }
     }

--- a/src/batched_indexer.cpp
+++ b/src/batched_indexer.cpp
@@ -4,6 +4,7 @@
 #include "cached_resource_stat.h"
 #include "collection_manager.h"
 #include <queue>
+#include <tuple>
 
 BatchedIndexer::BatchedIndexer(HttpServer* server, Store* store, Store* meta_store, const size_t num_threads,
                                const Config& config, const std::atomic<bool>& skip_writes):
@@ -98,25 +99,32 @@ void BatchedIndexer::enqueue(const std::shared_ptr<http_req>& req, const std::sh
             req->params["collection"] = coll_name;
             update_coll_to_references(req, coll_name);
 
+            bool queued_on_main_q = false;
             {
-                std::unique_lock lk2(mutex);
+                // Dependency selection, tail registration, and queue placement must be one atomic state change.
+                // Otherwise a snapshot or a later request could observe the new tail before the request is present
+                // in either queue.
+                std::unique_lock lk(mutex);
                 req_res_map[req->start_ts].is_complete = true;
+
+                auto wait_on_request_ids = get_requests_to_wait_on(req->start_ts, coll_name);
+                if (!coll_name.empty()) {
+                    collection_request_tails[coll_name] = req->start_ts;
+                }
+
+                if(wait_on_request_ids.empty()) {
+                    std::unique_lock qlk(qmutuxes[queue_id].mcv);
+                    queues[queue_id].emplace_back(req->start_ts);
+                    queued_on_main_q = true;
+                } else {
+                    refq_entry ref(queue_id, req->start_ts);
+                    ref.waiting_on_requests = std::move(wait_on_request_ids);
+                    add_reference_request_with_lock(std::move(ref));
+                }
             }
 
-            auto wait_on_request_ids = get_requests_to_wait_on_with_lock(req->start_ts, coll_name);
-            if(wait_on_request_ids.empty()) {
-                std::unique_lock qlk(qmutuxes[queue_id].mcv);
-                queues[queue_id].emplace_back(req->start_ts);
-                qlk.unlock();
+            if (queued_on_main_q) {
                 qmutuxes[queue_id].cv.notify_one();
-            } else {
-                refq_entry ref(queue_id, req->start_ts);
-                ref.waiting_on_requests = std::move(wait_on_request_ids);
-
-                std::unique_lock lk(refq_wait.mcv);
-                reference_q.emplace_back(std::move(ref));
-                lk.unlock();
-                refq_wait.cv.notify_one();
             }
         }
 
@@ -332,56 +340,19 @@ void BatchedIndexer::run() {
 
                 std::unique_lock lk(mutex);
 
-                update_coll_to_references_after_request(orig_req, get_collection_name(orig_req));
+                const std::string completed_coll_name = get_collection_name(orig_req);
+                update_coll_to_references_after_request(orig_req, completed_coll_name);
 
                 req_res_map.erase(req_id);
+                const auto tail_it = collection_request_tails.find(completed_coll_name);
+                if (tail_it != collection_request_tails.end() && tail_it->second == req_id) {
+                    collection_request_tails.erase(tail_it);
+                }
                 lk.unlock();
-                refq_wait.cv.notify_one();
+                process_reference_queue_with_lock(req_id);
             }
         });
     }
-
-    std::thread ref_sequence_thread([&]() {
-        // Waits for dependent requests that are ahead to finish before pushing a request onto main indexing queue.
-        LOG(INFO) << "Starting reference sequence thread.";
-
-        while(!quit) {
-            std::unique_lock ref_qlk(refq_wait.mcv);
-            refq_wait.cv.wait(ref_qlk, [&] {
-                return quit || !reference_q.empty();
-            });
-
-            if(quit) {
-                break;
-            }
-
-            std::lock_guard lock(mutex);
-
-            // We will iterate on the reference queue and check if there are any ongoing requests that have been
-            // sent prior to this request.
-            auto reference_q_it = reference_q.begin();
-            while(reference_q_it != reference_q.end()) {
-                std::unordered_set<uint64_t> waiting_on_requests_updated;
-                for (const auto& waiting_on_req_id : reference_q_it->waiting_on_requests) {
-                    if (req_res_map.count(waiting_on_req_id) != 0) {
-                        waiting_on_requests_updated.insert(waiting_on_req_id);
-                    }
-                }
-                if (waiting_on_requests_updated.empty()) {
-                    // All the dependent requests have been completed. Push this request onto main processing queue and
-                    // remove node from reference_q.
-                    std::unique_lock qlk(qmutuxes[reference_q_it->queue_id].mcv);
-                    queues[reference_q_it->queue_id].emplace_back(reference_q_it->start_ts);
-                    qlk.unlock();
-                    qmutuxes[reference_q_it->queue_id].cv.notify_one();
-                    reference_q_it = reference_q.erase(reference_q_it);
-                } else {
-                    reference_q_it->waiting_on_requests = std::move(waiting_on_requests_updated);
-                    reference_q_it++;
-                }
-            }
-        }
-    });
 
     uint64_t stuck_counter = 0;
     uint64_t prev_count = 0;
@@ -456,13 +427,56 @@ void BatchedIndexer::run() {
         queue_mutex.cv.notify_one();
     }
 
-    LOG(INFO) << "Notifying reference sequence thread about shutdown...";
-    refq_wait.cv.notify_one();
-    ref_sequence_thread.join();
-
     LOG(INFO) << "Batched indexer threadpool shutdown...";
     thread_pool->shutdown();
     delete thread_pool;
+}
+
+void BatchedIndexer::add_reference_request_with_lock(refq_entry&& ref) {
+    const auto request_id = ref.start_ts;
+    reference_q.emplace_back(std::move(ref));
+    const auto reference_q_it = std::prev(reference_q.end());
+    reference_q_by_request[request_id] = reference_q_it;
+    for (const auto dependency_id : reference_q_it->waiting_on_requests) {
+        reference_waiters[dependency_id].push_back(request_id);
+    }
+}
+
+size_t BatchedIndexer::process_reference_queue_with_lock(const uint64_t completed_request_id) {
+    std::lock_guard lock(mutex);
+    const auto waiters_it = reference_waiters.find(completed_request_id);
+    if (waiters_it == reference_waiters.end()) {
+        return 0;
+    }
+
+    auto affected_waiters = std::move(waiters_it->second);
+    reference_waiters.erase(waiters_it);
+
+    size_t entries_examined = 0;
+    for (const auto waiting_request_id : affected_waiters) {
+        const auto reference_q_index_it = reference_q_by_request.find(waiting_request_id);
+        if (reference_q_index_it == reference_q_by_request.end()) {
+            continue;
+        }
+
+        entries_examined++;
+        const auto reference_q_it = reference_q_index_it->second;
+        reference_q_it->waiting_on_requests.erase(completed_request_id);
+        if (!reference_q_it->waiting_on_requests.empty()) {
+            continue;
+        }
+
+        const auto queue_id = reference_q_it->queue_id;
+        {
+            std::unique_lock qlk(qmutuxes[queue_id].mcv);
+            queues[queue_id].emplace_back(waiting_request_id);
+        }
+        qmutuxes[queue_id].cv.notify_one();
+        reference_q.erase(reference_q_it);
+        reference_q_by_request.erase(reference_q_index_it);
+    }
+
+    return entries_examined;
 }
 
 std::string BatchedIndexer::get_req_prefix_key(uint64_t req_id) {
@@ -545,6 +559,11 @@ void BatchedIndexer::serialize_state(nlohmann::json& state) {
         state["reference_q"].push_back(ref_req_obj);
     }
 
+    state["collection_request_tails"] = nlohmann::json::object();
+    for (const auto& [coll_name, request_id] : collection_request_tails) {
+        state["collection_request_tails"][coll_name] = request_id;
+    }
+
     LOG(INFO) << "Serialized " << num_reqs_stored << " in-flight requests for snapshot.";
 }
 
@@ -559,6 +578,13 @@ void BatchedIndexer::load_state(const nlohmann::json& state) {
     const int64_t persisted_queued_writes = state.contains("queued_writes") ?
                                                 state["queued_writes"].get<int64_t>() : 0;
     queued_writes = 0;
+    {
+        std::unique_lock lk(mutex);
+        reference_q.clear();
+        reference_q_by_request.clear();
+        reference_waiters.clear();
+        collection_request_tails.clear();
+    }
 
     // Tracked alongside `queued_writes` purely for the post-load sanity check below: by the time we log, the
     // restored queues have been notified and a worker may have already decremented the live counter, so we
@@ -623,12 +649,75 @@ void BatchedIndexer::load_state(const nlohmann::json& state) {
 
     if(state.contains("reference_q")) {
         std::unique_lock lk(mutex);
+
+        // Preserve the complete persisted graph while compacting individual entries below. A dependency is safe to
+        // remove only when another dependency is known to wait on it; request ordering alone does not prove coverage
+        // because a main-queue request might have bypassed an older request blocked in `reference_q`.
+        std::unordered_map<uint64_t, std::unordered_set<uint64_t>> persisted_dependencies;
+        for (const auto& item : state["reference_q"].items()) {
+            const nlohmann::json& ref_entry = item.value();
+            if (!ref_entry.contains("waiting_on_requests")) {
+                continue;
+            }
+
+            auto& dependencies = persisted_dependencies[ref_entry["start_ts"].get<uint64_t>()];
+            for (const auto& waiting_on_req_id : ref_entry["waiting_on_requests"]) {
+                const auto dependency_id = waiting_on_req_id.get<uint64_t>();
+                const auto dependency_it = req_res_map.find(dependency_id);
+                if (dependency_it != req_res_map.end() && dependency_it->second.is_complete) {
+                    dependencies.insert(dependency_id);
+                }
+            }
+        }
+
         for(const auto& item: state["reference_q"].items()) {
             const nlohmann::json& ref_entry = item.value();
             refq_entry ref(ref_entry["queue_id"], ref_entry["start_ts"]);
             if (ref_entry.contains("waiting_on_requests")) {
-                for (const auto& waiting_on_req_id : ref_entry["waiting_on_requests"]) {
-                    ref.waiting_on_requests.insert(waiting_on_req_id.get<uint64_t>());
+                // Legacy snapshots can contain the transitive closure of every earlier related request. Reduce each
+                // collection to its independent dependency frontier. Unlike choosing the logically latest request,
+                // this keeps multiple same-collection dependencies when none is proven to cover another.
+                std::unordered_map<std::string, std::unordered_set<uint64_t>> dependency_frontiers;
+                const auto restored_dependencies_it =
+                    persisted_dependencies.find(ref_entry["start_ts"].get<uint64_t>());
+                if (restored_dependencies_it != persisted_dependencies.end()) {
+                    for (const auto dependency_id : restored_dependencies_it->second) {
+                        const auto& dependency_collection =
+                            get_collection_name(req_res_map.at(dependency_id).req);
+                        auto& frontier = dependency_frontiers[dependency_collection];
+                        bool is_covered = false;
+                        for (const auto frontier_dependency_id : frontier) {
+                            const auto frontier_dependencies_it =
+                                persisted_dependencies.find(frontier_dependency_id);
+                            if (frontier_dependencies_it != persisted_dependencies.end() &&
+                                frontier_dependencies_it->second.count(dependency_id) != 0) {
+                                is_covered = true;
+                                break;
+                            }
+                        }
+                        if (is_covered) {
+                            continue;
+                        }
+
+                        // Iteration order is unspecified. If the new dependency covers an entry already retained in
+                        // the frontier, replace that covered entry so the result does not depend on JSON/set order.
+                        const auto dependency_dependencies_it = persisted_dependencies.find(dependency_id);
+                        if (dependency_dependencies_it != persisted_dependencies.end()) {
+                            for (auto frontier_it = frontier.begin(); frontier_it != frontier.end();) {
+                                if (dependency_dependencies_it->second.count(*frontier_it) != 0) {
+                                    frontier_it = frontier.erase(frontier_it);
+                                } else {
+                                    ++frontier_it;
+                                }
+                            }
+                        }
+                        frontier.insert(dependency_id);
+                    }
+                }
+
+                for (const auto& dependency_frontier : dependency_frontiers) {
+                    ref.waiting_on_requests.insert(dependency_frontier.second.begin(),
+                                                   dependency_frontier.second.end());
                 }
             } else {
                 // For backwards compatibility since `ref_entry["waiting_on_requests"]` will not be present in previous
@@ -637,27 +726,73 @@ void BatchedIndexer::load_state(const nlohmann::json& state) {
                 if (req_res_it != req_res_map.end()) {
                     const auto& req = req_res_it->second.req;
                     const std::string& coll_name = get_collection_name(req);
-                    ref.waiting_on_requests = get_requests_to_wait_on(ref.start_ts, coll_name);
+                    ref.waiting_on_requests = get_requests_to_wait_on(ref.start_ts, coll_name, true);
                 }
             }
-            reference_q.emplace_back(std::move(ref));
+            if (ref.waiting_on_requests.empty()) {
+                queue_ids.insert(ref.queue_id);
+                std::unique_lock qlk(qmutuxes[ref.queue_id].mcv);
+                queues[ref.queue_id].emplace_back(ref.start_ts);
+            } else {
+                add_reference_request_with_lock(std::move(ref));
+            }
+        }
+    }
+
+    {
+        std::unique_lock lk(mutex);
+        if (state.contains("collection_request_tails")) {
+            for (const auto& item : state["collection_request_tails"].items()) {
+                const auto request_id = item.value().get<uint64_t>();
+                if (req_res_map.count(request_id) != 0) {
+                    collection_request_tails[item.key()] = request_id;
+                }
+            }
         }
 
-        lk.unlock();
-        refq_wait.cv.notify_one();
+        // Older snapshots did not persist collection tails. Reconstruct any missing collection in the same total
+        // order used by the main queues below, without overwriting authoritative tails from a newer snapshot.
+        std::unordered_map<std::string, uint64_t> reconstructed_tails;
+        for (const auto& [request_id, req_res] : req_res_map) {
+            if (!req_res.is_complete) {
+                continue;
+            }
+
+            const auto& coll_name = get_collection_name(req_res.req);
+            if (coll_name.empty() || collection_request_tails.count(coll_name) != 0) {
+                continue;
+            }
+
+            const auto tail_it = reconstructed_tails.find(coll_name);
+            if (tail_it == reconstructed_tails.end()) {
+                reconstructed_tails[coll_name] = request_id;
+                continue;
+            }
+
+            const auto& existing_tail = req_res_map.at(tail_it->second);
+            if (is_request_earlier(existing_tail.latest_chunk_log_index, existing_tail.last_updated, tail_it->second,
+                                   req_res.latest_chunk_log_index, req_res.last_updated, request_id)) {
+                tail_it->second = request_id;
+            }
+        }
+        collection_request_tails.insert(reconstructed_tails.begin(), reconstructed_tails.end());
     }
 
     std::unordered_map<uint64_t, std::pair<uint64_t, uint64_t>> restored_request_order;
+    std::unordered_map<uint64_t, std::string> restored_request_collections;
+    std::unordered_map<std::string, uint64_t> restored_collection_tails;
     {
         std::unique_lock lk(mutex);
         for (const auto& [req_id, req_res] : req_res_map) {
-            const uint64_t log_index = req_res.latest_chunk_log_index;
-            restored_request_order.emplace(req_id, std::make_pair(log_index, req_id));
+            restored_request_order.emplace(req_id,
+                                           std::make_pair(req_res.latest_chunk_log_index, req_res.last_updated));
+            restored_request_collections.emplace(req_id, get_collection_name(req_res.req));
         }
+        restored_collection_tails = collection_request_tails;
     }
 
-    // Replay the restored per-collection queues in the same order as live writes: prefer raft log order when
-    // present, and fall back to start_ts for older serialized requests that do not have log indices.
+    // Replay the restored per-collection queues in the same total order used for reference dependencies: indexed
+    // requests in raft log order, followed by legacy requests in last_updated and then start_ts order.
     for(auto queue_id: queue_ids) {
         std::unique_lock lk(qmutuxes[queue_id].mcv);
         std::sort(queues[queue_id].begin(), queues[queue_id].end(),
@@ -665,18 +800,31 @@ void BatchedIndexer::load_state(const nlohmann::json& state) {
                       const auto lhs_it = restored_request_order.find(lhs);
                       const auto rhs_it = restored_request_order.find(rhs);
 
-                      const auto [lhs_log_order, lhs_req_id] = (lhs_it != restored_request_order.end()) ?
-                                             lhs_it->second : std::make_pair(UINT64_MAX, lhs);
-                      const auto [rhs_log_order, rhs_req_id] = (rhs_it != restored_request_order.end()) ?
-                                             rhs_it->second : std::make_pair(UINT64_MAX, rhs);
+                      const auto [lhs_log_index, lhs_last_updated] = (lhs_it != restored_request_order.end()) ?
+                                             lhs_it->second : std::make_pair(uint64_t{0}, uint64_t{0});
+                      const auto [rhs_log_index, rhs_last_updated] = (rhs_it != restored_request_order.end()) ?
+                                             rhs_it->second : std::make_pair(uint64_t{0}, uint64_t{0});
 
-                      const bool has_log_order = lhs_log_order != UINT64_MAX && rhs_log_order != UINT64_MAX;
-                      if (has_log_order && lhs_log_order != rhs_log_order) {
-                          return lhs_log_order < rhs_log_order;
-                      }
-
-                      return lhs_req_id < rhs_req_id;
+                      return is_request_earlier(lhs_log_index, lhs_last_updated, lhs,
+                                                rhs_log_index, rhs_last_updated, rhs);
                   });
+
+        // A persisted tail records actual enqueue order, which can differ from the total fallback order for a mix of
+        // legacy and indexed requests. Keep every tail after the other main-queue entries for its collection.
+        std::deque<uint64_t> non_tail_requests;
+        std::deque<uint64_t> tail_requests;
+        for (const auto request_id : queues[queue_id]) {
+            const auto coll_it = restored_request_collections.find(request_id);
+            const auto tail_it = coll_it == restored_request_collections.end() ? restored_collection_tails.end() :
+                                 restored_collection_tails.find(coll_it->second);
+            if (tail_it != restored_collection_tails.end() && tail_it->second == request_id) {
+                tail_requests.push_back(request_id);
+            } else {
+                non_tail_requests.push_back(request_id);
+            }
+        }
+        non_tail_requests.insert(non_tail_requests.end(), tail_requests.begin(), tail_requests.end());
+        queues[queue_id] = std::move(non_tail_requests);
         qmutuxes[queue_id].cv.notify_one();
     }
 
@@ -707,7 +855,7 @@ void BatchedIndexer::clear_skip_indices() {
 
 void BatchedIndexer::update_coll_to_references(const std::shared_ptr<http_req>& req, const std::string& coll_name) {
     route_path* found_rpath = nullptr;
-    const bool route_found = server->get_route(req->route_hash, &found_rpath);
+    const bool route_found = server != nullptr && server->get_route(req->route_hash, &found_rpath);
     if (!route_found || (found_rpath->handler != post_create_collection &&
                          found_rpath->handler != patch_update_collection &&
                          found_rpath->handler != post_import_documents)) {
@@ -788,8 +936,23 @@ std::unordered_set<uint64_t> BatchedIndexer::get_requests_to_wait_on_with_lock(c
     return get_requests_to_wait_on(req_id, coll_name);
 }
 
+bool BatchedIndexer::is_request_earlier(const uint64_t lhs_latest_chunk_log_index, const uint64_t lhs_last_updated,
+                                        const uint64_t lhs_req_id, const uint64_t rhs_latest_chunk_log_index,
+                                        const uint64_t rhs_last_updated, const uint64_t rhs_req_id) {
+    const auto order_key = [](const uint64_t latest_chunk_log_index, const uint64_t last_updated,
+                              const uint64_t req_id) {
+        const bool is_legacy_request = latest_chunk_log_index == 0;
+        const uint64_t order = is_legacy_request ? last_updated : latest_chunk_log_index;
+        return std::make_tuple(is_legacy_request, order, req_id);
+    };
+
+    return order_key(lhs_latest_chunk_log_index, lhs_last_updated, lhs_req_id) <
+           order_key(rhs_latest_chunk_log_index, rhs_last_updated, rhs_req_id);
+}
+
 std::unordered_set<uint64_t> BatchedIndexer::get_requests_to_wait_on(const uint64_t req_id,
-                                                                     const std::string& coll_name) {
+                                                                     const std::string& coll_name,
+                                                                     const bool use_order_fallback) {
     std::unordered_set<std::string> processed_collections;
     std::queue<std::string> pending_collections;
     std::unordered_set<std::string> wait_for_collections;
@@ -828,44 +991,74 @@ std::unordered_set<uint64_t> BatchedIndexer::get_requests_to_wait_on(const uint6
     }
 
     wait_for_collections.insert(processed_collections.begin(), processed_collections.end());
-    if (wait_for_collections.empty()) {
+    const bool has_related_collections = !wait_for_collections.empty();
+    if (coll_name.empty()) {
         return {};
     }
-
-    // Requests waiting in `reference_q` temporarily leave the collection's main queue, so later writes to the
-    // same collection must wait on them as well to preserve per-collection ordering.
-    wait_for_collections.insert(coll_name);
 
     const auto current_req_it = req_res_map.find(req_id);
     if (current_req_it == req_res_map.end()) {
         return {};
     }
 
-    const auto current_req_last_log_index = current_req_it->second.latest_chunk_log_index;
-    std::unordered_set<uint64_t> wait_on_request_ids;
-    for (const auto& [other_req_id, other_req_res] : req_res_map) {
-        // We won't wait on requests whose last chunk has still not been received.
-        if (!other_req_res.is_complete) {
-            continue;
-        }
-        const auto& other_req_last_log_index = other_req_res.latest_chunk_log_index;
-        const bool has_log_order = current_req_last_log_index != 0 && other_req_last_log_index != 0;
-        const auto& other_req_last_updated = other_req_res.last_updated;
-        const auto& current_req_last_updated = current_req_it->second.last_updated;
-        const bool is_earlier_request = has_log_order ? (other_req_last_log_index < current_req_last_log_index)
-                                                      : (other_req_last_updated < current_req_last_updated ||
-                                                         (other_req_last_updated == current_req_last_updated &&
-                                                            other_req_id < req_id));
-        if (!is_earlier_request) {
-            continue;
+    const auto find_collection_tail = [&](const std::string& collection_name) {
+        const auto tail_it = collection_request_tails.find(collection_name);
+        if (tail_it != collection_request_tails.end() && tail_it->second != req_id) {
+            const auto tail_req_it = req_res_map.find(tail_it->second);
+            if (tail_req_it != req_res_map.end() && tail_req_it->second.is_complete) {
+                // Persisted tails describe actual queue order, which can intentionally differ from logical request
+                // order after a request is released from `reference_q`.
+                return std::make_pair(true, tail_it->second);
+            }
         }
 
-        const auto& ref_coll_name = get_collection_name(other_req_res.req);
-        if (wait_for_collections.count(ref_coll_name) == 0) {
-            continue;
+        if (!use_order_fallback) {
+            return std::make_pair(false, uint64_t{0});
         }
-        wait_on_request_ids.insert(other_req_id);
+
+        // Snapshots from versions without collection tails need a bounded fallback. Select only the latest logically
+        // earlier request for this collection; live enqueueing always uses the O(1) tail above.
+        bool found = false;
+        uint64_t selected_request_id = 0;
+        for (const auto& [other_req_id, other_req_res] : req_res_map) {
+            if (other_req_id == req_id || !other_req_res.is_complete ||
+                get_collection_name(other_req_res.req) != collection_name ||
+                !is_request_earlier(other_req_res.latest_chunk_log_index, other_req_res.last_updated, other_req_id,
+                                    current_req_it->second.latest_chunk_log_index,
+                                    current_req_it->second.last_updated, req_id)) {
+                continue;
+            }
+
+            if (!found) {
+                found = true;
+                selected_request_id = other_req_id;
+                continue;
+            }
+
+            const auto& selected_req_res = req_res_map.at(selected_request_id);
+            if (is_request_earlier(selected_req_res.latest_chunk_log_index, selected_req_res.last_updated,
+                                   selected_request_id, other_req_res.latest_chunk_log_index,
+                                   other_req_res.last_updated, other_req_id)) {
+                selected_request_id = other_req_id;
+            }
+        }
+        return std::make_pair(found, selected_request_id);
+    };
+
+    // Direct tails form the ordering chain, so the dependency count is bounded by the number of related collections
+    // instead of the number of pending requests.
+    std::unordered_set<uint64_t> wait_on_request_ids;
+    for (const auto& related_collection_name : wait_for_collections) {
+        const auto [found, tail_request_id] = find_collection_tail(related_collection_name);
+        if (found) {
+            wait_on_request_ids.insert(tail_request_id);
+        }
     }
 
+    const auto [found_own_tail, own_tail_request_id] = find_collection_tail(coll_name);
+    if (found_own_tail &&
+        (has_related_collections || reference_q_by_request.count(own_tail_request_id) != 0)) {
+        wait_on_request_ids.insert(own_tail_request_id);
+    }
     return wait_on_request_ids;
 }

--- a/src/raft_server.cpp
+++ b/src/raft_server.cpp
@@ -661,7 +661,7 @@ void ReplicationState::on_snapshot_save(braft::SnapshotWriter* writer, braft::Cl
     bthread_start_urgent(&tid, NULL, save_snapshot, arg);
 }
 
-int ReplicationState::init_db() {
+int ReplicationState::init_db(const bool batched_indexer_workers_paused) {
     LOG(INFO) << "Loading collections from disk...";
 
     Option<bool> init_op = CollectionManager::get_instance().load(
@@ -687,9 +687,23 @@ int ReplicationState::init_db() {
         LOG(INFO) << "Initializing batched indexer from snapshot state...";
         std::string batched_indexer_state_str;
         StoreStatus s = store->get(BATCHED_INDEXER_STATE_KEY, batched_indexer_state_str);
-        if(s == FOUND) {
-            nlohmann::json batch_indexer_state = nlohmann::json::parse(batched_indexer_state_str);
-            batched_indexer->load_state(batch_indexer_state);
+
+        const auto restore_batched_indexer = [&]() {
+            if(s == FOUND) {
+                nlohmann::json batch_indexer_state = nlohmann::json::parse(batched_indexer_state_str);
+                batched_indexer->load_state_unlocked(batch_indexer_state);
+            } else {
+                // The incoming store is authoritative. A snapshot from an older version might not contain batched
+                // indexer state at all, in which case no state from the replaced store may survive.
+                batched_indexer->clear_state_unlocked();
+            }
+        };
+
+        if(batched_indexer_workers_paused) {
+            restore_batched_indexer();
+        } else {
+            std::unique_lock lifecycle_lock(batched_indexer->lifecycle_mutex);
+            restore_batched_indexer();
         }
     }
 
@@ -714,6 +728,14 @@ int ReplicationState::on_snapshot_load(braft::SnapshotReader* reader) {
     read_caught_up = false;
     write_caught_up = false;
 
+    // Batch workers can retain request-map references and RocksDB iterators after dequeueing. Stop enqueue, worker,
+    // and GC activity before replacing the store, and keep it stopped until the in-memory indexer state has also
+    // been replaced.
+    std::unique_lock<std::shared_mutex> batched_indexer_lifecycle_lock;
+    if(batched_indexer != nullptr) {
+        batched_indexer_lifecycle_lock = std::unique_lock<std::shared_mutex>(batched_indexer->lifecycle_mutex);
+    }
+
     // Load snapshot from leader, replacing the running StateMachine
     std::string analytics_snapshot_path = reader->get_path();
     analytics_snapshot_path.append(std::string("/") + analytics_db_snapshot_name);
@@ -736,7 +758,7 @@ int ReplicationState::on_snapshot_load(braft::SnapshotReader* reader) {
         return reload_store;
     }
 
-    bool init_db_status = init_db();
+    bool init_db_status = init_db(true);
 
     return init_db_status;
 }

--- a/src/raft_server.cpp
+++ b/src/raft_server.cpp
@@ -724,6 +724,12 @@ int ReplicationState::on_snapshot_load(braft::SnapshotReader* reader) {
 
     LOG(INFO) << "on_snapshot_load";
 
+    // `refresh_catchup_status` runs independently of braft snapshot callbacks. Serialize it with installation so it
+    // cannot republish readiness from a stale raft status while the Store and in-memory state are being replaced.
+    // A failed installation deliberately leaves the gate closed until a later snapshot succeeds.
+    std::unique_lock snapshot_load_lock(snapshot_load_mutex);
+    snapshot_load_blocks_readiness = true;
+
     // ensures that reads and writes are rejected, as `store->reload()` unique locks the DB handle
     read_caught_up = false;
     write_caught_up = false;
@@ -758,7 +764,12 @@ int ReplicationState::on_snapshot_load(braft::SnapshotReader* reader) {
         return reload_store;
     }
 
-    bool init_db_status = init_db(true);
+    const int init_db_status = init_db(true);
+    if(init_db_status == 0) {
+        read_caught_up = false;
+        write_caught_up = false;
+        snapshot_load_blocks_readiness = false;
+    }
 
     return init_db_status;
 }
@@ -815,6 +826,12 @@ void ReplicationState::refresh_nodes(const std::string & nodes, const size_t raf
 }
 
 void ReplicationState::refresh_catchup_status(bool log_msg) {
+    std::shared_lock snapshot_load_lock(snapshot_load_mutex);
+    if(snapshot_load_blocks_readiness) {
+        read_caught_up = write_caught_up = false;
+        return;
+    }
+
     std::shared_lock lock(node_mutex);
     if(node == nullptr ) {
         read_caught_up = write_caught_up = false;
@@ -930,6 +947,7 @@ ReplicationState::ReplicationState(HttpServer* server, BatchedIndexer* batched_i
         num_collections_parallel_load(num_collections_parallel_load),
         num_documents_parallel_load(num_documents_parallel_load),
         read_caught_up(false), write_caught_up(false),
+        snapshot_load_blocks_readiness(false),
         ready(false), shutting_down(false), pending_writes(0), snapshot_in_progress(false),
         last_snapshot_ts(std::time(nullptr)), snapshot_interval_s(config->get_snapshot_interval_seconds()) {
 

--- a/src/raft_server.cpp
+++ b/src/raft_server.cpp
@@ -687,23 +687,10 @@ int ReplicationState::init_db(const bool batched_indexer_workers_paused) {
         LOG(INFO) << "Initializing batched indexer from snapshot state...";
         std::string batched_indexer_state_str;
         StoreStatus s = store->get(BATCHED_INDEXER_STATE_KEY, batched_indexer_state_str);
-
-        const auto restore_batched_indexer = [&]() {
-            if(s == FOUND) {
-                nlohmann::json batch_indexer_state = nlohmann::json::parse(batched_indexer_state_str);
-                batched_indexer->load_state_unlocked(batch_indexer_state);
-            } else {
-                // The incoming store is authoritative. A snapshot from an older version might not contain batched
-                // indexer state at all, in which case no state from the replaced store may survive.
-                batched_indexer->clear_state_unlocked();
-            }
-        };
-
-        if(batched_indexer_workers_paused) {
-            restore_batched_indexer();
-        } else {
-            std::unique_lock lifecycle_lock(batched_indexer->lifecycle_mutex);
-            restore_batched_indexer();
+        const int restore_status =
+            restore_batched_indexer_state(s, batched_indexer_state_str, batched_indexer_workers_paused);
+        if(restore_status != 0) {
+            return restore_status;
         }
     }
 
@@ -715,6 +702,64 @@ int ReplicationState::init_db(const bool batched_indexer_workers_paused) {
     }
 
     return 0;
+}
+
+int ReplicationState::restore_batched_indexer_state(const StoreStatus status, const std::string& state,
+                                                    const bool batched_indexer_workers_paused) {
+    if(batched_indexer == nullptr) {
+        return 0;
+    }
+
+    const auto restore = [&]() {
+        if(status == StoreStatus::ERROR) {
+            LOG(ERROR) << "Failed to read batched indexer state from the incoming store.";
+            batched_indexer->clear_state_unlocked();
+            return 1;
+        }
+
+        if(status == StoreStatus::NOT_FOUND) {
+            // The incoming store is authoritative. A snapshot from an older version might not contain batched
+            // indexer state at all, in which case no state from the replaced store may survive.
+            batched_indexer->clear_state_unlocked();
+            return 0;
+        }
+
+        try {
+            const auto batch_indexer_state = nlohmann::json::parse(state, nullptr, false);
+            if(batch_indexer_state.is_discarded() || !batch_indexer_state.is_object() ||
+               !batch_indexer_state.contains("req_res_map") ||
+               !batch_indexer_state["req_res_map"].is_object()) {
+                LOG(ERROR) << "Invalid batched indexer state in the incoming store.";
+                batched_indexer->clear_state_unlocked();
+                return 1;
+            }
+
+            batched_indexer->load_state_unlocked(batch_indexer_state);
+            return 0;
+        } catch(const std::exception& e) {
+            LOG(ERROR) << "Failed to restore batched indexer state: " << e.what();
+            // A nested type error can be detected after restoration has begun. Do not expose that partial state.
+            batched_indexer->clear_state_unlocked();
+            return 1;
+        }
+    };
+
+    if(batched_indexer_workers_paused) {
+        return restore();
+    }
+
+    std::unique_lock lifecycle_lock(batched_indexer->lifecycle_mutex);
+    return restore();
+}
+
+int ReplicationState::fail_snapshot_load_unlocked(const int status) {
+    snapshot_load_blocks_readiness = true;
+    read_caught_up = false;
+    write_caught_up = false;
+    if(batched_indexer != nullptr) {
+        batched_indexer->clear_state_unlocked();
+    }
+    return status == 0 ? 1 : status;
 }
 
 int ReplicationState::on_snapshot_load(braft::SnapshotReader* reader) {
@@ -752,7 +797,7 @@ int ReplicationState::on_snapshot_load(braft::SnapshotReader* reader) {
                                                    Config::get_instance().get_analytics_db_ttl());
         if (reload_store != 0) {
             LOG(ERROR) << "Failed to reload analytics db snapshot.";
-            return reload_store;
+            return fail_snapshot_load_unlocked(reload_store);
         }
     }
 
@@ -761,17 +806,18 @@ int ReplicationState::on_snapshot_load(braft::SnapshotReader* reader) {
 
     int reload_store = store->reload(true, db_snapshot_path);
     if(reload_store != 0) {
-        return reload_store;
+        return fail_snapshot_load_unlocked(reload_store);
     }
 
     const int init_db_status = init_db(true);
-    if(init_db_status == 0) {
-        read_caught_up = false;
-        write_caught_up = false;
-        snapshot_load_blocks_readiness = false;
+    if(init_db_status != 0) {
+        return fail_snapshot_load_unlocked(init_db_status);
     }
 
-    return init_db_status;
+    read_caught_up = false;
+    write_caught_up = false;
+    snapshot_load_blocks_readiness = false;
+    return 0;
 }
 
 void ReplicationState::refresh_nodes(const std::string & nodes, const size_t raft_counter,

--- a/src/raft_server.cpp
+++ b/src/raft_server.cpp
@@ -725,10 +725,19 @@ int ReplicationState::restore_batched_indexer_state(const StoreStatus status, co
         }
 
         try {
-            const auto batch_indexer_state = nlohmann::json::parse(state, nullptr, false);
+            auto batch_indexer_state = nlohmann::json::parse(state, nullptr, false);
             if(batch_indexer_state.is_discarded() || !batch_indexer_state.is_object() ||
-               !batch_indexer_state.contains("req_res_map") ||
-               !batch_indexer_state["req_res_map"].is_object()) {
+               !batch_indexer_state.contains("req_res_map")) {
+                LOG(ERROR) << "Invalid batched indexer state in the incoming store.";
+                batched_indexer->clear_state_unlocked();
+                return 1;
+            }
+
+            // Empty request maps were serialized as JSON null before they were explicitly initialized as objects.
+            // Treat that legacy representation as an empty map so existing snapshots remain restorable.
+            if(batch_indexer_state["req_res_map"].is_null()) {
+                batch_indexer_state["req_res_map"] = nlohmann::json::object();
+            } else if(!batch_indexer_state["req_res_map"].is_object()) {
                 LOG(ERROR) << "Invalid batched indexer state in the incoming store.";
                 batched_indexer->clear_state_unlocked();
                 return 1;

--- a/test/batched_indexer_test.cpp
+++ b/test/batched_indexer_test.cpp
@@ -7,6 +7,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include "string_utils.h"
+
 #define private public
 #include "batched_indexer.h"
 #undef private
@@ -521,6 +523,98 @@ TEST(BatchedIndexerTest, PreservesIndependentSameCollectionDependenciesWhenMigra
     };
 
     EXPECT_TRUE(has_dependency_path(40, 20));
+}
+
+TEST(BatchedIndexerTest, KeepsReplayedRequestBehindBlockedSameCollectionRequestAfterLegacyRestore) {
+    std::atomic<bool> skip_writes(false);
+    auto& config = Config::get_instance();
+
+    constexpr size_t num_threads = 4;
+    const std::string collection = "orders";
+    const auto queue_id_for = [](const std::string& collection_name) {
+        return StringUtils::hash_wy(collection_name.c_str(), collection_name.size()) % num_threads;
+    };
+    const auto collection_queue_id = queue_id_for(collection);
+
+    // Use a different worker queue for request 10 so request 30 can finish while request 10 is still blocking
+    // request 20.
+    std::string blocker_collection;
+    for (size_t i = 0; i < 100 && blocker_collection.empty(); i++) {
+        const auto candidate = "inventory_" + std::to_string(i);
+        if (queue_id_for(candidate) != collection_queue_id) {
+            blocker_collection = candidate;
+        }
+    }
+    ASSERT_FALSE(blocker_collection.empty());
+
+    BatchedIndexer source_indexer(nullptr, nullptr, nullptr, num_threads, config, skip_writes);
+    const auto add_request = [&source_indexer](const uint64_t request_id, const std::string& collection_name,
+                                               const bool is_complete) {
+        auto req = make_req(request_id, request_id, collection_name);
+        source_indexer.req_res_map.emplace(
+            request_id, BatchedIndexer::req_res_t(request_id, "", req, make_res(), request_id,
+                                                  1, 0, is_complete, request_id));
+    };
+
+    add_request(10, blocker_collection, true);
+    add_request(20, collection, true);
+    add_request(30, collection, true);
+    add_request(40, collection, false);
+
+    // This is state produced by an older version during a reference-topology gap: request 20 remained blocked while
+    // request 30 from the same collection bypassed it. Request 40 had not finished replay when the snapshot was taken.
+    BatchedIndexer::refq_entry blocked_request(collection_queue_id, 20);
+    blocked_request.waiting_on_requests.insert(10);
+    source_indexer.reference_q.emplace_back(std::move(blocked_request));
+    source_indexer.queued_writes = 3;
+
+    nlohmann::json legacy_state;
+    source_indexer.serialize_state(legacy_state);
+    legacy_state.erase("collection_request_tails");
+
+    BatchedIndexer restored_indexer(nullptr, nullptr, nullptr, num_threads, config, skip_writes);
+    restored_indexer.load_state(legacy_state);
+
+    // Requests 10 and 30 have been dequeued by their separate workers but are still in progress.
+    for (auto& queue : restored_indexer.queues) {
+        queue.clear();
+    }
+
+    // Finish replaying request 40 using the same dependency selection and queue placement as enqueue().
+    {
+        std::unique_lock lk(restored_indexer.mutex);
+        restored_indexer.req_res_map.at(40).is_complete = true;
+        auto waiting_on_requests = restored_indexer.get_requests_to_wait_on(40, collection);
+        restored_indexer.collection_request_tails[collection] = 40;
+        if (waiting_on_requests.empty()) {
+            restored_indexer.queues[collection_queue_id].emplace_back(40);
+        } else {
+            BatchedIndexer::refq_entry replayed_request(collection_queue_id, 40);
+            replayed_request.waiting_on_requests = std::move(waiting_on_requests);
+            restored_indexer.add_reference_request(std::move(replayed_request));
+        }
+    }
+
+    // Request 30 finishes first. Request 40 must remain blocked because request 20 will be appended after 30.
+    {
+        std::unique_lock lk(restored_indexer.mutex);
+        restored_indexer.req_res_map.erase(30);
+    }
+    restored_indexer.process_reference_queue_with_lock(30);
+    EXPECT_TRUE(restored_indexer.queues[collection_queue_id].empty());
+
+    // Once request 10 finishes, request 20 is the next same-collection write. Request 40 must still wait for it.
+    {
+        std::unique_lock lk(restored_indexer.mutex);
+        restored_indexer.req_res_map.erase(10);
+    }
+    restored_indexer.process_reference_queue_with_lock(10);
+
+    ASSERT_EQ(1, restored_indexer.queues[collection_queue_id].size());
+    EXPECT_EQ(20, restored_indexer.queues[collection_queue_id].front());
+    const auto replayed_request_it = restored_indexer.reference_q_by_request.find(40);
+    ASSERT_NE(restored_indexer.reference_q_by_request.end(), replayed_request_it);
+    EXPECT_EQ(1, replayed_request_it->second->waiting_on_requests.count(20));
 }
 
 TEST(BatchedIndexerTest, SerializesLatestChunkLogIndex) {

--- a/test/batched_indexer_test.cpp
+++ b/test/batched_indexer_test.cpp
@@ -123,7 +123,7 @@ TEST(BatchedIndexerTest, RevisitsOnlyReferenceWaitersAffectedByCompletion) {
 
             BatchedIndexer::refq_entry ref(0, request_id);
             ref.waiting_on_requests.insert(request_id - 1);
-            indexer.add_reference_request_with_lock(std::move(ref));
+            indexer.add_reference_request(std::move(ref));
         }
         indexer.req_res_map.erase(1);
     }
@@ -154,7 +154,7 @@ TEST(BatchedIndexerTest, ReleasesIndexedReferenceWaiterAfterEveryDependencyCompl
         BatchedIndexer::refq_entry ref(0, 30);
         ref.waiting_on_requests.insert(10);
         ref.waiting_on_requests.insert(20);
-        indexer.add_reference_request_with_lock(std::move(ref));
+        indexer.add_reference_request(std::move(ref));
         indexer.req_res_map.erase(10);
     }
 
@@ -192,7 +192,7 @@ TEST(BatchedIndexerTest, ReleasesAffectedReferenceWaitersInQueueOrder) {
         for (const auto request_id : {uint64_t{20}, uint64_t{30}}) {
             BatchedIndexer::refq_entry ref(0, request_id);
             ref.waiting_on_requests.insert(10);
-            indexer.add_reference_request_with_lock(std::move(ref));
+            indexer.add_reference_request(std::move(ref));
         }
         indexer.req_res_map.erase(10);
     }
@@ -264,7 +264,7 @@ TEST(BatchedIndexerTest, ChainsSameCollectionRequestsThroughReferenceQueueTail) 
         std::unique_lock lk(indexer.mutex);
         BatchedIndexer::refq_entry ref(0, 20);
         ref.waiting_on_requests.insert(10);
-        indexer.add_reference_request_with_lock(std::move(ref));
+        indexer.add_reference_request(std::move(ref));
     }
     indexer.collection_request_tails["orders"] = 20;
 

--- a/test/batched_indexer_test.cpp
+++ b/test/batched_indexer_test.cpp
@@ -449,6 +449,74 @@ TEST(BatchedIndexerTest, MigratesLegacySnapshotDependenciesToBoundedCollectionTa
     EXPECT_EQ(backlog_size, migrated_state["collection_request_tails"]["orders"].get<uint64_t>());
 }
 
+TEST(BatchedIndexerTest, MigratesLegacyMainQueueDependenciesToBoundedCollectionTails) {
+    std::atomic<bool> skip_writes(false);
+    auto& config = Config::get_instance();
+    BatchedIndexer source_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+
+    constexpr uint64_t backlog_size = 64;
+    constexpr uint64_t waiter_count = 64;
+    constexpr uint64_t waiter_offset = 1000;
+    for (uint64_t request_id = 1; request_id <= backlog_size; request_id++) {
+        auto req = make_req(request_id, request_id, "products");
+        source_indexer.req_res_map.emplace(
+            request_id, BatchedIndexer::req_res_t(request_id, "", req, make_res(), request_id,
+                                                  1, 0, true, request_id));
+    }
+
+    for (uint64_t i = 1; i <= waiter_count; i++) {
+        const auto request_id = waiter_offset + i;
+        auto req = make_req(request_id, request_id, "links");
+        source_indexer.req_res_map.emplace(
+            request_id, BatchedIndexer::req_res_t(request_id, "", req, make_res(), request_id,
+                                                  1, 0, true, request_id));
+
+        BatchedIndexer::refq_entry ref(0, request_id);
+        for (uint64_t predecessor_id = 1; predecessor_id <= backlog_size; predecessor_id++) {
+            ref.waiting_on_requests.insert(predecessor_id);
+        }
+        source_indexer.reference_q.emplace_back(std::move(ref));
+    }
+    source_indexer.queued_writes = backlog_size + waiter_count;
+
+    nlohmann::json legacy_state;
+    source_indexer.serialize_state(legacy_state);
+    legacy_state.erase("collection_request_tails");
+
+    BatchedIndexer restored_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+    restored_indexer.load_state(legacy_state);
+
+    size_t restored_dependency_count = 0;
+    size_t restored_product_dependency_count = 0;
+    for (const auto& ref : restored_indexer.reference_q) {
+        restored_dependency_count += ref.waiting_on_requests.size();
+        for (const auto dependency_id : ref.waiting_on_requests) {
+            if (dependency_id <= backlog_size) {
+                restored_product_dependency_count++;
+            }
+        }
+    }
+
+    size_t indexed_dependency_count = 0;
+    for (const auto& dependency_waiters : restored_indexer.reference_waiters) {
+        indexed_dependency_count += dependency_waiters.second.size();
+    }
+
+    // Every legacy waiter originally contained the full products closure. Since products replay through one FIFO
+    // worker queue, waiting on that queue's restored tail transitively covers the other product requests.
+    EXPECT_LE(restored_product_dependency_count, waiter_count);
+    EXPECT_LE(restored_dependency_count, (2 * waiter_count) - 1);
+    EXPECT_EQ(restored_dependency_count, indexed_dependency_count);
+
+    nlohmann::json migrated_state;
+    restored_indexer.serialize_state(migrated_state);
+    size_t serialized_dependency_count = 0;
+    for (const auto& ref : migrated_state["reference_q"]) {
+        serialized_dependency_count += ref["waiting_on_requests"].size();
+    }
+    EXPECT_LE(serialized_dependency_count, (2 * waiter_count) - 1);
+}
+
 TEST(BatchedIndexerTest, PreservesIndependentSameCollectionDependenciesWhenMigratingLegacySnapshot) {
     std::atomic<bool> skip_writes(false);
     auto& config = Config::get_instance();
@@ -523,6 +591,7 @@ TEST(BatchedIndexerTest, PreservesIndependentSameCollectionDependenciesWhenMigra
     };
 
     EXPECT_TRUE(has_dependency_path(40, 20));
+    EXPECT_TRUE(has_dependency_path(40, 30));
 }
 
 TEST(BatchedIndexerTest, KeepsReplayedRequestBehindBlockedSameCollectionRequestAfterLegacyRestore) {

--- a/test/batched_indexer_test.cpp
+++ b/test/batched_indexer_test.cpp
@@ -617,6 +617,54 @@ TEST(BatchedIndexerTest, KeepsReplayedRequestBehindBlockedSameCollectionRequestA
     EXPECT_EQ(1, replayed_request_it->second->waiting_on_requests.count(20));
 }
 
+TEST(BatchedIndexerTest, ReplacesExistingStateWhenLoadingSnapshot) {
+    std::atomic<bool> skip_writes(false);
+    auto& config = Config::get_instance();
+
+    BatchedIndexer snapshot_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+    auto snapshot_req = make_req(30, 30, "snapshot_collection");
+    snapshot_indexer.req_res_map.emplace(
+        30, BatchedIndexer::req_res_t(30, "", snapshot_req, make_res(), 30, 1, 0, true, 30));
+    snapshot_indexer.collection_request_tails["snapshot_collection"] = 30;
+    snapshot_indexer.queued_writes = 1;
+
+    nlohmann::json snapshot_state;
+    snapshot_indexer.serialize_state(snapshot_state);
+
+    BatchedIndexer restored_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+    auto blocked_req = make_req(10, 10, "stale_collection");
+    auto queued_req = make_req(20, 20, "stale_collection");
+    restored_indexer.req_res_map.emplace(
+        10, BatchedIndexer::req_res_t(10, "", blocked_req, make_res(), 10, 1, 0, true, 10));
+    restored_indexer.req_res_map.emplace(
+        20, BatchedIndexer::req_res_t(20, "", queued_req, make_res(), 20, 1, 0, true, 20));
+
+    BatchedIndexer::refq_entry stale_blocked_request(0, 10);
+    stale_blocked_request.waiting_on_requests.insert(99);
+    restored_indexer.add_reference_request(std::move(stale_blocked_request));
+    restored_indexer.queues[0].emplace_back(20);
+    restored_indexer.collection_request_tails["stale_collection"] = 10;
+    restored_indexer.coll_to_references["stale_collection"] = {"removed_reference"};
+    restored_indexer.queued_writes = 2;
+
+    restored_indexer.load_state(snapshot_state);
+
+    ASSERT_EQ(1, restored_indexer.req_res_map.size());
+    EXPECT_EQ(1, restored_indexer.req_res_map.count(30));
+    EXPECT_EQ(0, restored_indexer.req_res_map.count(10));
+    EXPECT_EQ(0, restored_indexer.req_res_map.count(20));
+
+    ASSERT_EQ(1, restored_indexer.queues[0].size());
+    EXPECT_EQ(30, restored_indexer.queues[0].front());
+    EXPECT_TRUE(restored_indexer.reference_q.empty());
+    EXPECT_TRUE(restored_indexer.reference_q_by_request.empty());
+    EXPECT_TRUE(restored_indexer.reference_waiters.empty());
+    EXPECT_EQ(0, restored_indexer.coll_to_references.count("stale_collection"));
+    EXPECT_EQ(1, restored_indexer.queued_writes.load());
+    ASSERT_EQ(1, restored_indexer.collection_request_tails.size());
+    EXPECT_EQ(30, restored_indexer.collection_request_tails.at("snapshot_collection"));
+}
+
 TEST(BatchedIndexerTest, SerializesLatestChunkLogIndex) {
     std::atomic<bool> skip_writes(false);
     auto& config = Config::get_instance();

--- a/test/batched_indexer_test.cpp
+++ b/test/batched_indexer_test.cpp
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <chrono>
+#include <future>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -703,10 +705,13 @@ TEST(BatchedIndexerTest, ReplacesExistingStateWhenLoadingSnapshot) {
     BatchedIndexer restored_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
     auto blocked_req = make_req(10, 10, "stale_collection");
     auto queued_req = make_req(20, 20, "stale_collection");
+    auto queued_res = make_res();
+    queued_res->is_alive = true;
+    queued_res->final = false;
     restored_indexer.req_res_map.emplace(
         10, BatchedIndexer::req_res_t(10, "", blocked_req, make_res(), 10, 1, 0, true, 10));
     restored_indexer.req_res_map.emplace(
-        20, BatchedIndexer::req_res_t(20, "", queued_req, make_res(), 20, 1, 0, true, 20));
+        20, BatchedIndexer::req_res_t(20, "", queued_req, queued_res, 20, 1, 0, true, 20));
 
     BatchedIndexer::refq_entry stale_blocked_request(0, 10);
     stale_blocked_request.waiting_on_requests.insert(99);
@@ -732,6 +737,42 @@ TEST(BatchedIndexerTest, ReplacesExistingStateWhenLoadingSnapshot) {
     EXPECT_EQ(1, restored_indexer.queued_writes.load());
     ASSERT_EQ(1, restored_indexer.collection_request_tails.size());
     EXPECT_EQ(30, restored_indexer.collection_request_tails.at("snapshot_collection"));
+    EXPECT_EQ(503, queued_res->status_code);
+    EXPECT_TRUE(queued_res->final);
+}
+
+TEST(BatchedIndexerTest, WaitsForActiveWorkBeforeReplacingSnapshotState) {
+    std::atomic<bool> skip_writes(false);
+    auto& config = Config::get_instance();
+
+    BatchedIndexer source_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+    auto snapshot_req = make_req(30, 30, "snapshot_collection");
+    source_indexer.req_res_map.emplace(
+        30, BatchedIndexer::req_res_t(30, "", snapshot_req, make_res(), 30, 1, 0, true, 30));
+    nlohmann::json snapshot_state;
+    source_indexer.serialize_state(snapshot_state);
+
+    BatchedIndexer restored_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+    auto stale_req = make_req(20, 20, "stale_collection");
+    restored_indexer.req_res_map.emplace(
+        20, BatchedIndexer::req_res_t(20, "", stale_req, make_res(), 20, 1, 0, true, 20));
+
+    std::shared_lock active_work(restored_indexer.lifecycle_mutex);
+    std::promise<void> load_started;
+    auto load_started_future = load_started.get_future();
+    auto load = std::async(std::launch::async, [&]() {
+        load_started.set_value();
+        restored_indexer.load_state(snapshot_state);
+    });
+
+    load_started_future.wait();
+    EXPECT_EQ(std::future_status::timeout, load.wait_for(std::chrono::milliseconds(50)));
+    EXPECT_EQ(1, restored_indexer.req_res_map.count(20));
+
+    active_work.unlock();
+    EXPECT_EQ(std::future_status::ready, load.wait_for(std::chrono::seconds(1)));
+    ASSERT_EQ(1, restored_indexer.req_res_map.size());
+    EXPECT_EQ(1, restored_indexer.req_res_map.count(30));
 }
 
 TEST(BatchedIndexerTest, SerializesLatestChunkLogIndex) {

--- a/test/batched_indexer_test.cpp
+++ b/test/batched_indexer_test.cpp
@@ -3,6 +3,9 @@
 #include <atomic>
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #define private public
 #include "batched_indexer.h"
@@ -47,11 +50,477 @@ TEST(BatchedIndexerTest, UsesLatestChunkLogIndexForReferenceDependencies) {
     req_res.is_complete = true;
     indexer.req_res_map.emplace(later_req->start_ts, req_res);
 
-    const auto wait_on = indexer.get_requests_to_wait_on(current_req->start_ts, "product_vehicle_fitments_se");
+    const auto wait_on = indexer.get_requests_to_wait_on(current_req->start_ts,
+                                                          "product_vehicle_fitments_se", true);
 
     EXPECT_EQ(1, wait_on.size());
     EXPECT_EQ(1, wait_on.count(earlier_req->start_ts));
     EXPECT_EQ(0, wait_on.count(later_req->start_ts));
+}
+
+TEST(BatchedIndexerTest, KeepsRelatedRequestDependenciesBoundedByCollectionTails) {
+    std::atomic<bool> skip_writes(false);
+    auto& config = Config::get_instance();
+    BatchedIndexer indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+
+    indexer.coll_to_references["link_a"] = {"products"};
+    indexer.coll_to_references["link_b"] = {"products"};
+    indexer.coll_to_references["link_c"] = {"products"};
+
+    const auto add_request = [&indexer](const uint64_t start_ts, const int64_t log_index,
+                                        const std::string& collection) {
+        auto req = make_req(start_ts, log_index, collection);
+        indexer.req_res_map.emplace(start_ts,
+                                    BatchedIndexer::req_res_t(start_ts, "", req, make_res(), 0, 1, 0, true,
+                                                              log_index));
+    };
+
+    constexpr uint64_t backlog_size = 64;
+    constexpr uint64_t link_a_offset = 1000;
+    constexpr uint64_t link_b_offset = 2000;
+    constexpr uint64_t link_c_offset = 3000;
+    for (uint64_t i = 1; i <= backlog_size; i++) {
+        add_request(i, i, "products");
+        add_request(link_a_offset + i, link_a_offset + i, "link_a");
+        add_request(link_b_offset + i, link_b_offset + i, "link_b");
+        add_request(link_c_offset + i, link_c_offset + i, "link_c");
+    }
+    indexer.collection_request_tails["products"] = backlog_size;
+    indexer.collection_request_tails["link_a"] = link_a_offset + backlog_size;
+    indexer.collection_request_tails["link_b"] = link_b_offset + backlog_size;
+    indexer.collection_request_tails["link_c"] = link_c_offset + backlog_size;
+
+    constexpr uint64_t current_request_id = 10000;
+    add_request(current_request_id, current_request_id, "products");
+
+    const auto wait_on = indexer.get_requests_to_wait_on(current_request_id, "products");
+
+    // The backlog length must not affect dependency-set size. The tail of each relevant collection already carries
+    // the ordering chain for all of its predecessors.
+    EXPECT_EQ(4, wait_on.size());
+    EXPECT_EQ(1, wait_on.count(backlog_size));
+    EXPECT_EQ(1, wait_on.count(link_a_offset + backlog_size));
+    EXPECT_EQ(1, wait_on.count(link_b_offset + backlog_size));
+    EXPECT_EQ(1, wait_on.count(link_c_offset + backlog_size));
+}
+
+TEST(BatchedIndexerTest, RevisitsOnlyReferenceWaitersAffectedByCompletion) {
+    std::atomic<bool> skip_writes(false);
+    auto& config = Config::get_instance();
+    BatchedIndexer indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+
+    constexpr uint64_t backlog_size = 64;
+    {
+        std::unique_lock lk(indexer.mutex);
+        for (uint64_t request_id = 1; request_id <= backlog_size; request_id++) {
+            auto req = make_req(request_id, request_id, "orders");
+            indexer.req_res_map.emplace(request_id,
+                                        BatchedIndexer::req_res_t(request_id, "", req, make_res(), request_id,
+                                                                  1, 0, true, request_id));
+            if (request_id == 1) {
+                continue;
+            }
+
+            BatchedIndexer::refq_entry ref(0, request_id);
+            ref.waiting_on_requests.insert(request_id - 1);
+            indexer.add_reference_request_with_lock(std::move(ref));
+        }
+        indexer.req_res_map.erase(1);
+    }
+
+    // Completing request 1 affects only request 2. An indexed waiter lookup should not revisit requests 3 through 64.
+    const auto entries_examined = indexer.process_reference_queue_with_lock(1);
+
+    EXPECT_EQ(1, entries_examined);
+    ASSERT_EQ(1, indexer.queues[0].size());
+    EXPECT_EQ(2, indexer.queues[0].front());
+    EXPECT_EQ(backlog_size - 2, indexer.reference_q.size());
+}
+
+TEST(BatchedIndexerTest, ReleasesIndexedReferenceWaiterAfterEveryDependencyCompletes) {
+    std::atomic<bool> skip_writes(false);
+    auto& config = Config::get_instance();
+    BatchedIndexer indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+
+    {
+        std::unique_lock lk(indexer.mutex);
+        for (const auto request_id : {uint64_t{10}, uint64_t{20}, uint64_t{30}}) {
+            auto req = make_req(request_id, request_id, "orders");
+            indexer.req_res_map.emplace(request_id,
+                                        BatchedIndexer::req_res_t(request_id, "", req, make_res(), request_id,
+                                                                  1, 0, true, request_id));
+        }
+
+        BatchedIndexer::refq_entry ref(0, 30);
+        ref.waiting_on_requests.insert(10);
+        ref.waiting_on_requests.insert(20);
+        indexer.add_reference_request_with_lock(std::move(ref));
+        indexer.req_res_map.erase(10);
+    }
+
+    EXPECT_EQ(1, indexer.process_reference_queue_with_lock(10));
+    EXPECT_TRUE(indexer.queues[0].empty());
+    ASSERT_EQ(1, indexer.reference_q.size());
+    EXPECT_EQ(1, indexer.reference_q.front().waiting_on_requests.count(20));
+
+    {
+        std::unique_lock lk(indexer.mutex);
+        indexer.req_res_map.erase(20);
+    }
+    EXPECT_EQ(1, indexer.process_reference_queue_with_lock(20));
+    EXPECT_TRUE(indexer.reference_q.empty());
+    EXPECT_TRUE(indexer.reference_q_by_request.empty());
+    EXPECT_TRUE(indexer.reference_waiters.empty());
+    ASSERT_EQ(1, indexer.queues[0].size());
+    EXPECT_EQ(30, indexer.queues[0].front());
+}
+
+TEST(BatchedIndexerTest, ReleasesAffectedReferenceWaitersInQueueOrder) {
+    std::atomic<bool> skip_writes(false);
+    auto& config = Config::get_instance();
+    BatchedIndexer indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+
+    {
+        std::unique_lock lk(indexer.mutex);
+        for (const auto request_id : {uint64_t{10}, uint64_t{20}, uint64_t{30}}) {
+            auto req = make_req(request_id, request_id, "orders");
+            indexer.req_res_map.emplace(request_id,
+                                        BatchedIndexer::req_res_t(request_id, "", req, make_res(), request_id,
+                                                                  1, 0, true, request_id));
+        }
+
+        for (const auto request_id : {uint64_t{20}, uint64_t{30}}) {
+            BatchedIndexer::refq_entry ref(0, request_id);
+            ref.waiting_on_requests.insert(10);
+            indexer.add_reference_request_with_lock(std::move(ref));
+        }
+        indexer.req_res_map.erase(10);
+    }
+
+    EXPECT_EQ(2, indexer.process_reference_queue_with_lock(10));
+    ASSERT_EQ(2, indexer.queues[0].size());
+    EXPECT_EQ(20, indexer.queues[0][0]);
+    EXPECT_EQ(30, indexer.queues[0][1]);
+}
+
+TEST(BatchedIndexerTest, WaitsOnReorderedQueueTailAfterReferenceRequestIsReleased) {
+    std::atomic<bool> skip_writes(false);
+    auto& config = Config::get_instance();
+    BatchedIndexer indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+
+    const auto add_request = [&indexer](const uint64_t start_ts, const std::string& collection) {
+        auto req = make_req(start_ts, start_ts, collection);
+        indexer.req_res_map.emplace(start_ts,
+                                    BatchedIndexer::req_res_t(start_ts, "", req, make_res(), start_ts,
+                                                              1, 0, true, start_ts));
+    };
+
+    // Request 20 entered the reference queue while orders referenced inventory and was blocked on request 10. Request
+    // 30 bypassed it while the reference was absent, modeling state produced before that gap was prevented.
+    add_request(10, "inventory");
+    add_request(20, "orders");
+    BatchedIndexer::refq_entry blocked_request(0, 20);
+    blocked_request.waiting_on_requests.insert(10);
+    indexer.reference_q.emplace_back(std::move(blocked_request));
+
+    add_request(30, "orders");
+    indexer.queues[0].emplace_back(30);
+
+    // Once request 10 completes, request 20 leaves reference_q and is appended behind request 30. Its logical request
+    // order is older, but it is now the physical tail that a related request must wait for.
+    indexer.req_res_map.erase(10);
+    indexer.queues[0].emplace_back(20);
+    indexer.reference_q.clear();
+    indexer.collection_request_tails["orders"] = 20;
+    ASSERT_EQ(2, indexer.queues[0].size());
+    EXPECT_EQ(30, indexer.queues[0][0]);
+    EXPECT_EQ(20, indexer.queues[0][1]);
+
+    indexer.coll_to_references["orders"] = {"products"};
+    add_request(40, "products");
+
+    const auto wait_on = indexer.get_requests_to_wait_on(40, "products");
+
+    EXPECT_EQ(1, wait_on.size());
+    EXPECT_EQ(1, wait_on.count(20));
+    EXPECT_EQ(0, wait_on.count(30));
+}
+
+TEST(BatchedIndexerTest, ChainsSameCollectionRequestsThroughReferenceQueueTail) {
+    std::atomic<bool> skip_writes(false);
+    auto& config = Config::get_instance();
+    BatchedIndexer indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+
+    const auto add_request = [&indexer](const uint64_t request_id) {
+        auto req = make_req(request_id, request_id, "orders");
+        indexer.req_res_map.emplace(request_id,
+                                    BatchedIndexer::req_res_t(request_id, "", req, make_res(), request_id,
+                                                              1, 0, true, request_id));
+    };
+
+    add_request(10);
+    add_request(20);
+    {
+        std::unique_lock lk(indexer.mutex);
+        BatchedIndexer::refq_entry ref(0, 20);
+        ref.waiting_on_requests.insert(10);
+        indexer.add_reference_request_with_lock(std::move(ref));
+    }
+    indexer.collection_request_tails["orders"] = 20;
+
+    // Even if a schema update temporarily removes every reference, request 30 must extend request 20's explicit
+    // chain instead of entering the collection's main queue ahead of it.
+    add_request(30);
+    const auto wait_on = indexer.get_requests_to_wait_on(30, "orders");
+
+    ASSERT_EQ(1, wait_on.size());
+    EXPECT_EQ(1, wait_on.count(20));
+}
+
+TEST(BatchedIndexerTest, OrdersMixedLogIndexRequestsTransitively) {
+    // Pair-dependent ordering previously compared A and B by raft log index but pairs involving legacy request C
+    // by last_updated, producing A < B < C < A. The total request order must not contain that cycle (or its
+    // reverse), since it is used by std::sort and to select the latest predecessor for a collection.
+    constexpr uint64_t a_log_index = 10;
+    constexpr uint64_t a_last_updated = 30;
+    constexpr uint64_t a_req_id = 1;
+    constexpr uint64_t b_log_index = 20;
+    constexpr uint64_t b_last_updated = 10;
+    constexpr uint64_t b_req_id = 2;
+    constexpr uint64_t c_log_index = 0;
+    constexpr uint64_t c_last_updated = 20;
+    constexpr uint64_t c_req_id = 3;
+
+    const bool a_before_b = BatchedIndexer::is_request_earlier(a_log_index, a_last_updated, a_req_id,
+                                                                b_log_index, b_last_updated, b_req_id);
+    const bool b_before_a = BatchedIndexer::is_request_earlier(b_log_index, b_last_updated, b_req_id,
+                                                                a_log_index, a_last_updated, a_req_id);
+    const bool b_before_c = BatchedIndexer::is_request_earlier(b_log_index, b_last_updated, b_req_id,
+                                                                c_log_index, c_last_updated, c_req_id);
+    const bool c_before_b = BatchedIndexer::is_request_earlier(c_log_index, c_last_updated, c_req_id,
+                                                                b_log_index, b_last_updated, b_req_id);
+    const bool c_before_a = BatchedIndexer::is_request_earlier(c_log_index, c_last_updated, c_req_id,
+                                                                a_log_index, a_last_updated, a_req_id);
+    const bool a_before_c = BatchedIndexer::is_request_earlier(a_log_index, a_last_updated, a_req_id,
+                                                                c_log_index, c_last_updated, c_req_id);
+
+    EXPECT_FALSE((a_before_b && b_before_c && c_before_a) ||
+                 (b_before_a && c_before_b && a_before_c));
+}
+
+TEST(BatchedIndexerTest, RestoresMixedLogIndexRequestsInReferenceDependencyOrder) {
+    std::atomic<bool> skip_writes(false);
+    auto& config = Config::get_instance();
+    BatchedIndexer source_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+
+    const auto add_request = [&source_indexer](const uint64_t start_ts, const int64_t log_index,
+                                                const uint64_t last_updated, const std::string& collection) {
+        auto req = make_req(start_ts, log_index, collection);
+        source_indexer.req_res_map.emplace(start_ts,
+                                           BatchedIndexer::req_res_t(start_ts, "", req, make_res(), last_updated,
+                                                                     1, 0, true, log_index));
+    };
+
+    // The legacy request has no raft log index but was updated later, so it is the latest dependency. A restart
+    // must not replay it before the older, raft-indexed request merely because zero sorts before a real log index.
+    add_request(10, 0, 30, "products");
+    add_request(20, 80, 10, "products");
+    add_request(30, 0, 40, "link_a");
+
+    nlohmann::json state;
+    source_indexer.serialize_state(state);
+
+    BatchedIndexer restored_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+    restored_indexer.load_state(state);
+    restored_indexer.coll_to_references["link_a"] = {"products"};
+
+    const auto wait_on = restored_indexer.get_requests_to_wait_on(30, "link_a");
+    EXPECT_EQ(1, wait_on.size());
+    EXPECT_EQ(1, wait_on.count(10));
+    EXPECT_EQ(0, wait_on.count(20));
+
+    const auto& restored_queue = restored_indexer.queues[0];
+    ASSERT_EQ(3, restored_queue.size());
+    EXPECT_EQ(20, restored_queue[0]);
+    EXPECT_EQ(10, restored_queue[1]);
+    EXPECT_EQ(30, restored_queue[2]);
+}
+
+TEST(BatchedIndexerTest, KeepsPersistedCollectionTailLastAfterMixedOrderRestore) {
+    std::atomic<bool> skip_writes(false);
+    auto& config = Config::get_instance();
+    BatchedIndexer source_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+
+    const auto add_request = [&source_indexer](const uint64_t request_id, const int64_t log_index,
+                                                const uint64_t last_updated) {
+        auto req = make_req(request_id, log_index, "products");
+        source_indexer.req_res_map.emplace(request_id,
+                                           BatchedIndexer::req_res_t(request_id, "", req, make_res(), last_updated,
+                                                                     1, 0, true, log_index));
+    };
+
+    add_request(10, 0, 30);
+    add_request(20, 80, 10);
+    source_indexer.collection_request_tails["products"] = 20;
+
+    nlohmann::json state;
+    source_indexer.serialize_state(state);
+
+    BatchedIndexer restored_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+    restored_indexer.load_state(state);
+
+    const auto& restored_queue = restored_indexer.queues[0];
+    ASSERT_EQ(2, restored_queue.size());
+    EXPECT_EQ(10, restored_queue[0]);
+    EXPECT_EQ(20, restored_queue[1]);
+    EXPECT_EQ(20, restored_indexer.collection_request_tails.at("products"));
+}
+
+TEST(BatchedIndexerTest, MigratesLegacySnapshotDependenciesToBoundedCollectionTails) {
+    std::atomic<bool> skip_writes(false);
+    auto& config = Config::get_instance();
+    BatchedIndexer source_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+
+    constexpr uint64_t backlog_size = 64;
+    for (uint64_t request_id = 1; request_id <= backlog_size; request_id++) {
+        auto req = make_req(request_id, request_id, "orders");
+        source_indexer.req_res_map.emplace(request_id,
+                                           BatchedIndexer::req_res_t(request_id, "", req, make_res(), request_id,
+                                                                     1, 0, true, request_id));
+
+        if (request_id == 1) {
+            continue;
+        }
+
+        BatchedIndexer::refq_entry ref(0, request_id);
+        for (uint64_t predecessor_id = 1; predecessor_id < request_id; predecessor_id++) {
+            ref.waiting_on_requests.insert(predecessor_id);
+        }
+        source_indexer.reference_q.emplace_back(std::move(ref));
+    }
+    source_indexer.queued_writes = backlog_size;
+
+    nlohmann::json legacy_state;
+    source_indexer.serialize_state(legacy_state);
+    legacy_state.erase("collection_request_tails");
+
+    BatchedIndexer restored_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+    restored_indexer.load_state(legacy_state);
+
+    size_t restored_dependency_count = 0;
+    size_t restored_max_dependencies = 0;
+    for (const auto& ref : restored_indexer.reference_q) {
+        restored_dependency_count += ref.waiting_on_requests.size();
+        if (ref.waiting_on_requests.size() > restored_max_dependencies) {
+            restored_max_dependencies = ref.waiting_on_requests.size();
+        }
+    }
+
+    size_t indexed_dependency_count = 0;
+    for (const auto& dependency_waiters : restored_indexer.reference_waiters) {
+        indexed_dependency_count += dependency_waiters.second.size();
+    }
+
+    EXPECT_LE(restored_dependency_count, backlog_size - 1);
+    EXPECT_LE(restored_max_dependencies, 1);
+    EXPECT_EQ(restored_dependency_count, indexed_dependency_count);
+    EXPECT_EQ(restored_indexer.reference_q.size(), restored_indexer.reference_q_by_request.size());
+    ASSERT_FALSE(restored_indexer.reference_q.empty());
+    EXPECT_EQ(1, restored_indexer.reference_q.back().waiting_on_requests.count(backlog_size - 1));
+
+    nlohmann::json migrated_state;
+    restored_indexer.serialize_state(migrated_state);
+
+    size_t serialized_dependency_count = 0;
+    size_t serialized_max_dependencies = 0;
+    for (const auto& ref : migrated_state["reference_q"]) {
+        const auto dependency_count = ref["waiting_on_requests"].size();
+        serialized_dependency_count += dependency_count;
+        if (dependency_count > serialized_max_dependencies) {
+            serialized_max_dependencies = dependency_count;
+        }
+    }
+
+    EXPECT_LE(serialized_dependency_count, backlog_size - 1);
+    EXPECT_LE(serialized_max_dependencies, 1);
+    EXPECT_TRUE(migrated_state.contains("collection_request_tails"));
+    EXPECT_EQ(backlog_size, migrated_state["collection_request_tails"]["orders"].get<uint64_t>());
+}
+
+TEST(BatchedIndexerTest, PreservesIndependentSameCollectionDependenciesWhenMigratingLegacySnapshot) {
+    std::atomic<bool> skip_writes(false);
+    auto& config = Config::get_instance();
+    BatchedIndexer source_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+
+    const auto add_request = [&source_indexer](const uint64_t request_id, const std::string& collection) {
+        auto req = make_req(request_id, request_id, collection);
+        source_indexer.req_res_map.emplace(request_id,
+                                           BatchedIndexer::req_res_t(request_id, "", req, make_res(), request_id,
+                                                                     1, 0, true, request_id));
+    };
+
+    add_request(10, "inventory");
+    add_request(20, "orders");
+    add_request(30, "orders");
+    add_request(40, "orders");
+
+    // Request 20 was blocked while orders referenced inventory. During a topology gap, request 30 bypassed it and
+    // entered the main queue. Once the reference was restored, request 40 had to wait on both independent requests.
+    BatchedIndexer::refq_entry blocked_request(0, 20);
+    blocked_request.waiting_on_requests.insert(10);
+    source_indexer.reference_q.emplace_back(std::move(blocked_request));
+
+    BatchedIndexer::refq_entry follower_request(0, 40);
+    follower_request.waiting_on_requests.insert(20);
+    follower_request.waiting_on_requests.insert(30);
+    source_indexer.reference_q.emplace_back(std::move(follower_request));
+    source_indexer.queued_writes = 4;
+
+    nlohmann::json legacy_state;
+    source_indexer.serialize_state(legacy_state);
+    legacy_state.erase("collection_request_tails");
+
+    BatchedIndexer restored_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+    restored_indexer.load_state(legacy_state);
+
+    std::unordered_map<uint64_t, std::unordered_set<uint64_t>> restored_dependencies;
+    for (const auto& ref : restored_indexer.reference_q) {
+        restored_dependencies.emplace(ref.start_ts, ref.waiting_on_requests);
+    }
+
+    ASSERT_EQ(1, restored_dependencies.count(20));
+    ASSERT_EQ(1, restored_dependencies.at(20).count(10));
+    ASSERT_EQ(1, restored_dependencies.count(40));
+
+    // Migration may retain 20 directly or make 30 depend on 20 before reducing request 40 to the tail. Either way,
+    // the restored dependency graph must still contain a path from request 40 to independently blocked request 20.
+    const auto has_dependency_path = [&restored_dependencies](const uint64_t request_id,
+                                                               const uint64_t dependency_id) {
+        std::unordered_set<uint64_t> visited;
+        std::vector<uint64_t> pending{request_id};
+        while (!pending.empty()) {
+            const auto current_request_id = pending.back();
+            pending.pop_back();
+            if (!visited.insert(current_request_id).second) {
+                continue;
+            }
+
+            const auto dependencies_it = restored_dependencies.find(current_request_id);
+            if (dependencies_it == restored_dependencies.end()) {
+                continue;
+            }
+
+            for (const auto current_dependency_id : dependencies_it->second) {
+                if (current_dependency_id == dependency_id) {
+                    return true;
+                }
+                pending.push_back(current_dependency_id);
+            }
+        }
+        return false;
+    };
+
+    EXPECT_TRUE(has_dependency_path(40, 20));
 }
 
 TEST(BatchedIndexerTest, SerializesLatestChunkLogIndex) {
@@ -62,10 +531,16 @@ TEST(BatchedIndexerTest, SerializesLatestChunkLogIndex) {
     auto req = make_req(123, 10, "products_se");
     indexer.req_res_map.emplace(req->start_ts,
                                 BatchedIndexer::req_res_t(req->start_ts, "", req, make_res(), 0, 2, 1, true, 25));
+    indexer.collection_request_tails["products_se"] = req->start_ts;
 
     nlohmann::json state;
     indexer.serialize_state(state);
 
     const auto& req_state = state["req_res_map"][std::to_string(req->start_ts)];
     EXPECT_EQ(25, req_state["latest_chunk_log_index"].get<uint64_t>());
+    EXPECT_EQ(req->start_ts, state["collection_request_tails"]["products_se"].get<uint64_t>());
+
+    BatchedIndexer restored_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+    restored_indexer.load_state(state);
+    EXPECT_EQ(req->start_ts, restored_indexer.collection_request_tails.at("products_se"));
 }

--- a/test/raft_server_test.cpp
+++ b/test/raft_server_test.cpp
@@ -1,6 +1,11 @@
 #include <gtest/gtest.h>
+#include <chrono>
+#include <future>
 #include <string>
+
+#define private public
 #include "raft_server.h"
+#undef private
 
 namespace {
     bool matches_either_ip_version(const std::string& result, 
@@ -23,6 +28,30 @@ namespace {
         struct sockaddr_in6 sa;
         return inet_pton(AF_INET6, ipv6.c_str(), &(sa.sin6_addr)) != 0;
     }
+}
+
+TEST(RaftServerTest, SnapshotLoadGateBlocksReadinessAndCatchupRefresh) {
+    auto& config = Config::get_instance();
+    ReplicationState replication_state(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, false,
+                                       &config, 1, 1);
+
+    replication_state.read_caught_up = true;
+    replication_state.write_caught_up = true;
+    replication_state.snapshot_load_blocks_readiness = true;
+    EXPECT_FALSE(replication_state.is_read_caught_up());
+    EXPECT_FALSE(replication_state.is_write_caught_up());
+
+    std::unique_lock snapshot_load_lock(replication_state.snapshot_load_mutex);
+    replication_state.snapshot_load_blocks_readiness = false;
+    auto refresh = std::async(std::launch::async, [&replication_state]() {
+        replication_state.refresh_catchup_status(false);
+    });
+
+    EXPECT_EQ(std::future_status::timeout, refresh.wait_for(std::chrono::milliseconds(50)));
+    snapshot_load_lock.unlock();
+    EXPECT_EQ(std::future_status::ready, refresh.wait_for(std::chrono::seconds(1)));
+    EXPECT_FALSE(replication_state.is_read_caught_up());
+    EXPECT_FALSE(replication_state.is_write_caught_up());
 }
 
 TEST(RaftServerTest, ResolveNodesConfigWithHostNames) {

--- a/test/raft_server_test.cpp
+++ b/test/raft_server_test.cpp
@@ -128,6 +128,34 @@ TEST(RaftServerTest, RestoresBatchedIndexerStateByStoreStatusAndFailsClosed) {
     EXPECT_FALSE(replication_state.is_write_caught_up());
 }
 
+TEST(RaftServerTest, RestoresEmptyAndLegacyNullBatchedIndexerState) {
+    std::atomic<bool> skip_writes(false);
+    auto& config = Config::get_instance();
+    BatchedIndexer source_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+
+    nlohmann::json empty_state;
+    source_indexer.serialize_state(empty_state);
+    EXPECT_TRUE(empty_state["req_res_map"].is_object());
+    EXPECT_TRUE(empty_state["req_res_map"].empty());
+
+    BatchedIndexer restored_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+    ReplicationState replication_state(nullptr, &restored_indexer, nullptr, nullptr, nullptr, nullptr, false,
+                                       &config, 1, 1);
+    seed_indexer_request(restored_indexer, 10, false);
+    EXPECT_EQ(0, replication_state.restore_batched_indexer_state(
+                     StoreStatus::FOUND, empty_state.dump(), false));
+    EXPECT_TRUE(restored_indexer.req_res_map.empty());
+    EXPECT_TRUE(restored_indexer.queues[0].empty());
+
+    auto legacy_empty_state = empty_state;
+    legacy_empty_state["req_res_map"] = nullptr;
+    seed_indexer_request(restored_indexer, 20, false);
+    EXPECT_EQ(0, replication_state.restore_batched_indexer_state(
+                     StoreStatus::FOUND, legacy_empty_state.dump(), false));
+    EXPECT_TRUE(restored_indexer.req_res_map.empty());
+    EXPECT_TRUE(restored_indexer.queues[0].empty());
+}
+
 TEST(RaftServerTest, ResolveNodesConfigWithHostNames) {
     ASSERT_EQ("127.0.0.1:8107:8108,127.0.0.1:7107:7108,127.0.0.1:6107:6108",
               ReplicationState::resolve_node_hosts("127.0.0.1:8107:8108,127.0.0.1:7107:7108,127.0.0.1:6107:6108"));

--- a/test/raft_server_test.cpp
+++ b/test/raft_server_test.cpp
@@ -8,6 +8,24 @@
 #undef private
 
 namespace {
+    std::shared_ptr<http_res> seed_indexer_request(BatchedIndexer& indexer, const uint64_t request_id,
+                                                   const bool live_response) {
+        auto req = std::make_shared<http_req>();
+        req->start_ts = request_id;
+        req->log_index = request_id;
+        req->params["collection"] = "products";
+
+        auto res = std::make_shared<http_res>(nullptr);
+        res->is_alive = live_response;
+        res->final = !live_response;
+        indexer.req_res_map.emplace(
+            request_id, BatchedIndexer::req_res_t(request_id, "", req, res, request_id,
+                                                  1, 0, true, request_id));
+        indexer.queues[0].emplace_back(request_id);
+        indexer.queued_writes++;
+        return res;
+    }
+
     bool matches_either_ip_version(const std::string& result, 
                                  const std::string& ipv4_version,
                                  const std::string& ipv6_version) {
@@ -50,6 +68,62 @@ TEST(RaftServerTest, SnapshotLoadGateBlocksReadinessAndCatchupRefresh) {
     EXPECT_EQ(std::future_status::timeout, refresh.wait_for(std::chrono::milliseconds(50)));
     snapshot_load_lock.unlock();
     EXPECT_EQ(std::future_status::ready, refresh.wait_for(std::chrono::seconds(1)));
+    EXPECT_FALSE(replication_state.is_read_caught_up());
+    EXPECT_FALSE(replication_state.is_write_caught_up());
+}
+
+TEST(RaftServerTest, RestoresBatchedIndexerStateByStoreStatusAndFailsClosed) {
+    std::atomic<bool> skip_writes(false);
+    auto& config = Config::get_instance();
+    BatchedIndexer indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+    ReplicationState replication_state(nullptr, &indexer, nullptr, nullptr, nullptr, nullptr, false,
+                                       &config, 1, 1);
+
+    auto read_error_res = seed_indexer_request(indexer, 10, true);
+    EXPECT_EQ(1, replication_state.restore_batched_indexer_state(StoreStatus::ERROR, "", false));
+    EXPECT_TRUE(indexer.req_res_map.empty());
+    EXPECT_TRUE(indexer.queues[0].empty());
+    EXPECT_EQ(503, read_error_res->status_code);
+    EXPECT_TRUE(read_error_res->final);
+
+    seed_indexer_request(indexer, 20, false);
+    EXPECT_EQ(0, replication_state.restore_batched_indexer_state(StoreStatus::NOT_FOUND, "", false));
+    EXPECT_TRUE(indexer.req_res_map.empty());
+    EXPECT_TRUE(indexer.queues[0].empty());
+
+    BatchedIndexer source_indexer(nullptr, nullptr, nullptr, 1, config, skip_writes);
+    seed_indexer_request(source_indexer, 30, false);
+    nlohmann::json valid_state;
+    source_indexer.serialize_state(valid_state);
+
+    auto partially_invalid_state = valid_state;
+    partially_invalid_state["req_res_map"]["40"] = {
+        {"start_ts", 40},
+        {"req", 123},
+    };
+    seed_indexer_request(indexer, 20, false);
+    EXPECT_EQ(1, replication_state.restore_batched_indexer_state(
+                     StoreStatus::FOUND, partially_invalid_state.dump(), false));
+    EXPECT_TRUE(indexer.req_res_map.empty());
+    EXPECT_TRUE(indexer.queues[0].empty());
+
+    EXPECT_EQ(0, replication_state.restore_batched_indexer_state(
+                     StoreStatus::FOUND, valid_state.dump(), false));
+    ASSERT_EQ(1, indexer.req_res_map.size());
+    EXPECT_EQ(1, indexer.req_res_map.count(30));
+
+    auto reload_failure_res = seed_indexer_request(indexer, 50, true);
+    replication_state.read_caught_up = true;
+    replication_state.write_caught_up = true;
+    replication_state.snapshot_load_blocks_readiness = false;
+    {
+        std::unique_lock lifecycle_lock(indexer.lifecycle_mutex);
+        EXPECT_EQ(-7, replication_state.fail_snapshot_load_unlocked(-7));
+    }
+    EXPECT_TRUE(indexer.req_res_map.empty());
+    EXPECT_TRUE(indexer.queues[0].empty());
+    EXPECT_EQ(503, reload_failure_res->status_code);
+    EXPECT_TRUE(reload_failure_res->final);
     EXPECT_FALSE(replication_state.is_read_caught_up());
     EXPECT_FALSE(replication_state.is_write_caught_up());
 }


### PR DESCRIPTION
## Change Summary
  - Fixes the follower stall reported in #2992, where async-reference writes could leave the apply pipeline permanently stuck.
  - Replaces repeated full reference_q scans with dependency-to-waiter and request-to-queue-entry indexes. Completion work is now proportional to affected requests.
  - Introduces bounded per-collection dependency chains and consistent ordering across Raft-indexed and legacy writes.
  - Persists collection tails and safely reconstructs them from older snapshots, compacting legacy dependency graphs without losing independent blockers.
  - Makes snapshot installation atomic with batched-indexer activity, preventing workers from retaining stale requests or database iterators.
  - Clears displaced state during restoration and returns 503 for cancelled live requests.
  - Keeps nodes unready if snapshot restoration fails or contains malformed indexer state, reopening readiness only after a successful load.
  - Adds extensive tests for dependency ordering, bounded queue behavior, legacy migration, snapshot replacement, and readiness gating.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
