### PR TITLE
Fix union search returning fewer hits than `found`

### DIFF
--- a/include/topster.h
+++ b/include/topster.h
@@ -217,17 +217,21 @@ struct Union_KV : public KV {
                     std::tie(j->scores[0], j->scores[1], j->scores[2], i->search_index, j->key);
     }
 
+    // The key identifies one document of one search or collection. Both parts are 32-bit, so
+    // packing them is exact, whereas hashing them together collides between documents whose
+    // sequence ids differ by a small multiple of 64 (e.g. (3, 1000) and (4, 932)) and makes the
+    // topster drop one of them as a duplicate.
     static constexpr uint64_t get_key(const Union_KV* union_kv) {
         if(union_kv->remove_duplicates) {
-            return StringUtils::hash_combine(union_kv->collection_id, union_kv->distinct_key);
+            return (uint64_t(union_kv->collection_id) << 32) | union_kv->distinct_key;
         }
 
-        return StringUtils::hash_combine(union_kv->search_index, union_kv->key);
+        return (uint64_t(union_kv->search_index) << 32) | union_kv->key;
     }
 
     static constexpr uint64_t get_distinct_key(const Union_KV* union_kv) {
         if(union_kv->remove_duplicates) {
-            return StringUtils::hash_combine(union_kv->collection_id, union_kv->distinct_key);
+            return (uint64_t(union_kv->collection_id) << 32) | union_kv->distinct_key;
         }
 
         return StringUtils::hash_combine(union_kv->search_index, union_kv->distinct_key);

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -4425,7 +4425,7 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
         curated_union_keys.reserve(curation_result_kvs.size());
         for(const auto& kvs : curation_result_kvs) {
             const auto* kv = kvs[0];
-            curated_union_keys.insert(StringUtils::hash_combine(kv->collection_id, kv->distinct_key));
+            curated_union_keys.insert(Union_KV::get_key(kv));
         }
     }
 
@@ -4445,7 +4445,7 @@ Option<bool> Collection::do_union(const std::vector<uint32_t>& collection_ids,
 
         if(should_remove_duplicates) {
             const auto* raw_kv = raw_result_kvs[raw_results_index][0];
-            const auto raw_union_key = StringUtils::hash_combine(raw_kv->collection_id, raw_kv->distinct_key);
+            const auto raw_union_key = Union_KV::get_key(raw_kv);
             if(curated_union_keys.count(raw_union_key) != 0) {
                 raw_results_index++;
                 continue;

--- a/test/topster_test.cpp
+++ b/test/topster_test.cpp
@@ -3,6 +3,7 @@
 #include "topster.h"
 #include "match_score.h"
 #include <fstream>
+#include <unordered_set>
 
 TEST(TopsterTest, MaxIntValues) {
     Topster<KV> topster(5);
@@ -298,4 +299,25 @@ TEST(TopsterTest, EmptyGroupAllowlistRejectsEveryGroup) {
     ASSERT_EQ(2, topster.add(&kv));
     ASSERT_TRUE(topster.group_kv_map.empty());
     ASSERT_TRUE(topster.group_doc_seq_ids.empty());
+}
+
+TEST(TopsterTest, UnionKVKeyIsUniquePerDocument) {
+    // Every collection numbers its documents from 0, so a union sees the same sequence ids from
+    // every collection and search. The keys must still tell all of them apart.
+    int64_t scores[3] = {0, 0, 0};
+    std::unordered_set<uint64_t> collection_keys, search_keys;
+    const uint32_t ids = 32, seq_ids = 4096;
+
+    for(uint32_t id = 0; id < ids; id++) {
+        for(uint32_t seq_id = 0; seq_id < seq_ids; seq_id++) {
+            KV kv(0, seq_id, seq_id, 0, scores);
+            Union_KV by_collection(kv, id, id, true);
+            Union_KV by_search(kv, id, id, false);
+            collection_keys.insert(Union_KV::get_key(&by_collection));
+            search_keys.insert(Union_KV::get_key(&by_search));
+        }
+    }
+
+    ASSERT_EQ(ids * seq_ids, collection_keys.size());
+    ASSERT_EQ(ids * seq_ids, search_keys.size());
 }

--- a/test/union_test.cpp
+++ b/test/union_test.cpp
@@ -3072,3 +3072,63 @@ TEST_F(UnionTest, ReturnsEveryHitAcrossCollections) {
     ASSERT_EQ(200, json_res["found"].get<size_t>());
     ASSERT_EQ(200, json_res["hits"].size());
 }
+
+TEST_F(UnionTest, CuratedHitShouldNotSuppressUnrelatedRawHit) {
+    // The curated dedup keys must identify documents the same way the union topster does: a
+    // curated document of one collection must only ever suppress its own raw duplicate, not an
+    // unrelated document of another collection.
+    auto schema_json =
+            R"({
+                "name": "coll_curated_a",
+                "fields": [
+                    {"name": "title", "type": "string"}
+                ]
+            })"_json;
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto coll_a = collection_create_op.get();
+
+    auto schema_json_b =
+            R"({
+                "name": "coll_curated_b",
+                "fields": [
+                    {"name": "title", "type": "string"}
+                ]
+            })"_json;
+    collection_create_op = collectionManager.create_collection(schema_json_b);
+    ASSERT_TRUE(collection_create_op.ok());
+    auto coll_b = collection_create_op.get();
+
+    for(size_t i = 0; i < 100; i++) {
+        ASSERT_TRUE(coll_a->add(R"({"id": ")" + std::to_string(i) + R"(", "title": "doc"})").ok());
+        ASSERT_TRUE(coll_b->add(R"({"id": ")" + std::to_string(i) + R"(", "title": "doc"})").ok());
+    }
+
+    auto& curation_manager = CurationIndexManager::get_instance();
+    curation_manager.init_store(store);
+    auto upsert_set = nlohmann::json::array({
+        nlohmann::json{
+            {"id", "pin-99"},
+            {"rule", {{"query", "doc"}, {"match", curation_t::MATCH_EXACT}}},
+            {"includes", nlohmann::json::array({
+                nlohmann::json{{"id", "99"}, {"position", 1}}
+            })}
+        }
+    });
+    ASSERT_TRUE(curation_manager.upsert_curation_set("union_curations", upsert_set).ok());
+    ASSERT_TRUE(coll_a->set_curation_sets({"union_curations"}).ok());
+
+    req_params = {{"remove_duplicates", "true"}, {"per_page", "250"}};
+    embedded_params = std::vector<nlohmann::json>(2, nlohmann::json::object());
+    searches = R"([
+                    {"collection": "coll_curated_a", "q": "doc", "query_by": "title"},
+                    {"collection": "coll_curated_b", "q": "doc", "query_by": "title"}
+                ])"_json;
+
+    auto search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(200, json_res["found"].get<size_t>());
+    ASSERT_EQ(200, json_res["hits"].size());
+    ASSERT_EQ("99", json_res["hits"][0]["document"]["id"]);
+    ASSERT_TRUE(json_res["hits"][0]["curated"].get<bool>());
+}

