### PR TITLE
fix(search): stop re-segmenting query tokens in word tokenizer locales

### DIFF
--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -5165,6 +5165,22 @@ void Collection::process_filter_sort_curations(std::vector<const curation_t*>& f
     }
 }
 
+// drops the ascii chars a tokenizer configured with `index_symbols` would not index, without
+// re-running the segmenter over the token
+static std::string strip_non_index_ascii(const std::string& token, const std::vector<char>& index_symbols) {
+    std::string out;
+    out.reserve(token.size());
+
+    for(char c: token) {
+        if(!Tokenizer::is_ascii_char(c) || std::isalnum(static_cast<unsigned char>(c)) ||
+           std::find(index_symbols.begin(), index_symbols.end(), c) != index_symbols.end()) {
+            out += c;
+        }
+    }
+
+    return out;
+}
+
 void Collection::process_tokens(std::vector<std::string>& tokens, std::vector<std::string>& q_include_tokens,
                                 std::vector<std::vector<std::string>>& q_exclude_tokens,
                                 std::vector<std::vector<std::string>>& q_phrases, bool& exclude_operator_prior, 
@@ -5214,6 +5230,16 @@ void Collection::process_tokens(std::vector<std::string>& tokens, std::vector<st
 
         if(already_segmented) {
             StringUtils::split(token, sub_tokens, " ");
+        } else if(Tokenizer::has_word_tokenizer(locale)) {
+            // dictionary segmented locales must not be re-segmented: their own output is not a stable
+            // input. thai normalizes SARA AM (U+0E33) to U+0E4D U+0E32, and the break iterator splits
+            // the decomposed form into two tokens, which no longer matches how the document or the
+            // synonym term was tokenized. the first pass already applied this config, so only the
+            // symbols it was told to keep (the phrase quote) need stripping here.
+            auto cleaned = strip_non_index_ascii(token, custom_symbols);
+            if(!cleaned.empty()) {
+                sub_tokens.push_back(cleaned);
+            }
         } else {
             Tokenizer(token, true, false, locale, custom_symbols, custom_separators).tokenize(sub_tokens);
         }

--- a/test/collection_locale_test.cpp
+++ b/test/collection_locale_test.cpp
@@ -977,3 +977,83 @@ TEST_F(CollectionLocaleTest, TranslitPad) {
 
     delete transliterator;
 }*/
+
+TEST_F(CollectionLocaleTest, ThaiQueryTokenizationShouldMatchIndexing) {
+    // https://github.com/typesense/typesense/issues/3025
+    // the query used to be tokenized twice, and the second pass re-segmented thai at the normalized
+    // SARA AM, leaving query tokens that no document token could match. split/join hid it for plain
+    // search, so this asserts an exact match with that fallback off.
+    nlohmann::json schema = R"({
+        "name": "coll_th_tokens",
+        "fields": [
+          {"name": "t", "type": "string", "locale": "th"}
+        ]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+    Collection* coll = op.get();
+
+    const std::vector<std::string> terms = {
+        "น้ำหอม",   // perfume
+        "ทำงาน",    // work
+        "คำถาม",    // question
+        "กำลัง",    // power
+        "น้ำ",      // water
+        "กำไล",     // bangle
+    };
+
+    for(size_t i = 0; i < terms.size(); i++) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["t"] = terms[i];
+        ASSERT_TRUE(coll->add(doc.dump()).ok());
+    }
+
+    for(size_t i = 0; i < terms.size(); i++) {
+        auto res = coll->search(terms[i], {"t"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0,
+                                spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(),
+                                10, "", 30, 4, "", 40, {}, {}, {}, 0, "<mark>", "</mark>", {}, 1000,
+                                true, false, true, "", false, 6000*1000, 4, 7, off).get();
+
+        ASSERT_EQ(1, res["found"].get<size_t>()) << "no exact match for " << terms[i];
+        ASSERT_EQ(std::to_string(i), res["hits"][0]["document"]["id"].get<std::string>());
+    }
+
+    collectionManager.drop_collection("coll_th_tokens");
+}
+
+TEST_F(CollectionLocaleTest, ThaiPhraseSearch) {
+    // https://github.com/typesense/typesense/issues/3025
+    // re-segmenting the query broke phrase matching too, since the phrase was assembled from tokens
+    // the index never held
+    nlohmann::json schema = R"({
+        "name": "coll_th_phrase",
+        "fields": [
+          {"name": "t", "type": "string", "locale": "th"}
+        ]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+    Collection* coll = op.get();
+
+    nlohmann::json doc0;
+    doc0["id"] = "0";
+    doc0["t"] = "น้ำหอม ชาแนล";
+    ASSERT_TRUE(coll->add(doc0.dump()).ok());
+
+    nlohmann::json doc1;
+    doc1["id"] = "1";
+    doc1["t"] = "น้ำหอม ลิปสติก";
+    ASSERT_TRUE(coll->add(doc1.dump()).ok());
+
+    auto res = coll->search("\"น้ำหอม ชาแนล\"", {"t"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+    ASSERT_EQ(1, res["found"].get<size_t>());
+    ASSERT_EQ("0", res["hits"][0]["document"]["id"].get<std::string>());
+
+    res = coll->search("น้ำหอม", {"t"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+    ASSERT_EQ(2, res["found"].get<size_t>());
+
+    collectionManager.drop_collection("coll_th_phrase");
+}

--- a/test/collection_synonyms_test.cpp
+++ b/test/collection_synonyms_test.cpp
@@ -2094,3 +2094,89 @@ TEST_F(CollectionSynonymsTest, SynonymResolutionPreferExactMatch) {
     ASSERT_EQ("1", res["hits"][0]["document"]["id"].get<std::string>());
     ASSERT_EQ("headphones", res["hits"][0]["document"]["title"].get<std::string>());
 }
+
+TEST_F(CollectionSynonymsTest, ThaiSaraAmSynonymAtTokenBoundary) {
+    // https://github.com/typesense/typesense/issues/3025
+    nlohmann::json schema = R"({
+        "name": "coll_th_sara_am",
+        "fields": [
+          {"name": "t", "type": "string", "locale": "th"}
+        ],
+        "synonym_sets": ["index"]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+    Collection* coll = op.get();
+
+    nlohmann::json doc;
+    doc["id"] = "0";
+    doc["t"] = "item perfume";
+    ASSERT_TRUE(coll->add(doc.dump()).ok());
+
+    // น้ำหอม (perfume) carries SARA AM (U+0E33) at a token boundary
+    nlohmann::json synonym = R"({
+        "id": "perfume-syn",
+        "synonyms": ["น้ำหอม", "perfume"],
+        "locale": "th"
+    })"_json;
+    ASSERT_TRUE(manager.upsert_synonym_item("index", synonym).ok());
+
+    auto res = coll->search("น้ำหอม", {"t"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+    ASSERT_EQ(1, res["found"].get<size_t>());
+    ASSERT_EQ("0", res["hits"][0]["document"]["id"].get<std::string>());
+
+    collectionManager.drop_collection("coll_th_sara_am");
+}
+
+TEST_F(CollectionSynonymsTest, ThaiSaraAmSynonymTermVariants) {
+    // https://github.com/typesense/typesense/issues/3025
+    // a th term is unreachable as a synonym whenever re-tokenizing its own token stream splits it,
+    // which happens right after the NFKC-decomposed SARA AM
+    nlohmann::json schema = R"({
+        "name": "coll_th_variants",
+        "fields": [
+          {"name": "t", "type": "string", "locale": "th"}
+        ],
+        "synonym_sets": ["index"]
+    })"_json;
+
+    auto op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(op.ok());
+    Collection* coll = op.get();
+
+    nlohmann::json doc;
+    doc["id"] = "0";
+    doc["t"] = "item zmk";
+    ASSERT_TRUE(coll->add(doc.dump()).ok());
+
+    const std::vector<std::string> terms = {
+        "น้ำหอม",   // perfume, sara am mid-term
+        "ทำงาน",    // work
+        "คำถาม",    // question
+        "กำลัง",    // power
+        "บำรุง",    // nourish
+        "สำหรับ",   // for
+        "น้ำ",      // water, sara am ends the term
+        "กำไล",     // bangle, sara am followed by a leading vowel
+        "ชาแนล",    // chanel, no sara am
+    };
+
+    for(size_t i = 0; i < terms.size(); i++) {
+        const std::string syn_id = "syn-" + std::to_string(i);
+
+        nlohmann::json synonym;
+        synonym["id"] = syn_id;
+        synonym["synonyms"] = {terms[i], "zmk"};
+        synonym["locale"] = "th";
+        ASSERT_TRUE(manager.upsert_synonym_item("index", synonym).ok());
+
+        auto res = coll->search(terms[i], {"t"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {false}, 0).get();
+        ASSERT_EQ(1, res["found"].get<size_t>()) << "no synonym match for " << terms[i];
+        ASSERT_EQ("0", res["hits"][0]["document"]["id"].get<std::string>());
+
+        ASSERT_TRUE(manager.delete_synonym_item("index", syn_id).ok());
+    }
+
+    collectionManager.drop_collection("coll_th_variants");
+}


### PR DESCRIPTION
## Change Summary
fix #3025 

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
