### PR TITLE
Fix scoped limit_hits enforcement in union search

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -4364,13 +4364,21 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
     for (size_t search_index = 0; search_index < searches.size(); search_index++) {
         auto& search_param = search_params_guards[search_index];
 
+        size_t raw_results_added = 0;
         for (auto& kvs: search_param->raw_result_kvs) {
+            if(raw_results_added++ >= search_param->fetch_size) {
+                break;
+            }
             Union_KV kv(*kvs[0], search_index, collection_ids[search_index], should_remove_duplicates);
             union_topster->add(&kv);
         }
 
         //populate curations
+        size_t curation_results_added = 0;
         for(auto& kvs : search_param->curation_result_kvs) {
+            if(curation_results_added++ >= search_param->fetch_size) {
+                break;
+            }
             Union_KV kv(*kvs[0], search_index, collection_ids[search_index], should_remove_duplicates);
             curations_topster->add(&kv);
         }
@@ -10421,7 +10429,7 @@ void collection_search_args_t::curation_union_global_params(union_global_params_
     page = global_params.page;
     per_page = global_params.per_page;
     offset = global_params.offset;
-    limit_hits = global_params.limit_hits;
+    limit_hits = std::min(limit_hits, global_params.limit_hits);
 }
 
 Option<bool> Collection::set_curation_sets(const std::vector<std::string>& curation_sets) {

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -4364,23 +4364,36 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
     for (size_t search_index = 0; search_index < searches.size(); search_index++) {
         auto& search_param = search_params_guards[search_index];
 
-        size_t raw_results_added = 0;
-        for (auto& kvs: search_param->raw_result_kvs) {
-            if(raw_results_added++ >= search_param->fetch_size) {
-                break;
+        size_t results_added = 0;
+        size_t raw_result_index = 0;
+        size_t curation_result_index = 0;
+
+        while(results_added < search_param->fetch_size && raw_result_index < search_param->raw_result_kvs.size()) {
+            if(curation_result_index < search_param->curation_result_kvs.size()) {
+                const auto curation_kv = search_param->curation_result_kvs[curation_result_index][0];
+                const auto curation_position = static_cast<size_t>(-curation_kv->scores[0]);
+                if(results_added + 1 == curation_position) {
+                    Union_KV kv(*curation_kv, search_index, collection_ids[search_index], should_remove_duplicates);
+                    curations_topster->add(&kv);
+                    curation_result_index++;
+                    results_added++;
+                    continue;
+                }
             }
-            Union_KV kv(*kvs[0], search_index, collection_ids[search_index], should_remove_duplicates);
+
+            Union_KV kv(*search_param->raw_result_kvs[raw_result_index][0], search_index, collection_ids[search_index],
+                        should_remove_duplicates);
             union_topster->add(&kv);
+            raw_result_index++;
+            results_added++;
         }
 
-        //populate curations
-        size_t curation_results_added = 0;
-        for(auto& kvs : search_param->curation_result_kvs) {
-            if(curation_results_added++ >= search_param->fetch_size) {
-                break;
-            }
-            Union_KV kv(*kvs[0], search_index, collection_ids[search_index], should_remove_duplicates);
+        while(results_added < search_param->fetch_size && curation_result_index < search_param->curation_result_kvs.size()) {
+            Union_KV kv(*search_param->curation_result_kvs[curation_result_index][0], search_index,
+                        collection_ids[search_index], should_remove_duplicates);
             curations_topster->add(&kv);
+            curation_result_index++;
+            results_added++;
         }
     }
 

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -2123,6 +2123,13 @@ Option<bool> apply_embedded_params(nlohmann::json& embedded_params, std::map<std
     return Option<bool>(true);
 }
 
+void enforce_scoped_filter_for_curated_hits(const nlohmann::json& embedded_params,
+                                            std::map<std::string, std::string>& req_params) {
+    if(embedded_params.count("filter_by") != 0) {
+        req_params["filter_curated_hits"] = "true";
+    }
+}
+
 Option<bool> apply_preset(std::map<std::string, std::string>& req_params) {
     const auto preset_it = req_params.find("preset");
 
@@ -2187,6 +2194,7 @@ Option<bool> CollectionManager::do_search(std::map<std::string, std::string>& re
     if (!apply_preset_op.ok()) {
         return apply_preset_op;
     }
+    enforce_scoped_filter_for_curated_hits(embedded_params, req_params);
 
     std::string stopwords_set;
     auto const get_stopwords_op = get_stopword_set(req_params, stopwords_set);
@@ -2443,6 +2451,7 @@ Option<bool> CollectionManager::do_union(std::map<std::string, std::string>& req
             result_op = std::move(apply_preset_op);
             break;
         }
+        enforce_scoped_filter_for_curated_hits(embedded_params, req_params);
 
         std::string stopwords_set;
         auto get_stopwords_op = get_stopword_set(req_params, stopwords_set);

--- a/test/union_test.cpp
+++ b/test/union_test.cpp
@@ -399,6 +399,7 @@ protected:
         auto products = collection_create_op.get();
         for (auto i = 0; i < 50; i++) {
             nlohmann::json json = {
+                    {"id", std::to_string(i)},
                     {"title", "product " + std::to_string(i)},
                     {"price", static_cast<float>(i)}
             };
@@ -994,7 +995,7 @@ TEST_F(UnionTest, ScopedKeyLimitHitsAndFilterByAreEnforcedInUnionSearch) {
     auto key_op = collectionManager.getAuthManager().create_key(parent_key);
     ASSERT_TRUE(key_op.ok());
 
-    const auto scoped_limit_key = makeScopedSearchKey(parent_key.value, R"({"limit_hits":5})");
+    const auto scoped_limit_key = makeScopedSearchKey(parent_key.value, R"({"limit_hits":5,"pinned_hits":"0:1"})");
     embedded_params = std::vector<nlohmann::json>(1, nlohmann::json::object());
     std::map<std::string, std::string> auth_params;
     ASSERT_TRUE(collectionManager.getAuthManager().authenticate(
@@ -1015,6 +1016,8 @@ TEST_F(UnionTest, ScopedKeyLimitHitsAndFilterByAreEnforcedInUnionSearch) {
     auto search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
     ASSERT_TRUE(search_op.ok());
     ASSERT_EQ(5, json_res["hits"].size());
+    ASSERT_EQ("0", json_res["hits"][0]["document"]["id"]);
+    ASSERT_TRUE(json_res["hits"][0]["curated"].get<bool>());
     json_res.clear();
 
     const auto scoped_filter_key = makeScopedSearchKey(parent_key.value, R"({"filter_by":"price:<10"})");
@@ -1032,6 +1035,7 @@ TEST_F(UnionTest, ScopedKeyLimitHitsAndFilterByAreEnforcedInUnionSearch) {
                         "collection": "ScopedUnionProducts",
                         "q": "*",
                         "query_by": "title",
+                        "pinned_hits": "49:1",
                         "filter_by": "price:>=0"
                     }
                 ])"_json;
@@ -1040,6 +1044,9 @@ TEST_F(UnionTest, ScopedKeyLimitHitsAndFilterByAreEnforcedInUnionSearch) {
     ASSERT_TRUE(search_op.ok());
     ASSERT_EQ(10, json_res["hits"].size());
     ASSERT_EQ(10, json_res["found"]);
+    for(const auto& hit : json_res["hits"]) {
+        ASSERT_NE("49", hit["document"]["id"]);
+    }
     json_res.clear();
     req_params.clear();
 }

--- a/test/union_test.cpp
+++ b/test/union_test.cpp
@@ -8,7 +8,9 @@
 #include <chrono>
 #include <thread>
 #include <sstream>
+#include <auth_manager.h>
 #include <collection_manager.h>
+#include <string_utils.h>
 #include "curation_index_manager.h"
 
 class UnionTest : public ::testing::Test {
@@ -366,6 +368,39 @@ protected:
         for (auto i = 0; i < 500; i++) {
             nlohmann::json json = {
                     {"title", "title_" + std::to_string(i)}
+            };
+            auto add_op = products->add(json.dump());
+            if (!add_op.ok()) {
+                LOG(INFO) << add_op.error();
+            }
+            ASSERT_TRUE(add_op.ok());
+        }
+    }
+
+    static std::string makeScopedSearchKey(const std::string& parent_key, const std::string& custom_params) {
+        const std::string scoped_key_payload = StringUtils::hmac(parent_key, custom_params) +
+                                               parent_key.substr(0, api_key_t::PREFIX_LEN) + custom_params;
+        return StringUtils::base64_encode(scoped_key_payload);
+    }
+
+    void setupScopedUnionProductsCollection() {
+        auto schema_json =
+                R"({
+                "name": "ScopedUnionProducts",
+                "fields": [
+                    {"name": "title", "type": "string"},
+                    {"name": "price", "type": "float"}
+                ]
+            })"_json;
+
+        auto collection_create_op = collectionManager.create_collection(schema_json);
+        ASSERT_TRUE(collection_create_op.ok());
+
+        auto products = collection_create_op.get();
+        for (auto i = 0; i < 50; i++) {
+            nlohmann::json json = {
+                    {"title", "product " + std::to_string(i)},
+                    {"price", static_cast<float>(i)}
             };
             auto add_op = products->add(json.dump());
             if (!add_op.ok()) {
@@ -925,6 +960,86 @@ TEST_F(UnionTest, Pagination) {
     ASSERT_EQ(500, json_res["out_of"]);
     ASSERT_EQ(4, json_res["page"]);
     ASSERT_EQ(100, json_res["hits"].size());
+    json_res.clear();
+    req_params.clear();
+}
+
+TEST_F(UnionTest, EmbeddedLimitHitsCapsUnionSearchContribution) {
+    setupFiveHundredCollection();
+
+    req_params = {
+            {"page", "1"},
+            {"per_page", "100"}
+    };
+    embedded_params = std::vector<nlohmann::json>(1, R"({"limit_hits": 5})"_json);
+    searches = R"([
+                    {
+                        "collection": "FiveHundred",
+                        "q": "*"
+                    }
+                ])"_json;
+
+    auto search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(5, json_res["hits"].size());
+    json_res.clear();
+    req_params.clear();
+}
+
+TEST_F(UnionTest, ScopedKeyLimitHitsAndFilterByAreEnforcedInUnionSearch) {
+    setupScopedUnionProductsCollection();
+
+    api_key_t parent_key("UnionScopedSearchParentKey", "scoped search parent", {"documents:search"},
+                         {"ScopedUnionProducts"}, api_key_t::FAR_FUTURE_TIMESTAMP);
+    auto key_op = collectionManager.getAuthManager().create_key(parent_key);
+    ASSERT_TRUE(key_op.ok());
+
+    const auto scoped_limit_key = makeScopedSearchKey(parent_key.value, R"({"limit_hits":5})");
+    embedded_params = std::vector<nlohmann::json>(1, nlohmann::json::object());
+    std::map<std::string, std::string> auth_params;
+    ASSERT_TRUE(collectionManager.getAuthManager().authenticate(
+            "documents:search", {collection_key_t("ScopedUnionProducts", scoped_limit_key)}, auth_params, embedded_params));
+
+    req_params = {
+            {"page", "1"},
+            {"per_page", "100"}
+    };
+    searches = R"([
+                    {
+                        "collection": "ScopedUnionProducts",
+                        "q": "*",
+                        "query_by": "title"
+                    }
+                ])"_json;
+
+    auto search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(5, json_res["hits"].size());
+    json_res.clear();
+
+    const auto scoped_filter_key = makeScopedSearchKey(parent_key.value, R"({"filter_by":"price:<10"})");
+    embedded_params = std::vector<nlohmann::json>(1, nlohmann::json::object());
+    auth_params.clear();
+    ASSERT_TRUE(collectionManager.getAuthManager().authenticate(
+            "documents:search", {collection_key_t("ScopedUnionProducts", scoped_filter_key)}, auth_params, embedded_params));
+
+    req_params = {
+            {"page", "1"},
+            {"per_page", "100"}
+    };
+    searches = R"([
+                    {
+                        "collection": "ScopedUnionProducts",
+                        "q": "*",
+                        "query_by": "title",
+                        "filter_by": "price:>=0"
+                    }
+                ])"_json;
+
+    search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(10, json_res["hits"].size());
+    ASSERT_EQ(10, json_res["found"]);
     json_res.clear();
     req_params.clear();
 }


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
  - Enforced scoped-key `limit_hits` in union search.
  - Preserved the stricter value between embedded and global `limit_hits`.
  - Changed union branch budgeting so raw and curated/pinned hits share the same `fetch_size` cap.
  - Forced scoped-key filter_by to apply to curated/pinned hits via `filter_curated_hits=true`.
  - Added regression coverage for embedded `limit_hits`.
  - Added scoped-key auth regression covering `limit_hits` with pinned hits.
  - Added scoped-key auth regression covering `filter_by` widening plus out-of-scope pinned hits.
## PR Checklist
<!--- Put an `x` inside the box : -->
- [X] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
