### PR TITLE
fix(validator): stop dropping store:false non-optional docs on reload

### DIFF
--- a/api_tests/tests/store_false_reload.test.ts
+++ b/api_tests/tests/store_false_reload.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "bun:test";
+import { Phases } from "../src/constants";
+import { fetchSingleNode } from "../src/request";
+
+// a field declared `store: false` is stripped before the document is written to
+// disk. when it is also `optional: false`, the reloaded document used to fail
+// validation and the whole collection loaded 0 documents, silently
+// the documents must survive a restart and a snapshot restore. SINGLE_SNAPSHOT
+// is the important phase. The snapshot truncates the raft log, so the 
+// restart is a true cold-load from the on-disk store.
+const COLLECTION = "store_false_reload";
+
+async function foundCount(): Promise<number> {
+  const res = await fetchSingleNode(
+    `/collections/${COLLECTION}/documents/search?q=*&per_page=250`,
+    { method: "GET" },
+  );
+  expect(res.ok).toBe(true);
+  const body: any = await res.json();
+  return body.found as number;
+}
+
+describe(Phases.SINGLE_FRESH, () => {
+  it("seed store:false + optional:false fields", async () => {
+    let res = await fetchSingleNode("/collections", {
+      method: "POST",
+      body: JSON.stringify({
+        name: COLLECTION,
+        fields: [
+          { name: "title", type: "string" },
+          { name: "embedding", type: "float[]", num_dim: 4, optional: false, store: false },
+          { name: "secret", type: "string", optional: false, store: false },
+        ],
+      }),
+    });
+    expect(res.ok).toBe(true);
+
+    const jsonl = [
+      JSON.stringify({ id: "1", title: "alpha", embedding: [0.1, 0.2, 0.3, 0.4], secret: "s1" }),
+      JSON.stringify({ id: "2", title: "bravo", embedding: [0.2, 0.3, 0.4, 0.5], secret: "s2" }),
+      JSON.stringify({ id: "3", title: "charlie", embedding: [0.3, 0.4, 0.5, 0.6], secret: "s3" }),
+    ].join("\n");
+    res = await fetchSingleNode(
+      `/collections/${COLLECTION}/documents/import?action=create`,
+      { method: "POST", body: jsonl },
+    );
+    expect(res.ok).toBe(true);
+    const importBody = await res.text();
+    expect(importBody.split("\n").every((l) => l.includes('"success":true'))).toBe(true);
+
+    expect(await foundCount()).toBe(3);
+  });
+
+  it("returns the stored field but not the unstored ones", async () => {
+    const res = await fetchSingleNode(
+      `/collections/${COLLECTION}/documents/search?q=*&per_page=250`,
+      { method: "GET" },
+    );
+    expect(res.ok).toBe(true);
+    const body: any = await res.json();
+    const doc = body.hits[0].document;
+    expect(doc.title).toBeDefined();
+    expect(doc.embedding).toBeUndefined();
+    expect(doc.secret).toBeUndefined();
+  });
+});
+
+describe(Phases.SINGLE_RESTARTED, () => {
+  it("documents survive a restart", async () => {
+    expect(await foundCount()).toBe(3);
+  });
+});
+
+describe(Phases.SINGLE_SNAPSHOT, () => {
+  it("documents survive a snapshot restore (cold-load from store)", async () => {
+    expect(await foundCount()).toBe(3);
+  });
+});

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -669,8 +669,10 @@ Option<uint32_t> validator_t::validate_index_in_memory(nlohmann::json& document,
 
         nlohmann::json& doc_ele = document[field_name];
 
-        if(a_field.optional && doc_ele.is_null()) {
-            // we will ignore `null` on an option field
+        if((a_field.optional || !a_field.store) && doc_ele.is_null()) {
+            // ignore null on an optional field, or on an unstored field that is absent after a reload.
+            // store:false strips the value before it is persisted, so on cold-load the key is missing.
+            // without this the whole document is dropped and the collection silently loads empty.
             if(!is_update) {
                 // for updates, the erasure is done later since we need to keep the key for overwrite
                 document.erase(field_name);

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -3192,6 +3192,68 @@ TEST_F(CollectionSpecificMoreTest, TestFieldStore) {
     ASSERT_TRUE(res.get()["hits"][0]["document"].count("word_not_to_store") == 0);
 }
 
+TEST_F(CollectionSpecificMoreTest, StoreFalseNonOptionalFieldSurvivesRestart) {
+    // a `store: false` field is stripped before the document is written to disk. when the field is
+    // also `optional: false`, the reloaded document used to fail validation and the entire
+    // collection loaded 0 documents, silently, while /health stayed ok. the documents (and their
+    // stored fields) must survive a restart. covers a customer-supplied vector field and a plain
+    // string field, mirroring the two broken cases.
+    nlohmann::json schema = R"({
+         "name": "listings",
+         "fields": [
+           {"name": "title", "type": "string"},
+           {"name": "embedding", "type": "float[]", "num_dim": 4, "optional": false, "store": false},
+           {"name": "secret", "type": "string", "optional": false, "store": false}
+         ]
+    })"_json;
+
+    auto coll_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(coll_op.ok());
+    Collection* coll = coll_op.get();
+
+    for(size_t i = 0; i < 5; i++) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["title"] = "title " + std::to_string(i);
+        doc["embedding"] = {0.1, 0.2, 0.3, 0.4};
+        doc["secret"] = "s" + std::to_string(i);
+        ASSERT_TRUE(coll->add(doc.dump()).ok());
+    }
+
+    auto before_op = coll->search("*", {}, {}, {}, {}, {0}, 10, 1, FREQUENCY, {false}, 1);
+    ASSERT_TRUE(before_op.ok());
+    nlohmann::json before = before_op.get();
+    ASSERT_EQ(5, before["found"].get<size_t>());
+
+    // emulate restart: reload the collection from disk (cold-load path, no raft replay)
+    collectionManager.dispose();
+    stemmerManager.dispose();
+    delete store;
+
+    std::string state_dir_path = "/tmp/typesense_test/collection_specific_more";
+    store = new Store(state_dir_path);
+    stemmerManager.init(store);
+    collectionManager.init(store, 1.0, "auth_key", quit);
+    collectionManager.load(8, 1000);
+
+    coll = collectionManager.get_collection("listings").get();
+    ASSERT_TRUE(coll != nullptr);
+
+    auto after_op = coll->search("*", {}, {}, {}, {}, {0}, 10, 1, FREQUENCY, {false}, 1);
+    ASSERT_TRUE(after_op.ok());
+    nlohmann::json after = after_op.get();
+    ASSERT_EQ(5, after["found"].get<size_t>());
+    ASSERT_EQ(5, after["hits"].size());
+
+    // stored field is intact, unstored fields are gone (never persisted)
+    nlohmann::json doc0 = after["hits"][0]["document"];
+    ASSERT_EQ(1, doc0.count("title"));
+    ASSERT_EQ(0, doc0.count("embedding"));
+    ASSERT_EQ(0, doc0.count("secret"));
+
+    collectionManager.drop_collection("listings");
+}
+
 TEST_F(CollectionSpecificMoreTest, EnableTyposForAlphaNumericalTokens) {
     nlohmann::json schema = R"({
         "name": "coll1",


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- extend the null-skip in validate_index_in_memory to !a_field.store, so an absent unstored field is erased and skipped instead of failing validation on cold-load
- fix the whole collection silently loading 0 documents (with /health still ok) when a store:false field is also optional:false, since store:false strips the value before it is persisted
- reuse the existing absent-optional-field path that every index path already skips per-record. leave auto-embed fields untouched (guarded earlier by the embedding-fields check)
- add both integration and unit tests asserting docs survive an emulated restart with stored title intact and unstored embedding/secret gone

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