--- a/test/union_test.cpp
+++ b/test/union_test.cpp
@@ -3049,3 +3049,26 @@ TEST_F(UnionTest, DynamicFacetMinOccurrenceRatioShouldApplyAfterUnionMerge) {
     ASSERT_EQ("shared", json_res["facet_counts"][0]["counts"][0]["value"]);
     ASSERT_EQ(6, json_res["facet_counts"][0]["counts"][0]["count"].get<size_t>());
 }
+
+TEST_F(UnionTest, ReturnsEveryHitAcrossCollections) {
+    // Documents of different collections share sequence ids and must not be merged as duplicates.
+    std::vector<field> fields = {field("title", field_types::STRING, false)};
+    for(const auto& name: {"coll_a", "coll_b"}) {
+        auto coll = collectionManager.create_collection(name, 1, fields).get();
+        for(size_t i = 0; i < 100; i++) {
+            ASSERT_TRUE(coll->add(R"({"title": "doc"})").ok());
+        }
+    }
+
+    embedded_params = std::vector<nlohmann::json>(2, nlohmann::json::object());
+    req_params["per_page"] = "250";
+    searches = R"([
+                    {"collection": "coll_a", "q": "*"},
+                    {"collection": "coll_b", "q": "*"}
+                ])"_json;
+
+    auto search_op = collectionManager.do_union(req_params, embedded_params, searches, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+    ASSERT_EQ(200, json_res["found"].get<size_t>());
+    ASSERT_EQ(200, json_res["hits"].size());
+}


### PR DESCRIPTION
## Problem

A union search can silently drop documents: `found` is right, `hits` has fewer entries, `search_cutoff` is `false`.

The union topster identifies a document by `hash_combine(collection_id, seq_id)` (or `search_index, seq_id`). `hash_combine` is not injective for small integers: `(3, 1000)` and `(4, 932)` produce the same key, and so do any two documents of neighbouring collections whose sequence ids differ by roughly 64. The topster treats such a pair as one document and keeps only the higher-ranked one.

Repro: two collections with 100 documents each, union `q=*`, `per_page=250` → `found: 200`, 163 hits.

## Fix

Both parts of the key are 32-bit, so pack them (`id << 32 | seq_id`) instead of hashing them. The group-by path keeps `hash_combine`, as its second part is already a 64-bit group hash.

## Tests

- `TopsterTest.UnionKVKeyIsUniquePerDocument`: 32 ids × 4096 sequence ids give 131072 distinct keys in both modes.
- `UnionTest.ReturnsEveryHitAcrossCollections`: the repro above, asserting `found == hits == 200`.
