### PR TITLE
fix(search): check search_cutoff_ms deadline during geopoint filter exact matching [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -13,7 +13,6 @@
 #include "index.h"
 #include "posting.h"
 #include "collection_manager.h"
-#include "thread_local_vars.h"
 
 void copy_references_helper(const std::map<std::string, reference_filter_result_t>* from,
                             std::map<std::string, reference_filter_result_t>*& to, const uint32_t& count) {
@@ -1400,8 +1399,7 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation) {
                     if (query_region->Contains(s2_lat_lng.ToPoint())) {
                         exact_geo_result_ids.push_back(result_id);
                     }
-                    if (++geo_processed % 65536 == 0 && (std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count() - search_begin_us) > search_stop_us) {
-                        search_cutoff = true;
+                    if (++geo_processed % 65536 == 0 && timeout_info != nullptr && is_timed_out(true)) {
                         break;
                     }
                 }
@@ -1428,8 +1426,7 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation) {
                     if (point_found) {
                         exact_geo_result_ids.push_back(result_id);
                     }
-                    if (++geo_processed % 65536 == 0 && (std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count() - search_begin_us) > search_stop_us) {
-                        search_cutoff = true;
+                    if (++geo_processed % 65536 == 0 && timeout_info != nullptr && is_timed_out(true)) {
                         break;
                     }
                 }

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -1404,10 +1404,6 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation) {
                         search_cutoff = true;
                         break;
                     }
-                    if (++geo_processed % 65536 == 0 && (std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count() - search_begin_us) > search_stop_us) {
-                        search_cutoff = true;
-                        break;
-                    }
                 }
             } else {
                 spp::sparse_hash_map<uint32_t, int64_t*>* geo_field_index = index->geo_array_index.at(f.name);
@@ -1431,6 +1427,10 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation) {
 
                     if (point_found) {
                         exact_geo_result_ids.push_back(result_id);
+                    }
+                    if (++geo_processed % 65536 == 0 && (std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count() - search_begin_us) > search_stop_us) {
+                        search_cutoff = true;
+                        break;
                     }
                 }
             }

--- a/src/filter_result_iterator.cpp
+++ b/src/filter_result_iterator.cpp
@@ -13,6 +13,7 @@
 #include "index.h"
 #include "posting.h"
 #include "collection_manager.h"
+#include "thread_local_vars.h"
 
 void copy_references_helper(const std::map<std::string, reference_filter_result_t>* from,
                             std::map<std::string, reference_filter_result_t>*& to, const uint32_t& count) {
@@ -1390,6 +1391,7 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation) {
             if (f.is_single_geopoint()) {
                 auto sort_field_index = index->sort_index.at(f.name);
 
+                uint64_t geo_processed = 0;
                 for (auto result_id : geo_result_ids) {
                     // no need to check for existence of `result_id` because of indexer based pre-filtering above
                     int64_t lat_lng = sort_field_index->at(result_id);
@@ -1398,10 +1400,19 @@ void filter_result_iterator_t::init(const bool& enable_lazy_evaluation) {
                     if (query_region->Contains(s2_lat_lng.ToPoint())) {
                         exact_geo_result_ids.push_back(result_id);
                     }
+                    if (++geo_processed % 65536 == 0 && (std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count() - search_begin_us) > search_stop_us) {
+                        search_cutoff = true;
+                        break;
+                    }
+                    if (++geo_processed % 65536 == 0 && (std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count() - search_begin_us) > search_stop_us) {
+                        search_cutoff = true;
+                        break;
+                    }
                 }
             } else {
                 spp::sparse_hash_map<uint32_t, int64_t*>* geo_field_index = index->geo_array_index.at(f.name);
 
+                uint64_t geo_processed = 0;
                 for (auto result_id : geo_result_ids) {
                     int64_t* lat_lngs = geo_field_index->at(result_id);
 


### PR DESCRIPTION
## Change Summary

When a geopoint radius filter is used, the exact filtering loop iterates
over all pre-filtered geo result IDs without checking the `search_cutoff_ms`
deadline. This can cause the query to run far past the deadline, returning
the complete result set while still reporting `"search_cutoff": true`.

### Fix

Add deadline checks in both the single-geopoint and multi-geopoint (array)
exact filtering loops, using the same pattern used in `or_iterator.h` and
`posting_list.h` — check every 65536 iterations.

### Changes

| File | Change |
|------|--------|
| `src/filter_result_iterator.cpp` | Add `#include "thread_local_vars.h"` and deadline checks in the geopoint exact filtering loops |

Fixes #3019