### PR TITLE
fix: Natural Language Search hangs before LLM provider call for one collectio...

### DIFF
--- a/include/string_utils.h
+++ b/include/string_utils.h
@@ -358,9 +358,10 @@ struct StringUtils {
 
     static size_t get_num_chars(const std::string& text);
 
+    static std::string truncate_utf8(const std::string& text, size_t max_bytes);
+
     static Option<bool> split_include_exclude_fields(const std::string& include_exclude_fields,
                                                      std::vector<std::string>& tokens);
-
     static size_t get_occurence_count(const std::string& str, char symbol);
 
     static std::string url_encode(const std::string& value) {

--- a/src/facet_index.cpp
+++ b/src/facet_index.cpp
@@ -115,7 +115,7 @@ void facet_index_t::get_stringified_value(const nlohmann::json& value, const fie
         values.push_back(std::to_string(raw_val));
     }
     else if(afield.is_string()) {
-        const std::string& raw_val = value.get<std::string>().substr(0, MAX_FACET_VAL_LEN);
+        const std::string& raw_val = StringUtils::truncate_utf8(value.get<std::string>(), MAX_FACET_VAL_LEN);
         values.push_back(raw_val);
     }
     else if(afield.is_float()) {

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -856,9 +856,25 @@ int HttpServer::process_request(const std::shared_ptr<http_req>& request, const 
     thread_pool->enqueue([rpath, message_dispatcher, request, response]() {
         // call the API handler
         //LOG(INFO) << "Wait for response " << response.get() << ", action: " << rpath->_get_action();
-        (rpath->handler)(request, response);
+        bool handler_failed = false;
 
-        if(!rpath->async_res) {
+        try {
+            (rpath->handler)(request, response);
+        } catch(const std::exception& e) {
+            handler_failed = true;
+            LOG(ERROR) << "Uncaught exception while handling " << rpath->http_method << " "
+                       << request->path_without_query << ": " << e.what();
+            response->set_500(std::string("Uncaught exception: ") + e.what());
+            response->final = true;
+        } catch(...) {
+            handler_failed = true;
+            LOG(ERROR) << "Uncaught exception while handling " << rpath->http_method << " "
+                       << request->path_without_query;
+            response->set_500("Uncaught exception.");
+            response->final = true;
+        }
+
+        if(!rpath->async_res || handler_failed) {
             // lifecycle of non async res will be owned by stream responder
             auto req_res = new async_req_res_t(request, response, true);
             message_dispatcher->send_message(HttpServer::STREAM_RESPONSE_MESSAGE, req_res);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -814,7 +814,8 @@ void Index::index_field_in_memory(const field& afield, std::vector<index_record>
                             seq_id_to_fvalues[seq_id].push_back(facet_value_id);
                         } else if(afield.type == field_types::STRING_ARRAY) {
                             const std::string& raw_val =
-                                    field_values[i].get<std::string>().substr(0, facet_index_t::MAX_FACET_VAL_LEN);
+                                    StringUtils::truncate_utf8(field_values[i].get<std::string>(),
+                                                               facet_index_t::MAX_FACET_VAL_LEN);
                             facet_value_id_t facet_value_id(raw_val);
                             fvalue_to_seq_ids[facet_value_id].push_back(seq_id);
                             seq_id_to_fvalues[seq_id].push_back(facet_value_id);
@@ -849,7 +850,8 @@ void Index::index_field_in_memory(const field& afield, std::vector<index_record>
                     }
                     else if(afield.type == field_types::STRING) {
                         const std::string& raw_val =
-                                document[afield.name].get<std::string>().substr(0, facet_index_t::MAX_FACET_VAL_LEN);
+                                StringUtils::truncate_utf8(document[afield.name].get<std::string>(),
+                                                           facet_index_t::MAX_FACET_VAL_LEN);
                         facet_value_id_t facet_value_id(raw_val);
                         fvalue_to_seq_ids[facet_value_id].push_back(seq_id);
                         seq_id_to_fvalues[seq_id].push_back(facet_value_id);

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -354,6 +354,19 @@ size_t StringUtils::get_num_chars(const std::string& s) {
     return j;
 }
 
+std::string StringUtils::truncate_utf8(const std::string& text, size_t max_bytes) {
+    if(text.size() <= max_bytes) {
+        return text;
+    }
+
+    size_t num_bytes = max_bytes;
+    while(num_bytes > 0 && (static_cast<unsigned char>(text[num_bytes]) & 0xC0) == 0x80) {
+        num_bytes--;
+    }
+
+    return text.substr(0, num_bytes);
+}
+
 Option<bool> StringUtils::split_include_exclude_fields(const std::string& include_exclude_fields,
                                                        std::vector<std::string>& tokens) {
     std::string token;

--- a/test/collection_faceting_test.cpp
+++ b/test/collection_faceting_test.cpp
@@ -4231,3 +4231,41 @@ TEST_F(CollectionFacetingTest, FacetMinOccurrenceRatioValidation) {
 
     collectionManager.drop_collection("dynamic_facet_ratio_validation_coll");
 }
+
+TEST_F(CollectionFacetingTest, FacetValueTruncatedAtUtf8Boundary) {
+    nlohmann::json schema = R"({
+        "name": "utf8_facet_coll",
+        "fields": [
+            {"name": "title", "type": "string", "facet": true},
+            {"name": "tags", "type": "string[]", "facet": true}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    auto coll = create_op.get();
+
+    const std::string ascii_prefix(facet_index_t::MAX_FACET_VAL_LEN - 1, 'a');
+    const std::string long_value = ascii_prefix + "é" + "bbb";
+
+    nlohmann::json doc;
+    doc["id"] = "0";
+    doc["title"] = long_value;
+    doc["tags"] = nlohmann::json::array({long_value});
+    ASSERT_TRUE(coll->add(doc.dump()).ok());
+
+    auto search_op = coll->search("*", {}, "", {"title", "tags"}, {}, {0}, 10, 1, FREQUENCY, {false});
+    ASSERT_TRUE(search_op.ok());
+    auto results = search_op.get();
+
+    ASSERT_EQ(2, results["facet_counts"].size());
+
+    for(const auto& facet_count: results["facet_counts"]) {
+        ASSERT_EQ(1, facet_count["counts"].size());
+        ASSERT_EQ(ascii_prefix, facet_count["counts"][0]["value"].get<std::string>());
+    }
+
+    ASSERT_NO_THROW(results.dump());
+
+    collectionManager.drop_collection("utf8_facet_coll");
+}

--- a/test/string_utils_test.cpp
+++ b/test/string_utils_test.cpp
@@ -564,3 +564,17 @@ TEST(StringUtilsTest, ShouldURLEncode) {
     ASSERT_STREQ("Hello%20World%21%20%E2%82%AC%20test%40example.com", 
                  StringUtils::url_encode("Hello World! € test@example.com").c_str());
 }
+
+TEST(StringUtilsTest, TruncateUtf8) {
+    ASSERT_EQ("", StringUtils::truncate_utf8("", 5));
+    ASSERT_EQ("hello", StringUtils::truncate_utf8("hello", 5));
+    ASSERT_EQ("hello", StringUtils::truncate_utf8("hello", 10));
+    ASSERT_EQ("hel", StringUtils::truncate_utf8("hello", 3));
+
+    ASSERT_EQ("a", StringUtils::truncate_utf8("aé", 2));
+    ASSERT_EQ("aé", StringUtils::truncate_utf8("aé", 3));
+    ASSERT_EQ("", StringUtils::truncate_utf8("日本語", 2));
+    ASSERT_EQ("日", StringUtils::truncate_utf8("日本語", 3));
+    ASSERT_EQ("日", StringUtils::truncate_utf8("日本語", 5));
+    ASSERT_EQ("日本", StringUtils::truncate_utf8("日本語", 6));
+}


### PR DESCRIPTION
Fixes #2965

## Root cause

Facet values truncated mid-UTF-8 character make the NL prompt un-serializable, and the resulting exception is silently swallowed so the HTTP request never completes

## Changes

- Truncate facet values at a UTF-8 character boundary via a new StringUtils::truncate_utf8 helper (used at all three MAX_FACET_VAL_LEN truncation sites), and make HttpServer::process_request catch handler exceptions so a failing request is logged and answered with a 500 instead of hanging forever. Added regression tests for the truncation helper and for facet values that straddle the byte limit.