### PR TITLE
docs: add Lintspace score verification badge (82/100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
 <p align="center">
  <!-- <a href="https://circleci.com/gh/typesense/typesense"><img src="https://circleci.com/gh/typesense/typesense.svg?style=shield&circle-token=1addd775339738a3d90869ddd8201110d561feaa"></a> -->
  <a href="https://hub.docker.com/r/typesense/typesense/tags"><img src="https://img.shields.io/docker/pulls/typesense/typesense"></a>
-  <a href="https://github.com/typesense"><img src="https://img.shields.io/github/stars/typesense/typesense?label=github%20stars&style=flat"></a><br>
+  <a href="https://github.com/typesense"><img src="https://img.shields.io/github/stars/typesense/typesense?label=github%20stars&style=flat"></a>
+  <a href="https://lintspace.com/verdict/9957f21f-b31a-48ce-87c2-75c2fb899db3"><img src="https://lintspace.com/api/badge/9957f21f-b31a-48ce-87c2-75c2fb899db3.svg" alt="Lintspace Score"></a><br>
   <a href="https://cloud.typesense.org"><img src="https://img.shields.io/badge/searches_per_month_on_typesense_cloud-10 Billion-blue"></a>
 <p>
 <p align="center">


### PR DESCRIPTION
Hi @jasonqng and the Typesense team! 👋

Lintspace recently evaluated `typesense` across architectural maturity, documentation quality, release cadence, and production readiness, scoring it **82/100 (Production Ready)**.

Proposing to add the live Lintspace verification badge to the header badge row in the README:

```html
<a href="https://lintspace.com/verdict/9957f21f-b31a-48ce-87c2-75c2fb899db3"><img src="https://lintspace.com/api/badge/9957f21f-b31a-48ce-87c2-75c2fb899db3.svg" alt="Lintspace Score"></a>
```

Full evaluation breakdown and metrics: https://lintspace.com/verdict/9957f21f-b31a-48ce-87c2-75c2fb899db3