### PR TITLE
fix: give each pinned hit its own joined reference data

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -621,7 +621,7 @@ private:
                               const size_t group_limit,
                               const std::vector<std::string>& group_by_fields,
                               const bool group_missing_values,
-                              const std::map<std::string, reference_filter_result_t>& references) const;
+                              const std::map<uint32_t, std::map<std::string, reference_filter_result_t>>& seq_id_to_references) const;
 
     static void compute_facet_stats(facet &a_facet, const std::string& raw_value,
                                     const std::string & field_type, const size_t count);
@@ -1181,7 +1181,8 @@ public:
                              filter_result_iterator_t* const filter_result_iterator,
                              std::set<uint32_t>& curated_ids,
                              std::map<size_t, std::map<size_t, uint32_t>>& included_ids_map,
-                             std::vector<uint32_t>& included_ids_vec) const;
+                             std::vector<uint32_t>& included_ids_vec,
+                             std::map<uint32_t, std::map<std::string, reference_filter_result_t>>& seq_id_to_references) const;
     
     int64_t get_doc_val_from_sort_index(sort_index_iterator it, uint32_t doc_seq_id) const;
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2755,7 +2755,7 @@ void Index::collate_included_ids(const std::vector<token_t>& q_included_tokens,
                                  const size_t group_limit,
                                  const std::vector<std::string>& group_by_fields,
                                  const bool group_missing_values,
-                                 const  std::map<std::string, reference_filter_result_t>& references) const {
+                                 const std::map<uint32_t, std::map<std::string, reference_filter_result_t>>& seq_id_to_references) const {
 
     if(included_ids_map.empty()) {
         return;
@@ -2789,6 +2789,9 @@ void Index::collate_included_ids(const std::vector<token_t>& q_included_tokens,
             scores[2] = int64_t(1);
 
             //included ids are upstream validated, so can directly add references
+            const auto& ref_it = seq_id_to_references.find(seq_id);
+            const auto& references = (ref_it != seq_id_to_references.end()) ? ref_it->second
+                                                                            : std::map<std::string, reference_filter_result_t>{};
             KV kv(0, seq_id, distinct_id, 0, scores, references);
             curated_topster->add(&kv);
         }
@@ -3612,12 +3615,13 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
     std::set<uint32_t> curated_ids;
     std::map<size_t, std::map<size_t, uint32_t>> included_ids_map;  // outer pos => inner pos => list of IDs
     std::vector<uint32_t> included_ids_vec;
+    std::map<uint32_t, std::map<std::string, reference_filter_result_t>> seq_id_to_references;
 
     process_curated_ids(included_ids, excluded_ids, group_limit, filter_curated_hits,
                         filter_result_iterator, curated_ids, included_ids_map,
-                        included_ids_vec);
+                        included_ids_vec, seq_id_to_references);
     collate_included_ids({}, included_ids_map, curated_topster, group_limit,
-                         group_by_fields, group_missing_values, filter_result_iterator->reference);
+                         group_by_fields, group_missing_values, seq_id_to_references);
     filter_result_iterator->reset();
     search_cutoff = search_cutoff || filter_result_iterator->validity == filter_result_iterator_t::timed_out;
 
