### PR TITLE
Fix out-of-bounds read when a query has multiple `_eval` sort clauses

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -398,6 +398,40 @@ struct group_by_field_it_t {
     bool is_array;
 };
 
+/// Forward-only cursors into each `_eval` expression's sorted seq_id array, held per sort field.
+///
+/// `compute_sort_scores` is called with monotonically increasing seq_ids within a query, so each
+/// expression only ever needs to scan forward. The cursors must be kept separate per sort field:
+/// a query may carry more than one `_eval` clause, and sharing a single flat vector between them
+/// both corrupts their cursors and lets a clause with more expressions index out of bounds.
+struct eval_filter_indexes_t {
+    std::vector<std::vector<uint32_t>> per_sort_field;
+
+    /// Cursors for `sort_field_index`, allocated on first use and preserved across documents.
+    std::vector<uint32_t>& get(const size_t sort_field_index, const size_t expression_count) {
+        auto& indexes = slot(sort_field_index);
+        if (indexes.size() != expression_count) {
+            indexes.assign(expression_count, 0);
+        }
+        return indexes;
+    }
+
+    /// Cursors for a reference sort, rewound every document because the referenced doc set varies.
+    std::vector<uint32_t>& reset(const size_t sort_field_index, const size_t count) {
+        auto& indexes = slot(sort_field_index);
+        indexes.assign(count, 0);
+        return indexes;
+    }
+
+private:
+    std::vector<uint32_t>& slot(const size_t sort_field_index) {
+        if (per_sort_field.size() <= sort_field_index) {
+            per_sort_field.resize(sort_field_index + 1);
+        }
+        return per_sort_field[sort_field_index];
+    }
+};
+
 #ifdef TEST_BUILD
     extern bool testing_not_equals_bug;
 #endif
@@ -1170,7 +1204,7 @@ public:
                                      std::array<spp::sparse_hash_map<uint32_t, int64_t, Hasher32>*, 3> field_values,
                                      const std::vector<size_t>& geopoint_indices, uint32_t seq_id,
                                      const std::map<basic_string<char>, reference_filter_result_t>& references,
-                                     std::vector<uint32_t>& filter_indexes, int64_t max_field_match_score,
+                                     eval_filter_indexes_t& filter_indexes, int64_t max_field_match_score,
                                      int64_t* scores, int64_t& match_score_index,
                                      float vector_distance = 0) const;
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -3785,7 +3785,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
             search_cutoff = search_cutoff || filter_result_iterator_no_groups->validity == filter_result_iterator_t::timed_out;
 
             std::vector<uint32_t> nearest_ids;
-            std::vector<uint32_t> eval_filter_indexes;
+            eval_filter_indexes_t eval_filter_indexes;
 
             std::vector<group_by_field_it_t> group_by_field_it_vec;
             if (group_limit != 0) {
@@ -4239,7 +4239,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
             }
 
             std::vector<uint32_t> vec_search_ids;  // list of IDs found only in vector search
