### PR TITLE
fix(curation): keep filter_by when trigger query contains a stopword

### DIFF
--- a/include/collection.h
+++ b/include/collection.h
@@ -616,6 +616,7 @@ private:
                              std::vector<std::pair<uint32_t, uint32_t>>& included_ids,
                              std::vector<uint32_t>& excluded_ids,
                              std::vector<const curation_t*>& filter_curations,
+                             std::set<const curation_t*>& matched_filter_curations,
                              bool& filter_curated_hits,
                              std::string& curated_sort_by,
                              nlohmann::json& curation_metadata,
@@ -627,6 +628,7 @@ private:
                         const std::vector<std::string>& hidden_hits,
                         std::vector<std::pair<uint32_t, uint32_t>>& included_ids,
                         std::vector<uint32_t>& excluded_ids, std::vector<const curation_t*>& filter_curations,
+                        std::set<const curation_t*>& matched_filter_curations,
                         bool& filter_curated_hits,
                         std::string& curated_sort_by, nlohmann::json& curation_metadata,
                         diversity_t& diversity, bool synonym_prefix, uint32_t synonym_num_typos) const;
@@ -717,6 +719,7 @@ private:
                                         std::string& fallback_field_type);
 
     void process_filter_sort_curations(std::vector<const curation_t*>& filter_curations,
+                                  const std::set<const curation_t*>& matched_filter_curations,
                                   std::vector<std::string>& q_include_tokens,
                                   token_ordering token_order,
                                   std::unique_ptr<filter_node_t>& filter_tree_root,

--- a/include/index.h
+++ b/include/index.h
@@ -539,7 +539,8 @@ private:
                    std::unordered_map<std::string, reference_filter_result_t>* reference_facet_ids) const;
 
     bool static_filter_query_eval(const curation_t* curation, const std::string& curation_normalized_query, std::vector<std::string>& tokens,
-                                  std::unique_ptr<filter_node_t>& filter_tree_root, const bool& validate_field_names) const;
+                                  std::unique_ptr<filter_node_t>& filter_tree_root, const bool& validate_field_names,
+                                  const bool force_apply = false) const;
 
     bool resolve_curation(const std::vector<std::string>& rule_tokens, bool exact_rule_match,
                           const std::vector<std::string>& query_tokens,
@@ -1154,6 +1155,7 @@ public:
                                      int64_t& out_best_field_match_score);
 
     void process_filter_sort_curations(const std::vector<const curation_t*>& filter_curations,
+                                  const std::set<const curation_t*>& matched_filter_curations,
                                   std::vector<std::string>& curation_normalized_queries,
                                   const std::vector<std::set<std::string>>& curation_rule_token_sets,
                                   std::vector<std::string>& query_tokens,

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -1489,6 +1489,25 @@ size_t Collection::batch_index_in_memory(std::vector<index_record>& index_record
     return num_indexed;
 }
 
+// re-tokenizes a curation rule query the same way rule.normalized_query is built at parse time,
+// but with a caller-supplied symbols_to_index. curations are parsed without a collection's symbols,
+// so the stored normalized_query strips symbols_to_index and can match too loosely. passing the
+// collection/field symbols here keeps the match symbol-aware.
+static std::string normalize_curation_rule_query(const std::string& rule_query, const std::string& locale,
+                                                 const std::vector<char>& symbols_to_index,
+                                                 const std::vector<char>& token_separators,
+                                                 std::shared_ptr<Stemmer> stemmer) {
+    std::vector<char> symbols = symbols_to_index;
+    symbols.push_back('{');
+    symbols.push_back('}');
+    symbols.push_back('*');
+    symbols.push_back('.');
+
+    std::vector<std::string> tokens;
+    Tokenizer(rule_query, true, false, locale, symbols, token_separators, stemmer, true).tokenize(tokens);
+    return StringUtils::join(tokens, " ");
+}
+
 bool Collection::does_curation_match(const curation_t& curation, std::string& query,
                                      std::set<uint32_t>& excluded_set,
                                      string& actual_query, const std::string& curation_normalized_query, const string& filter_query,
@@ -1608,9 +1627,26 @@ bool Collection::does_curation_match(const curation_t& curation, std::string& qu
 
     // a static filter rule that matched here must apply even if replace_query or stopword removal
     // later rewrites the query, so remember it instead of re-matching the rewritten query
-    // (sort_by is already carried out of here via curated_sort_by)
+    // (sort_by is already carried out of here via curated_sort_by).
+    //
+    // gate on a symbol-aware re-match: the stored normalized_query strips symbols_to_index and can
+    // match too loosely (rule "non-stick" normalizes to "nonstick" and would otherwise force-apply
+    // on a "nonstick" query for a '-' indexed collection, which static_filter_query_eval rejects).
+    // matches driven purely by synonyms or by rule.filter_by are intentionally not force-applied:
+    // they don't survive the query rewrite in static_filter_query_eval and never did before this.
     if(!curation.rule.dynamic_query && !curation.rule.dynamic_filter && !curation.filter_by.empty()) {
-        matched_filter_curations.insert(&curation);
+        auto stemmer = curation.rule.stem ?
+                StemmerManager::get_instance().get_stemmer(curation.rule.locale, curation.rule.stemming_dictionary) : nullptr;
+        const std::string symbol_aware_query = normalize_curation_rule_query(curation.rule.query, curation.rule.locale,
+                                                                             symbols_to_index, token_separators, stemmer);
+
+        const bool strict_match =
+                (curation.rule.match == curation_t::MATCH_EXACT && symbol_aware_query == query) ||
+                (curation.rule.match == curation_t::MATCH_CONTAINS && StringUtils::contains_word(query, symbol_aware_query));
+
+        if(strict_match) {
+            matched_filter_curations.insert(&curation);
+        }
     }
 
     return true;
@@ -5079,20 +5115,12 @@ void Collection::process_filter_sort_curations(std::vector<const curation_t*>& f
 
     std::vector<const curation_t*> matched_dynamic_curations;
     auto compute_normalized_query = [&](const curation_t& curation) {
-      auto symbols = query_symbols_to_index.empty() ? symbols_to_index : query_symbols_to_index;
-      symbols.push_back('{');
-      symbols.push_back('}');
-      symbols.push_back('*');
-      symbols.push_back('.');
-
+      const auto& symbols = query_symbols_to_index.empty() ? symbols_to_index : query_symbols_to_index;
       const auto& separators = query_token_separators.empty() ? token_separators : query_token_separators;
       const bool use_search_field_stemmer = !curation.rule.dynamic_query && !curation.rule.dynamic_filter;
 
-      std::vector<std::string> tokens;
-      Tokenizer tokenizer(curation.rule.query, true, false, query_locale, symbols, separators,
-                          use_search_field_stemmer ? stemmer : nullptr, true);
-      tokenizer.tokenize(tokens);
-      auto query_normalized = StringUtils::join(tokens, " ");
+      auto query_normalized = normalize_curation_rule_query(curation.rule.query, query_locale, symbols, separators,
+                                                            use_search_field_stemmer ? stemmer : nullptr);
       size_t i = 0;
       while(i < query_normalized.size()) {
           if(query_normalized[i] == '{') {

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -1500,6 +1500,7 @@ bool Collection::does_curation_match(const curation_t& curation, std::string& qu
                                      std::vector<std::pair<uint32_t, uint32_t>>& included_ids,
                                      std::vector<uint32_t>& excluded_ids,
                                      std::vector<const curation_t*>& filter_sort_curations,
+                                     std::set<const curation_t*>& matched_filter_curations,
                                      bool& filter_curated_hits,
                                      std::string& curated_sort_by,
                                      nlohmann::json& curation_metadata,
@@ -1604,6 +1605,14 @@ bool Collection::does_curation_match(const curation_t& curation, std::string& qu
     if(curation_metadata.empty()) {
         curation_metadata = curation.metadata;
     }
+
+    // a static filter rule that matched here must apply even if replace_query or stopword removal
+    // later rewrites the query, so remember it instead of re-matching the rewritten query
+    // (sort_by is already carried out of here via curated_sort_by)
+    if(!curation.rule.dynamic_query && !curation.rule.dynamic_filter && !curation.filter_by.empty()) {
+        matched_filter_curations.insert(&curation);
+    }
+
     return true;
 }
 
@@ -1615,6 +1624,7 @@ Option<bool> Collection::curate_results(string& actual_query, const string& filt
                                 std::vector<std::pair<uint32_t, uint32_t>>& included_ids,
                                 std::vector<uint32_t>& excluded_ids,
                                 std::vector<const curation_t*>& filter_sort_curations,
+                                std::set<const curation_t*>& matched_filter_curations,
                                 bool& filter_curated_hits,
                                 std::string& curated_sort_by,
                                 nlohmann::json& curation_metadata,
@@ -1694,7 +1704,7 @@ Option<bool> Collection::curate_results(string& actual_query, const string& filt
                                                                 ov->rule.normalized_query,
                                                                 filter_query, already_segmented, true, false,
                                                                 pinned_hits, hidden_hits, included_ids,
-                                                                excluded_ids, filter_sort_curations, filter_curated_hits,
+                                                                excluded_ids, filter_sort_curations, matched_filter_curations, filter_curated_hits,
                                                                 curated_sort_by, curation_metadata, ov->rule.synonyms,
                                                                 synonym_prefix, synonym_num_typos);
                           if(match_found) {
@@ -1724,7 +1734,7 @@ Option<bool> Collection::curate_results(string& actual_query, const string& filt
                                                              ov->rule.normalized_query,
                                                             filter_query, already_segmented, true, false,
                                                             pinned_hits, hidden_hits, included_ids,
-                                                            excluded_ids, filter_sort_curations, filter_curated_hits,
+                                                            excluded_ids, filter_sort_curations, matched_filter_curations, filter_curated_hits,
                                                             curated_sort_by, curation_metadata, ov->rule.synonyms,
                                                             synonym_prefix, synonym_num_typos);
                       if(match_found) {
@@ -1763,7 +1773,7 @@ Option<bool> Collection::curate_results(string& actual_query, const string& filt
                   bool match_found = does_curation_match(*ov, query, excluded_set, actual_query, ov->rule.normalized_query, filter_query,
                                                         already_segmented, false, wildcard_tag,
                                                         pinned_hits, hidden_hits, included_ids,
-                                                        excluded_ids, filter_sort_curations, filter_curated_hits,
+                                                        excluded_ids, filter_sort_curations, matched_filter_curations, filter_curated_hits,
                                                         curated_sort_by, curation_metadata, ov->rule.synonyms, synonym_prefix,
                                                         synonym_num_typos);
                   if(match_found) {
@@ -3153,6 +3163,7 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
     StringUtils::split(hidden_hits_str, hidden_hits, ",");
 
     std::vector<const curation_t*> filter_sort_curations;
+    std::set<const curation_t*> matched_filter_curations;
     std::string curated_sort_by;
     std::set<std::string> curation_tag_set;
 
@@ -3166,7 +3177,8 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
 
     diversity_t diversity{};
     auto curate_results_op = curate_results(query, filter_query, enable_curations, pre_segmented_query, curation_tag_set,
-                   pinned_hits, hidden_hits, included_ids, excluded_ids, filter_sort_curations, filter_curated_hits_curations,
+                   pinned_hits, hidden_hits, included_ids, excluded_ids, filter_sort_curations, matched_filter_curations,
+                   filter_curated_hits_curations,
                    curated_sort_by, curation_metadata, diversity, synonym_prefix, synonyms_num_typos);
     if(!curate_results_op.ok()) {
         return curate_results_op;
@@ -3222,7 +3234,7 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
                                field_query_tokens[0].q_exclude_tokens, field_query_tokens[0].q_phrases, "",
                                false, stopwords_set);
 
-            process_filter_sort_curations(filter_sort_curations, q_include_tokens, token_order, filter_tree_root_guard,
+            process_filter_sort_curations(filter_sort_curations, matched_filter_curations, q_include_tokens, token_order, filter_tree_root_guard,
                                      included_ids, excluded_ids, curation_metadata, curated_sort_by, enable_typos_for_numerical_tokens,
                                      enable_typos_for_alpha_numerical_tokens, validate_field_names);
 
@@ -3260,7 +3272,7 @@ Option<bool> Collection::init_index_search_args(collection_search_args_t& coll_a
         // process filter curations first, before synonyms (order is important)
 
         // included_ids, excluded_ids
-        process_filter_sort_curations(filter_sort_curations, q_include_tokens, token_order, filter_tree_root_guard,
+        process_filter_sort_curations(filter_sort_curations, matched_filter_curations, q_include_tokens, token_order, filter_tree_root_guard,
                                  included_ids, excluded_ids, curation_metadata, curated_sort_by, enable_typos_for_numerical_tokens,
                                  enable_typos_for_alpha_numerical_tokens, validate_field_names, field_locale,
                                  most_weighted_field.get_stemmer(), most_weighted_field.symbols_to_index,
@@ -5049,6 +5061,7 @@ void Collection::build_highlight_snapshots(
 }
 
 void Collection::process_filter_sort_curations(std::vector<const curation_t*>& filter_sort_curations,
+                                          const std::set<const curation_t*>& matched_filter_curations,
                                           std::vector<std::string>& q_include_tokens,
                                           token_ordering token_order,
                                           std::unique_ptr<filter_node_t>& filter_tree_root,
@@ -5107,7 +5120,8 @@ void Collection::process_filter_sort_curations(std::vector<const curation_t*>& f
       StringUtils::split(query_normalized, rule_tokens, " ");
       curation_rule_token_sets.emplace_back(rule_tokens.begin(), rule_tokens.end());
     }
-    index->process_filter_sort_curations(filter_sort_curations, curation_normalized_queries, curation_rule_token_sets,
+    index->process_filter_sort_curations(filter_sort_curations, matched_filter_curations, curation_normalized_queries,
+                                    curation_rule_token_sets,
                                     q_include_tokens, token_order, filter_tree_root, matched_dynamic_curations,
                                     curation_metadata, sort_by_clause, enable_typos_for_numerical_tokens,
                                     enable_typos_for_alpha_numerical_tokens, validate_field_names);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2817,14 +2817,15 @@ bool Index::static_filter_query_eval(const curation_t* curation,
                                      const std::string& curation_normalized_query,
                                      std::vector<std::string>& tokens,
                                      std::unique_ptr<filter_node_t>& filter_tree_root,
-                                     const bool& validate_field_names) const {
+                                     const bool& validate_field_names,
+                                     const bool force_apply) const {
     std::string query = StringUtils::join(tokens, " ");
     bool tag_matched = (!curation->rule.tags.empty() && curation->rule.filter_by.empty() &&
                          curation->rule.query.empty());
 
     bool wildcard_tag_matched = (curation->rule.tags.size() == 1 && *curation->rule.tags.begin() == "*");
 
-    if (tag_matched || wildcard_tag_matched ||
+    if (force_apply || tag_matched || wildcard_tag_matched ||
         (curation->rule.match == curation_t::MATCH_EXACT && curation_normalized_query == query) ||
         (curation->rule.match == curation_t::MATCH_CONTAINS &&
          StringUtils::contains_word(query, curation_normalized_query))) {
@@ -2950,6 +2951,7 @@ bool Index::resolve_curation(const std::vector<std::string>& rule_tokens, const 
 }
 
 void Index::process_filter_sort_curations(const std::vector<const curation_t*>& filter_sort_curations,
+                                     const std::set<const curation_t*>& matched_filter_curations,
                                      std::vector<std::string>& curation_normalized_queries,
                                      const std::vector<std::set<std::string>>& curation_rule_token_sets,
                                      std::vector<std::string>& query_tokens,
@@ -2968,14 +2970,18 @@ void Index::process_filter_sort_curations(const std::vector<const curation_t*>& 
         if (!curation->rule.dynamic_query && !curation->rule.dynamic_filter) {
             // Simple static filtering: add to filter_by and rewrite query if needed.
             // Check the original query and then the synonym variants until a rule matches.
+            // A rule already matched during curation (before replace_query/stopword rewrites) is
+            // force applied so it doesn't get silently dropped by re-matching the rewritten query.
+            const bool force_apply = matched_filter_curations.count(curation) != 0;
             bool resolved_curation = static_filter_query_eval(curation, curation_normalized_queries[i], query_tokens, filter_tree_root,
-                                                              validate_field_names);
+                                                              validate_field_names, force_apply);
 
             if (resolved_curation) {
                 if(curation_metadata.empty()) {
                     curation_metadata = curation->metadata;
                 }
-                if (curation->remove_matched_tokens) {
+                // don't strip rule tokens when replace_query already rewrote the query wholesale
+                if (curation->remove_matched_tokens && curation->replace_query.empty()) {
                     remove_matched_tokens(query_tokens, curation_rule_token_sets[i]);
                 }
 

--- a/test/collection_curation_test.cpp
+++ b/test/collection_curation_test.cpp
@@ -987,6 +987,58 @@ TEST_F(CollectionCurationTest, FilterByAppliedWhenTriggerQueryHasStopword) {
     collectionManager.drop_collection("coll1");
 }
 
+TEST_F(CollectionCurationTest, StaticFilterNotForcedWhenSymbolAwareTriggerMismatches) {
+    // curations are parsed without a collection's symbols_to_index, so rule "non-stick" is stored as
+    // normalized_query "nonstick". on a collection that indexes '-', a "nonstick" query must NOT
+    // force-apply the filter: the symbol-aware trigger is "non-stick", which does not match.
+    Collection *coll1;
+    auto& ov_manager = CurationIndexManager::get_instance();
+
+    std::vector<field> fields = {field("name", field_types::STRING, false),
+                                 field("price", field_types::FLOAT, false),
+                                 field("points", field_types::INT32, false)};
+
+    coll1 = collectionManager.get_collection("coll_sym").get();
+    if(coll1 == nullptr) {
+        coll1 = collectionManager.create_collection("coll_sym", 1, fields, "points",
+                                                    static_cast<uint64_t>(std::time(nullptr)), "", {"-"}).get();
+        coll1->set_curation_sets({"index"});
+    }
+
+    nlohmann::json doc1;
+    doc1["id"] = "0"; doc1["name"] = "nonstick pan";   doc1["price"] = 399.99; doc1["points"] = 30;
+    nlohmann::json doc2;
+    doc2["id"] = "1"; doc2["name"] = "nonstick spray"; doc2["price"] = 20.00;  doc2["points"] = 5;
+    ASSERT_TRUE(coll1->add(doc1.dump()).ok());
+    ASSERT_TRUE(coll1->add(doc2.dump()).ok());
+
+    std::vector<sort_by> sort_fields = { sort_by("_text_match", "DESC"), sort_by("points", "DESC") };
+
+    nlohmann::json curation_json = R"({
+       "id": "sym-rule",
+       "rule": { "query": "non-stick", "match": "exact" },
+       "remove_matched_tokens": false,
+       "filter_by": "price:>55"
+    })"_json;
+    ov_manager.upsert_curation_item("index", curation_json);
+
+    auto results = coll1->search("nonstick", {"name"}, "",
+                                 {}, sort_fields, {0}, 10, 1, FREQUENCY,
+                                 {true}, Index::DROP_TOKENS_THRESHOLD,
+                                 spp::sparse_hash_set<std::string>(),
+                                 spp::sparse_hash_set<std::string>(), 10, "", 30, 4, "", 20, {}, {}, {}, 0,
+                                 "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 10000,
+                                 4, 7, fallback, 4, {off}, 100, 100, 2, 2, false, "", true, 0, max_score, 100, 0, 0,
+                                 0, "exhaustive", 30000, 2, "", {}, {}, "right_to_left",
+                                 true, true, false, "", "", "").get();
+
+    // symbol-aware trigger "non-stick" != "nonstick", so the filter is not force-applied: both docs survive
+    ASSERT_EQ(2, results["hits"].size());
+
+    ov_manager.delete_curation_item("index", "sym-rule");
+    collectionManager.drop_collection("coll_sym");
+}
+
 TEST_F(CollectionCurationTest, ReplaceWildcardQueryWithKeyword) {
     Collection *coll1;
     auto& ov_manager = CurationIndexManager::get_instance();

--- a/test/collection_curation_test.cpp
+++ b/test/collection_curation_test.cpp
@@ -8,6 +8,7 @@
 #include "synonym_index.h"
 #include "synonym_index_manager.h"
 #include "curation_index_manager.h"
+#include "stopwords_manager.h"
 
 class CollectionCurationTest : public ::testing::Test {
 protected:
@@ -912,6 +913,78 @@ TEST_F(CollectionCurationTest, ReplaceQuery) {
     curation_json["remove_matched_tokens"] = false;
     op = curation_t::parse(curation_json, "rule-1", curation_rule);
     ASSERT_TRUE(op.ok());
+}
+
+TEST_F(CollectionCurationTest, FilterByAppliedWhenTriggerQueryHasStopword) {
+    Collection *coll1;
+    auto& ov_manager = CurationIndexManager::get_instance();
+    auto& stopwordsManager = StopwordsManager::get_instance();
+    stopwordsManager.init(store);
+
+    std::vector<field> fields = {field("name", field_types::STRING, false),
+                                 field("price", field_types::FLOAT, false),
+                                 field("points", field_types::INT32, false)};
+
+    coll1 = collectionManager.get_collection("coll1").get();
+    if(coll1 == nullptr) {
+        coll1 = collectionManager.create_collection("coll1", 1, fields, "points").get();
+        coll1->set_curation_sets({"index"});
+    }
+
+    nlohmann::json doc1;
+    doc1["id"] = "0"; doc1["name"] = "Comfortable Shoes for men"; doc1["price"] = 399.99; doc1["points"] = 30;
+    nlohmann::json doc2;
+    doc2["id"] = "1"; doc2["name"] = "Cheap Shoes for men";       doc2["price"] = 20.00;  doc2["points"] = 5;
+    ASSERT_TRUE(coll1->add(doc1.dump()).ok());
+    ASSERT_TRUE(coll1->add(doc2.dump()).ok());
+
+    // stopword set containing "for"
+    auto sw = R"({"stopwords": ["for"], "locale": "en"})"_json;
+    ASSERT_TRUE(stopwordsManager.upsert_stopword("sw_set", sw).ok());
+
+    std::vector<sort_by> sort_fields = { sort_by("_text_match", "DESC"), sort_by("points", "DESC") };
+
+    // trigger query contains the stopword "for", plus a filter_by
+    nlohmann::json curation_json = R"({
+       "id": "rule-1",
+       "rule": { "query": "shoes for men", "match": "exact" },
+       "remove_matched_tokens": false,
+       "filter_by": "price:>55"
+    })"_json;
+
+    curation_t curation_rule;
+    ASSERT_TRUE(curation_t::parse(curation_json, "rule-1", curation_rule).ok());
+    ov_manager.upsert_curation_item("index", curation_json);
+
+    auto results = coll1->search("shoes for men", {"name"}, "",
+                                 {}, sort_fields, {0}, 10, 1, FREQUENCY,
+                                 {true}, Index::DROP_TOKENS_THRESHOLD,
+                                 spp::sparse_hash_set<std::string>(),
+                                 spp::sparse_hash_set<std::string>(), 10, "", 30, 4, "", 20, {}, {}, {}, 0,
+                                 "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 10000,
+                                 4, 7, fallback, 4, {off}, 100, 100, 2, 2, false, "", true, 0, max_score, 100, 0, 0,
+                                 0, "exhaustive", 30000, 2, "sw_set", {}, {}, "right_to_left",
+                                 true, true, false, "", "", "").get();
+
+    // filter_by must be applied even though the trigger query contains a stopword: only the >55 doc survives
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("0", results["hits"][0]["document"]["id"].get<std::string>());
+
+    results = coll1->search("cheap", {"name"}, "",
+                            {}, sort_fields, {0}, 10, 1, FREQUENCY,
+                            {true}, Index::DROP_TOKENS_THRESHOLD,
+                            spp::sparse_hash_set<std::string>(),
+                            spp::sparse_hash_set<std::string>(), 10, "", 30, 4, "", 20, {}, {}, {}, 0,
+                            "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 10000,
+                            4, 7, fallback, 4, {off}, 100, 100, 2, 2, false, "", true, 0, max_score, 100, 0, 0,
+                            0, "exhaustive", 30000, 2, "sw_set", {}, {}, "right_to_left",
+                            true, true, false, "", "", "").get();
+
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"].get<std::string>());
+
+    stopwordsManager.delete_stopword("sw_set");
+    collectionManager.drop_collection("coll1");
 }
 
 TEST_F(CollectionCurationTest, ReplaceWildcardQueryWithKeyword) {

--- a/test/stopwords_manager_test.cpp
+++ b/test/stopwords_manager_test.cpp
@@ -21,6 +21,8 @@ protected:
         collectionManager.init(store, 1.0, "auth_key", quit);
         collectionManager.load(8, 1000);
         stopwordsManager.init(store);
+        // manager is a singleton, clear configs leaked by prior tests for a clean slate
+        stopwordsManager.dispose();
     }
 
     virtual void TearDown() {


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