@@ -4862,7 +4866,8 @@ void Index::process_curated_ids(const std::vector<std::pair<uint32_t, uint32_t>>
                                 const bool filter_curated_hits, filter_result_iterator_t* const filter_result_iterator,
                                 std::set<uint32_t>& curated_ids,
                                 std::map<size_t, std::map<size_t, uint32_t>>& included_ids_map,
-                                std::vector<uint32_t>& included_ids_vec) const {
+                                std::vector<uint32_t>& included_ids_vec,
+                                std::map<uint32_t, std::map<std::string, reference_filter_result_t>>& seq_id_to_references) const {
 
     for(const auto& seq_id_pos: included_ids) {
         included_ids_vec.push_back(seq_id_pos.first);
@@ -4886,6 +4891,8 @@ void Index::process_curated_ids(const std::vector<std::pair<uint32_t, uint32_t>>
 
             if (result == 1) {
                 included_ids_set.insert(included_id);
+
+                seq_id_to_references[included_id] = filter_result_iterator->reference;
             }
         }
     }

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -15526,6 +15526,113 @@ TEST_F(CollectionJoinTest, PinnedHitsShouldIncludeJoinedFields) {
     ASSERT_EQ("Blyton", res_obj["hits"][0]["document"]["product_data"]["extra_data"]);
 }
 
+TEST_F(CollectionJoinTest, MultiplePinnedHitsWithJoinShouldEachGetTheirOwnJoinedData) {
+    auto schema_json =
+            R"({
+                "name":  "products",
+                "fields": [
+                    {"name": "name", "type": "string"}
+                ]
+            })"_json;
+    std::vector<nlohmann::json> documents = {
+            R"({
+                "id": "124",
+                "name": "Product 1"
+            })"_json,
+            R"({
+                "id": "125",
+                "name": "Product 2"
+            })"_json,
+            R"({
+                "id": "126",
+                "name": "Product 3"
+            })"_json,
+    };
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto products_coll = collection_create_op.get();
+    for (auto const &json: documents) {
+        auto add_op = products_coll->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    schema_json =
+            R"({
+                "name": "product_data",
+                "fields": [
+                    {"name": "product_id", "type": "string", "reference": "products.id" },
+                    {"name": "extra_data", "type": "string" }
+                ]
+            })"_json;
+    documents = {
+            R"({
+                "id": "11",
+                "product_id": "124",
+                "extra_data": "foo"
+            })"_json,
+            R"({
+                "id": "15",
+                "product_id": "125",
+                "extra_data": "hello"
+            })"_json,
+            R"({
+                "id": "34",
+                "product_id": "126",
+                "extra_data": "bar"
+            })"_json,
+    };
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto product_data_coll = collection_create_op.get();
+    for (auto const &json: documents) {
+        auto add_op = product_data_coll->add(json.dump());
+        if (!add_op.ok()) {
+            LOG(INFO) << add_op.error();
+        }
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    std::map<std::string, std::string> req_params = {
+            {"collection", "products"},
+            {"q", "*"},
+            {"filter_by", "$product_data(id:*)"},
+            {"pinned_hits", "124:1,125:2"},
+            {"filter_curated_hits", "true"},
+            {"include_fields", "$product_data(*) as product_data"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    auto res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(3, res_obj["found"].get<size_t>());
+    ASSERT_EQ(3, res_obj["hits"].size());
+
+    ASSERT_EQ("124", res_obj["hits"][0]["document"]["id"]);
+    ASSERT_TRUE(res_obj["hits"][0]["curated"].get<bool>());
+    ASSERT_TRUE(res_obj["hits"][0]["document"].contains("product_data"));
+    ASSERT_EQ("11", res_obj["hits"][0]["document"]["product_data"]["id"]);
+    ASSERT_EQ("foo", res_obj["hits"][0]["document"]["product_data"]["extra_data"]);
+
+    ASSERT_EQ("125", res_obj["hits"][1]["document"]["id"]);
+    ASSERT_TRUE(res_obj["hits"][1]["curated"].get<bool>());
+    ASSERT_TRUE(res_obj["hits"][1]["document"].contains("product_data"));
+    ASSERT_EQ("15", res_obj["hits"][1]["document"]["product_data"]["id"]);
+    ASSERT_EQ("hello", res_obj["hits"][1]["document"]["product_data"]["extra_data"]);
+
+    ASSERT_NE(res_obj["hits"][0]["document"]["product_data"]["id"],
+              res_obj["hits"][1]["document"]["product_data"]["id"]);
+    ASSERT_NE(res_obj["hits"][0]["document"]["product_data"]["extra_data"],
+              res_obj["hits"][1]["document"]["product_data"]["extra_data"]);
+}
+
 TEST_F(CollectionJoinTest, FixReferencesAtQueryTime) {
     auto schema_json =
             R"({


### PR DESCRIPTION
Fixes #3006

## Change Summary
Pin hits previously all received the join references of only the last
hit validated by the filter iterator (a single mutable map reused
across is_valid() calls). Capture references per seq_id and thread the
map through collate_included_ids so each pinned hit keeps its own
joined data. Includes a regression test.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