-            std::vector<uint32_t> eval_filter_indexes;
+            eval_filter_indexes_t eval_filter_indexes;
 
             std::vector<group_by_field_it_t> group_by_field_it_vec;
             if (group_limit != 0) {
@@ -5539,7 +5539,7 @@ Option<bool> Index::search_across_fields(const std::vector<token_t>& query_token
     get_field_token_its(num_search_fields, token_its, expanded_plists, query_tokens, the_fields);
 
     std::vector<uint32_t> result_ids;
-    std::vector<uint32_t> eval_filter_indexes;
+    eval_filter_indexes_t eval_filter_indexes;
     Option<bool> status(true);
 
     result_iter_state_t istate(excluded_result_ids, excluded_result_ids_size, filter_result_iterator);
@@ -5740,7 +5740,7 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
                                         std::array<spp::sparse_hash_map<uint32_t, int64_t, Hasher32>*, 3> field_values,
                                         const std::vector<size_t>& geopoint_indices,
                                         uint32_t seq_id, const std::map<basic_string<char>, reference_filter_result_t>& references,
-                                        std::vector<uint32_t>& filter_indexes, int64_t max_field_match_score, int64_t* scores,
+                                        eval_filter_indexes_t& filter_indexes, int64_t max_field_match_score, int64_t* scores,
                                         int64_t& match_score_index, float vector_distance) const {
 
     int64_t geopoint_distances[3];
@@ -5848,7 +5848,7 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
             if (is_reference_sort) {
                 // Both ref_seq_ids and eval.eval_ids_vec will be ordered. So we can take advantage of binary search
                 // and break early if there are no matches.
-                filter_indexes = std::vector<uint32_t>(ref_seq_ids.size(), 0);
+                auto& ref_filter_indexes = filter_indexes.reset(i, ref_seq_ids.size());
 
                 // Trying to find a match for every reference doc. The score will be the value of eval expression where
                 // we find the first match.
@@ -5858,7 +5858,7 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
                     for (eval_index = 0; eval_index < count; eval_index++) {
                         auto const& eval_ids = eval.eval_ids_vec[eval_index];
                         auto const& eval_ids_count = eval.eval_ids_count_vec[eval_index];
-                        auto& filter_index = filter_indexes[j];
+                        auto& filter_index = ref_filter_indexes[j];
 
                         if (filter_index >= eval_ids_count) {
                             // When all the indexes of eval.eval_ids_vec have reached to the end, we can stop looking.
@@ -5883,15 +5883,13 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
                     }
                 }
             } else {
-                if (filter_indexes.empty()) {
-                    filter_indexes = std::vector<uint32_t>(count, 0);
-                }
+                auto& eval_indexes = filter_indexes.get(i, count);
 
                 for (; eval_index < count; eval_index++) {
                     auto const& eval_ids = eval.eval_ids_vec[eval_index];
                     auto const& eval_ids_count = eval.eval_ids_count_vec[eval_index];
 
-                    auto& filter_index = filter_indexes[eval_index];
+                    auto& filter_index = eval_indexes[eval_index];
                     if (filter_index >= eval_ids_count) {
                         continue;
                     }
@@ -6112,7 +6110,7 @@ Option<bool> Index::do_phrase_search(const size_t num_search_fields, const std::
     all_result_ids_len = filter_result_iterator->to_filter_id_array(all_result_ids);
     filter_result_iterator->reset();
 
-    std::vector<uint32_t> eval_filter_indexes;
+    eval_filter_indexes_t eval_filter_indexes;
 
     std::vector<group_by_field_it_t> group_by_field_it_vec;
     if (group_limit != 0) {
@@ -6291,7 +6289,7 @@ Option<bool> Index::do_infix_search(const size_t num_search_fields, const std::v
                 }
 
                 bool field_is_array = search_schema.at(the_fields[field_id].name).is_array();
-                std::vector<uint32_t> eval_filter_indexes;
+                eval_filter_indexes_t eval_filter_indexes;
                 for(size_t i = 0; i < raw_infix_ids_length; i++) {
                     auto seq_id = raw_infix_ids[i];
 
@@ -6793,7 +6791,7 @@ Option<bool> Index::search_wildcard(const std::vector<sort_by>& sort_fields, Top
             search_stop_us = parent_search_stop_ms;
             search_cutoff = false;
 
-            std::vector<uint32_t> filter_indexes;
+            eval_filter_indexes_t filter_indexes;
 
             std::vector<group_by_field_it_t> group_by_field_it_vec;
             if (group_limit != 0) {
@@ -9161,7 +9159,7 @@ Option<bool> Index::process_ref_include_fields_sort(std::vector<sort_by>& sort_f
         return populate_op;
     }
 
-    std::vector<uint32_t> eval_filter_indexes;
+    eval_filter_indexes_t eval_filter_indexes;
     std::map<basic_string<char>, reference_filter_result_t> references;
     Topster<KV> topster(limit);
 

--- a/test/collection_sorting_test.cpp
+++ b/test/collection_sorting_test.cpp
@@ -3956,3 +3956,85 @@ TEST_F(CollectionSortingTest, IgnoreInvalidFieldsIfNotValidateFieldNames) {
     ASSERT_TRUE(results.ok());
     ASSERT_EQ(2, results.get()["hits"].size());
 }
+TEST_F(CollectionSortingTest, ReferenceAndNormalEvalKeepSeparateCursors) {
+    // 16 expressions against a referenced-doc count of 1: indices 1..15 used to fall past the end of
+    // the shared cursor vector, so the ranking came back different on every run.
+    static constexpr size_t NUM_EVAL_FIELDS = 16;
+
+    // A reference `_eval` and a normal `_eval` can coexist in one query: `eval_sort_count` is only
+    // incremented for non-reference clauses, so the "Only one sorting eval expression is allowed"
+    // guard does not catch the pair. They used to share one cursor vector, which the reference
+    // clause sized to the referenced-doc count (1 here) and the normal clause then indexed past.
+    nlohmann::json prod_schema;
+    prod_schema["name"] = "eval_prod";
+    prod_schema["fields"] = nlohmann::json::array();
+    nlohmann::json pid_field;
+    pid_field["name"] = "pid";
+    pid_field["type"] = "string";
+    prod_schema["fields"].push_back(pid_field);
+
+    for (size_t n = 1; n <= NUM_EVAL_FIELDS; n++) {
+        nlohmann::json bool_field;
+        bool_field["name"] = "f" + std::to_string(n);
+        bool_field["type"] = "bool";
+        prod_schema["fields"].push_back(bool_field);
+    }
+    ASSERT_TRUE(collectionManager.create_collection(prod_schema).ok());
+
+    auto stock_schema = R"({
+        "name": "eval_stock",
+        "fields": [
+            {"name": "pid", "type": "string", "reference": "eval_prod.pid"},
+            {"name": "in_stock", "type": "bool"}
+        ]
+    })"_json;
+    ASSERT_TRUE(collectionManager.create_collection(stock_schema).ok());
+
+    // Document i matches only f(i+1), so scoring has to walk deep into the expression list.
+    for (size_t i = 0; i < NUM_EVAL_FIELDS; i++) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["pid"] = "p" + std::to_string(i);
+        for (size_t n = 1; n <= NUM_EVAL_FIELDS; n++) {
+            doc["f" + std::to_string(n)] = (n == i + 1);
+        }
+        ASSERT_TRUE(collectionManager.get_collection("eval_prod")->add(doc.dump()).ok());
+
+        nlohmann::json stock;
+        stock["id"] = std::to_string(i);
+        stock["pid"] = "p" + std::to_string(i);
+        stock["in_stock"] = true;
+        ASSERT_TRUE(collectionManager.get_collection("eval_stock")->add(stock.dump()).ok());
+    }
+
+    std::string rules;
+    for (size_t n = 1; n <= NUM_EVAL_FIELDS; n++) {
+        rules += (n == 1 ? "" : ",");
+        rules += "(f" + std::to_string(n) + ":true):" + std::to_string(NUM_EVAL_FIELDS + 1 - n);
+    }
+
+    // Every doc is in stock, so the reference clause ties and the second clause decides the order.
+    std::map<std::string, std::string> req_params = {
+            {"collection", "eval_prod"},
+            {"q", "*"},
+            {"per_page", std::to_string(NUM_EVAL_FIELDS)},
+            {"filter_by", "$eval_stock(id:*)"},
+            {"sort_by", "$eval_stock(_eval([(in_stock:true):5]):desc), _eval([" + rules + "]):desc"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    ASSERT_TRUE(collectionManager.do_search(req_params, embedded_params, json_res, now_ts).ok());
+    auto res_obj = nlohmann::json::parse(json_res);
+
+    ASSERT_EQ(NUM_EVAL_FIELDS, res_obj["hits"].size());
+    for (size_t i = 0; i < NUM_EVAL_FIELDS; i++) {
+        ASSERT_EQ(std::to_string(i), res_obj["hits"][i]["document"]["id"].get<std::string>())
+                            << "wrong document at rank " << i;
+    }
+
+    collectionManager.drop_collection("eval_stock");
+    collectionManager.drop_collection("eval_prod");
+}


### PR DESCRIPTION
Fixes #3009.

> Earlier revisions of this PR described the trigger as two plain `_eval` clauses. That was wrong —
> validation rejects those with *"Only one sorting eval expression is allowed"*, and the regression
> test I first pushed failed in CI for exactly that reason. The real trigger and a working
> reproduction are below.

## Problem

`compute_sort_scores` shares one `filter_indexes` cursor vector across every `_eval` sort field, and
sizes it from whichever clause is scored first:

```cpp
if (filter_indexes.empty()) {
    filter_indexes = std::vector<uint32_t>(count, 0);   // sized by the first clause
}
...
auto& filter_index = filter_indexes[eval_index];        // indexed by this clause's count
```

Two `_eval` clauses *can* coexist, despite the `eval_sort_count` guard: that counter is only
incremented in the non-reference branch, because the `$Collection(...)` branch `continue`s before
reaching it. So a **reference `_eval` plus a normal `_eval`** passes validation, and both land in the
eval branch of `compute_sort_scores`.

From there:

- the reference clause reassigns the shared vector to `ref_seq_ids.size()` for every document;
- the normal clause then sees it non-empty, skips its own sizing, and indexes it with its own
  expression count.

When the referenced-doc count is smaller than the expression count, the reads run past the end of the
allocation. `lower_bound` starts from whatever happens to be on the heap, so matches get missed — and
missed differently on each request.

## Reproduction (released v29.0, no build needed)

Full script in #3009. Every document is in stock so the reference clause ties and the 16-expression
clause alone decides the order; document `i` matches only `f(i+1)`, worth `16-i`, so the correct
order is `0,1,...,15`:

```
run1 buggy : ['0','1','3','4','5','7','11','15','14','13','12','10','9','8','6','2']
run2 buggy : ['0','1','3','4','5','7','8','9','11','12','13','15','14','10','6','2']
run3 buggy : ['0','1','3','12','13','15','14','11','10','9','8','7','6','5','4','2']
control    : ['0','1','2','3','4','5','6','7','8','9','10','11','12','13','14','15']
```

Three identical requests, three different orders. The control — the same `_eval` without the
reference clause — is stable and correct.

It only bites when the first expression fails to match, since first-match semantics `break` before
reaching the out-of-range indices. That is why a short expression list usually looks fine.

## Fix

`eval_filter_indexes_t` (`include/index.h`) keys the cursors by sort-field index so each clause keeps
its own state. Two accessors, because the call sites need opposite lifetimes:

- `get(sort_field_index, expression_count)` — allocated on first use and **preserved across
  documents**, which the forward-only scan depends on.
- `reset(sort_field_index, count)` — **rewound every document**, matching what the reference branch
  already did (it reassigned the whole vector per document) and still needs, since the referenced doc
  set varies per document.

Scoring logic is untouched; this is only about where the cursors live.

## Test

`CollectionSortingTest.ReferenceAndNormalEvalKeepSeparateCursors` builds the scenario above —
referenced-doc count of 1 against 16 expressions — and asserts the full `0..15` ordering.

## Note

While here I noticed the reference branch reuses a single cursor (`ref_filter_indexes[j]`, keyed by
referenced-doc index) across all eval expressions in its inner loop, so `lower_bound` for expression
*n+1* starts from a cursor left by expression *n* over a different array. That looks unintended, but
it is pre-existing behaviour with existing coverage, so I have left those semantics exactly as they
were rather than changing them in a bugfix. Happy to file it separately.
