### PR TITLE
Fix union search hang on prefix queries with multi-byte characters

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -6246,6 +6246,12 @@ bool Collection::handle_highlight_text(std::string& text, const bool& normalise,
 
                 size_t char_diff = num_letters - prefix_letters;
                 auto new_tok_end = (char_diff <= 2 && qtoken_it.value().num_typos != 0) ? tok_end : prefix_end;
+                // `prefix_end` is computed from character counts but used as a byte offset,
+                // so it can fall inside a multi-byte UTF-8 character. Extend the span to the
+                // end of that character, otherwise highlighting produces invalid UTF-8 (#2995).
+                while (new_tok_end < tok_end && (text[new_tok_end + 1] & 0xC0) == 0x80) {
+                    new_tok_end++;
+                }
                 token_offsets.emplace(tok_start, new_tok_end);
             } else {
                 token_offsets.emplace(tok_start, tok_end);

--- a/test/union_test.cpp
+++ b/test/union_test.cpp
@@ -2927,3 +2927,40 @@ TEST_F(UnionTest, DynamicFacetMinOccurrenceRatioShouldApplyAfterUnionMerge) {
     ASSERT_EQ("shared", json_res["facet_counts"][0]["counts"][0]["value"]);
     ASSERT_EQ(6, json_res["facet_counts"][0]["counts"][0]["count"].get<size_t>());
 }
+TEST_F(UnionTest, PrefixQueryWithMultibyteChars) {
+    // https://github.com/typesense/typesense/issues/2995
+    // A union search used to hang when a prefix query token contained multiple multi-byte
+    // characters: prefix highlighting computed a byte offset in the middle of a UTF-8
+    // character, producing an invalid `matched_tokens` string which made the response
+    // fail to serialize.
+    auto schema_json = R"({
+        "name": "foods",
+        "fields": [
+            {"name": "name", "type": "string"}
+        ]
+    })"_json;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto foods = collection_create_op.get();
+
+    ASSERT_TRUE(foods->add(R"({"name": "blåbær"})").ok());
+    ASSERT_TRUE(foods->add(R"({"name": "jordbær"})").ok());
+    ASSERT_TRUE(foods->add(R"({"name": "chicken"})").ok());
+
+    embedded_params = std::vector<nlohmann::json>(1, nlohmann::json::object());
+    searches = R"([
+                    {
+                        "collection": "foods",
+                        "q": "blåbæ",
+                        "query_by": "name"
+                    }
+                ])"_json;
+
+    auto search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(1, json_res["found"].get<size_t>());
+    ASSERT_EQ("blåbær", json_res["hits"][0]["document"]["name"].get<std::string>());
+    // the highlight must not contain an invalid UTF-8 string, so serializing must not throw
+    ASSERT_NO_THROW((void)json_res.dump());
+    ASSERT_EQ(1, json_res["hits"][0]["highlight"]["name"]["matched_tokens"].size());
+}


### PR DESCRIPTION
Fixes #2995

## Root cause

A `multi_search` request with `union: true` hangs forever when the last query token is a prefix that contains multiple multi-byte characters and prefix-matches an indexed token.

Chain of events:

1. Prefix highlighting in `Collection::handle_highlight_text` computes `prefix_end` from character counts but then uses it as a byte offset into the text. With multi-byte UTF-8 in the text, the span can end in the middle of a character (e.g. between the two bytes of `æ`).
2. `matched_tokens` in the highlight then contains an invalid UTF-8 string.
3. Serializing the response with `response.dump()` throws `json.exception.type_error.316`, and the request never completes — the client hangs while the server stays healthy.

Only the union hit-assembly path renders the affected highlight into the response, which is why the identical non-union query returns normally.

## Fix

In `src/collection.cpp`, extend the computed span end to the end of the current UTF-8 character before recording the offset, so highlight ranges never split a multi-byte character.

## Verification

- Reproduced first on 31.0.rc10 with the exact steps from the issue: union request hangs past 15s, non-union returns instantly.
- With the fix, every query from the issue's characterization matrix returns 200 with valid highlights: `blåbæ`, `røræ`, `jordbæ`, `blåb`, `blåbær`, `chicke`, `rødgrø`.
- Added a regression test: `UnionTest.PrefixQueryWithMultibyteChars`.
- Test suites: `UnionTest` 20/20, `CollectionTest`/`CollectionSpecificTest`/`CollectionSpecificMoreTest` 277/277.
