### PR TITLE
Add a `sum` mode to `_eval` so multiple matching filter scores add up

### DIFF
--- a/api_tests/tests/nested_curly_filter.test.ts
+++ b/api_tests/tests/nested_curly_filter.test.ts
@@ -333,6 +333,15 @@ describe(Phases.SINGLE_FRESH, () => {
     });
     expect(res.ok).toBe(true);
 
+    const importResults = (await res.text())
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { success: boolean });
+    expect(importResults).toHaveLength(items.length);
+    for (const result of importResults) {
+      expect(result.success).toBe(true);
+    }
+
     const twoPredicateExpected = countSameObjectMatches(
       items,
       (offer) => offer.quantities.some((quantity) => quantity >= 2) && offer.minCost <= 7500,

--- a/include/field.h
+++ b/include/field.h
@@ -501,6 +501,11 @@ namespace sort_field_const {
     static const std::string exclude_radius = "exclude_radius";
     static const std::string precision = "precision";
 
+    // `_eval([...], mode: <...>)` parameter and its accepted values.
+    static const std::string eval_mode = "mode";
+    static const std::string eval_mode_first_match = "first_match";
+    static const std::string eval_mode_sum = "sum";
+
     static const std::string missing_values = "missing_values";
 
     static const std::string vector_distance = "_vector_distance";
@@ -621,11 +626,23 @@ struct sort_by {
         linear,
     };
 
+    /// How the scores of matching `_eval` expressions combine into the sort value, selected by the
+    /// `mode` parameter of the clause.
+    enum eval_mode_t {
+        /// Default: score of the first expression that matches, 0 if none do. Expressions are
+        /// treated as an ordered if/else-if chain.
+        first_match,
+        /// `mode: sum`: sum of the scores of every expression that matches. Expressions are
+        /// treated as independent signals in a linear model.
+        sum_matches,
+    };
+
     struct eval_t {
         filter_node_t** filter_trees = nullptr; // Array of filter_node_t pointers.
         std::vector<uint32_t*> eval_ids_vec;
         std::vector<uint32_t> eval_ids_count_vec;
         std::vector<int64_t> scores;
+        eval_mode_t mode = first_match;
     };
 
     std::string name;
@@ -669,11 +686,13 @@ struct sort_by {
             geo_precision(0), missing_values(normal) {
     }
 
-    sort_by(std::vector<std::string> eval_expressions, std::vector<int64_t> scores, std::string  order):
+    sort_by(std::vector<std::string> eval_expressions, std::vector<int64_t> scores, std::string  order,
+            eval_mode_t eval_mode = first_match):
             eval_expressions(std::move(eval_expressions)), order(std::move(order)), text_match_buckets(0), text_match_bucket_size(0),
             geopoint(0), exclude_radius(0), geo_precision(0), missing_values(normal) {
         name = sort_field_const::eval;
         eval.scores = std::move(scores);
+        eval.mode = eval_mode;
         type = eval_expression;
     }
 

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -1847,6 +1847,19 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
                 return Option<bool>(400, "Reference `sort_by` is malformed.");
             }
 
+            // Referenced eval sorting scores a single referenced document and stops at the first
+            // match, so there is no well-defined set of signals for `mode: sum` to add up. Reject
+            // before validation allocates filter trees that cannot be transferred to the outer
+            // sort-fields cleanup guard on this error path.
+            for (const auto& ref_sort_field: ref_sort_fields) {
+                if (ref_sort_field.type == sort_by::eval_expression &&
+                    ref_sort_field.eval.mode == sort_by::eval_mode_t::sum_matches) {
+                    return Option<bool>(400, "`" + sort_field_const::eval_mode + ": " +
+                                                sort_field_const::eval_mode_sum +
+                                                "` is not supported on a referenced collection.");
+                }
+            }
+
             std::vector<sort_by> ref_sort_fields_std;
             auto sort_validation_op = ref_collection->validate_and_standardize_sort_fields_with_lock(ref_sort_fields,
                                                                                                      ref_sort_fields_std,
@@ -1873,16 +1886,6 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
             }
 
             for (auto& ref_sort_field_std: ref_sort_fields_std) {
-                // The reference eval path scores against the referenced docs of a single document and stops at the
-                // first match, so there is no well-defined set of signals to add up. Reject rather than silently
-                // falling back to first-match semantics.
-                if (ref_sort_field_std.type == sort_by::eval_expression &&
-                    ref_sort_field_std.eval.mode == sort_by::eval_mode_t::sum_matches) {
-                    return Option<bool>(400, "`" + sort_field_const::eval_mode + ": " +
-                                                sort_field_const::eval_mode_sum +
-                                                "` is not supported on a referenced collection.");
-                }
-
                 ref_sort_field_std.reference_collection_name = ref_collection_name;
                 ref_sort_field_std.nested_join_collection_names.insert(ref_sort_field_std.nested_join_collection_names.begin(),
                                                                        nested_join_coll_names.begin(),

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -1873,6 +1873,16 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
             }
 
             for (auto& ref_sort_field_std: ref_sort_fields_std) {
+                // The reference eval path scores against the referenced docs of a single document and stops at the
+                // first match, so there is no well-defined set of signals to add up. Reject rather than silently
+                // falling back to first-match semantics.
+                if (ref_sort_field_std.type == sort_by::eval_expression &&
+                    ref_sort_field_std.eval.mode == sort_by::eval_mode_t::sum_matches) {
+                    return Option<bool>(400, "`" + sort_field_const::eval_mode + ": " +
+                                                sort_field_const::eval_mode_sum +
+                                                "` is not supported on a referenced collection.");
+                }
+
                 ref_sort_field_std.reference_collection_name = ref_collection_name;
                 ref_sort_field_std.nested_join_collection_names.insert(ref_sort_field_std.nested_join_collection_names.begin(),
                                                                        nested_join_coll_names.begin(),
@@ -1895,6 +1905,7 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
             sort_field_std.eval.filter_trees = new filter_node_t*[count]{nullptr};
             sort_field_std.eval_expressions = _sort_field.eval_expressions;
             sort_field_std.eval.scores = _sort_field.eval.scores;
+            sort_field_std.eval.mode = _sort_field.eval.mode;
             sort_field_std.type = sort_by::eval_expression;
             auto doc_id_prefix = std::to_string(collection_id) + "_" + DOC_ID_PREFIX + "_";
 

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -1847,20 +1847,8 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
                 return Option<bool>(400, "Reference `sort_by` is malformed.");
             }
 
-            // Referenced eval sorting scores a single referenced document and stops at the first
-            // match, so there is no well-defined set of signals for `mode: sum` to add up. Reject
-            // before validation allocates filter trees that cannot be transferred to the outer
-            // sort-fields cleanup guard on this error path.
-            for (const auto& ref_sort_field: ref_sort_fields) {
-                if (ref_sort_field.type == sort_by::eval_expression &&
-                    ref_sort_field.eval.mode == sort_by::eval_mode_t::sum_matches) {
-                    return Option<bool>(400, "`" + sort_field_const::eval_mode + ": " +
-                                                sort_field_const::eval_mode_sum +
-                                                "` is not supported on a referenced collection.");
-                }
-            }
-
-            std::vector<sort_by> ref_sort_fields_std;
+            sort_fields_guard_t ref_sort_fields_guard;
+            auto& ref_sort_fields_std = ref_sort_fields_guard.sort_fields_std;
             auto sort_validation_op = ref_collection->validate_and_standardize_sort_fields_with_lock(ref_sort_fields,
                                                                                                      ref_sort_fields_std,
                                                                                                      is_wildcard_query,
@@ -1873,6 +1861,11 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
                                                                                                      true,
                                                                                                      is_union_search,
                                                                                                      union_search_index);
+
+            if (!sort_validation_op.ok()) {
+                return Option<bool>(sort_validation_op.code(), "Referenced collection `" + ref_collection_name + "`: " +
+                                                                sort_validation_op.error());
+            }
 
             std::vector<std::string> nested_join_coll_names;
             for (auto const& coll_name: _sort_field.nested_join_collection_names) {
@@ -1890,14 +1883,13 @@ Option<bool> Collection::validate_and_standardize_sort_fields(const std::vector<
                 ref_sort_field_std.nested_join_collection_names.insert(ref_sort_field_std.nested_join_collection_names.begin(),
                                                                        nested_join_coll_names.begin(),
                                                                        nested_join_coll_names.end());
-
-                sort_fields_std.emplace_back(ref_sort_field_std);
             }
 
-            if (!sort_validation_op.ok()) {
-                return Option<bool>(sort_validation_op.code(), "Referenced collection `" + ref_collection_name + "`: " +
-                                                                sort_validation_op.error());
-            }
+            // `sort_by` copies the raw eval pointers. Once every referenced sort field is valid,
+            // transfer their cleanup ownership to the outer search guard by copying the fields and
+            // releasing them from the local guard.
+            sort_fields_std.insert(sort_fields_std.end(), ref_sort_fields_std.begin(), ref_sort_fields_std.end());
+            ref_sort_fields_std.clear();
 
             continue;
         } else if (_sort_field.name == sort_field_const::eval) {

--- a/src/collection_manager.cpp
+++ b/src/collection_manager.cpp
@@ -1770,9 +1770,51 @@ AuthManager& CollectionManager::getAuthManager() {
     return auth_manager;
 }
 
+/// Parses the optional trailing parameters of a multi-eval clause, i.e. everything between the
+/// closing `]` and the closing `)` of `_eval([...], <params>)`.
+static bool parse_multi_eval_params(const std::string& params_str, sort_by::eval_mode_t& eval_mode) {
+    auto params_substr = params_str;
+    StringUtils::trim(params_substr);
+    if (params_substr.empty()) {
+        return true;
+    }
+
+    // The span starts right after `]`, so a parameter list opens with the separating comma.
+    if (params_substr[0] != ',') {
+        return false;
+    }
+    params_substr = params_substr.substr(1);
+
+    std::vector<std::string> params;
+    StringUtils::split(params_substr, params, ",");
+    if (params.empty()) {
+        return false;
+    }
+
+    for (const auto& param: params) {
+        // `split` trims each token, so `mode:sum` and `mode: sum` both arrive here the same way.
+        std::vector<std::string> param_parts;
+        StringUtils::split(param, param_parts, ":");
+        if (param_parts.size() != 2 || param_parts[0] != sort_field_const::eval_mode) {
+            return false;
+        }
+
+        if (param_parts[1] == sort_field_const::eval_mode_sum) {
+            eval_mode = sort_by::eval_mode_t::sum_matches;
+        } else if (param_parts[1] == sort_field_const::eval_mode_first_match) {
+            eval_mode = sort_by::eval_mode_t::first_match;
+        } else {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 bool parse_multi_eval(const std::string& sort_by_str, uint32_t& index, std::vector<sort_by>& sort_fields) {
     // FORMAT:
     // _eval([ (<expr_1>): <score_1>, (<expr_2>): <score_2> ]):<order>
+    // _eval([ (<expr_1>): <score_1>, (<expr_2>): <score_2> ], mode: sum):<order>
 
     std::vector<std::string> eval_expressions;
     std::vector<std::int64_t> scores;
@@ -1826,6 +1868,20 @@ bool parse_multi_eval(const std::string& sort_by_str, uint32_t& index, std::vect
         scores.emplace_back(std::stoll(score));
     }
 
+    // `index` is at the closing `]`, so everything up to the closing `)` of `_eval(` is the optional
+    // parameter list. It has to be consumed before the scan below, which stops at the first `:`.
+    // With a parameter present that first colon belongs to `mode: sum`, not to the order.
+    auto const close_paren_pos = sort_by_str.find(')', index);
+    if (close_paren_pos == std::string::npos) {
+        return false;
+    }
+
+    sort_by::eval_mode_t eval_mode = sort_by::eval_mode_t::first_match;
+    if (!parse_multi_eval_params(sort_by_str.substr(index + 1, close_paren_pos - index - 1), eval_mode)) {
+        return false;
+    }
+    index = close_paren_pos;
+
     while (++index < sort_by_str.size() && sort_by_str[index] != ':');
     if (index >= sort_by_str.size()) {
         return false;
@@ -1838,13 +1894,70 @@ bool parse_multi_eval(const std::string& sort_by_str, uint32_t& index, std::vect
     StringUtils::trim(order_str);
     StringUtils::toupper(order_str);
 
-    sort_fields.emplace_back(eval_expressions, scores, order_str);
+    sort_fields.emplace_back(eval_expressions, scores, order_str, eval_mode);
+    return true;
+}
+
+/// Splits a trailing parameter list off the single-expression form, `_eval((<expr>), mode: sum)`.
+///
+/// The array form is delimited by `]`, so everything after it is unambiguously a parameter. The
+/// single-expression form has no such delimiter and a filter value may legally hold a top level
+/// comma, as `title:Hello, World` does. Parameters are therefore only recognised when the
+/// expression is wrapped in its own parentheses, which lets a plain parenthesis count find where it
+/// ends. `_eval(brand:nike, mode: sum)` stays a filter, exactly as it parses today.
+///
+/// Returns false only when the parameter list is present but unusable.
+static bool split_trailing_eval_params(std::string& eval_expr, sort_by::eval_mode_t& eval_mode) {
+    auto expr = eval_expr;
+    StringUtils::trim(expr);
+    if (expr.empty() || expr[0] != '(') {
+        return true;
+    }
+
+    int paren_count = 0;
+    bool in_backtick = false;
+    size_t expr_end = std::string::npos;
+
+    for (size_t i = 0; i < expr.size(); i++) {
+        const char c = expr[i];
+        if (c == '`') {
+            in_backtick = !in_backtick;
+        } else if (in_backtick) {
+            continue;
+        } else if (c == '(') {
+            paren_count++;
+        } else if (c == ')' && --paren_count == 0) {
+            expr_end = i;
+            break;
+        }
+    }
+
+    if (expr_end == std::string::npos) {
+        return true;
+    }
+
+    // A parameter list is introduced by a comma. Anything else following the group belongs to the
+    // filter, as in `(a:1) && (b:2)`, and the expression is left exactly as it was.
+    auto trailing = expr.substr(expr_end + 1);
+    StringUtils::trim(trailing);
+    if (trailing.empty() || trailing[0] != ',') {
+        return true;
+    }
+
+    if (!parse_multi_eval_params(trailing, eval_mode)) {
+        return false;
+    }
+
+    // Drop the wrapping parentheses along with the parameter list.
+    eval_expr = expr.substr(1, expr_end - 1);
+    StringUtils::trim(eval_expr);
     return true;
 }
 
 bool parse_eval(const std::string& sort_by_str, uint32_t& index, std::vector<sort_by>& sort_fields) {
     // FORMAT:
     // _eval(<expr>):<order>
+    // _eval((<expr>), mode: sum):<order>
     std::string eval_expr = "(";
     int paren_count = 1;
     bool in_backtick = false;
@@ -1866,6 +1979,11 @@ bool parse_eval(const std::string& sort_by_str, uint32_t& index, std::vector<sor
         return false;
     }
 
+    sort_by::eval_mode_t eval_mode = sort_by::eval_mode_t::first_match;
+    if (!split_trailing_eval_params(eval_expr, eval_mode)) {
+        return false;
+    }
+
     while (sort_by_str[index] != ':' && ++index < sort_by_str.size());
     if (index >= sort_by_str.size()) {
         return false;
@@ -1880,7 +1998,7 @@ bool parse_eval(const std::string& sort_by_str, uint32_t& index, std::vector<sor
 
     std::vector<std::string> eval_expressions = {eval_expr};
     std::vector<int64_t> scores = {1};
-    sort_fields.emplace_back(eval_expressions, scores, order_str);
+    sort_fields.emplace_back(eval_expressions, scores, order_str, eval_mode);
 
     return true;
 }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -5737,18 +5737,20 @@ void Index::get_field_token_its(const size_t num_search_fields,
 }
 
 /// Clamps an exact `_eval(..., mode: sum)` total to the range supported by sort scores.
-///
-/// The lower bound is `INT64_MIN + 1` and not `INT64_MIN`, because an ascending sort negates the
-/// score at the end of `compute_sort_scores` and `-INT64_MIN` is undefined behaviour.
 static inline int64_t clamp_eval_sum(const __int128 sum) {
     if (sum > static_cast<__int128>(INT64_MAX)) {
         return INT64_MAX;
     }
-    if (sum < static_cast<__int128>(INT64_MIN + 1)) {
-        return INT64_MIN + 1;
+    if (sum < static_cast<__int128>(INT64_MIN)) {
+        return INT64_MIN;
     }
 
     return static_cast<int64_t>(sum);
+}
+
+/// Reverses the ordering of an eval score across the full int64 range without negating INT64_MIN.
+static inline int64_t reverse_eval_score(const int64_t score) {
+    return static_cast<int64_t>(-static_cast<__int128>(score) - 1);
 }
 
 Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields, const int* sort_order,
@@ -6045,7 +6047,7 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
         }
 
         if (sort_order[i] == -1) {
-            scores[i] = -scores[i];
+            scores[i] = field_values[i] == &eval_sentinel_value ? reverse_eval_score(scores[i]) : -scores[i];
         }
     }
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -5858,48 +5858,91 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
             }
 
             uint32_t eval_index = 0;
+            auto const is_sum_mode = (eval.mode == sort_by::eval_mode_t::sum_matches);
             if (is_reference_sort) {
-                // Both ref_seq_ids and eval.eval_ids_vec will be ordered. So we can take advantage of binary search
-                // and break early if there are no matches.
-                auto& ref_filter_indexes = filter_indexes.reset(i, ref_seq_ids.size());
+                if (is_sum_mode) {
+                    if (ref_seq_ids.empty()) {
+                        scores[i] = 0;
+                    } else {
+                        // A source document can reach the same referenced document through multiple
+                        // join paths. Score each referenced document once and process them in ascending
+                        // order so that every expression can maintain a monotonic filter cursor.
+                        gfx::timsort(ref_seq_ids.begin(), ref_seq_ids.end());
+                        ref_seq_ids.erase(std::unique(ref_seq_ids.begin(), ref_seq_ids.end()), ref_seq_ids.end());
 
-                // Trying to find a match for every reference doc. The score will be the value of eval expression where
-                // we find the first match.
-                for (size_t j = 0; j < ref_seq_ids.size(); j++) {
-                    const auto& ref_seq_id = ref_seq_ids[j];
-                    bool break_early = true;
-                    for (eval_index = 0; eval_index < count; eval_index++) {
-                        auto const& eval_ids = eval.eval_ids_vec[eval_index];
-                        auto const& eval_ids_count = eval.eval_ids_count_vec[eval_index];
-                        auto& filter_index = ref_filter_indexes[j];
+                        auto& ref_filter_indexes = filter_indexes.reset(i, count);
+                        const bool is_asc = (sort_order[i] == -1);
+                        int64_t selected_score = is_asc ? INT64_MAX : INT64_MIN;
 
-                        if (filter_index >= eval_ids_count) {
-                            // When all the indexes of eval.eval_ids_vec have reached to the end, we can stop looking.
-                            continue;
+                        for (const auto& ref_seq_id: ref_seq_ids) {
+                            int64_t ref_score = 0;
+                            for (eval_index = 0; eval_index < count; eval_index++) {
+                                auto const& eval_ids = eval.eval_ids_vec[eval_index];
+                                auto const& eval_ids_count = eval.eval_ids_count_vec[eval_index];
+                                auto& filter_index = ref_filter_indexes[eval_index];
+
+                                if (filter_index >= eval_ids_count) {
+                                    continue;
+                                }
+
+                                // Returns the first element that is >= to the referenced document id.
+                                filter_index = std::lower_bound(eval_ids + filter_index,
+                                                                eval_ids + eval_ids_count,
+                                                                ref_seq_id) - eval_ids;
+                                if (filter_index < eval_ids_count && eval_ids[filter_index] == ref_seq_id) {
+                                    filter_index++;
+                                    ref_score = saturating_add_score(ref_score, eval.scores[eval_index]);
+                                }
+                            }
+
+                            selected_score = is_asc ? std::min(selected_score, ref_score) :
+                                                      std::max(selected_score, ref_score);
                         }
-                        break_early = false;
 
-                        // Returns iterator to the first element that is >= to value or last if no such element is found.
-                        filter_index = std::lower_bound(eval_ids + filter_index, eval_ids + eval_ids_count,
-                                                        ref_seq_id) - eval_ids;
+                        scores[i] = selected_score;
+                    }
+                } else {
+                    // Both ref_seq_ids and eval.eval_ids_vec will be ordered. So we can take advantage of binary search
+                    // and break early if there are no matches.
+                    auto& ref_filter_indexes = filter_indexes.reset(i, ref_seq_ids.size());
 
-                        if (filter_index < eval_ids_count && eval_ids[filter_index] == ref_seq_id) {
-                            found = true;
-                            break_early = true;
+                    // Trying to find a match for every reference doc. The score will be the value of eval expression where
+                    // we find the first match.
+                    for (size_t j = 0; j < ref_seq_ids.size(); j++) {
+                        const auto& ref_seq_id = ref_seq_ids[j];
+                        bool break_early = true;
+                        for (eval_index = 0; eval_index < count; eval_index++) {
+                            auto const& eval_ids = eval.eval_ids_vec[eval_index];
+                            auto const& eval_ids_count = eval.eval_ids_count_vec[eval_index];
+                            auto& filter_index = ref_filter_indexes[j];
+
+                            if (filter_index >= eval_ids_count) {
+                                // When all the indexes of eval.eval_ids_vec have reached to the end, we can stop looking.
+                                continue;
+                            }
+                            break_early = false;
+
+                            // Returns iterator to the first element that is >= to value or last if no such element is found.
+                            filter_index = std::lower_bound(eval_ids + filter_index, eval_ids + eval_ids_count,
+                                                            ref_seq_id) - eval_ids;
+
+                            if (filter_index < eval_ids_count && eval_ids[filter_index] == ref_seq_id) {
+                                found = true;
+                                break_early = true;
+                                break;
+                            }
+                        }
+
+                        if (break_early) {
+                            // Either all the indexes of eval.eval_ids_vec have reached to the end or we've found a match.
                             break;
                         }
                     }
 
-                    if (break_early) {
-                        // Either all the indexes of eval.eval_ids_vec have reached to the end or we've found a match.
-                        break;
-                    }
+                    scores[i] = found ? eval.scores[eval_index] : 0;
                 }
-
-                scores[i] = found ? eval.scores[eval_index] : 0;
             } else {
                 auto& eval_indexes = filter_indexes.get(i, count);
-                auto const is_sum_mode = (eval.mode == sort_by::eval_mode_t::sum_matches);
                 int64_t sum_score = 0;
 
                 for (; eval_index < count; eval_index++) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -5736,17 +5736,19 @@ void Index::get_field_token_its(const size_t num_search_fields,
     }
 }
 
-/// Saturating signed addition for `_eval([...], mode: sum)` scores.
+/// Clamps an exact `_eval(..., mode: sum)` total to the range supported by sort scores.
 ///
-/// Clamps to `INT64_MIN + 1` and not `INT64_MIN`, because a descending sort negates the score at the
-/// end of `compute_sort_scores` and `-INT64_MIN` is undefined behaviour.
-static inline int64_t saturating_add_score(const int64_t a, const int64_t b) {
-    int64_t sum = 0;
-    if (__builtin_add_overflow(a, b, &sum)) {
-        return b > 0 ? INT64_MAX : (INT64_MIN + 1);
+/// The lower bound is `INT64_MIN + 1` and not `INT64_MIN`, because an ascending sort negates the
+/// score at the end of `compute_sort_scores` and `-INT64_MIN` is undefined behaviour.
+static inline int64_t clamp_eval_sum(const __int128 sum) {
+    if (sum > static_cast<__int128>(INT64_MAX)) {
+        return INT64_MAX;
+    }
+    if (sum < static_cast<__int128>(INT64_MIN + 1)) {
+        return INT64_MIN + 1;
     }
 
-    return sum < (INT64_MIN + 1) ? (INT64_MIN + 1) : sum;
+    return static_cast<int64_t>(sum);
 }
 
 Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields, const int* sort_order,
@@ -5875,7 +5877,7 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
                         int64_t selected_score = is_asc ? INT64_MAX : INT64_MIN;
 
                         for (const auto& ref_seq_id: ref_seq_ids) {
-                            int64_t ref_score = 0;
+                            __int128 ref_score = 0;
                             for (eval_index = 0; eval_index < count; eval_index++) {
                                 auto const& eval_ids = eval.eval_ids_vec[eval_index];
                                 auto const& eval_ids_count = eval.eval_ids_count_vec[eval_index];
@@ -5891,12 +5893,13 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
                                                                 ref_seq_id) - eval_ids;
                                 if (filter_index < eval_ids_count && eval_ids[filter_index] == ref_seq_id) {
                                     filter_index++;
-                                    ref_score = saturating_add_score(ref_score, eval.scores[eval_index]);
+                                    ref_score += static_cast<__int128>(eval.scores[eval_index]);
                                 }
                             }
 
-                            selected_score = is_asc ? std::min(selected_score, ref_score) :
-                                                      std::max(selected_score, ref_score);
+                            const auto clamped_ref_score = clamp_eval_sum(ref_score);
+                            selected_score = is_asc ? std::min(selected_score, clamped_ref_score) :
+                                                      std::max(selected_score, clamped_ref_score);
                         }
 
                         scores[i] = selected_score;
@@ -5943,7 +5946,7 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
                 }
             } else {
                 auto& eval_indexes = filter_indexes.get(i, count);
-                int64_t sum_score = 0;
+                __int128 sum_score = 0;
 
                 for (; eval_index < count; eval_index++) {
                     auto const& eval_ids = eval.eval_ids_vec[eval_index];
@@ -5965,12 +5968,12 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
                         if (!is_sum_mode) {
                             break;
                         }
-                        sum_score = saturating_add_score(sum_score, eval.scores[eval_index]);
+                        sum_score += static_cast<__int128>(eval.scores[eval_index]);
                     }
                 }
 
                 if (is_sum_mode) {
-                    scores[i] = sum_score;
+                    scores[i] = clamp_eval_sum(sum_score);
                 } else {
                     scores[i] = found ? eval.scores[eval_index] : 0;
                 }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -5736,6 +5736,19 @@ void Index::get_field_token_its(const size_t num_search_fields,
     }
 }
 
+/// Saturating signed addition for `_eval([...], mode: sum)` scores.
+///
+/// Clamps to `INT64_MIN + 1` and not `INT64_MIN`, because a descending sort negates the score at the
+/// end of `compute_sort_scores` and `-INT64_MIN` is undefined behaviour.
+static inline int64_t saturating_add_score(const int64_t a, const int64_t b) {
+    int64_t sum = 0;
+    if (__builtin_add_overflow(a, b, &sum)) {
+        return b > 0 ? INT64_MAX : (INT64_MIN + 1);
+    }
+
+    return sum < (INT64_MIN + 1) ? (INT64_MIN + 1) : sum;
+}
+
 Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields, const int* sort_order,
                                         std::array<spp::sparse_hash_map<uint32_t, int64_t, Hasher32>*, 3> field_values,
                                         const std::vector<size_t>& geopoint_indices,
@@ -5882,8 +5895,12 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
                         break;
                     }
                 }
+
+                scores[i] = found ? eval.scores[eval_index] : 0;
             } else {
                 auto& eval_indexes = filter_indexes.get(i, count);
+                auto const is_sum_mode = (eval.mode == sort_by::eval_mode_t::sum_matches);
+                int64_t sum_score = 0;
 
                 for (; eval_index < count; eval_index++) {
                     auto const& eval_ids = eval.eval_ids_vec[eval_index];
@@ -5901,12 +5918,20 @@ Option<bool> Index::compute_sort_scores(const std::vector<sort_by>& sort_fields,
                     if (filter_index < eval_ids_count && eval_ids[filter_index] == seq_id) {
                         filter_index++;
                         found = true;
-                        break;
+
+                        if (!is_sum_mode) {
+                            break;
+                        }
+                        sum_score = saturating_add_score(sum_score, eval.scores[eval_index]);
                     }
                 }
-            }
 
-            scores[i] = found ? eval.scores[eval_index] : 0;
+                if (is_sum_mode) {
+                    scores[i] = sum_score;
+                } else {
+                    scores[i] = found ? eval.scores[eval_index] : 0;
+                }
+            }
         } else if(field_values[i] == &vector_distance_sentinel_value) {
             scores[i] = float_to_int64_t(vector_distance);
         } else if(field_values[i] == &vector_query_sentinel_value) {

--- a/src/join.cpp
+++ b/src/join.cpp
@@ -901,12 +901,47 @@ Option<bool> parse_nested_exclude(const std::string& exclude_field_exp,
     return Option<bool>(true);
 }
 
+static void split_ref_include_parameters(const std::string& parameters, std::vector<std::string>& tokens) {
+    size_t token_start = 0;
+    size_t parenthesis_depth = 0;
+    size_t bracket_depth = 0;
+    bool in_backtick = false;
+
+    for (size_t i = 0; i < parameters.size(); ++i) {
+        const char c = parameters[i];
+        if (c == '`') {
+            in_backtick = !in_backtick;
+        } else if (!in_backtick && c == '(') {
+            ++parenthesis_depth;
+        } else if (!in_backtick && c == ')' && parenthesis_depth > 0) {
+            --parenthesis_depth;
+        } else if (!in_backtick && c == '[') {
+            ++bracket_depth;
+        } else if (!in_backtick && c == ']' && bracket_depth > 0) {
+            --bracket_depth;
+        } else if (!in_backtick && c == ',' && parenthesis_depth == 0 && bracket_depth == 0) {
+            auto token = parameters.substr(token_start, i - token_start);
+            StringUtils::trim(token);
+            if (!token.empty()) {
+                tokens.emplace_back(std::move(token));
+            }
+            token_start = i + 1;
+        }
+    }
+
+    auto token = parameters.substr(token_start);
+    StringUtils::trim(token);
+    if (!token.empty()) {
+        tokens.emplace_back(std::move(token));
+    }
+}
+
 Option<bool> parse_ref_include_parameters(const std::string& include_field_exp, const std::string& parameters,
                                           ref_include::strategy_enum& strategy_enum, std::string& related_docs_field,
                                           std::string& sort_by_str, size_t& limit) {
 
     std::vector<std::string> tokens, kv_tokens;
-    StringUtils::split(parameters, tokens, ",");
+    split_ref_include_parameters(parameters, tokens);
 
     for(const auto& tok : tokens) {
         kv_tokens.clear();

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -15112,7 +15112,34 @@ TEST_F(JoinIncludeExcludeFieldsTest, IncludeFieldsSortLimit) {
     ASSERT_EQ(3.5, res_obj["hits"][0]["document"]["books.popularity"][2].get<double>());
     ASSERT_EQ(4.8, res_obj["hits"][0]["document"]["books.popularity"][3].get<double>());
 
-    //now apply limiting to last search query
+    // Commas inside a multi-expression `_eval`, including its trailing mode parameter, must not be
+    // interpreted as delimiters between reference include parameters.
+    req_params = {
+            {"collection",     "authors"},
+            {"q",              "*"},
+            {"filter_by",      "$books(id:*)"},
+            {"include_fields", "$books(*, sort_by:_eval([(in_stock:true):1, (popularity:>4):2], mode:sum):desc, "
+                               "strategy:merge, limit:2) as books"}
+    };
+    now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok()) << search_op.error();
+
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, res_obj["found"].get<size_t>());
+    ASSERT_EQ(2, res_obj["hits"].size());
+
+    ASSERT_EQ(2, res_obj["hits"][0]["document"]["books.id"].size());
+    ASSERT_EQ("4", res_obj["hits"][0]["document"]["books.id"][0]);
+    ASSERT_EQ("5", res_obj["hits"][0]["document"]["books.id"][1]);
+
+    ASSERT_EQ(2, res_obj["hits"][1]["document"]["books.id"].size());
+    ASSERT_EQ("0", res_obj["hits"][1]["document"]["books.id"][0]);
+    ASSERT_EQ("2", res_obj["hits"][1]["document"]["books.id"][1]);
+
+    // Apply limiting to a single-expression `_eval` sort.
 
     req_params = {
             {"collection",     "authors"},

--- a/test/collection_manager_test.cpp
+++ b/test/collection_manager_test.cpp
@@ -1525,6 +1525,69 @@ TEST_F(CollectionManagerTest, ParseSortByClause) {
     ASSERT_EQ("points", sort_fields[1].name);
     ASSERT_EQ("DESC", sort_fields[1].order);
 
+    // The single expression form takes `mode` too, and the parameter must not leak into the filter.
+    sort_fields.clear();
+    sort_by_parsed = CollectionManager::parse_sort_by_str("_eval((brand:nike), mode: sum):DESC", sort_fields);
+    ASSERT_TRUE(sort_by_parsed);
+    ASSERT_EQ(1, sort_fields.size());
+    ASSERT_EQ("brand:nike", sort_fields[0].eval_expressions[0]);
+    ASSERT_EQ(sort_by::eval_mode_t::sum_matches, sort_fields[0].eval.mode);
+    ASSERT_EQ("DESC", sort_fields[0].order);
+
+    sort_fields.clear();
+    sort_by_parsed = CollectionManager::parse_sort_by_str("_eval((brand:nike),mode:first_match):ASC", sort_fields);
+    ASSERT_TRUE(sort_by_parsed);
+    ASSERT_EQ("brand:nike", sort_fields[0].eval_expressions[0]);
+    ASSERT_EQ(sort_by::eval_mode_t::first_match, sort_fields[0].eval.mode);
+
+    // An unusable mode is an error rather than something that quietly ends up in the filter.
+    sort_fields.clear();
+    ASSERT_FALSE(CollectionManager::parse_sort_by_str("_eval((brand:nike), mode: sumx):DESC", sort_fields));
+
+    // Without the wrapping parentheses there is no parameter list, so this stays a plain filter.
+    sort_fields.clear();
+    sort_by_parsed = CollectionManager::parse_sort_by_str("_eval(brand:nike, mode: sum):DESC", sort_fields);
+    ASSERT_TRUE(sort_by_parsed);
+    ASSERT_EQ("brand:nike, mode: sum", sort_fields[0].eval_expressions[0]);
+    ASSERT_EQ(sort_by::eval_mode_t::first_match, sort_fields[0].eval.mode);
+
+    // A parenthesised group followed by anything other than a comma is an ordinary compound filter.
+    sort_fields.clear();
+    sort_by_parsed = CollectionManager::parse_sort_by_str("_eval((brand:nike) && (size:10)):DESC", sort_fields);
+    ASSERT_TRUE(sort_by_parsed);
+    ASSERT_EQ("(brand:nike) && (size:10)", sort_fields[0].eval_expressions[0]);
+    ASSERT_EQ(sort_by::eval_mode_t::first_match, sort_fields[0].eval.mode);
+
+    sort_fields.clear();
+    sort_by_parsed = CollectionManager::parse_sort_by_str("_eval((brand:nike || brand:air) && size:10):DESC",
+                                                          sort_fields);
+    ASSERT_TRUE(sort_by_parsed);
+    ASSERT_EQ("(brand:nike || brand:air) && size:10", sort_fields[0].eval_expressions[0]);
+
+    // A comma that belongs to the filter value is left alone, so these keep parsing as they always did.
+    sort_fields.clear();
+    sort_by_parsed = CollectionManager::parse_sort_by_str("_eval(title:Hello, World):DESC", sort_fields);
+    ASSERT_TRUE(sort_by_parsed);
+    ASSERT_EQ("title:Hello, World", sort_fields[0].eval_expressions[0]);
+    ASSERT_EQ(sort_by::eval_mode_t::first_match, sort_fields[0].eval.mode);
+
+    sort_fields.clear();
+    sort_by_parsed = CollectionManager::parse_sort_by_str("_eval(brand:[nike,adidas]):DESC", sort_fields);
+    ASSERT_TRUE(sort_by_parsed);
+    ASSERT_EQ("brand:[nike,adidas]", sort_fields[0].eval_expressions[0]);
+
+    sort_fields.clear();
+    sort_by_parsed = CollectionManager::parse_sort_by_str("_eval(loc:(48.90,2.33,5.1 km)):DESC", sort_fields);
+    ASSERT_TRUE(sort_by_parsed);
+    ASSERT_EQ("loc:(48.90,2.33,5.1 km)", sort_fields[0].eval_expressions[0]);
+
+    // Backticks protect a value that would otherwise look like a parameter.
+    sort_fields.clear();
+    sort_by_parsed = CollectionManager::parse_sort_by_str("_eval(title:`Hello, mode: sum`):DESC", sort_fields);
+    ASSERT_TRUE(sort_by_parsed);
+    ASSERT_EQ("title:`Hello, mode: sum`", sort_fields[0].eval_expressions[0]);
+    ASSERT_EQ(sort_by::eval_mode_t::first_match, sort_fields[0].eval.mode);
+
     sort_fields.clear();
     sort_by_parsed = CollectionManager::parse_sort_by_str("_eval([(brand:nike || brand:air):3, (brand:adidas):2]):DESC", sort_fields);
     ASSERT_TRUE(sort_by_parsed);
@@ -1536,6 +1599,58 @@ TEST_F(CollectionManagerTest, ParseSortByClause) {
     ASSERT_EQ(3, sort_fields[0].eval.scores[0]);
     ASSERT_EQ(2, sort_fields[0].eval.scores[1]);
     ASSERT_EQ("DESC", sort_fields[0].order);
+    ASSERT_EQ(sort_by::eval_mode_t::first_match, sort_fields[0].eval.mode);
+
+    // `mode: sum` carries a colon of its own, which must not be mistaken for the one introducing the order.
+    sort_fields.clear();
+    sort_by_parsed = CollectionManager::parse_sort_by_str("_eval([(brand:nike):3, (brand:adidas):2], mode: sum):DESC, "
+                                                          "points:desc", sort_fields);
+    ASSERT_TRUE(sort_by_parsed);
+    ASSERT_EQ(2, sort_fields.size());
+    ASSERT_EQ("_eval", sort_fields[0].name);
+    ASSERT_EQ(sort_by::eval_mode_t::sum_matches, sort_fields[0].eval.mode);
+    ASSERT_EQ(2, sort_fields[0].eval_expressions.size());
+    ASSERT_EQ("brand:nike", sort_fields[0].eval_expressions[0]);
+    ASSERT_EQ("brand:adidas", sort_fields[0].eval_expressions[1]);
+    ASSERT_EQ(3, sort_fields[0].eval.scores[0]);
+    ASSERT_EQ(2, sort_fields[0].eval.scores[1]);
+    ASSERT_EQ("DESC", sort_fields[0].order);
+    ASSERT_EQ("points", sort_fields[1].name);
+    ASSERT_EQ("DESC", sort_fields[1].order);
+
+    // Whitespace around the parameter is optional.
+    sort_fields.clear();
+    sort_by_parsed = CollectionManager::parse_sort_by_str("_eval([(brand:nike):3],mode:sum):DESC", sort_fields);
+    ASSERT_TRUE(sort_by_parsed);
+    ASSERT_EQ(1, sort_fields.size());
+    ASSERT_EQ(sort_by::eval_mode_t::sum_matches, sort_fields[0].eval.mode);
+    ASSERT_EQ("DESC", sort_fields[0].order);
+
+    // The default is accepted explicitly too.
+    sort_fields.clear();
+    sort_by_parsed = CollectionManager::parse_sort_by_str("_eval([(brand:nike):3], mode: first_match):ASC",
+                                                          sort_fields);
+    ASSERT_TRUE(sort_by_parsed);
+    ASSERT_EQ(1, sort_fields.size());
+    ASSERT_EQ(sort_by::eval_mode_t::first_match, sort_fields[0].eval.mode);
+    ASSERT_EQ("ASC", sort_fields[0].order);
+
+    // Unknown parameter name, unknown mode value, and a malformed parameter are all rejected.
+    sort_fields.clear();
+    ASSERT_FALSE(CollectionManager::parse_sort_by_str("_eval([(brand:nike):3], combine: sum):DESC", sort_fields));
+
+    sort_fields.clear();
+    ASSERT_FALSE(CollectionManager::parse_sort_by_str("_eval([(brand:nike):3], mode: product):DESC", sort_fields));
+
+    sort_fields.clear();
+    ASSERT_FALSE(CollectionManager::parse_sort_by_str("_eval([(brand:nike):3], mode):DESC", sort_fields));
+
+    sort_fields.clear();
+    ASSERT_FALSE(CollectionManager::parse_sort_by_str("_eval([(brand:nike):3], ):DESC", sort_fields));
+
+    // An unterminated clause has no parameter span to read at all.
+    sort_fields.clear();
+    ASSERT_FALSE(CollectionManager::parse_sort_by_str("_eval([(brand:nike):3]:DESC", sort_fields));
 
     sort_fields.clear();
     sort_by_parsed = CollectionManager::parse_sort_by_str("points:desc, loc(24.56,10.45):ASC, "

--- a/test/collection_sorting_test.cpp
+++ b/test/collection_sorting_test.cpp
@@ -4155,13 +4155,169 @@ TEST_F(CollectionSortingTest, EvalSumSaturatesInsteadOfOverflowing) {
     collectionManager.drop_collection("eval_sum_overflow");
 }
 
-TEST_F(CollectionSortingTest, EvalSumRejectedOnReferencedCollection) {
+TEST_F(CollectionSortingTest, EvalSumOnReferencedCollection) {
+    auto locations_schema = R"({
+        "name": "es_locations",
+        "fields": [
+            {"name": "location_id", "type": "string"},
+            {"name": "fast", "type": "bool"},
+            {"name": "discount", "type": "bool"}
+        ]
+    })"_json;
+    ASSERT_TRUE(collectionManager.create_collection(locations_schema).ok());
+
+    auto stock_schema = R"({
+        "name": "es_stock",
+        "fields": [
+            {"name": "stock_id", "type": "string"},
+            {"name": "location_ids", "type": "string[]", "reference": "es_locations.location_id", "optional": true},
+            {"name": "signal_a", "type": "bool"},
+            {"name": "signal_b", "type": "bool"},
+            {"name": "signal_c", "type": "bool"},
+            {"name": "overflow", "type": "bool"}
+        ]
+    })"_json;
+    ASSERT_TRUE(collectionManager.create_collection(stock_schema).ok());
+
     auto products_schema = R"({
         "name": "es_products",
         "fields": [
             {"name": "product_id", "type": "string"},
-            {"name": "product_name", "type": "string"}
+            {"name": "stock_ids", "type": "string[]", "reference": "es_stock.stock_id", "optional": true},
+            {"name": "rank", "type": "int32"}
         ]
+    })"_json;
+    ASSERT_TRUE(collectionManager.create_collection(products_schema).ok());
+
+    const std::vector<nlohmann::json> location_documents = {
+            {{"id", "0"}, {"location_id", "l0"}, {"fast", true}, {"discount", true}},
+            {{"id", "1"}, {"location_id", "l1"}, {"fast", true}, {"discount", false}},
+            {{"id", "2"}, {"location_id", "l2"}, {"fast", false}, {"discount", true}},
+    };
+    for (const auto& location: location_documents) {
+        ASSERT_TRUE(collectionManager.get_collection("es_locations")->add(location.dump()).ok());
+    }
+
+    const std::vector<nlohmann::json> stock_documents = {
+            {{"id", "0"}, {"stock_id", "s0"}, {"location_ids", {"l0"}},
+             {"signal_a", true}, {"signal_b", true}, {"signal_c", false}, {"overflow", false}},
+            {{"id", "1"}, {"stock_id", "s1"},
+             {"signal_a", false}, {"signal_b", false}, {"signal_c", true}, {"overflow", false}},
+            {{"id", "2"}, {"stock_id", "s2"}, {"location_ids", {"l1"}},
+             {"signal_a", true}, {"signal_b", true}, {"signal_c", true}, {"overflow", true}},
+            {{"id", "3"}, {"stock_id", "s3"}, {"location_ids", {"l2"}},
+             {"signal_a", true}, {"signal_b", false}, {"signal_c", false}, {"overflow", false}},
+            {{"id", "4"}, {"stock_id", "s4"},
+             {"signal_a", true}, {"signal_b", true}, {"signal_c", false}, {"overflow", false}},
+            {{"id", "5"}, {"stock_id", "s5"},
+             {"signal_a", false}, {"signal_b", false}, {"signal_c", false}, {"overflow", false}},
+    };
+    for (const auto& stock: stock_documents) {
+        ASSERT_TRUE(collectionManager.get_collection("es_stock")->add(stock.dump()).ok());
+    }
+
+    const std::vector<std::vector<std::string>> product_stock_ids = {
+            {"s0", "s1"}, {"s2"}, {"s3", "s4"}, {}, {"s5"}
+    };
+    for (size_t i = 0; i < product_stock_ids.size(); i++) {
+        nlohmann::json product;
+        product["id"] = std::to_string(i);
+        product["product_id"] = "p" + std::to_string(i);
+        if (!product_stock_ids[i].empty()) {
+            product["stock_ids"] = product_stock_ids[i];
+        }
+        product["rank"] = i;
+        ASSERT_TRUE(collectionManager.get_collection("es_products")->add(product.dump()).ok());
+    }
+
+    const std::string rules = "[(signal_a:true):7, (signal_b:true):5, (signal_c:true):20]";
+
+    std::map<std::string, std::string> req_params = {
+            {"collection", "es_products"},
+            {"q", "*"},
+            {"sort_by", "$es_stock(_eval(" + rules + ", mode: sum):desc), rank:asc"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    // Scores are calculated per referenced document and reduced with max for DESC:
+    // p0=max(7+5,20)=20, p1=7+5+20=32, p2=max(7,7+5)=12, p3=0 (no refs),
+    // and p4=0 (referenced document has no matching expression).
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok()) << search_op.error();
+    auto results = nlohmann::json::parse(json_res);
+    const std::vector<std::string> desc_order = {"p1", "p0", "p2", "p3", "p4"};
+    ASSERT_EQ(desc_order.size(), results["hits"].size());
+    for (size_t i = 0; i < desc_order.size(); i++) {
+        ASSERT_EQ(desc_order[i], results["hits"][i]["document"]["product_id"]) << results.dump();
+    }
+
+    // Providing the join in filter_by uses the same scoring semantics.
+    req_params["filter_by"] = "id:* || $es_stock(id:*)";
+    json_res.clear();
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok()) << search_op.error();
+    results = nlohmann::json::parse(json_res);
+    for (size_t i = 0; i < desc_order.size(); i++) {
+        ASSERT_EQ(desc_order[i], results["hits"][i]["document"]["product_id"]);
+    }
+
+    // ASC selects the minimum referenced-document score and keeps a missing reference at zero:
+    // p0=min(12,20)=12, p1=32, p2=min(7,12)=7, p3=0.
+    req_params.erase("filter_by");
+    req_params["sort_by"] = "$es_stock(_eval(" + rules + ", mode: sum):asc), rank:asc";
+    json_res.clear();
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok()) << search_op.error();
+    results = nlohmann::json::parse(json_res);
+    const std::vector<std::string> asc_order = {"p3", "p4", "p2", "p0", "p1"};
+    for (size_t i = 0; i < asc_order.size(); i++) {
+        ASSERT_EQ(asc_order[i], results["hits"][i]["document"]["product_id"]);
+    }
+
+    // Negative expression scores participate in the same min reduction.
+    req_params["sort_by"] = "$es_stock(_eval([(signal_a:true):-10, (signal_b:true):3], "
+                            "mode: sum):asc), rank:asc";
+    json_res.clear();
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok()) << search_op.error();
+    results = nlohmann::json::parse(json_res);
+    const std::vector<std::string> negative_order = {"p2", "p0", "p1", "p3", "p4"};
+    for (size_t i = 0; i < negative_order.size(); i++) {
+        ASSERT_EQ(negative_order[i], results["hits"][i]["document"]["product_id"]);
+    }
+
+    // A referenced sum saturates instead of wrapping to a negative score.
+    req_params["sort_by"] = "$es_stock(_eval([(overflow:true):9223372036854775806, "
+                            "(overflow:true):9223372036854775806], mode: sum):desc), rank:asc";
+    json_res.clear();
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok()) << search_op.error();
+    results = nlohmann::json::parse(json_res);
+    ASSERT_EQ("p1", results["hits"][0]["document"]["product_id"]);
+
+    req_params["sort_by"] = "$es_stock($es_locations(_eval([(fast:true):5, "
+                            "(discount:true):4], mode: sum):desc)), rank:asc";
+    json_res.clear();
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok()) << search_op.error();
+    results = nlohmann::json::parse(json_res);
+    const std::vector<std::string> nested_order = {"p0", "p1", "p2", "p3", "p4"};
+    for (size_t i = 0; i < nested_order.size(); i++) {
+        ASSERT_EQ(nested_order[i], results["hits"][i]["document"]["product_id"]);
+    }
+
+    collectionManager.drop_collection("es_products");
+    collectionManager.drop_collection("es_stock");
+    collectionManager.drop_collection("es_locations");
+}
+
+TEST_F(CollectionSortingTest, EvalSumReferencedValidationFailureDoesNotLeak) {
+    auto products_schema = R"({
+        "name": "es_products",
+        "fields": [{"name": "product_id", "type": "string"}]
     })"_json;
     ASSERT_TRUE(collectionManager.create_collection(products_schema).ok());
 
@@ -4174,37 +4330,24 @@ TEST_F(CollectionSortingTest, EvalSumRejectedOnReferencedCollection) {
     })"_json;
     ASSERT_TRUE(collectionManager.create_collection(stock_schema).ok());
 
-    nlohmann::json product;
-    product["id"] = "0";
-    product["product_id"] = "p0";
-    product["product_name"] = "shoe";
-    ASSERT_TRUE(collectionManager.get_collection("es_products")->add(product.dump()).ok());
-
-    nlohmann::json stock;
-    stock["id"] = "0";
-    stock["product_id"] = "p0";
-    stock["in_stock"] = true;
-    ASSERT_TRUE(collectionManager.get_collection("es_stock")->add(stock.dump()).ok());
-
     std::map<std::string, std::string> req_params = {
             {"collection", "es_products"},
             {"q", "*"},
-            {"sort_by", "$es_stock(_eval([(in_stock:true):3], mode: sum):desc)"}
+            {"sort_by", "$es_stock(_eval([(in_stock:true):3, (missing:true):2], mode: sum):desc)"}
     };
     nlohmann::json embedded_params;
     std::string json_res;
     auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::system_clock::now().time_since_epoch()).count();
 
-    // Repeated rejected requests must not retain the parsed filter trees. This loop is also a
-    // LeakSanitizer regression: before the early rejection in sort validation, each iteration
-    // leaked the filter-tree pointer array and the parsed filter tree.
+    // The first expression allocates a filter tree before validation of the second expression
+    // fails. Repetition makes this an ASan/LeakSanitizer regression for partial validation cleanup.
     for (size_t i = 0; i < 10; i++) {
         json_res.clear();
         auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
         ASSERT_FALSE(search_op.ok());
-        ASSERT_TRUE(search_op.error().find("`mode: sum` is not supported on a referenced collection")
-                    != std::string::npos) << search_op.error();
+        ASSERT_EQ("Referenced collection `es_stock`: Error parsing eval expression in sort_by clause.",
+                  search_op.error());
     }
 
     collectionManager.drop_collection("es_stock");

--- a/test/collection_sorting_test.cpp
+++ b/test/collection_sorting_test.cpp
@@ -4038,3 +4038,169 @@ TEST_F(CollectionSortingTest, ReferenceAndNormalEvalKeepSeparateCursors) {
     collectionManager.drop_collection("eval_stock");
     collectionManager.drop_collection("eval_prod");
 }
+
+TEST_F(CollectionSortingTest, EvalSumAddsEveryMatchingExpression) {
+    // `_eval` scores the first matching expression only; `mode: sum` adds them all up. The two
+    // produce a different order for the same rules, which is what this asserts.
+    auto schema = R"({
+        "name": "eval_sum",
+        "fields": [
+            {"name": "domain", "type": "string"},
+            {"name": "seniority", "type": "int32"},
+            {"name": "skills", "type": "string[]"}
+        ]
+    })"_json;
+
+    Collection* coll = collectionManager.create_collection(schema).get();
+
+    nlohmann::json doc1;
+    doc1["id"] = "1";
+    doc1["domain"] = "engineering";
+    doc1["seniority"] = 1;
+    doc1["skills"] = nlohmann::json::array({"java"});
+
+    nlohmann::json doc2;
+    doc2["id"] = "2";
+    doc2["domain"] = "design";
+    doc2["seniority"] = 3;
+    doc2["skills"] = nlohmann::json::array({"react", "typescript", "graphql"});
+
+    nlohmann::json doc3;
+    doc3["id"] = "3";
+    doc3["domain"] = "sales";
+    doc3["seniority"] = 2;
+    doc3["skills"] = nlohmann::json::array({"excel"});
+
+    ASSERT_TRUE(coll->add(doc1.dump()).ok());
+    ASSERT_TRUE(coll->add(doc2.dump()).ok());
+    ASSERT_TRUE(coll->add(doc3.dump()).ok());
+
+    const std::string rules = "[(domain:=engineering):25, (seniority:=3):6, (skills:=react):8, "
+                              "(skills:=typescript):8, (skills:=graphql):8]";
+
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    // doc1 = 25, doc2 = 6+8+8+8 = 30, doc3 = 0
+    std::map<std::string, std::string> sum_params = {
+            {"collection", "eval_sum"},
+            {"q", "*"},
+            {"sort_by", "_eval(" + rules + ", mode: sum):desc"}
+    };
+    ASSERT_TRUE(collectionManager.do_search(sum_params, embedded_params, json_res, now_ts).ok());
+    auto res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(3, res_obj["hits"].size());
+    ASSERT_EQ("2", res_obj["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_EQ("1", res_obj["hits"][1]["document"]["id"].get<std::string>());
+    ASSERT_EQ("3", res_obj["hits"][2]["document"]["id"].get<std::string>());
+
+    // Same rules under `_eval`: doc1 = 25, doc2 = 6, doc3 = 0. The top two swap.
+    std::map<std::string, std::string> first_match_params = {
+            {"collection", "eval_sum"},
+            {"q", "*"},
+            {"sort_by", "_eval(" + rules + "):desc"}
+    };
+    json_res.clear();
+    ASSERT_TRUE(collectionManager.do_search(first_match_params, embedded_params, json_res, now_ts).ok());
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(3, res_obj["hits"].size());
+    ASSERT_EQ("1", res_obj["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_EQ("2", res_obj["hits"][1]["document"]["id"].get<std::string>());
+    ASSERT_EQ("3", res_obj["hits"][2]["document"]["id"].get<std::string>());
+
+    collectionManager.drop_collection("eval_sum");
+}
+
+TEST_F(CollectionSortingTest, EvalSumSaturatesInsteadOfOverflowing) {
+    auto schema = R"({
+        "name": "eval_sum_overflow",
+        "fields": [
+            {"name": "domain", "type": "string"}
+        ]
+    })"_json;
+
+    Collection* coll = collectionManager.create_collection(schema).get();
+
+    nlohmann::json doc1;
+    doc1["id"] = "1";
+    doc1["domain"] = "engineering";
+
+    nlohmann::json doc2;
+    doc2["id"] = "2";
+    doc2["domain"] = "design";
+
+    ASSERT_TRUE(coll->add(doc1.dump()).ok());
+    ASSERT_TRUE(coll->add(doc2.dump()).ok());
+
+    // Both expressions match doc1; the sum would wrap negative without saturation, dropping it last.
+    std::map<std::string, std::string> req_params = {
+            {"collection", "eval_sum_overflow"},
+            {"q", "*"},
+            {"sort_by", "_eval([(domain:=engineering):9223372036854775806, "
+                        "(domain:=engineering):9223372036854775806], mode: sum):desc"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    ASSERT_TRUE(collectionManager.do_search(req_params, embedded_params, json_res, now_ts).ok());
+    auto res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, res_obj["hits"].size());
+    ASSERT_EQ("1", res_obj["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_EQ("2", res_obj["hits"][1]["document"]["id"].get<std::string>());
+
+    collectionManager.drop_collection("eval_sum_overflow");
+}
+
+TEST_F(CollectionSortingTest, EvalSumRejectedOnReferencedCollection) {
+    auto products_schema = R"({
+        "name": "es_products",
+        "fields": [
+            {"name": "product_id", "type": "string"},
+            {"name": "product_name", "type": "string"}
+        ]
+    })"_json;
+    ASSERT_TRUE(collectionManager.create_collection(products_schema).ok());
+
+    auto stock_schema = R"({
+        "name": "es_stock",
+        "fields": [
+            {"name": "product_id", "type": "string", "reference": "es_products.product_id"},
+            {"name": "in_stock", "type": "bool"}
+        ]
+    })"_json;
+    ASSERT_TRUE(collectionManager.create_collection(stock_schema).ok());
+
+    nlohmann::json product;
+    product["id"] = "0";
+    product["product_id"] = "p0";
+    product["product_name"] = "shoe";
+    ASSERT_TRUE(collectionManager.get_collection("es_products")->add(product.dump()).ok());
+
+    nlohmann::json stock;
+    stock["id"] = "0";
+    stock["product_id"] = "p0";
+    stock["in_stock"] = true;
+    ASSERT_TRUE(collectionManager.get_collection("es_stock")->add(stock.dump()).ok());
+
+    std::map<std::string, std::string> req_params = {
+            {"collection", "es_products"},
+            {"q", "*"},
+            {"sort_by", "$es_stock(_eval([(in_stock:true):3], mode: sum):desc)"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_FALSE(search_op.ok());
+    ASSERT_TRUE(search_op.error().find("`mode: sum` is not supported on a referenced collection")
+                != std::string::npos) << search_op.error();
+
+    collectionManager.drop_collection("es_stock");
+    collectionManager.drop_collection("es_products");
+}

--- a/test/collection_sorting_test.cpp
+++ b/test/collection_sorting_test.cpp
@@ -4117,7 +4117,8 @@ TEST_F(CollectionSortingTest, EvalSumSaturatesInsteadOfOverflowing) {
     auto schema = R"({
         "name": "eval_sum_overflow",
         "fields": [
-            {"name": "domain", "type": "string"}
+            {"name": "domain", "type": "string"},
+            {"name": "rank", "type": "int32"}
         ]
     })"_json;
 
@@ -4126,10 +4127,12 @@ TEST_F(CollectionSortingTest, EvalSumSaturatesInsteadOfOverflowing) {
     nlohmann::json doc1;
     doc1["id"] = "1";
     doc1["domain"] = "engineering";
+    doc1["rank"] = 0;
 
     nlohmann::json doc2;
     doc2["id"] = "2";
     doc2["domain"] = "design";
+    doc2["rank"] = 1;
 
     ASSERT_TRUE(coll->add(doc1.dump()).ok());
     ASSERT_TRUE(coll->add(doc2.dump()).ok());
@@ -4149,6 +4152,26 @@ TEST_F(CollectionSortingTest, EvalSumSaturatesInsteadOfOverflowing) {
     ASSERT_TRUE(collectionManager.do_search(req_params, embedded_params, json_res, now_ts).ok());
     auto res_obj = nlohmann::json::parse(json_res);
     ASSERT_EQ(2, res_obj["hits"].size());
+    ASSERT_EQ("1", res_obj["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_EQ("2", res_obj["hits"][1]["document"]["id"].get<std::string>());
+
+    // Clamp only after every matching weight is added. Both expression orders sum doc1 to
+    // INT64_MAX, tying doc2 and leaving rank:asc to put doc1 first.
+    req_params["sort_by"] = "_eval([(domain:=engineering):9223372036854775807, "
+                            "(domain:=engineering):1, (domain:=engineering):-1, "
+                            "(domain:=design):9223372036854775807], mode: sum):desc, rank:asc";
+    json_res.clear();
+    ASSERT_TRUE(collectionManager.do_search(req_params, embedded_params, json_res, now_ts).ok());
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ("1", res_obj["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_EQ("2", res_obj["hits"][1]["document"]["id"].get<std::string>());
+
+    req_params["sort_by"] = "_eval([(domain:=engineering):9223372036854775807, "
+                            "(domain:=engineering):-1, (domain:=engineering):1, "
+                            "(domain:=design):9223372036854775807], mode: sum):desc, rank:asc";
+    json_res.clear();
+    ASSERT_TRUE(collectionManager.do_search(req_params, embedded_params, json_res, now_ts).ok());
+    res_obj = nlohmann::json::parse(json_res);
     ASSERT_EQ("1", res_obj["hits"][0]["document"]["id"].get<std::string>());
     ASSERT_EQ("2", res_obj["hits"][1]["document"]["id"].get<std::string>());
 
@@ -4312,6 +4335,89 @@ TEST_F(CollectionSortingTest, EvalSumOnReferencedCollection) {
     collectionManager.drop_collection("es_products");
     collectionManager.drop_collection("es_stock");
     collectionManager.drop_collection("es_locations");
+}
+
+TEST_F(CollectionSortingTest, ReferencedEvalSumIsOrderIndependentNearOverflow) {
+    auto refs_schema = R"({
+        "name": "eval_order_refs",
+        "fields": [
+            {"name": "ref_id", "type": "string"},
+            {"name": "max_signal", "type": "bool"},
+            {"name": "plus_signal", "type": "bool"},
+            {"name": "minus_signal", "type": "bool"},
+            {"name": "ceiling_signal", "type": "bool"}
+        ]
+    })"_json;
+    ASSERT_TRUE(collectionManager.create_collection(refs_schema).ok());
+
+    auto products_schema = R"({
+        "name": "eval_order_products",
+        "fields": [
+            {"name": "product_id", "type": "string"},
+            {"name": "ref_id", "type": "string", "reference": "eval_order_refs.ref_id"},
+            {"name": "rank", "type": "int32"}
+        ]
+    })"_json;
+    ASSERT_TRUE(collectionManager.create_collection(products_schema).ok());
+
+    const std::vector<nlohmann::json> ref_documents = {
+            {{"id", "0"}, {"ref_id", "r0"}, {"max_signal", true}, {"plus_signal", true},
+             {"minus_signal", true}, {"ceiling_signal", false}},
+            {{"id", "1"}, {"ref_id", "r1"}, {"max_signal", false}, {"plus_signal", false},
+             {"minus_signal", false}, {"ceiling_signal", true}},
+    };
+    for (const auto& ref_document: ref_documents) {
+        ASSERT_TRUE(collectionManager.get_collection("eval_order_refs")->add(ref_document.dump()).ok());
+    }
+
+    const std::vector<nlohmann::json> product_documents = {
+            {{"id", "0"}, {"product_id", "p0"}, {"ref_id", "r0"}, {"rank", 0}},
+            {{"id", "1"}, {"product_id", "p1"}, {"ref_id", "r1"}, {"rank", 1}},
+    };
+    for (const auto& product_document: product_documents) {
+        ASSERT_TRUE(collectionManager.get_collection("eval_order_products")->add(product_document.dump()).ok());
+    }
+
+    std::map<std::string, std::string> req_params = {
+            {"collection", "eval_order_products"},
+            {"q", "*"},
+            {"sort_by", "$eval_order_refs(_eval([(max_signal:true):9223372036854775807, "
+                        "(plus_signal:true):1, (minus_signal:true):-1, "
+                        "(ceiling_signal:true):9223372036854775807], mode: sum):desc), rank:asc"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok()) << search_op.error();
+    auto results = nlohmann::json::parse(json_res);
+    std::vector<std::string> saturating_first_order;
+    for (const auto& hit: results["hits"]) {
+        saturating_first_order.emplace_back(hit["document"]["product_id"]);
+    }
+
+    req_params["sort_by"] = "$eval_order_refs(_eval([(max_signal:true):9223372036854775807, "
+                            "(minus_signal:true):-1, (plus_signal:true):1, "
+                            "(ceiling_signal:true):9223372036854775807], mode: sum):desc), rank:asc";
+    json_res.clear();
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok()) << search_op.error();
+    results = nlohmann::json::parse(json_res);
+    std::vector<std::string> cancelling_first_order;
+    for (const auto& hit: results["hits"]) {
+        cancelling_first_order.emplace_back(hit["document"]["product_id"]);
+    }
+
+    // Both r0 sums are mathematically INT64_MAX and should tie r1. rank:asc must therefore put p0 first.
+    const std::vector<std::string> expected_order = {"p0", "p1"};
+    EXPECT_EQ(expected_order, saturating_first_order);
+    EXPECT_EQ(expected_order, cancelling_first_order);
+    EXPECT_EQ(saturating_first_order, cancelling_first_order);
+
+    collectionManager.drop_collection("eval_order_products");
+    collectionManager.drop_collection("eval_order_refs");
 }
 
 TEST_F(CollectionSortingTest, EvalSumReferencedValidationFailureDoesNotLeak) {

--- a/test/collection_sorting_test.cpp
+++ b/test/collection_sorting_test.cpp
@@ -4178,6 +4178,50 @@ TEST_F(CollectionSortingTest, EvalSumSaturatesInsteadOfOverflowing) {
     collectionManager.drop_collection("eval_sum_overflow");
 }
 
+TEST_F(CollectionSortingTest, EvalSumPreservesInt64MinScores) {
+    auto schema = R"({
+        "name": "eval_sum_int64_min",
+        "fields": [
+            {"name": "signal", "type": "string"},
+            {"name": "tie_breaker", "type": "int32"}
+        ]
+    })"_json;
+
+    Collection* coll = collectionManager.create_collection(schema).get();
+    ASSERT_TRUE(coll->add(R"({"id":"0","signal":"minimum","tie_breaker":0})").ok());
+    ASSERT_TRUE(coll->add(R"({"id":"1","signal":"next","tie_breaker":1})").ok());
+
+    std::map<std::string, std::string> req_params = {
+            {"collection", "eval_sum_int64_min"},
+            {"q", "*"},
+            {"sort_by", "_eval([(signal:=minimum):-9223372036854775808, "
+                        "(signal:=next):-9223372036854775807], mode: sum):desc, tie_breaker:asc"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok()) << search_op.error();
+    auto results = nlohmann::json::parse(json_res);
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"]);
+    ASSERT_EQ("0", results["hits"][1]["document"]["id"]);
+
+    // Reversing the secondary sort makes a collapsed score produce the opposite, incorrect order.
+    // Ascending eval sorting must also avoid trying to negate INT64_MIN.
+    req_params["sort_by"] = "_eval([(signal:=minimum):-9223372036854775808, "
+                            "(signal:=next):-9223372036854775807], mode: sum):asc, tie_breaker:desc";
+    json_res.clear();
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok()) << search_op.error();
+    results = nlohmann::json::parse(json_res);
+    ASSERT_EQ("0", results["hits"][0]["document"]["id"]);
+    ASSERT_EQ("1", results["hits"][1]["document"]["id"]);
+
+    collectionManager.drop_collection("eval_sum_int64_min");
+}
+
 TEST_F(CollectionSortingTest, EvalSumOnReferencedCollection) {
     auto locations_schema = R"({
         "name": "es_locations",

--- a/test/collection_sorting_test.cpp
+++ b/test/collection_sorting_test.cpp
@@ -4196,10 +4196,16 @@ TEST_F(CollectionSortingTest, EvalSumRejectedOnReferencedCollection) {
     auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
             std::chrono::system_clock::now().time_since_epoch()).count();
 
-    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
-    ASSERT_FALSE(search_op.ok());
-    ASSERT_TRUE(search_op.error().find("`mode: sum` is not supported on a referenced collection")
-                != std::string::npos) << search_op.error();
+    // Repeated rejected requests must not retain the parsed filter trees. This loop is also a
+    // LeakSanitizer regression: before the early rejection in sort validation, each iteration
+    // leaked the filter-tree pointer array and the parsed filter tree.
+    for (size_t i = 0; i < 10; i++) {
+        json_res.clear();
+        auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+        ASSERT_FALSE(search_op.ok());
+        ASSERT_TRUE(search_op.error().find("`mode: sum` is not supported on a referenced collection")
+                    != std::string::npos) << search_op.error();
+    }
 
     collectionManager.drop_collection("es_stock");
     collectionManager.drop_collection("es_products");


### PR DESCRIPTION
Fixes #2014.

## Problem

`_eval([(a):1, (b):2, (c):4])` returns the score of the first matching expression and stops. A
`sort_by` written as a list of additive boosts therefore does not add: a document matching the last
three rules scores 4, not 7, and loses to one matching only the first. Nothing in the response
signals it, and reordering the expressions changes the result.

Expressing a real additive model meant enumerating every combination, which needs `2^n - 1`
expressions — 15 rules for 4 signals.

## Change

`mode: sum` adds the scores of every expression that matches, so `n` signals need `n` expressions:

```
sort_by=_eval([(domain:=engineering):25, (seniority:=3):6, (skills:=react):8], mode: sum):desc
sort_by=_eval((brand:nike), mode: sum):desc
```

| document | default | `mode: sum` |
|---|---|---|
| engineering, seniority 1 | 25 | 25 |
| design, seniority 3, react | 6 | **14** |

The default stays `first_match`. Summing by default would silently re-rank every released query and
break the if/else-if idiom, where a document that is both in stock and backordered should score as
in stock rather than as the sum of both.

## Parsing

The array form is delimited by `]`, so its parameters are unambiguous.

The single-expression form has no such delimiter, and a filter value may legally hold a top level
comma — `_eval(title:Hello, World)` matches that literal string today. Parameters are recognised
there only when the expression is wrapped in its own parentheses **and** the trailing span is
introduced by a comma. Everything else parses exactly as it does now:

```
_eval((brand:nike), mode: sum)           -> expression `brand:nike`, mode sum
_eval(brand:nike, mode: sum)             -> filter, unchanged
_eval(title:Hello, World)                -> filter, unchanged
_eval((a:1) && (b:2))                    -> filter, unchanged
_eval((brand:nike || brand:air) && x:1)  -> filter, unchanged
```

A recognised `mode` carrying an unusable value (`mode: sumx`) is an error rather than being left in
the expression, so a typo fails loudly instead of silently becoming a filter that matches nothing.

Reference `include_fields` parameters are now split with the same nesting awareness, so a nested
`sort_by` carrying a comma is no longer torn apart at it.

## Referenced collections

Supported. Each referenced document is scored on its own and the results are reduced to one value
for the source document: the maximum for a descending sort, the minimum for an ascending one, so the
reduction always favours the end of the ordering the caller asked for. A source document reaching
the same referenced document through several join paths scores it once. No referenced documents
scores 0.

## Overflow

Weights are accumulated in `__int128` and clamped once per document to `[INT64_MIN, INT64_MAX]`.
Accumulating exactly and clamping at the end keeps the total independent of the order the
expressions are listed in, which a per-addition saturating add does not.

The full int64 range stays usable: rather than negating the score for an ascending sort, which is
undefined for `INT64_MIN`, the ordering is reversed with `-x - 1` computed in `__int128`. That is a
bijection over int64, so no value has to be sacrificed to the clamp.

## Tests

- `EvalSumAddsEveryMatchingExpression` — the order inverts between the default and `mode: sum` on
  identical rules
- `EvalSumOnReferencedCollection` — per-referenced-document scoring and the max/min reduction
- `ReferencedEvalSumIsOrderIndependentNearOverflow`
- `EvalSumReferencedValidationFailureDoesNotLeak`
- `EvalSumSaturatesInsteadOfOverflowing`
- `ParseSortByClause` — both forms, the compound-filter cases above, and the invalid-mode error
- join tests covering the nested-comma `include_fields` split

## Credit

Commits 2-7 are @happy-san's: the validation-path leak fix, referenced-collection scoring, `__int128`
accumulation, the `include_fields` comma split, `INT64_MIN` preservation, and an `api_tests` fix that
consumes the import response so the search no longer races indexing.

The leak and the order-dependence of my original saturating add were both real defects in my commit.
