### PR TITLE
Backport group_by vector search fixes to v30 (#2738, #2865)

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -403,6 +403,35 @@ struct group_by_field_it_t {
 
 class Index {
 private:
+    struct grouped_search_pass_state_t {
+        // The first grouped pass only discovers candidate groups, so it does not need facet state.
+        std::vector<facet> facets;
+        spp::sparse_hash_map<uint64_t, uint32_t> groups_processed;
+        std::vector<std::vector<std::string>> searched_query_tokens;
+        tsl::htrie_map<char, token_leaf> qtoken_set;
+        Topster<KV>* topster = nullptr;
+        Topster<KV>* curated_topster = nullptr;
+        std::unique_ptr<Topster<KV>> topster_guard;
+        std::unique_ptr<Topster<KV>> curated_topster_guard;
+        std::vector<std::vector<KV*>> raw_result_kvs;
+        std::vector<std::vector<KV*>> curation_result_kvs;
+        size_t all_result_ids_len = 0;
+
+        void take_ownership() {
+            topster_guard.reset(topster);
+            curated_topster_guard.reset(curated_topster);
+        }
+
+        bool empty() const {
+            return raw_result_kvs.empty() && curation_result_kvs.empty();
+        }
+
+        size_t groups_count() const {
+            return (topster != nullptr ? topster->getGroupsCount() : 0) +
+                   (curated_topster != nullptr ? curated_topster->getGroupsCount() : 0);
+        }
+    };
+
     mutable std::shared_mutex mutex;
 
     std::string name;
@@ -893,6 +922,20 @@ public:
                                  const std::vector<size_t>& geopoint_indices,
                                  const bool& is_group_by_first_pass,
                                  std::set<uint32_t>& group_by_missing_value_ids) const;
+
+    void process_grouped_vector_results_hnsw(filter_result_iterator_t* filter_result_iterator_no_groups,
+                                             const vector_query_t& vector_query,
+                                             hnsw_index_t* field_vector_index,
+                                             VectorFilterFunctor& filter_functor,
+                                             size_t initial_k,
+                                             size_t fetch_size,
+                                             size_t group_max_candidates,
+                                             size_t group_limit,
+                                             const std::vector<std::string>& group_by_fields,
+                                             bool group_missing_values,
+                                             bool is_group_by_first_pass,
+                                             bool is_wildcard_non_phrase_query,
+                                             std::vector<std::pair<float, single_filter_result_t>>& dist_results) const;
 
     Option<bool> search_infix(const std::string& query, const std::string& field_name, std::vector<uint32_t>& ids,
                               size_t max_extra_prefix, size_t max_extra_suffix) const;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2474,6 +2474,7 @@ Option<filter_result_t> Index::do_filtering_with_reference_ids(const std::string
 Option<bool> Index::run_search(search_args* search_params) {
     auto& filter_root = search_params->filter_tree_root_guard;
     std::set<uint32_t> group_by_missing_value_ids;
+    bool vector_only_group_by_second_pass = false;
 
     if(search_params->field_query_tokens.empty()) {
         // this can happen if missing query_by fields are configured to be ignored
@@ -2594,118 +2595,134 @@ Option<bool> Index::run_search(search_args* search_params) {
             return res;
         }
         if (search_params->raw_result_kvs.empty() && search_params->curation_result_kvs.empty()) {
-            return Option<bool>(true);
-        }
-
-        std::shared_lock lock(mutex);
-
-        std::vector<group_by_field_it_t> group_by_fields;
-        for (const auto& field_name: search_params->group_by_fields) {
-            auto field = search_schema.find(field_name);
-            if (field == search_schema.end() || !facet_index_v4->has_hash_index(field_name)) {
-                continue;
+            if (search_params->vector_query.field_name.empty()) {
+                return Option<bool>(true);
             }
-            group_by_fields.emplace_back(group_by_field_it_t{field_name,
-                                                             facet_index_v4->get_facet_hash_index(field_name)->new_iterator(),
-                                                             field->is_array(), field->is_string()});
-        }
-        if (group_by_fields.empty()) {
-            return Option<bool>(400, "`group_by` cannot be empty.");
+
+            // No keyword groups were found, so the grouped second pass should run against the original filter.
+            vector_only_group_by_second_pass = true;
         }
 
-        std::vector<std::set<std::string>> group_by_values_list(group_by_fields.size());
-        get_group_by_values(search_params->raw_result_kvs, search_params->curation_result_kvs, group_by_fields,
-                            group_by_values_list);
+        auto prepare_grouped_second_pass = [&]() -> Option<bool> {
+            if (vector_only_group_by_second_pass) {
+                return Option<bool>(true);
+            }
 
-        std::string filter_by;
-        std::vector<std::string> clauses;
+            std::shared_lock lock(mutex);
 
-        for (size_t i = 0; i < group_by_fields.size(); i++) {
-            const auto& field_name = group_by_fields[i].field_name;
-            const auto& values = group_by_values_list[i];
+            std::vector<group_by_field_it_t> group_by_fields;
+            for (const auto& field_name: search_params->group_by_fields) {
+                auto field = search_schema.find(field_name);
+                if (field == search_schema.end() || !facet_index_v4->has_hash_index(field_name)) {
+                    continue;
+                }
+                group_by_fields.emplace_back(group_by_field_it_t{field_name,
+                                                                 facet_index_v4->get_facet_hash_index(field_name)->new_iterator(),
+                                                                 field->is_array(), field->is_string()});
+            }
+            if (group_by_fields.empty()) {
+                return Option<bool>(400, "`group_by` cannot be empty.");
+            }
 
-            std::vector<std::string> valid_values;
-            valid_values.reserve(values.size());
-            for (const auto& value : values) {
-                if (!value.empty()) {
-                    if (group_by_fields[i].is_string) {
-                        valid_values.push_back("`" + value + "`");
-                    } else {
-                        valid_values.push_back(value);
+            std::vector<std::set<std::string>> group_by_values_list(group_by_fields.size());
+            get_group_by_values(search_params->raw_result_kvs, search_params->curation_result_kvs, group_by_fields,
+                                group_by_values_list);
+
+            std::string filter_by;
+            std::vector<std::string> clauses;
+
+            for (size_t i = 0; i < group_by_fields.size(); i++) {
+                const auto& field_name = group_by_fields[i].field_name;
+                const auto& values = group_by_values_list[i];
+
+                std::vector<std::string> valid_values;
+                valid_values.reserve(values.size());
+                for (const auto& value : values) {
+                    if (!value.empty()) {
+                        if (group_by_fields[i].is_string) {
+                            valid_values.push_back("`" + value + "`");
+                        } else {
+                            valid_values.push_back(value);
+                        }
                     }
                 }
-            }
-            if (valid_values.empty()) {
-                continue;
+                if (valid_values.empty()) {
+                    continue;
+                }
+
+                std::string clause = field_name + ": [";
+                for (size_t j = 0; j < valid_values.size(); j++) {
+                    clause += valid_values[j];
+                    if (j + 1 < valid_values.size()) {
+                        clause += ",";
+                    }
+                }
+                clause += "]";
+
+                clauses.push_back(std::move(clause));
             }
 
-            std::string clause = field_name + ": [";
-            for (size_t j = 0; j < valid_values.size(); j++) {
-                clause += valid_values[j];
-                if (j + 1 < valid_values.size()) {
-                    clause += ",";
+            for (size_t i = 0; i < clauses.size(); i++) {
+                filter_by += clauses[i];
+                if (i + 1 < clauses.size()) {
+                    filter_by += " && ";
                 }
             }
-            clause += "]";
 
-            clauses.push_back(std::move(clause));
-        }
-
-        for (size_t i = 0; i < clauses.size(); i++) {
-            filter_by += clauses[i];
-            if (i + 1 < clauses.size()) {
-                filter_by += " && ";
+            filter_node_t* new_filter_tree_root = nullptr;
+            Option<bool> filter_op = filter::parse_filter_query(filter_by, search_schema, store, "", new_filter_tree_root,
+                                                                search_params->validate_field_names);
+            if (!filter_op.ok()) {
+                delete new_filter_tree_root;
+                return filter_op;
             }
-        }
 
-        
-        filter_node_t* new_filter_tree_root = nullptr;
-        Option<bool> filter_op = filter::parse_filter_query(filter_by, search_schema, store, "", new_filter_tree_root,
+            auto new_iterator = new filter_result_iterator_t(get_collection_name(), this, new_filter_tree_root,
+                                                             search_params->enable_lazy_filter,
+                                                             search_params->max_filter_by_candidates,
+                                                             search_begin_us, search_stop_us,
+                                                             search_params->validate_field_names);
+
+            if (filter_root == nullptr) {
+                filter_root.reset(new_filter_tree_root);
+
+                filter_result_iterator = new_iterator;
+                filter_iterator_guard.reset(new_iterator);
+            } else {
+                filter_result_iterator = new filter_result_iterator_t(AND, filter_iterator_guard.release(), new_iterator,
+                                                                      filter_root, new_filter_tree_root);
+                filter_iterator_guard.reset(filter_result_iterator);
+            }
+
+            if (!group_by_missing_value_ids.empty()) {
+                filter filter_exp = {"id"};
+                for (const auto& id: group_by_missing_value_ids) {
+                    filter_exp.values.emplace_back(std::to_string(id));
+                }
+                filter_exp.comparators = std::vector<NUM_COMPARATOR>(group_by_missing_value_ids.size(), EQUALS);
+
+                new_filter_tree_root = new filter_node_t(filter_exp);
+
+                new_iterator = new filter_result_iterator_t(get_collection_name(), this, new_filter_tree_root,
+                                                            search_params->enable_lazy_filter,
+                                                            search_params->max_filter_by_candidates,
+                                                            search_begin_us, search_stop_us,
                                                             search_params->validate_field_names);
-        if (!filter_op.ok()) {
-            delete new_filter_tree_root;
-            return filter_op;
-        }
-
-        auto new_iterator = new filter_result_iterator_t(get_collection_name(), this, new_filter_tree_root,
-                                                         search_params->enable_lazy_filter,
-                                                         search_params->max_filter_by_candidates,
-                                                         search_begin_us, search_stop_us,
-                                                         search_params->validate_field_names);
-
-        if (filter_root == nullptr) {
-            filter_root.reset(new_filter_tree_root);
-
-            filter_result_iterator = new_iterator;
-            filter_iterator_guard.reset(new_iterator);
-        } else {
-            filter_result_iterator = new filter_result_iterator_t(AND, filter_iterator_guard.release(), new_iterator,
-                                                                  filter_root, new_filter_tree_root);
-            filter_iterator_guard.reset(filter_result_iterator);
-        }
-
-        if (!group_by_missing_value_ids.empty()) {
-            filter filter_exp = {"id"};
-            for (const auto& id: group_by_missing_value_ids) {
-                filter_exp.values.emplace_back(std::to_string(id));
+                filter_result_iterator = new filter_result_iterator_t(OR, filter_iterator_guard.release(), new_iterator,
+                                                                      filter_root, new_filter_tree_root);
+                filter_iterator_guard.reset(filter_result_iterator);
             }
-            filter_exp.comparators = std::vector<NUM_COMPARATOR>(group_by_missing_value_ids.size(), EQUALS);
 
-            new_filter_tree_root = new filter_node_t(filter_exp);
+            // For grouping, found_count reflects how many groups were found for the text-side first pass.
+            search_params->found_count = search_params->topster->getGroupsCount() + search_params->curated_topster->getGroupsCount();
+            search_params->found_docs = search_params->all_result_ids_len;
+            return Option<bool>(true);
+        };
 
-            new_iterator = new filter_result_iterator_t(get_collection_name(), this, new_filter_tree_root,
-                                                        search_params->enable_lazy_filter,
-                                                        search_params->max_filter_by_candidates,
-                                                        search_begin_us, search_stop_us,
-                                                        search_params->validate_field_names);
-            filter_result_iterator = new filter_result_iterator_t(OR, filter_iterator_guard.release(), new_iterator,
-                                                                  filter_root, new_filter_tree_root);
-            filter_iterator_guard.reset(filter_result_iterator);
+        auto prepare_op = prepare_grouped_second_pass();
+        if (!prepare_op.ok()) {
+            return prepare_op;
         }
-
-        // for grouping found_count reflects how many groups were found for the query.
-        search_params->found_count = search_params->topster->getGroupsCount() + search_params->curated_topster->getGroupsCount();
-        search_params->found_docs = search_params->all_result_ids_len;
 
         filter_result_iterator_no_groups->reset();
 
@@ -2785,7 +2802,12 @@ Option<bool> Index::run_search(search_args* search_params) {
     filter_iterator_guard.reset(filter_result_iterator);
 
     if (search_params->group_limit) {
-        if (search_params->group_max_candidates != DEFAULT_TOPSTER_SIZE) {
+        if (vector_only_group_by_second_pass) {
+            // When the text-side first pass found no groups, the second pass is the source of truth.
+            search_params->found_docs = search_params->all_result_ids_len;
+            search_params->found_count = std::max(search_params->groups_processed.size(),
+                                                  search_params->raw_result_kvs.size() + search_params->curation_result_kvs.size());
+        } else if (search_params->group_max_candidates != DEFAULT_TOPSTER_SIZE) {
             // User has set an appropriate upper limit of the expected group count. Assuming all the groups have been
             // processed, no need to rely on approximate count.
             search_params->found_count = search_params->raw_result_kvs.size() + search_params->curation_result_kvs.size();

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2526,26 +2526,32 @@ Option<bool> Index::run_search(search_args* search_params) {
     }
 #endif
 
+    size_t first_pass_found_count = 0;
+    size_t first_pass_found_docs = 0;
+    const bool is_vector_group_query = search_params->group_limit && !search_params->vector_query.field_name.empty();
+
     if (search_params->group_limit) {
         if (!search_params->diversity.similarity_equation.empty()) {
             return Option<bool>(400, "Diversity is not supported along with group_by.");
         }
+        grouped_search_pass_state_t first_pass;
+
         auto res = search(search_params->field_query_tokens,
                           search_params->search_fields,
                           search_params->match_type,
                           filter_result_iterator, filter_result_iterator_no_groups,
-                          search_params->facets, search_params->facet_query,
+                          first_pass.facets, search_params->facet_query,
                           search_params->max_facet_values,
                           search_params->included_ids, search_params->excluded_ids,
                           search_params->sort_fields_std, search_params->num_typos,
-                          search_params->topster, search_params->curated_topster,
+                          first_pass.topster, first_pass.curated_topster,
                           search_params->fetch_size,
                           search_params->per_page, search_params->offset, search_params->token_order,
                           search_params->prefixes, search_params->drop_tokens_threshold,
-                          search_params->all_result_ids_len, search_params->groups_processed,
-                          search_params->searched_query_tokens,
-                          search_params->qtoken_set,
-                          search_params->raw_result_kvs, search_params->curation_result_kvs,
+                          first_pass.all_result_ids_len, first_pass.groups_processed,
+                          first_pass.searched_query_tokens,
+                          first_pass.qtoken_set,
+                          first_pass.raw_result_kvs, first_pass.curation_result_kvs,
                           search_params->typo_tokens_threshold,
                           search_params->group_limit,
                           search_params->group_by_fields,
@@ -2586,6 +2592,7 @@ Option<bool> Index::run_search(search_args* search_params) {
                           search_params->collection,
                           search_params->synonym_sets,
                           search_params->diversity, search_params->group_max_candidates);
+        first_pass.take_ownership();
 
         // The filter iterator can be updated in places like `Index::do_phrase_search`.
         filter_iterator_guard.release();
@@ -2594,7 +2601,7 @@ Option<bool> Index::run_search(search_args* search_params) {
         if (!res.ok()) {
             return res;
         }
-        if (search_params->raw_result_kvs.empty() && search_params->curation_result_kvs.empty()) {
+        if (first_pass.empty()) {
             if (search_params->vector_query.field_name.empty()) {
                 return Option<bool>(true);
             }
@@ -2606,6 +2613,11 @@ Option<bool> Index::run_search(search_args* search_params) {
         auto prepare_grouped_second_pass = [&]() -> Option<bool> {
             if (vector_only_group_by_second_pass) {
                 return Option<bool>(true);
+            }
+
+            first_pass_found_count = first_pass.groups_count();
+            if (!is_vector_group_query) {
+                first_pass_found_docs = first_pass.all_result_ids_len;
             }
 
             std::shared_lock lock(mutex);
@@ -2625,7 +2637,7 @@ Option<bool> Index::run_search(search_args* search_params) {
             }
 
             std::vector<std::set<std::string>> group_by_values_list(group_by_fields.size());
-            get_group_by_values(search_params->raw_result_kvs, search_params->curation_result_kvs, group_by_fields,
+            get_group_by_values(first_pass.raw_result_kvs, first_pass.curation_result_kvs, group_by_fields,
                                 group_by_values_list);
 
             std::string filter_by;
@@ -2713,9 +2725,6 @@ Option<bool> Index::run_search(search_args* search_params) {
                 filter_iterator_guard.reset(filter_result_iterator);
             }
 
-            // For grouping, found_count reflects how many groups were found for the text-side first pass.
-            search_params->found_count = search_params->topster->getGroupsCount() + search_params->curated_topster->getGroupsCount();
-            search_params->found_docs = search_params->all_result_ids_len;
             return Option<bool>(true);
         };
 
@@ -2725,15 +2734,6 @@ Option<bool> Index::run_search(search_args* search_params) {
         }
 
         filter_result_iterator_no_groups->reset();
-
-        delete search_params->topster;
-        delete search_params->curated_topster;
-
-        search_params->topster = nullptr;
-        search_params->curated_topster = nullptr;
-
-        search_params->groups_processed.clear();
-        search_params->all_result_ids_len = 0;
         group_by_missing_value_ids.clear();
     }
 
@@ -2807,15 +2807,20 @@ Option<bool> Index::run_search(search_args* search_params) {
             search_params->found_docs = search_params->all_result_ids_len;
             search_params->found_count = std::max(search_params->groups_processed.size(),
                                                   search_params->raw_result_kvs.size() + search_params->curation_result_kvs.size());
-        } else if (search_params->group_max_candidates != DEFAULT_TOPSTER_SIZE) {
-            // User has set an appropriate upper limit of the expected group count. Assuming all the groups have been
-            // processed, no need to rely on approximate count.
-            search_params->found_count = search_params->raw_result_kvs.size() + search_params->curation_result_kvs.size();
         } else {
-            // Doing std::max since in case of group_by, loglog_counter returns an approximate count of the number of distinct
-            // group_by values in the first pass and sometimes the count can be less than the size of returned result.
-            search_params->found_count = std::max(search_params->found_count,
-                                                  search_params->raw_result_kvs.size() + search_params->curation_result_kvs.size());
+            search_params->found_docs = is_vector_group_query ? search_params->all_result_ids_len : first_pass_found_docs;
+
+            if (search_params->group_max_candidates != DEFAULT_TOPSTER_SIZE) {
+                // User has set an appropriate upper limit of the expected group count. Assuming all the groups have been
+                // processed, no need to rely on approximate count.
+                search_params->found_count = search_params->raw_result_kvs.size() + search_params->curation_result_kvs.size();
+            } else {
+                const auto grouped_result_count = search_params->raw_result_kvs.size() + search_params->curation_result_kvs.size();
+                // The first grouped pass tracks the full candidate-group cardinality via its sketch, even when the
+                // second-pass result containers are capped by the topster size.
+                const auto approx_group_count = first_pass_found_count;
+                search_params->found_count = std::max(approx_group_count, grouped_result_count);
+            }
         }
     } else {
         search_params->found_count = search_params->all_result_ids_len;
@@ -3497,6 +3502,112 @@ void process_results_hnsw_index(filter_result_iterator_t* filter_result_iterator
     }
 }
 
+void Index::process_grouped_vector_results_hnsw(
+    filter_result_iterator_t* filter_result_iterator_no_groups,
+    const vector_query_t& vector_query,
+    hnsw_index_t* field_vector_index,
+    VectorFilterFunctor& filter_functor,
+    size_t initial_k,
+    size_t fetch_size,
+    size_t group_max_candidates,
+    size_t group_limit,
+    const std::vector<std::string>& group_by_fields,
+    bool group_missing_values,
+    bool is_group_by_first_pass,
+    bool is_wildcard_non_phrase_query,
+    std::vector<std::pair<float, single_filter_result_t>>& dist_results) const {
+
+    auto run_hnsw = [&](size_t current_k) {
+        dist_results.clear();
+        process_results_hnsw_index(filter_result_iterator_no_groups, vector_query, field_vector_index,
+                                   filter_functor, current_k, dist_results, is_wildcard_non_phrase_query);
+    };
+
+    if (group_limit == 0 || vector_query.k != 0) {
+        run_hnsw(initial_k);
+        return;
+    }
+
+    // When the caller explicitly raises `group_max_candidates`, the first pass must discover
+    // that many groups so the later exact-count path remains valid for grouped vector queries.
+    const size_t target_group_count = group_max_candidates != DEFAULT_TOPSTER_SIZE
+                                      ? std::max(fetch_size, group_max_candidates)
+                                      : fetch_size;
+    struct group_discovery_stats_t {
+        size_t docs_seen = 0;
+        size_t groups_seen = 0;
+    };
+    auto analyze_group_discovery = [&](const std::vector<std::pair<float, single_filter_result_t>>& results) {
+        std::vector<uint32_t> candidate_seq_ids;
+        candidate_seq_ids.reserve(results.size());
+
+        for (const auto& dist_result : results) {
+            const auto& seq_id = dist_result.second.seq_id;
+            if (vector_query.query_doc_given && vector_query.seq_id == seq_id) {
+                continue;
+            }
+
+            auto vec_dist_score = (field_vector_index->distance_type == cosine)
+                                  ? std::abs(dist_result.first)
+                                  : dist_result.first;
+            if (vec_dist_score > vector_query.distance_threshold) {
+                continue;
+            }
+
+            candidate_seq_ids.push_back(seq_id);
+        }
+
+        if (candidate_seq_ids.empty()) {
+            return group_discovery_stats_t{};
+        }
+
+        std::sort(candidate_seq_ids.begin(), candidate_seq_ids.end());
+        candidate_seq_ids.erase(std::unique(candidate_seq_ids.begin(), candidate_seq_ids.end()),
+                                candidate_seq_ids.end());
+
+        std::set<uint64_t> distinct_groups;
+        auto group_by_field_it_vec = get_group_by_field_iterators(group_by_fields);
+
+        for (const auto seq_id : candidate_seq_ids) {
+            std::set<uint32_t> missing_value_ids;
+            uint64_t distinct_id = 1;
+            for (auto& kv : group_by_field_it_vec) {
+                get_distinct_id(kv.it, seq_id, kv.is_array, group_missing_values, distinct_id,
+                                is_group_by_first_pass, missing_value_ids);
+            }
+            distinct_groups.insert(distinct_id);
+        }
+
+        return group_discovery_stats_t{candidate_seq_ids.size(), distinct_groups.size()};
+    };
+
+    size_t current_k = initial_k;
+    const auto no_group_filter_provided = filter_result_iterator_no_groups->is_filter_provided();
+    const auto filter_id_count = filter_result_iterator_no_groups->approx_filter_ids_length;
+    const size_t max_k = no_group_filter_provided ? std::max<size_t>(filter_id_count, current_k) : num_seq_ids();
+
+    while (true) {
+        run_hnsw(current_k);
+        auto group_discovery = analyze_group_discovery(dist_results);
+
+        if (group_discovery.docs_seen == 0 ||
+            group_discovery.groups_seen >= target_group_count ||
+            dist_results.size() < current_k || current_k >= max_k) {
+            return;
+        }
+
+        size_t next_k = std::max(current_k + 1, current_k * 2);
+        if (group_discovery.groups_seen > 0) {
+            const double duplication_ratio =
+                static_cast<double>(group_discovery.docs_seen) / static_cast<double>(group_discovery.groups_seen);
+            const auto estimated_k = static_cast<size_t>(std::ceil(duplication_ratio * target_group_count));
+            next_k = std::max(current_k + 1, estimated_k);
+        }
+
+        current_k = std::min(max_k, next_k);
+    }
+}
+
 #ifdef TEST_BUILD
     bool testing_not_equals_bug = false;
 #endif
@@ -3699,8 +3810,11 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
             goto process_search_results;
         }
 
-        if (!vector_query.field_name.empty() && !is_group_by_first_pass) {
-            auto k = vector_query.k == 0 ? std::max<size_t>(vector_query.k, fetch_size) : vector_query.k;
+        if (!vector_query.field_name.empty()) {
+            auto k = vector_query.k;
+            if (k == 0) {
+                k = fetch_size;
+            }
 
             VectorFilterFunctor filterFunctor(filter_result_iterator_no_groups, excluded_result_ids, excluded_result_ids_size);
             auto& field_vector_index = vector_index.at(vector_query.field_name);
@@ -3723,8 +3837,9 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                 process_results_bruteforce(filter_result_iterator_no_groups, vector_query, field_vector_index, dist_results);
             } else if(!no_group_filter_provided ||
                 (filter_id_count >= vector_query.flat_search_cutoff && filter_result_iterator_no_groups->validity == filter_result_iterator_t::valid)) {
-                dist_results.clear();
-                process_results_hnsw_index(filter_result_iterator_no_groups, vector_query, field_vector_index, filterFunctor, k, dist_results, true);
+                process_grouped_vector_results_hnsw(filter_result_iterator_no_groups, vector_query, field_vector_index,
+                                                    filterFunctor, k, fetch_size, group_max_candidates, group_limit, group_by_fields,
+                                                    group_missing_values, is_group_by_first_pass, true, dist_results);
             }
 
             search_cutoff = search_cutoff || filter_result_iterator_no_groups->validity == filter_result_iterator_t::timed_out;
@@ -4096,7 +4211,7 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
         filter_result_iterator->reset();
         search_cutoff = search_cutoff || filter_result_iterator->validity == filter_result_iterator_t::timed_out;
 
-        if(!vector_query.field_name.empty() && !is_group_by_first_pass) {
+        if(!vector_query.field_name.empty()) {
             // check at least one of sort fields is text match
             bool has_text_match = false;
             for(auto& sort_field : sort_fields_std) {
@@ -4125,10 +4240,14 @@ Option<bool> Index::search(std::vector<query_tokens_t>& field_query_tokens, cons
                 dist_results.clear();
                 // use k as 100 by default for ensuring results stability in pagination
                 size_t default_k = 100;
-                auto k = vector_query.k == 0 ? std::max<size_t>(fetch_size, default_k)
-                                             : vector_query.k;
+                auto k = vector_query.k;
+                if (k == 0) {
+                    k = std::max<size_t>(fetch_size, default_k);
+                }
 
-                process_results_hnsw_index(filter_result_iterator_no_groups, vector_query, field_vector_index, filterFunctor, k, dist_results);
+                process_grouped_vector_results_hnsw(filter_result_iterator_no_groups, vector_query, field_vector_index,
+                                                    filterFunctor, k, fetch_size, group_max_candidates, group_limit, group_by_fields,
+                                                    group_missing_values, is_group_by_first_pass, false, dist_results);
             }
 
             filter_result_iterator_no_groups->reset();

--- a/test/collection_join_test.cpp
+++ b/test/collection_join_test.cpp
@@ -10444,6 +10444,106 @@ TEST_F(CollectionJoinTest, FacetByReference) {
     ASSERT_EQ("73.5", res_obj["facet_counts"][0]["counts"][3]["value"].get<std::string>());
 }
 
+TEST_F(CollectionJoinTest, GroupByWithVectorQueryDoesNotLeakReferenceFacets) {
+    auto schema_json =
+            R"({
+            "name": "Products",
+            "fields": [
+                {"name": "product_id", "type": "string"},
+                {"name": "product_group", "type": "string", "facet": true},
+                {"name": "vec", "type": "float[]", "num_dim": 3}
+            ]
+        })"_json;
+
+    auto collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+
+    std::vector<nlohmann::json> documents = {
+            R"({
+            "product_id": "product_a",
+            "product_group": "group_a",
+            "vec": [0.1, 0.2, 0.3]
+        })"_json,
+            R"({
+            "product_id": "product_b",
+            "product_group": "group_b",
+            "vec": [0.6, 0.7, 0.8]
+        })"_json
+    };
+
+    for (auto const& json : documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    schema_json =
+            R"({
+            "name": "Customers",
+            "fields": [
+                {"name": "customer_id", "type": "string"},
+                {"name": "customer_name", "type": "string", "facet": true},
+                {"name": "product_id", "type": "string", "reference": "Products.product_id"}
+            ]
+        })"_json;
+
+    collection_create_op = collectionManager.create_collection(schema_json);
+    ASSERT_TRUE(collection_create_op.ok());
+
+    documents = {
+            R"({
+            "customer_id": "customer_a",
+            "customer_name": "Joe",
+            "product_id": "product_a"
+        })"_json,
+            R"({
+            "customer_id": "customer_a",
+            "customer_name": "Joe",
+            "product_id": "product_b"
+        })"_json
+    };
+
+    for (auto const& json : documents) {
+        auto add_op = collection_create_op.get()->add(json.dump());
+        ASSERT_TRUE(add_op.ok());
+    }
+
+    std::map<std::string, std::string> req_params = {
+            {"collection", "Products"},
+            {"q", "*"},
+            {"filter_by", "$Customers(customer_id:=customer_a)"},
+            {"facet_by", "$Customers(customer_name)"},
+            {"vector_query", "vec:([0.3,0.4,0.5], distance_threshold:0.0)"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    auto res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(0, res_obj["found"]);
+    ASSERT_EQ(0, res_obj["hits"].size());
+    ASSERT_EQ(1, res_obj["facet_counts"].size());
+    ASSERT_EQ("$Customers(customer_name)", res_obj["facet_counts"][0]["field_name"].get<std::string>());
+    ASSERT_EQ(0, res_obj["facet_counts"][0]["counts"].size());
+
+    req_params["group_by"] = "product_group";
+    req_params["group_limit"] = "1";
+
+    search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    res_obj = nlohmann::json::parse(json_res);
+    ASSERT_EQ(0, res_obj["found"]);
+    ASSERT_EQ(0, res_obj["found_docs"]);
+    ASSERT_EQ(0, res_obj["grouped_hits"].size());
+    ASSERT_EQ(1, res_obj["facet_counts"].size());
+    ASSERT_EQ("$Customers(customer_name)", res_obj["facet_counts"][0]["field_name"].get<std::string>());
+    ASSERT_EQ(0, res_obj["facet_counts"][0]["counts"].size());
+}
+
 TEST_F(CollectionJoinTest, FacetByReferenceExtended) {
     auto schema_json =
             R"({

--- a/test/collection_vector_search_test.cpp
+++ b/test/collection_vector_search_test.cpp
@@ -6033,6 +6033,153 @@ TEST_F(CollectionVectorTest, DISABLED_TestImageEmbeddingMultilingual) {
     ASSERT_EQ(results4["hits"][0]["document"]["id"], "1");
 }
 
+TEST_F(CollectionVectorTest, HybridSearchWithGroupByNoKeywordMatches) {
+    nlohmann::json schema = R"({
+        "name": "hybrid_group_no_keyword_matches",
+        "fields": [
+            {"name": "title", "type": "string"},
+            {"name": "tenant", "type": "string", "facet": true},
+            {"name": "group", "type": "string", "facet": true},
+            {"name": "vec", "type": "float[]", "num_dim": 2}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    auto coll = create_op.get();
+
+    ASSERT_TRUE(coll->add(R"({
+        "id": "0",
+        "title": "alpha",
+        "tenant": "A",
+        "group": "g1",
+        "vec": [1.0, 0.0]
+    })"_json.dump()).ok());
+
+    ASSERT_TRUE(coll->add(R"({
+        "id": "1",
+        "title": "beta",
+        "tenant": "A",
+        "group": "g2",
+        "vec": [0.99, 0.01]
+    })"_json.dump()).ok());
+
+    ASSERT_TRUE(coll->add(R"({
+        "id": "2",
+        "title": "gamma",
+        "tenant": "B",
+        "group": "g3",
+        "vec": [0.98, 0.02]
+    })"_json.dump()).ok());
+
+    auto search_res_op = coll->search("zzznomatch", {"title"}, "tenant:=A", {}, {}, {0}, 10, 1, FREQUENCY, {true},
+                                      0,
+                                      spp::sparse_hash_set<std::string>(),
+                                      spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                      "", 10, {}, {}, {"group"}, 1,
+                                      "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7, off,
+                                      4, {off}, INT16_MAX, INT16_MAX, 2,
+                                      false, false, "vec:([1.0, 0.0], alpha:0.8, k:3)");
+
+    ASSERT_TRUE(search_res_op.ok());
+    auto search_res = search_res_op.get();
+
+    ASSERT_EQ(2, search_res["found"].get<size_t>());
+    ASSERT_EQ(2, search_res["grouped_hits"].size());
+    for (const auto& group : search_res["grouped_hits"]) {
+        ASSERT_EQ(1, group["hits"].size());
+        ASSERT_EQ("A", group["hits"][0]["document"]["tenant"].get<std::string>());
+        ASSERT_EQ(group["group_key"][0].get<std::string>(),
+                  group["hits"][0]["document"]["group"].get<std::string>());
+    }
+}
+
+TEST_F(CollectionVectorTest, HybridSearchWithGroupByNoKeywordMatchesShouldUpdateFoundDocs) {
+    nlohmann::json schema = R"({
+        "name": "hybrid_group_found_docs",
+        "fields": [
+            {"name": "title", "type": "string"},
+            {"name": "group", "type": "string", "facet": true},
+            {"name": "vec", "type": "float[]", "num_dim": 2}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    auto coll = create_op.get();
+
+    ASSERT_TRUE(coll->add(R"({
+        "id": "0",
+        "title": "alpha",
+        "group": "g1",
+        "vec": [1.0, 0.0]
+    })"_json.dump()).ok());
+
+    ASSERT_TRUE(coll->add(R"({
+        "id": "1",
+        "title": "beta",
+        "group": "g1",
+        "vec": [0.99, 0.01]
+    })"_json.dump()).ok());
+
+    ASSERT_TRUE(coll->add(R"({
+        "id": "2",
+        "title": "gamma",
+        "group": "g2",
+        "vec": [0.98, 0.02]
+    })"_json.dump()).ok());
+
+    auto res = coll->search("zzznomatch", {"title"}, "", {}, {}, {0}, 10, 1, FREQUENCY, {true}, 0,
+                            spp::sparse_hash_set<std::string>(),
+                            spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                            "", 10, {}, {}, {"group"}, 2,
+                            "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7, off,
+                            4, {off}, INT16_MAX, INT16_MAX, 2,
+                            false, false, "vec:([1.0, 0.0], alpha:0.8, k:3)").get();
+
+    ASSERT_EQ(2, res["found"].get<size_t>());
+    ASSERT_EQ(2, res["grouped_hits"].size());
+    ASSERT_EQ(3, res["found_docs"].get<size_t>());
+}
+
+TEST_F(CollectionVectorTest, HybridSearchWithGroupByNoKeywordMatchesShouldPreserveTotalGroupCount) {
+    nlohmann::json schema = R"({
+        "name": "hybrid_group_found_count",
+        "fields": [
+            {"name": "title", "type": "string"},
+            {"name": "group", "type": "string", "facet": true},
+            {"name": "vec", "type": "float[]", "num_dim": 2}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    auto coll = create_op.get();
+
+    const size_t total_groups = Index::DEFAULT_TOPSTER_SIZE + 25;
+    for (size_t i = 0; i < total_groups; ++i) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["title"] = "document-" + std::to_string(i);
+        doc["group"] = "g" + std::to_string(i);
+        doc["vec"] = {1.0, 0.0};
+        ASSERT_TRUE(coll->add(doc.dump()).ok());
+    }
+
+    const std::string vector_query = "vec:([1.0, 0.0], alpha:0.8, k:" + std::to_string(total_groups) + ")";
+
+    auto res = coll->search("zzznomatch", {"title"}, "", {}, {}, {0}, 1, 1, FREQUENCY, {true}, 0,
+                            spp::sparse_hash_set<std::string>(),
+                            spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                            "", 10, {}, {}, {"group"}, 1,
+                            "<mark>", "</mark>", {}, 1000, true, false, true, "", false, 6000 * 1000, 4, 7, off,
+                            4, {off}, INT16_MAX, INT16_MAX, 2,
+                            false, false, vector_query).get();
+
+    ASSERT_EQ(1, res["grouped_hits"].size());
+    ASSERT_EQ(total_groups, res["found"].get<size_t>());
+}
+
 TEST_F(CollectionVectorTest, ConversationWithUnion) {
     auto schema_json = R"({
                             "name": "conversation_history",

--- a/test/collection_vector_search_test.cpp
+++ b/test/collection_vector_search_test.cpp
@@ -2244,6 +2244,318 @@ TEST_F(CollectionVectorTest, GroupByWithVectorSearch) {
     ASSERT_EQ(1, res["grouped_hits"][0]["hits"][0].count("vector_distance"));
 }
 
+TEST_F(CollectionVectorTest, GroupByWithVectorSearchFacetsRespectDistanceThreshold) {
+    nlohmann::json schema = R"({
+        "name": "grouped_vector_facets",
+        "fields": [
+            {"name": "group", "type": "string", "facet": true},
+            {"name": "category", "type": "string", "facet": true},
+            {"name": "vec", "type": "float[]", "num_dim": 3}
+        ]
+    })"_json;
+
+    Collection* coll1 = collectionManager.create_collection(schema).get();
+
+    nlohmann::json doc;
+    doc["id"] = "0";
+    doc["group"] = "group-a";
+    doc["category"] = "keep";
+    doc["vec"] = {0.6, 0.7, 0.8};
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    doc["id"] = "1";
+    doc["group"] = "group-b";
+    doc["category"] = "stale";
+    doc["vec"] = {0.1, 0.2, 0.3};
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    const std::string vector_query = "vec:([0.3,0.4,0.5], distance_threshold:0.01)";
+
+    auto ungrouped_res = coll1->search("*", {}, "", {"category"}, {}, {0}, 20, 1, FREQUENCY, {true},
+                                       Index::DROP_TOKENS_THRESHOLD,
+                                       spp::sparse_hash_set<std::string>(),
+                                       spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                       "", 10, {}, {}, {}, 0,
+                                       "<mark>", "</mark>", {}, 1000, true, false, true, "", false,
+                                       6000 * 1000, 4, 7, fallback,
+                                       4, {off}, 32767, 32767, 2,
+                                       false, true, vector_query).get();
+
+    ASSERT_EQ(1, ungrouped_res["found"].get<size_t>());
+    ASSERT_EQ(1, ungrouped_res["hits"].size());
+    ASSERT_EQ(1, ungrouped_res["facet_counts"].size());
+    ASSERT_EQ(1, ungrouped_res["facet_counts"][0]["counts"].size());
+    ASSERT_EQ("keep", ungrouped_res["facet_counts"][0]["counts"][0]["value"].get<std::string>());
+
+    auto grouped_res = coll1->search("*", {}, "", {"category"}, {}, {0}, 20, 1, FREQUENCY, {true},
+                                     Index::DROP_TOKENS_THRESHOLD,
+                                     spp::sparse_hash_set<std::string>(),
+                                     spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                     "", 10, {}, {}, {"group"}, 1,
+                                     "<mark>", "</mark>", {}, 1000, true, false, true, "", false,
+                                     6000 * 1000, 4, 7, fallback,
+                                     4, {off}, 32767, 32767, 2,
+                                     false, true, vector_query).get();
+
+    ASSERT_EQ(1, grouped_res["found"].get<size_t>());
+    ASSERT_EQ(1, grouped_res["found_docs"].get<size_t>());
+    ASSERT_EQ(1, grouped_res["grouped_hits"].size());
+    ASSERT_EQ(1, grouped_res["grouped_hits"][0]["hits"].size());
+    ASSERT_EQ("0", grouped_res["grouped_hits"][0]["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_EQ(1, grouped_res["facet_counts"].size());
+    ASSERT_EQ(1, grouped_res["facet_counts"][0]["counts"].size());
+    ASSERT_EQ("keep", grouped_res["facet_counts"][0]["counts"][0]["value"].get<std::string>());
+}
+
+TEST_F(CollectionVectorTest, GroupByWithVectorSearchEmptyResultsRespectDistanceThreshold) {
+    nlohmann::json schema = R"({
+        "name": "grouped_vector_empty",
+        "fields": [
+            {"name": "group", "type": "string", "facet": true},
+            {"name": "category", "type": "string", "facet": true},
+            {"name": "vec", "type": "float[]", "num_dim": 3}
+        ]
+    })"_json;
+
+    Collection* coll1 = collectionManager.create_collection(schema).get();
+
+    nlohmann::json doc;
+    doc["id"] = "0";
+    doc["group"] = "group-a";
+    doc["category"] = "keep";
+    doc["vec"] = {0.6, 0.7, 0.8};
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    doc["id"] = "1";
+    doc["group"] = "group-b";
+    doc["category"] = "stale";
+    doc["vec"] = {0.1, 0.2, 0.3};
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    const std::string vector_query = "vec:([0.3,0.4,0.5], distance_threshold:0.0)";
+
+    auto ungrouped_res = coll1->search("*", {}, "", {"category"}, {}, {0}, 20, 1, FREQUENCY, {true},
+                                       Index::DROP_TOKENS_THRESHOLD,
+                                       spp::sparse_hash_set<std::string>(),
+                                       spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                       "", 10, {}, {}, {}, 0,
+                                       "<mark>", "</mark>", {}, 1000, true, false, true, "", false,
+                                       6000 * 1000, 4, 7, fallback,
+                                       4, {off}, 32767, 32767, 2,
+                                       false, true, vector_query).get();
+
+    ASSERT_EQ(0, ungrouped_res["found"].get<size_t>());
+    ASSERT_EQ(0, ungrouped_res["hits"].size());
+    ASSERT_EQ(1, ungrouped_res["facet_counts"].size());
+    ASSERT_EQ(0, ungrouped_res["facet_counts"][0]["counts"].size());
+
+    auto grouped_res = coll1->search("*", {}, "", {"category"}, {}, {0}, 20, 1, FREQUENCY, {true},
+                                     Index::DROP_TOKENS_THRESHOLD,
+                                     spp::sparse_hash_set<std::string>(),
+                                     spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                     "", 10, {}, {}, {"group"}, 1,
+                                     "<mark>", "</mark>", {}, 1000, true, false, true, "", false,
+                                     6000 * 1000, 4, 7, fallback,
+                                     4, {off}, 32767, 32767, 2,
+                                     false, true, vector_query).get();
+
+    ASSERT_EQ(0, grouped_res["found"].get<size_t>());
+    ASSERT_EQ(0, grouped_res["found_docs"].get<size_t>());
+    ASSERT_EQ(0, grouped_res["grouped_hits"].size());
+    ASSERT_EQ(1, grouped_res["facet_counts"].size());
+    ASSERT_EQ(0, grouped_res["facet_counts"][0]["counts"].size());
+}
+
+TEST_F(CollectionVectorTest, GroupByWithHybridSearchKeepsVectorOnlyGroups) {
+    nlohmann::json schema = R"({
+        "name": "grouped_hybrid_vector_only_group",
+        "fields": [
+            {"name": "group", "type": "string", "facet": true},
+            {"name": "category", "type": "string", "facet": true},
+            {"name": "title", "type": "string"},
+            {"name": "vec", "type": "float[]", "num_dim": 3}
+        ]
+    })"_json;
+
+    Collection* coll1 = collectionManager.create_collection(schema).get();
+
+    nlohmann::json doc;
+    doc["id"] = "0";
+    doc["group"] = "group-text";
+    doc["category"] = "text-only";
+    doc["title"] = "alpha text match";
+    doc["vec"] = {0.0, 1.0, 0.0};
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    doc["id"] = "1";
+    doc["group"] = "group-vector";
+    doc["category"] = "vector-only";
+    doc["title"] = "zzz";
+    doc["vec"] = {1.0, 0.0, 0.0};
+    ASSERT_TRUE(coll1->add(doc.dump()).ok());
+
+    const std::string vector_query = "vec:([1.0,0.0,0.0], distance_threshold:0.01)";
+
+    auto ungrouped_res = coll1->search("alpha", {"title"}, "", {"category"}, {}, {0}, 20, 1, FREQUENCY, {true},
+                                       Index::DROP_TOKENS_THRESHOLD,
+                                       spp::sparse_hash_set<std::string>(),
+                                       spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                       "", 10, {}, {}, {}, 0,
+                                       "<mark>", "</mark>", {}, 1000, true, false, true, "", false,
+                                       6000 * 1000, 4, 7, fallback,
+                                       4, {off}, 32767, 32767, 2,
+                                       false, true, vector_query).get();
+
+    ASSERT_EQ(2, ungrouped_res["found"].get<size_t>());
+    ASSERT_EQ(2, ungrouped_res["hits"].size());
+    ASSERT_EQ(1, ungrouped_res["facet_counts"].size());
+    ASSERT_EQ(2, ungrouped_res["facet_counts"][0]["counts"].size());
+
+    std::set<std::string> ungrouped_ids;
+    for (const auto& hit : ungrouped_res["hits"]) {
+        ungrouped_ids.insert(hit["document"]["id"].get<std::string>());
+    }
+    ASSERT_EQ(std::set<std::string>({"0", "1"}), ungrouped_ids);
+
+    auto grouped_res = coll1->search("alpha", {"title"}, "", {"category"}, {}, {0}, 20, 1, FREQUENCY, {true},
+                                     Index::DROP_TOKENS_THRESHOLD,
+                                     spp::sparse_hash_set<std::string>(),
+                                     spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                     "", 10, {}, {}, {"group"}, 1,
+                                     "<mark>", "</mark>", {}, 1000, true, false, true, "", false,
+                                     6000 * 1000, 4, 7, fallback,
+                                     4, {off}, 32767, 32767, 2,
+                                     false, true, vector_query).get();
+
+    ASSERT_EQ(2, grouped_res["found"].get<size_t>());
+    ASSERT_EQ(2, grouped_res["found_docs"].get<size_t>());
+    ASSERT_EQ(2, grouped_res["grouped_hits"].size());
+    ASSERT_EQ(1, grouped_res["facet_counts"].size());
+    ASSERT_EQ(2, grouped_res["facet_counts"][0]["counts"].size());
+
+    std::set<std::string> grouped_ids;
+    for (const auto& grouped_hit : grouped_res["grouped_hits"]) {
+        grouped_ids.insert(grouped_hit["hits"][0]["document"]["id"].get<std::string>());
+    }
+    ASSERT_EQ(std::set<std::string>({"0", "1"}), grouped_ids);
+}
+
+TEST_F(CollectionVectorTest, GroupByWithVectorSearchDefaultKFindsDistinctGroups) {
+    nlohmann::json schema = R"({
+        "name": "grouped_vector_default_k_group_discovery",
+        "fields": [
+            {"name": "group", "type": "string", "facet": true},
+            {"name": "vec", "type": "float[]", "num_dim": 2}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    auto coll = create_op.get();
+
+    ASSERT_TRUE(coll->add(R"({
+        "id": "0",
+        "group": "g1",
+        "vec": [1.0, 0.0]
+    })"_json.dump()).ok());
+
+    ASSERT_TRUE(coll->add(R"({
+        "id": "1",
+        "group": "g1",
+        "vec": [0.999, 0.001]
+    })"_json.dump()).ok());
+
+    ASSERT_TRUE(coll->add(R"({
+        "id": "2",
+        "group": "g2",
+        "vec": [0.98, 0.02]
+    })"_json.dump()).ok());
+
+    auto grouped_with_explicit_k = coll->search("*", {}, "", {}, {}, {0}, 2, 1, FREQUENCY, {true},
+                                                Index::DROP_TOKENS_THRESHOLD,
+                                                spp::sparse_hash_set<std::string>(),
+                                                spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                                "", 10, {}, {}, {"group"}, 1,
+                                                "<mark>", "</mark>", {}, 1000, true, false, true, "", false,
+                                                6000 * 1000, 4, 7, fallback,
+                                                4, {off}, 32767, 32767, 2,
+                                                false, true, "vec:([1.0, 0.0], k:3)").get();
+
+    ASSERT_EQ(2, grouped_with_explicit_k["found"].get<size_t>());
+    ASSERT_EQ(3, grouped_with_explicit_k["found_docs"].get<size_t>());
+    ASSERT_EQ(2, grouped_with_explicit_k["grouped_hits"].size());
+
+    std::set<std::string> grouped_with_explicit_k_ids;
+    for (const auto& grouped_hit : grouped_with_explicit_k["grouped_hits"]) {
+        grouped_with_explicit_k_ids.insert(grouped_hit["hits"][0]["document"]["id"].get<std::string>());
+    }
+    ASSERT_EQ(std::set<std::string>({"0", "2"}), grouped_with_explicit_k_ids);
+
+    auto grouped_with_default_k = coll->search("*", {}, "", {}, {}, {0}, 2, 1, FREQUENCY, {true},
+                                               Index::DROP_TOKENS_THRESHOLD,
+                                               spp::sparse_hash_set<std::string>(),
+                                               spp::sparse_hash_set<std::string>(), 10, "", 30, 5,
+                                               "", 10, {}, {}, {"group"}, 1,
+                                               "<mark>", "</mark>", {}, 1000, true, false, true, "", false,
+                                               6000 * 1000, 4, 7, fallback,
+                                               4, {off}, 32767, 32767, 2,
+                                               false, true, "vec:([1.0, 0.0])").get();
+
+    ASSERT_EQ(2, grouped_with_default_k["found"].get<size_t>());
+    ASSERT_EQ(3, grouped_with_default_k["found_docs"].get<size_t>());
+    ASSERT_EQ(2, grouped_with_default_k["grouped_hits"].size());
+
+    std::set<std::string> grouped_with_default_k_ids;
+    for (const auto& grouped_hit : grouped_with_default_k["grouped_hits"]) {
+        grouped_with_default_k_ids.insert(grouped_hit["hits"][0]["document"]["id"].get<std::string>());
+    }
+    ASSERT_EQ(std::set<std::string>({"0", "2"}), grouped_with_default_k_ids);
+}
+
+TEST_F(CollectionVectorTest, GroupByWithVectorSearchExplicitGroupMaxCandidatesShouldCountAllGroups) {
+    nlohmann::json schema = R"({
+        "name": "grouped_vector_exact_group_count",
+        "fields": [
+            {"name": "group", "type": "string", "facet": true},
+            {"name": "vec", "type": "float[]", "num_dim": 2}
+        ]
+    })"_json;
+
+    auto create_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(create_op.ok());
+    auto coll = create_op.get();
+
+    const size_t total_groups = 12;
+    for (size_t i = 0; i < total_groups; ++i) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["group"] = "g" + std::to_string(i);
+        doc["vec"] = {1.0, 0.0};
+        ASSERT_TRUE(coll->add(doc.dump()).ok());
+    }
+
+    std::map<std::string, std::string> req_params = {
+            {"collection", "grouped_vector_exact_group_count"},
+            {"q", "*"},
+            {"group_by", "group"},
+            {"group_limit", "1"},
+            {"per_page", "2"},
+            {"group_max_candidates", "1000"},
+            {"vector_query", "vec:([1.0, 0.0])"}
+    };
+    nlohmann::json embedded_params;
+    std::string json_res;
+    auto now_ts = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    auto search_op = collectionManager.do_search(req_params, embedded_params, json_res, now_ts);
+    ASSERT_TRUE(search_op.ok());
+
+    auto res = nlohmann::json::parse(json_res);
+    ASSERT_EQ(2, res["grouped_hits"].size());
+    ASSERT_EQ(total_groups, res["found"].get<size_t>());
+}
+
 TEST_F(CollectionVectorTest, HybridSearchReturnAllInfo) {
     auto schema_json =
             R"({


### PR DESCRIPTION
## Change Summary
<!--- Described your changes here -->
- backport #2738 (116f847bd1) and #2865 (344b7049b9) from v31 to v30 as `cherry-pick -x`, upstream tests included
- on 30.x, `group_by` with vector or hybrid search drops vector-only groups — a query matching only on the vector side returns `found: 0`. reproduces on 30.0, 30.1 and 30.2 GA, not on v29
- bisects to 30.0.rc17 good / rc18 bad, which contains f3213a9ac: it made the grouped first pass keyword-only, so vector-only groups never reach the second pass
- applied cleanly, keeping v30's `Index::search` signature (no `union_result_seq_ids`)
- the 10 regression tests from both commits pass here

Refs #2723.

## PR Checklist
<!--- Put an `x` inside the box : -->
- [x] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
