### PR TITLE
feat(api): add token score rebuilding

### DIFF
--- a/api_tests/tests/token_score_rebuild.test.ts
+++ b/api_tests/tests/token_score_rebuild.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect } from "bun:test";
+import { Phases } from "../src/constants";
+import { fetchSingleNode, fetchMultiNode } from "../src/request";
+
+// art token max_score is stamped when a document is indexed and only ever raised
+// afterwards, so a collection whose default_sorting_field moves around ends up
+// picking prefix candidates on scores that no longer exist. the rebuild is an
+// on-demand operation on the collection PATCH route that recomputes them from the
+// live sort index.
+//
+// every assertion below runs with max_candidates=1, which means exactly one token
+// under the "ap" prefix gets expanded and the winner is decided purely by max_score.
+
+const COLLECTION = "token_score_rebuild";
+const NOSTORE_COLLECTION = "token_score_rebuild_nostore";
+const DELETE_COLLECTION = "token_score_rebuild_delete";
+const UNRANKED_COLLECTION = "token_score_rebuild_unranked";
+const MULTI_COLLECTION = "token_score_rebuild_multi";
+
+const SEARCH = "/documents/search?q=ap&query_by=title&prefix=true&num_typos=0&max_candidates=1";
+
+function schemaFor(name: string, storeTitle: boolean) {
+  return {
+    name,
+    fields: [
+      { name: "title", type: "string", store: storeTitle },
+      { name: "points", type: "int32" },
+    ],
+    default_sorting_field: "points",
+  };
+}
+
+// three distinct tokens share the "ap" prefix, one document each, so every leaf
+// max_score is just that document's score
+const SEED_DOCS = [
+  JSON.stringify({ id: "0", title: "apple", points: 100 }),
+  JSON.stringify({ id: "1", title: "apricot", points: 10 }),
+  JSON.stringify({ id: "2", title: "apron", points: 5 }),
+].join("\n");
+
+async function topHitId(collection: string): Promise<string> {
+  const res = await fetchSingleNode(`/collections/${collection}${SEARCH}`);
+  expect(res.ok).toBe(true);
+  const body: any = await res.json();
+  expect(body.hits.length).toBe(1);
+  return body.hits[0].document.id as string;
+}
+
+async function rebuild(collection: string): Promise<Response> {
+  return fetchSingleNode(`/collections/${collection}?rebuild_token_scores=true`, {
+    method: "PATCH",
+  });
+}
+
+async function updatePoints(collection: string, id: string, points: number) {
+  const res = await fetchSingleNode(`/collections/${collection}/documents/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ points }),
+  });
+  expect(res.ok).toBe(true);
+}
+
+describe(Phases.SINGLE_FRESH, () => {
+  it("seeds a collection whose candidate selection depends on token scores", async () => {
+    let res = await fetchSingleNode("/collections", {
+      method: "POST",
+      body: JSON.stringify(schemaFor(COLLECTION, true)),
+    });
+    expect(res.ok).toBe(true);
+
+    res = await fetchSingleNode(`/collections/${COLLECTION}/documents/import?action=create`, {
+      method: "POST",
+      body: SEED_DOCS,
+    });
+    expect(res.ok).toBe(true);
+    const importBody = await res.text();
+    expect(importBody.split("\n").every((l) => l.includes('"success":true'))).toBe(true);
+
+    expect(await topHitId(COLLECTION)).toBe("0");
+  });
+
+  it("leaves a sort-only increase stale until a rebuild is asked for", async () => {
+    // apricot outranks apple now, but nothing re-indexed its title
+    await updatePoints(COLLECTION, "1", 1000);
+    expect(await topHitId(COLLECTION)).toBe("0");
+
+    const res = await rebuild(COLLECTION);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ rebuild_token_scores: true });
+
+    expect(await topHitId(COLLECTION)).toBe("1");
+  });
+
+  it("brings scores back down, which the insert path can never do", async () => {
+    await updatePoints(COLLECTION, "1", 1);
+
+    // still stale-high at 1000 until the rebuild runs
+    expect(await topHitId(COLLECTION)).toBe("1");
+
+    const res = await rebuild(COLLECTION);
+    expect(res.status).toBe(200);
+
+    // apple at 100 is the highest live score again
+    expect(await topHitId(COLLECTION)).toBe("0");
+  });
+
+  it("recovers the score a deleted document was holding", async () => {
+    // the deleted document has to share its token with a survivor, otherwise the
+    // leaf is removed outright and there is no stale score left to observe
+    let res = await fetchSingleNode("/collections", {
+      method: "POST",
+      body: JSON.stringify(schemaFor(DELETE_COLLECTION, true)),
+    });
+    expect(res.ok).toBe(true);
+
+    const docs = [
+      JSON.stringify({ id: "0", title: "apple pie", points: 1000 }),
+      JSON.stringify({ id: "1", title: "apple tart", points: 1 }),
+      JSON.stringify({ id: "2", title: "apricot", points: 100 }),
+    ].join("\n");
+
+    res = await fetchSingleNode(`/collections/${DELETE_COLLECTION}/documents/import?action=create`, {
+      method: "POST",
+      body: docs,
+    });
+    expect(res.ok).toBe(true);
+
+    // apple wins the only candidate slot at 1000 and brings both its documents
+    res = await fetchSingleNode(`/collections/${DELETE_COLLECTION}${SEARCH}`);
+    let body: any = await res.json();
+    expect(body.hits.length).toBe(2);
+    expect(body.hits[0].document.id).toBe("0");
+
+    res = await fetchSingleNode(`/collections/${DELETE_COLLECTION}/documents/0`, { method: "DELETE" });
+    expect(res.ok).toBe(true);
+
+    // removing the document never lowered the leaf, so apple still claims 1000 and
+    // keeps the slot even though the only apple document left scores 1
+    res = await fetchSingleNode(`/collections/${DELETE_COLLECTION}${SEARCH}`);
+    body = await res.json();
+    expect(body.hits.length).toBe(1);
+    expect(body.hits[0].document.id).toBe("1");
+
+    res = await rebuild(DELETE_COLLECTION);
+    expect(res.status).toBe(200);
+
+    // apple drops to 1 and apricot at 100 takes the slot
+    expect(await topHitId(DELETE_COLLECTION)).toBe("2");
+  });
+
+  it("covers store:false fields, which no update-time fix could reach", async () => {
+    // a store:false field is stripped before the document is persisted, so there is
+    // no text left to re-tokenize on a later update. walking the tree needs none.
+    let res = await fetchSingleNode("/collections", {
+      method: "POST",
+      body: JSON.stringify(schemaFor(NOSTORE_COLLECTION, false)),
+    });
+    expect(res.ok).toBe(true);
+
+    res = await fetchSingleNode(`/collections/${NOSTORE_COLLECTION}/documents/import?action=create`, {
+      method: "POST",
+      body: SEED_DOCS,
+    });
+    expect(res.ok).toBe(true);
+
+    expect(await topHitId(NOSTORE_COLLECTION)).toBe("0");
+
+    await updatePoints(NOSTORE_COLLECTION, "1", 1000);
+    expect(await topHitId(NOSTORE_COLLECTION)).toBe("0");
+
+    res = await rebuild(NOSTORE_COLLECTION);
+    expect(res.status).toBe(200);
+
+    expect(await topHitId(NOSTORE_COLLECTION)).toBe("1");
+
+    // and the title really is unstored
+    res = await fetchSingleNode(`/collections/${NOSTORE_COLLECTION}${SEARCH}`);
+    const body: any = await res.json();
+    expect(body.hits[0].document.title).toBeUndefined();
+  });
+
+  it("rejects the parameter unless it is sent alone and without a body", async () => {
+    let res = await fetchSingleNode(`/collections/${COLLECTION}?rebuild_token_scores=true`, {
+      method: "PATCH",
+      body: JSON.stringify({ metadata: { a: 1 } }),
+    });
+    expect(res.status).toBe(400);
+    let body: any = await res.json();
+    expect(body.message).toContain("without a request body");
+
+    res = await fetchSingleNode(
+      `/collections/${COLLECTION}?rebuild_token_scores=true&exclude_fields=title`,
+      { method: "PATCH" },
+    );
+    expect(res.status).toBe(400);
+    body = await res.json();
+    expect(body.message).toContain("cannot be combined with other parameters");
+
+    res = await fetchSingleNode(`/collections/${COLLECTION}?rebuild_token_scores=false`, {
+      method: "PATCH",
+    });
+    expect(res.status).toBe(400);
+    body = await res.json();
+    expect(body.message).toContain("must be `true`");
+
+    // a normal alter is untouched by any of this
+    res = await fetchSingleNode(`/collections/${COLLECTION}`, {
+      method: "PATCH",
+      body: JSON.stringify({ metadata: { owner: "search" } }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects a rebuild on a collection ordered by frequency", async () => {
+    let res = await fetchSingleNode("/collections", {
+      method: "POST",
+      body: JSON.stringify({
+        name: UNRANKED_COLLECTION,
+        fields: [{ name: "title", type: "string" }],
+      }),
+    });
+    expect(res.ok).toBe(true);
+
+    // no default_sorting_field means max_score holds document counts, not scores
+    res = await rebuild(UNRANKED_COLLECTION);
+    expect(res.status).toBe(400);
+    const body: any = await res.json();
+    expect(body.message).toContain("default_sorting_field");
+  });
+});
+
+describe(Phases.SINGLE_RESTARTED, () => {
+  it("scores are recomputed from the reloaded index", async () => {
+    // a restart re-indexes every document, so scores start out correct
+    expect(await topHitId(COLLECTION)).toBe("0");
+
+    await updatePoints(COLLECTION, "1", 9000);
+    expect(await topHitId(COLLECTION)).toBe("0");
+
+    const res = await rebuild(COLLECTION);
+    expect(res.status).toBe(200);
+
+    expect(await topHitId(COLLECTION)).toBe("1");
+  });
+});
+
+describe(Phases.MULTI_FRESH, () => {
+  it("seeds the cluster", async () => {
+    let res = await fetchMultiNode(1, "/collections", {
+      method: "POST",
+      body: JSON.stringify(schemaFor(MULTI_COLLECTION, true)),
+    });
+    expect(res.ok).toBe(true);
+
+    res = await fetchMultiNode(1, `/collections/${MULTI_COLLECTION}/documents/import?action=create`, {
+      method: "POST",
+      body: SEED_DOCS,
+    });
+    expect(res.ok).toBe(true);
+
+    for(const node of [1, 2, 3]) {
+      const searchRes = await fetchMultiNode(node, `/collections/${MULTI_COLLECTION}${SEARCH}`);
+      expect(searchRes.ok).toBe(true);
+      const body: any = await searchRes.json();
+      expect(body.hits[0].document.id).toBe("0");
+    }
+  });
+
+  it("a rebuild sent to one node repairs every node", async () => {
+    // max_score is per node in-memory state, so this only works because the PATCH
+    // route is a replicated write: the parameter has to survive the raft log
+    let res = await fetchMultiNode(1, `/collections/${MULTI_COLLECTION}/documents/1`, {
+      method: "PATCH",
+      body: JSON.stringify({ points: 1000 }),
+    });
+    expect(res.ok).toBe(true);
+
+    for(const node of [1, 2, 3]) {
+      const searchRes = await fetchMultiNode(node, `/collections/${MULTI_COLLECTION}${SEARCH}`);
+      const body: any = await searchRes.json();
+      expect(body.hits[0].document.id).toBe("0");
+    }
+
+    res = await fetchMultiNode(1, `/collections/${MULTI_COLLECTION}?rebuild_token_scores=true`, {
+      method: "PATCH",
+    });
+    expect(res.status).toBe(200);
+
+    for(const node of [1, 2, 3]) {
+      const searchRes = await fetchMultiNode(node, `/collections/${MULTI_COLLECTION}${SEARCH}`);
+      expect(searchRes.ok).toBe(true);
+      const body: any = await searchRes.json();
+      expect(body.hits.length).toBe(1);
+      expect(body.hits[0].document.id).toBe("1");
+    }
+  });
+});

--- a/include/art.h
+++ b/include/art.h
@@ -219,6 +219,33 @@ void* art_delete(art_tree *t, const unsigned char *key, int key_len);
  */
 void* art_search(const art_tree *t, const unsigned char *key, int key_len);
 
+/* Returns the current score of a document, used to recompute a leaf's max_score. */
+typedef int64_t (*art_score_fn)(void* obj, uint32_t id);
+
+/* Invoked between leaves so the caller can release and reacquire its index lock. */
+typedef void (*art_yield_fn)(void* obj);
+
+/**
+ * Recomputes every leaf's max_score from live document scores and rebuilds inner
+ * node scores bottom-up. Only valid on score ordered trees: a frequency ordered
+ * tree stores document counts in max_score and must not be passed here.
+ *
+ * yield_fn is called once roughly every yield_budget scored postings, letting the
+ * caller drop its lock so searches are not blocked for the whole walk. The budget
+ * bounds work inside a single leaf as well as across leaves, so one very common
+ * token cannot hold the lock for its whole posting list.
+ *
+ * No node pointer is held across a yield. Each segment re-descends from the root to
+ * a saved key, so a writer that frees or collapses nodes while the lock is released
+ * cannot leave the walk holding freed memory. The tree may legitimately change under
+ * it: a token written during a yield keeps whatever score the insert path gave it,
+ * which is the same best effort the rest of this scoring is.
+ *
+ * Passing a NULL yield_fn runs the whole tree in one go and ignores the budget.
+ */
+void art_rebuild_max_scores(art_tree* t, art_score_fn score_fn, art_yield_fn yield_fn,
+                            void* fn_obj, size_t yield_budget);
+
 /**
  * Returns the minimum valued leaf
  * @return The minimum leaf or NULL

--- a/include/collection.h
+++ b/include/collection.h
@@ -869,6 +869,7 @@ public:
     static constexpr const char* COLLECTION_NEXT_SEQ_PREFIX = "$CS";
     static constexpr const char* SEQ_ID_PREFIX = "$SI";
     static constexpr const char* DOC_ID_PREFIX = "$DI";
+    static constexpr const char* TOKEN_SCORE_REBUILD_LOG_PREFIX = "$TR";
 
     static constexpr const char* COLLECTION_NAME_KEY = "name";
     static constexpr const char* COLLECTION_ID_KEY = "id";
@@ -945,6 +946,11 @@ public:
     tsl::htrie_set<char> get_object_reference_fields() const;
 
     std::string get_default_sorting_field();
+
+    // Recomputes token max_score values from current document scores. A positive Raft log
+    // index makes the operation durable-idempotent so completed rebuilds are not repeated
+    // when the log is replayed after restart. Returns false when that entry was already run.
+    Option<bool> rebuild_token_scores(int64_t raft_log_index = 0);
 
     std::vector<std::string> get_synonym_sets() const;
     std::vector<std::string> get_curation_sets() const;

--- a/include/index.h
+++ b/include/index.h
@@ -649,6 +649,20 @@ private:
                                       const std::vector<char>& token_separators,
                                       std::unordered_map<std::string, std::vector<uint32_t>>& token_to_offsets);
 
+    static void tokenize_doc_field(const field& the_field,
+                                   const nlohmann::json& value,
+                                   const std::vector<char>& local_symbols_to_index,
+                                   const std::vector<char>& local_token_separators,
+                                   std::unordered_map<std::string, std::vector<uint32_t>>& token_to_offsets);
+
+    static int64_t float_points(float value);
+
+    static int64_t sort_index_value_to_points(const field& a_field, int64_t value);
+
+    static int64_t token_score_from_sort_index(void* obj, uint32_t seq_id);
+
+    static void yield_index_lock(void* obj);
+
     void collate_included_ids(const std::vector<token_t>& q_included_tokens,
                               const std::map<size_t, std::map<size_t, uint32_t>> & included_ids_map,
                               Topster<KV>*& curated_topster,
@@ -740,6 +754,9 @@ public:
     // in the query that have the least individual hits one by one until enough results are found.
     static const int DROP_TOKENS_THRESHOLD = 1;
 
+    // Postings scored between index lock releases during a token score rebuild.
+    static constexpr size_t TOKEN_SCORE_YIELD_BUDGET = 100000;
+
     enum {DEFAULT_TOPSTER_SIZE = 250};
 
     Index() = delete;
@@ -753,6 +770,11 @@ public:
           const std::vector<char>& token_separators);
 
     ~Index();
+
+    // Recomputes every token's max_score from the live sort index. Takes the index write lock
+    // and drops it periodically so searches are not blocked for the whole walk; the walk itself
+    // tolerates a writer restructuring the tree while the lock is down.
+    void rebuild_token_scores(const std::string& default_sorting_field);
 
     static void concat_topster_ids(Topster<KV>*& topster, spp::sparse_hash_map<uint64_t, std::vector<KV*>>& topster_ids);
 

--- a/src/art.cpp
+++ b/src/art.cpp
@@ -104,8 +104,7 @@ bool compare_art_node_score_pq(const art_node* a, const art_node* b) {
 }
 
 /**
- * Allocates a node of the given type,
- * initializes to zero and sets the type.
+ * Allocates and initializes a node of the given type.
  */
 static art_node* alloc_node(uint8_t type) {
     art_node* n;
@@ -126,7 +125,9 @@ static art_node* alloc_node(uint8_t type) {
             abort();
     }
     n->type = type;
-    n->max_score = 0;
+    // Score-ordered trees may contain only negative values. Child insertion will raise
+    // this to the real subtree maximum; starting at zero would permanently overstate it.
+    n->max_score = INT64_MIN;
     return n;
 }
 
@@ -472,11 +473,15 @@ static void copy_header(art_node *dest, art_node *src) {
     memcpy(dest->partial, src->partial, min(MAX_PREFIX_LEN, src->partial_len));
 }
 
+static int64_t child_max_score(const art_node* child) {
+    return IS_LEAF(child) ? ((art_leaf*) LEAF_RAW(child))->max_score : child->max_score;
+}
+
 static void add_child256(art_node256 *n, art_node **ref, unsigned char c, void *child) {
     (void)ref;
     n->n.num_children++;
     n->children[c] = (art_node *) child;
-    n->n.max_score = MAX(n->n.max_score, ((art_leaf *) LEAF_RAW(child))->max_score);
+    n->n.max_score = MAX(n->n.max_score, child_max_score((art_node*) child));
 }
 
 static void add_child48(art_node48 *n, art_node **ref, unsigned char c, void *child) {
@@ -486,7 +491,7 @@ static void add_child48(art_node48 *n, art_node **ref, unsigned char c, void *ch
         n->children[pos] = (art_node *) child;
         n->keys[c] = pos + 1;
         n->n.num_children++;
-        n->n.max_score = MAX(n->n.max_score, ((art_leaf *) LEAF_RAW(child))->max_score);
+        n->n.max_score = MAX(n->n.max_score, child_max_score((art_node*) child));
     } else {
         art_node256 *new_n = (art_node256*)alloc_node(NODE256);
         for (int i=0;i<256;i++) {
@@ -527,7 +532,7 @@ static void add_child16(art_node16 *n, art_node **ref, unsigned char c, void *ch
         n->keys[idx] = c;
         n->children[idx] = (art_node *) child;
         n->n.num_children++;
-        n->n.max_score = MAX(n->n.max_score, ((art_leaf *) LEAF_RAW(child))->max_score);
+        n->n.max_score = MAX(n->n.max_score, child_max_score((art_node*) child));
 
     } else {
         art_node48 *new_n = (art_node48*)alloc_node(NODE48);
@@ -560,7 +565,7 @@ static void add_child4(art_node4 *n, art_node **ref, unsigned char c, void *chil
         n->keys[idx] = c;
         n->children[idx] = (art_node *) child;
         n->n.num_children++;
-        n->n.max_score = MAX(n->n.max_score, ((art_leaf *) LEAF_RAW(child))->max_score);
+        n->n.max_score = MAX(n->n.max_score, child_max_score((art_node*) child));
 
     } else {
         art_node16 *new_n = (art_node16*)alloc_node(NODE16);
@@ -664,10 +669,6 @@ static void* recursive_insert(art_node* n, art_node** ref, const unsigned char* 
         return NULL;
     }
 
-    if(docs_max_score != USE_FREQUENCY_SCORE) {
-        n->max_score = MAX(n->max_score, docs_max_score);
-    }
-
     // Check if given node has a prefix
     if (n->partial_len) {
         // Determine if the prefixes differ, since we need to split
@@ -709,6 +710,12 @@ static void* recursive_insert(art_node* n, art_node** ref, const unsigned char* 
     }
 
     RECURSE_SEARCH:;
+
+    // Only raise this node after its compressed prefix has matched. On a mismatch,
+    // `n` becomes a sibling of the new leaf and the new score does not belong in it.
+    if(docs_max_score != USE_FREQUENCY_SCORE) {
+        n->max_score = MAX(n->max_score, docs_max_score);
+    }
 
     // Find a child to recurse to
     art_node **child = find_child(n, key[depth]);
@@ -942,6 +949,414 @@ void* art_delete(art_tree *t, const unsigned char *key, int key_len) {
 
     return child->max_token_count;
 }*/
+
+// collects a node's child pointers along with the key byte each one is reached by.
+// both buffers must hold 256 entries. children come back in ascending byte order,
+// which is what lets the walk resume at a key.
+static int node_children(const art_node* n, art_node** out, unsigned char* out_bytes) {
+    int idx, count = 0;
+
+    switch (n->type) {
+        case NODE4:
+            for (int i = 0; i < n->num_children; i++) {
+                out_bytes[count] = ((art_node4*)n)->keys[i];
+                out[count++] = ((art_node4*)n)->children[i];
+            }
+            break;
+
+        case NODE16:
+            for (int i = 0; i < n->num_children; i++) {
+                out_bytes[count] = ((art_node16*)n)->keys[i];
+                out[count++] = ((art_node16*)n)->children[i];
+            }
+            break;
+
+        case NODE48:
+            for (int i = 0; i < 256; i++) {
+                idx = ((art_node48*)n)->keys[i];
+                if (!idx) continue;
+                out_bytes[count] = (unsigned char) i;
+                out[count++] = ((art_node48*)n)->children[idx-1];
+            }
+            break;
+
+        case NODE256:
+            for (int i = 0; i < 256; i++) {
+                if (!((art_node256*)n)->children[i]) continue;
+                out_bytes[count] = (unsigned char) i;
+                out[count++] = ((art_node256*)n)->children[i];
+            }
+            break;
+
+        default:
+            abort();
+    }
+
+    return count;
+}
+
+struct rebuild_frame_t {
+    art_node* node;
+    std::vector<art_node*> children;
+    std::vector<unsigned char> bytes;
+    size_t next_child;
+    int64_t max_score;
+};
+
+/**
+ * Where the walk stopped, expressed as a key rather than a node pointer. A pointer
+ * cannot survive a yield: a concurrent delete may free or collapse nodes while the
+ * lock is released. The key survives anything, so each segment re-descends from the
+ * root and picks up where the last one left off.
+ */
+struct art_rebuild_cursor_t {
+    std::vector<unsigned char> key;
+    bool started = false;         // false => start at the very first leaf
+    bool leaf_partial = false;    // true => `key`'s leaf is only partly scored
+    uint32_t next_id = 0;         // first posting of that leaf not yet scored
+    int64_t partial_max = INT64_MIN;
+};
+
+static bool leaf_key_equals(const art_leaf* l, const art_rebuild_cursor_t& cursor) {
+    return l->key_len == cursor.key.size() &&
+           memcmp(l->key, cursor.key.data(), l->key_len) == 0;
+}
+
+/**
+ * Scores at most `budget` postings of `l` starting at posting id `from_id`, folding
+ * each into `running_max`. Returns true when the leaf is exhausted; otherwise sets
+ * `stop_id` to the first posting still owing so a later segment can resume there.
+ * A budget of 0 means unlimited.
+ */
+// ids gathered from the posting list before being scored. advancing the iterator and
+// looking up scores in the same loop costs roughly 50% on a long posting list: the two
+// touch completely different memory and evict each other. gather, then score.
+static constexpr size_t REBUILD_GATHER_BATCH = 4096;
+
+static bool score_leaf_chunk(art_leaf* l, art_score_fn score_fn, void* fn_obj,
+                             uint32_t from_id, size_t budget,
+                             int64_t& running_max, uint32_t& stop_id, size_t& scored,
+                             std::vector<uint32_t>& id_buf) {
+    scored = 0;
+
+    if (IS_COMPACT_POSTING(l->values)) {
+        // a compact list tops out at COMPACT_LIST_THRESHOLD_LENGTH ids, so it is never
+        // worth chunking. walking it in place also avoids the full-list expansion that
+        // posting_t::merge would do just to read the ids back out
+        compact_posting_list_t* cl = COMPACT_POSTING_PTR(l->values);
+        size_t i = 0;
+
+        while (i < cl->length) {
+            size_t num_offsets = cl->id_offsets[i];
+            uint32_t id = cl->id_offsets[i + num_offsets + 1];
+
+            if (id >= from_id) {
+                int64_t score = score_fn(fn_obj, id);
+                if (score > running_max) {
+                    running_max = score;
+                }
+                scored++;
+            }
+
+            i += num_offsets + 2;
+        }
+
+        return true;
+    }
+
+    posting_list_t* pl = (posting_list_t*) l->values;
+    posting_list_t::iterator_t it = pl->new_iterator();
+
+    if (from_id != 0) {
+        it.skip_to(from_id);
+    }
+
+    while (it.valid()) {
+        size_t want = REBUILD_GATHER_BATCH;
+
+        if (budget != 0) {
+            if (scored >= budget) {
+                stop_id = it.id();
+                return false;
+            }
+
+            if (budget - scored < want) {
+                want = budget - scored;
+            }
+        }
+
+        id_buf.clear();
+        while (it.valid() && id_buf.size() < want) {
+            id_buf.push_back(it.id());
+            it.next();
+        }
+
+        for (size_t i = 0; i < id_buf.size(); i++) {
+            int64_t score = score_fn(fn_obj, id_buf[i]);
+            if (score > running_max) {
+                running_max = score;
+            }
+        }
+
+        scored += id_buf.size();
+    }
+
+    return true;
+}
+
+/**
+ * Scores one leaf, resuming inside it when the cursor says a previous segment ran out
+ * of budget partway. Returns true when the leaf is finished. Either way the cursor is
+ * left pointing at this leaf so the next segment can seek back to it.
+ */
+static bool score_leaf(art_leaf* l, art_score_fn score_fn, void* fn_obj,
+                       size_t budget, size_t& scored_in_segment,
+                       art_rebuild_cursor_t& cursor, std::vector<uint32_t>& id_buf) {
+
+    const bool resuming = cursor.leaf_partial && leaf_key_equals(l, cursor);
+
+    cursor.started = true;
+    cursor.key.assign(l->key, l->key + l->key_len);
+
+    // a leaf whose documents have all been deleted keeps whatever score it had: there is
+    // nothing live to recompute it from
+    if (posting_t::num_ids(l->values) == 0) {
+        cursor.leaf_partial = false;
+        return true;
+    }
+
+    int64_t running_max = resuming ? cursor.partial_max : INT64_MIN;
+    uint32_t from_id = resuming ? cursor.next_id : 0;
+
+    size_t remaining = 0;
+    if (budget != 0) {
+        // always allow at least one posting through, otherwise a segment that starts
+        // already at its budget would make no progress and the walk would not terminate
+        remaining = (scored_in_segment >= budget) ? 1 : (budget - scored_in_segment);
+    }
+
+    uint32_t stop_id = 0;
+    size_t scored = 0;
+    const bool finished = score_leaf_chunk(l, score_fn, fn_obj, from_id, remaining,
+                                           running_max, stop_id, scored, id_buf);
+    scored_in_segment += scored;
+
+    if (!finished) {
+        cursor.leaf_partial = true;
+        cursor.next_id = stop_id;
+        cursor.partial_max = running_max;
+        return false;
+    }
+
+    l->max_score = running_max;
+    cursor.leaf_partial = false;
+    cursor.next_id = 0;
+    cursor.partial_max = INT64_MIN;
+    return true;
+}
+
+/**
+ * Rebuilds the ancestor stack for the position the cursor names, descending from the
+ * root the same way art_search does. For every node on the path the frame's running max
+ * is seeded from the children that sort before the cursor: those subtrees were finished
+ * in an earlier segment and their scores are already final, so they only need reading,
+ * not revisiting.
+ */
+static void seed_stack(art_tree* t, const art_rebuild_cursor_t& cursor,
+                       std::vector<rebuild_frame_t>& stack) {
+    art_node* buf[256];
+    unsigned char byte_buf[256];
+
+    art_node* n = t->root;
+    int depth = 0;
+
+    const unsigned char* ckey = cursor.key.data();
+    const int ckey_len = (int) cursor.key.size();
+
+    while (!IS_LEAF(n)) {
+        rebuild_frame_t frame;
+        frame.node = n;
+        frame.max_score = INT64_MIN;
+
+        const int count = node_children(n, buf, byte_buf);
+        frame.children.assign(buf, buf + count);
+        frame.bytes.assign(byte_buf, byte_buf + count);
+
+        // the cursor key should run straight through this node's compressed path. when it
+        // does not, a writer reshaped the path while the lock was down. redo the subtree
+        // from its first child rather than guess which side of the cursor it fell on:
+        // rescoring a leaf is idempotent, whereas marking one done that never ran would
+        // leave the node holding INT64_MIN
+        const int prefix_cmp_len = min(min((int) n->partial_len, MAX_PREFIX_LEN),
+                                       ckey_len - depth);
+
+        if (prefix_cmp_len < 0 ||
+            (prefix_cmp_len > 0 && memcmp(n->partial, ckey + depth, prefix_cmp_len) != 0)) {
+            frame.next_child = 0;
+            stack.push_back(std::move(frame));
+            return;
+        }
+
+        depth += n->partial_len;
+
+        if (depth >= ckey_len) {
+            // the key ends inside the path, so the walk cannot tell where it resumes here
+            frame.next_child = 0;
+            stack.push_back(std::move(frame));
+            return;
+        }
+
+        const unsigned char c = ckey[depth];
+
+        size_t i = 0;
+        while (i < (size_t) count && frame.bytes[i] < c) {
+            frame.max_score = MAX(frame.max_score, child_max_score(frame.children[i]));
+            i++;
+        }
+
+        frame.next_child = i;
+
+        if (i == (size_t) count || frame.bytes[i] > c) {
+            // nothing left here at the cursor byte: either this node is done, in which
+            // case the main loop pops it straight away, or the key diverged and every
+            // remaining child is unprocessed. both are handled by the normal walk
+            stack.push_back(std::move(frame));
+            return;
+        }
+
+        art_node* child = frame.children[i];
+        depth++;
+
+        if (IS_LEAF(child)) {
+            art_leaf* l = (art_leaf*) LEAF_RAW(child);
+
+            if (!(cursor.leaf_partial && leaf_key_equals(l, cursor))) {
+                // that leaf is already finished, so step over it. a partial one is left
+                // under next_child instead, for the main loop to re-enter and resume
+                frame.max_score = MAX(frame.max_score, l->max_score);
+                frame.next_child = i + 1;
+            }
+
+            stack.push_back(std::move(frame));
+            return;
+        }
+
+        // the child goes on the stack as its own frame, so the parent has to point past
+        // it or the walk re-enters the subtree it is already inside
+        frame.next_child = i + 1;
+        stack.push_back(std::move(frame));
+        n = child;
+    }
+}
+
+/**
+ * Runs one locked segment of the walk. Returns true when the tree is exhausted, false
+ * when the budget ran out and the caller should yield and come back.
+ */
+static bool rebuild_segment(art_tree* t, art_score_fn score_fn, void* fn_obj,
+                            size_t budget, art_rebuild_cursor_t& cursor,
+                            std::vector<uint32_t>& id_buf) {
+    if (!t->root) {
+        return true;
+    }
+
+    size_t scored_in_segment = 0;
+
+    if (IS_LEAF(t->root)) {
+        // a single leaf root has no inner nodes to fix up, but it can still be large
+        // enough to need chunking
+        return score_leaf((art_leaf*) LEAF_RAW(t->root), score_fn, fn_obj,
+                          budget, scored_in_segment, cursor, id_buf);
+    }
+
+    art_node* buf[256];
+    unsigned char byte_buf[256];
+
+    std::vector<rebuild_frame_t> stack;
+
+    if (!cursor.started) {
+        rebuild_frame_t root_frame;
+        root_frame.node = t->root;
+        root_frame.next_child = 0;
+        root_frame.max_score = INT64_MIN;
+
+        const int count = node_children(t->root, buf, byte_buf);
+        root_frame.children.assign(buf, buf + count);
+        root_frame.bytes.assign(byte_buf, byte_buf + count);
+        stack.push_back(std::move(root_frame));
+    } else {
+        seed_stack(t, cursor, stack);
+    }
+
+    while (!stack.empty()) {
+        rebuild_frame_t& top = stack.back();
+
+        if (top.next_child == top.children.size()) {
+            const int64_t node_score = top.max_score;
+            top.node->max_score = node_score;
+            stack.pop_back();
+
+            if (!stack.empty()) {
+                stack.back().max_score = MAX(stack.back().max_score, node_score);
+            }
+
+            continue;
+        }
+
+        art_node* child = top.children[top.next_child];
+        top.next_child++;
+
+        if (IS_LEAF(child)) {
+            art_leaf* l = (art_leaf*) LEAF_RAW(child);
+
+            if (!score_leaf(l, score_fn, fn_obj, budget, scored_in_segment, cursor, id_buf)) {
+                return false;
+            }
+
+            top.max_score = MAX(top.max_score, l->max_score);
+
+            if (budget != 0 && scored_in_segment >= budget) {
+                return false;
+            }
+
+            continue;
+        }
+
+        // `top` is invalidated by the push below, so it must not be touched after this
+        rebuild_frame_t frame;
+        frame.node = child;
+        frame.next_child = 0;
+        frame.max_score = INT64_MIN;
+
+        const int count = node_children(child, buf, byte_buf);
+        frame.children.assign(buf, buf + count);
+        frame.bytes.assign(byte_buf, byte_buf + count);
+        stack.push_back(std::move(frame));
+    }
+
+    return true;
+}
+
+void art_rebuild_max_scores(art_tree* t, art_score_fn score_fn, art_yield_fn yield_fn,
+                            void* fn_obj, size_t yield_budget) {
+    if (!t->root || score_fn == NULL) {
+        return;
+    }
+
+    // with nothing to yield to there is no point splitting the walk up, and no budget
+    // to honour either
+    const size_t budget = (yield_fn == NULL) ? 0 : MAX(yield_budget, (size_t) 1);
+
+    art_rebuild_cursor_t cursor;
+
+    // reused across every leaf and segment so the gather buffer is allocated once
+    std::vector<uint32_t> id_buf;
+    id_buf.reserve(REBUILD_GATHER_BATCH);
+
+    while (!rebuild_segment(t, score_fn, fn_obj, budget, cursor, id_buf)) {
+        yield_fn(fn_obj);
+    }
+}
 
 const uint32_t* get_allowed_doc_ids(art_tree *t, const std::string& prev_token,
                                     const uint32_t* filter_ids, const size_t filter_ids_length,

--- a/src/collection.cpp
+++ b/src/collection.cpp
@@ -6929,6 +6929,72 @@ std::string Collection::get_default_sorting_field() {
     return default_sorting_field;
 }
 
+Option<bool> Collection::rebuild_token_scores(int64_t raft_log_index) {
+    // Keep field alters from destroying an ART while the index lock is yielded. Normal
+    // document writers take this lock in shared mode too, so they can still use the gaps.
+    std::shared_lock alter_shlock(alter_mutex);
+    std::shared_lock lock(mutex);
+
+    if(default_sorting_field.empty()) {
+        return Option<bool>(400, "Collection `" + name + "` does not have a `default_sorting_field`, so its token "
+                                 "scores are ordered by frequency and never go stale.");
+    }
+
+    // a string sort field lives in `str_sort_index`, not `sort_index`, and every document
+    // scores 0 either way. the walk would find nothing to read and report success
+    auto sort_field_it = search_schema.find(default_sorting_field);
+    if(sort_field_it != search_schema.end() && sort_field_it.value().is_string()) {
+        return Option<bool>(400, "Collection `" + name + "` sorts by the string field `" + default_sorting_field +
+                                 "`, which scores every token equally, so there is nothing to rebuild.");
+    }
+
+    const std::string sorting_field = default_sorting_field;
+    lock.unlock();
+
+    // The rebuild changes only the in-memory ART, so replaying its Raft entry after a
+    // restart used to repeat all of the expensive work. Record successful entries in the
+    // same store that snapshots capture. Each follower writes its own marker, so a live
+    // entry still runs on every node while an entry already completed by this node is skipped.
+    const std::string rebuild_log_key = std::to_string(collection_id) + "_" + TOKEN_SCORE_REBUILD_LOG_PREFIX;
+    if(raft_log_index > 0) {
+        std::string rebuilt_through_str;
+        const StoreStatus status = store->get(rebuild_log_key, rebuilt_through_str);
+        if(status == StoreStatus::ERROR) {
+            return Option<bool>(500, "Could not read the token score rebuild state for collection `" + name + "`.");
+        }
+
+        if(status == StoreStatus::FOUND && StringUtils::is_int64_t(rebuilt_through_str)) {
+            try {
+                if(std::stoll(rebuilt_through_str) >= raft_log_index) {
+                    LOG(INFO) << "Skipping token score rebuild for collection " << name << " at Raft log index "
+                              << raft_log_index << ": it already completed on this node.";
+                    return Option<bool>(false);
+                }
+            } catch(const std::exception&) {
+                // A malformed internal marker must not brick the repair endpoint. Rebuild
+                // once and overwrite it with the current, valid log index below.
+                LOG(WARNING) << "Ignoring malformed token score rebuild state for collection " << name << ".";
+            }
+        }
+    }
+
+    LOG(INFO) << "Rebuilding token scores for collection " << name << "...";
+    auto begin_us = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+
+    index->rebuild_token_scores(sorting_field);
+
+    auto took_us = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count() - begin_us;
+    LOG(INFO) << "Rebuilt token scores for collection " << name << " in " << (took_us / 1000) << "ms.";
+
+    if(raft_log_index > 0 && !store->insert(rebuild_log_key, std::to_string(raft_log_index))) {
+        return Option<bool>(500, "Could not persist the token score rebuild state for collection `" + name + "`.");
+    }
+
+    return Option<bool>(true);
+}
+
 void Collection::update_metadata(const nlohmann::json& meta) {
     std::shared_lock lock(mutex);
     metadata = meta;

--- a/src/core_api.cpp
+++ b/src/core_api.cpp
@@ -38,6 +38,8 @@ LRU::Cache<uint64_t, cached_res_t> res_cache;
 std::shared_mutex alter_mutex;
 std::set<std::string> alters_in_progress;
 
+static constexpr const char* REBUILD_TOKEN_SCORES = "rebuild_token_scores";
+
 class alter_guard_t {
     std::string collection_name;
 public:
@@ -362,17 +364,48 @@ bool patch_update_collection(const std::shared_ptr<http_req>& req, const std::sh
     // The actual check for this, happens in `ReplicationState::write` which is called only during live writes.
     alter_guard_t alter_guard(req->params["collection"]);
 
-    try {
-        req_json = nlohmann::json::parse(req->body);
-    } catch(const std::exception& e) {
-        //LOG(ERROR) << "JSON error: " << e.what();
-        res->set_400("Bad JSON.");
-        return false;
+    // `collection` is the route path param, the other two are filled in by the http layer
+    // whether or not the client sent them
+    static const std::set<std::string> non_client_params = {
+        "collection", http_req::AUTH_HEADER, http_req::USER_HEADER
+    };
+
+    const bool rebuild_token_scores = req->params.count(REBUILD_TOKEN_SCORES) != 0;
+
+    if(rebuild_token_scores) {
+        if(req->params[REBUILD_TOKEN_SCORES] != "true") {
+            res->set_400("Parameter `" + std::string(REBUILD_TOKEN_SCORES) + "` must be `true`.");
+            return false;
+        }
+
+        for(const auto& param: req->params) {
+            if(param.first != REBUILD_TOKEN_SCORES && non_client_params.count(param.first) == 0) {
+                res->set_400("Parameter `" + std::string(REBUILD_TOKEN_SCORES) +
+                             "` cannot be combined with other parameters.");
+                return false;
+            }
+        }
+
+        if(!req->body.empty()) {
+            res->set_400("Parameter `" + std::string(REBUILD_TOKEN_SCORES) +
+                         "` must be sent without a request body.");
+            return false;
+        }
     }
 
-    if(req_json.empty()) {
-        res->set_400("Alter payload is empty.");
-        return false;
+    if(!rebuild_token_scores) {
+        try {
+            req_json = nlohmann::json::parse(req->body);
+        } catch(const std::exception& e) {
+            //LOG(ERROR) << "JSON error: " << e.what();
+            res->set_400("Bad JSON.");
+            return false;
+        }
+
+        if(req_json.empty()) {
+            res->set_400("Alter payload is empty.");
+            return false;
+        }
     }
 
     for(auto it : req_json.items()) {
@@ -388,6 +421,19 @@ bool patch_update_collection(const std::shared_ptr<http_req>& req, const std::sh
     if(collection == nullptr) {
         res->set_404("Collection not found");
         return false;
+    }
+
+    if(rebuild_token_scores) {
+        auto rebuild_op = collection->rebuild_token_scores(req->log_index);
+        if(!rebuild_op.ok()) {
+            res->set(rebuild_op.code(), rebuild_op.error());
+            return false;
+        }
+
+        nlohmann::json response;
+        response["rebuild_token_scores"] = true;
+        res->set_200(response.dump());
+        return true;
     }
 
     if(req_json.contains("metadata")) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -252,15 +252,29 @@ Index::~Index() {
     field_geopolygon_index.clear();
 }
 
+int64_t Index::float_points(float value) {
+    // serialize float to an integer and reverse the inverted range
+    int64_t points = 0;
+    memcpy(&points, &value, sizeof(int32_t));
+    points ^= ((points >> (std::numeric_limits<int32_t>::digits - 1)) | INT32_MIN);
+    points = -1 * (INT32_MAX - points);
+    return points;
+}
+
+int64_t Index::sort_index_value_to_points(const field& a_field, int64_t value) {
+    // sort index stores floats via float_to_int64_t, art scores use the float_points encoding
+    if(a_field.type == field_types::FLOAT) {
+        return float_points(int64_t_to_float(value));
+    }
+
+    return value;
+}
+
 int64_t Index::get_points_from_doc(const nlohmann::json &document, const std::string & default_sorting_field) {
     int64_t points = 0;
 
     if(document[default_sorting_field].is_number_float()) {
-        // serialize float to an integer and reverse the inverted range
-        float n = document[default_sorting_field];
-        memcpy(&points, &n, sizeof(int32_t));
-        points ^= ((points >> (std::numeric_limits<int32_t>::digits - 1)) | INT32_MIN);
-        points = -1 * (INT32_MAX - points);
+        points = float_points(document[default_sorting_field].get<float>());
     } else if(document[default_sorting_field].is_string()) {
         // not much value in supporting default sorting field as string, so we will just dummy it out
         points = 0;
@@ -294,6 +308,81 @@ float Index::int64_t_to_float(int64_t n) {
     return f;
 }
 
+void Index::tokenize_doc_field(const field& the_field,
+                               const nlohmann::json& value,
+                               const std::vector<char>& local_symbols_to_index,
+                               const std::vector<char>& local_token_separators,
+                               std::unordered_map<std::string, std::vector<uint32_t>>& token_to_offsets) {
+
+    const auto& token_separators = the_field.token_separators.empty() ? local_token_separators : the_field.token_separators;
+    const auto& symbols_to_index = the_field.symbols_to_index.empty() ? local_symbols_to_index : the_field.symbols_to_index;
+
+    // non-string, non-geo faceted field should be indexed as faceted string field as well
+    if(the_field.facet && !the_field.is_string() && !the_field.is_geopoint()) {
+        if(the_field.is_array()) {
+            std::vector<std::string> strings;
+
+            if(the_field.type == field_types::INT32_ARRAY) {
+                for(int32_t v: value){
+                    auto str = std::to_string(v);
+                    strings.emplace_back(std::move(str));
+                }
+            } else if(the_field.type == field_types::INT64_ARRAY) {
+                for(int64_t v: value){
+                    auto str = std::to_string(v);
+                    strings.emplace_back(std::move(str));
+                }
+            } else if(the_field.type == field_types::FLOAT_ARRAY) {
+                for(float v: value){
+                    auto str = StringUtils::float_to_str(v);
+                    strings.emplace_back(std::move(str));
+                }
+            } else if(the_field.type == field_types::BOOL_ARRAY) {
+                for(bool v: value){
+                    auto str = std::to_string(v);
+                    strings.emplace_back(std::move(str));
+                }
+            }
+
+            tokenize_string_array(strings, the_field,
+                                  symbols_to_index, token_separators,
+                                  token_to_offsets);
+        } else {
+            std::string text;
+
+            if(the_field.type == field_types::INT32) {
+                auto val = value.get<int32_t>();
+                text = std::to_string(val);
+            } else if(the_field.type == field_types::INT64) {
+                auto val = value.get<int64_t>();
+                text = std::to_string(val);
+            } else if(the_field.type == field_types::FLOAT) {
+                auto val = value.get<float>();
+                text = StringUtils::float_to_str(val);
+            } else if(the_field.type == field_types::BOOL) {
+                auto val = value.get<bool>();
+                text = std::to_string(val);
+            }
+
+            tokenize_string(text, the_field,
+                            symbols_to_index, token_separators,
+                            token_to_offsets);
+        }
+    }
+
+    if(the_field.is_string()) {
+        if(the_field.type == field_types::STRING) {
+            tokenize_string(value, the_field,
+                            symbols_to_index, token_separators,
+                            token_to_offsets);
+        } else {
+            tokenize_string_array(value, the_field,
+                                  symbols_to_index, token_separators,
+                                  token_to_offsets);
+        }
+    }
+}
+
 void Index::compute_token_offsets_facets(index_record& record,
                                          const tsl::htrie_map<char, field>& search_schema,
                                          const std::vector<char>& local_token_separators,
@@ -309,80 +398,74 @@ void Index::compute_token_offsets_facets(index_record& record,
 
         offsets_facet_hashes_t offset_facet_hashes;
 
-        bool is_facet = search_schema.at(field_name).facet;
-
-        const auto& token_separators = the_field.token_separators.empty() ? local_token_separators : the_field.token_separators;
-        const auto& symbols_to_index = the_field.symbols_to_index.empty() ? local_symbols_to_index : the_field.symbols_to_index;
-
-        // non-string, non-geo faceted field should be indexed as faceted string field as well
-        if(the_field.facet && !the_field.is_string() && !the_field.is_geopoint()) {
-            if(the_field.is_array()) {
-                std::vector<std::string> strings;
-
-                if(the_field.type == field_types::INT32_ARRAY) {
-                    for(int32_t value: document[field_name]){
-                        auto str = std::to_string(value);
-                        strings.emplace_back(std::move(str));
-                    }
-                } else if(the_field.type == field_types::INT64_ARRAY) {
-                    for(int64_t value: document[field_name]){
-                        auto str = std::to_string(value);
-                        strings.emplace_back(std::move(str));
-                    }
-                } else if(the_field.type == field_types::FLOAT_ARRAY) {
-                    for(float value: document[field_name]){
-                        auto str = StringUtils::float_to_str(value);
-                        strings.emplace_back(std::move(str));
-                    }
-                } else if(the_field.type == field_types::BOOL_ARRAY) {
-                    for(bool value: document[field_name]){
-                        auto str = std::to_string(value);
-                        strings.emplace_back(std::move(str));
-                    }
-                }
-
-                tokenize_string_array(strings, the_field,
-                                      symbols_to_index, token_separators,
-                                      offset_facet_hashes.offsets);
-            } else {
-                std::string text;
-
-                if(the_field.type == field_types::INT32) {
-                    auto val = document[field_name].get<int32_t>();
-                    text = std::to_string(val);
-                } else if(the_field.type == field_types::INT64) {
-                    auto val = document[field_name].get<int64_t>();
-                    text = std::to_string(val);
-                } else if(the_field.type == field_types::FLOAT) {
-                    auto val = document[field_name].get<float>();
-                    text = StringUtils::float_to_str(val);
-                } else if(the_field.type == field_types::BOOL) {
-                    auto val = document[field_name].get<bool>();
-                    text = std::to_string(val);
-                }
-
-                tokenize_string(text, the_field,
-                                symbols_to_index, token_separators,
-                                offset_facet_hashes.offsets);
-            }
-        }
-
-        if(the_field.is_string()) {
-            if(the_field.type == field_types::STRING) {
-                tokenize_string(document[field_name], the_field,
-                                symbols_to_index, token_separators,
-                                offset_facet_hashes.offsets);
-            } else {
-                tokenize_string_array(document[field_name], the_field,
-                                      symbols_to_index, token_separators,
-                                      offset_facet_hashes.offsets);
-            }
-        }
+        tokenize_doc_field(the_field, document[field_name], local_symbols_to_index, local_token_separators,
+                           offset_facet_hashes.offsets);
 
         if(!offset_facet_hashes.offsets.empty()) {
             record.field_index.emplace(field_name, std::move(offset_facet_hashes));
         }
     }
+}
+
+struct token_score_rebuild_ctx {
+    Index* index;
+    std::string sort_field;
+    const spp::sparse_hash_map<uint32_t, int64_t, Hasher32>* doc_to_score;
+    bool is_float;
+    std::unique_lock<std::shared_mutex>* ulock;
+};
+
+void Index::rebuild_token_scores(const std::string& default_sorting_field) {
+    // token max_score is set when a document is indexed and only ever raised after that, so a
+    // collection whose sort field values move around ends up ordering prefix candidates on
+    // scores that no longer exist. this recomputes them from the live sort index
+    if(default_sorting_field.empty()) {
+        return;
+    }
+
+    std::unique_lock ulock(mutex);
+
+    auto sort_field_it = search_schema.find(default_sorting_field);
+    auto sort_it = sort_index.find(default_sorting_field);
+
+    if(sort_field_it == search_schema.end() || sort_it == sort_index.end()) {
+        return;
+    }
+
+    token_score_rebuild_ctx ctx;
+    ctx.index = this;
+    ctx.sort_field = default_sorting_field;
+    ctx.doc_to_score = sort_it->second;
+    ctx.is_float = (sort_field_it.value().type == field_types::FLOAT);
+    ctx.ulock = &ulock;
+
+    // the walk below drops the lock periodically, so iterating `search_index` directly would
+    // carry an iterator across a rehash. the trees themselves stay put because Collection holds
+    // its shared alter lock for the length of this request
+    std::vector<art_tree*> trees;
+    trees.reserve(search_index.size());
+    for(const auto& tree_it: search_index) {
+        trees.push_back(tree_it.second);
+    }
+
+    for(art_tree* t: trees) {
+        art_rebuild_max_scores(t, token_score_from_sort_index, yield_index_lock,
+                               &ctx, TOKEN_SCORE_YIELD_BUDGET);
+    }
+}
+
+void Index::yield_index_lock(void* obj) {
+    // searches take a shared lock on the same mutex, so a rebuild that never let go would
+    // stall every query on the collection for the length of the walk
+    auto ctx = (token_score_rebuild_ctx*) obj;
+    ctx->ulock->unlock();
+    std::this_thread::yield();
+    ctx->ulock->lock();
+
+    // a writer may have rehashed the sort index while the lock was down, so resolve the
+    // field again instead of carrying a pointer across the gap
+    auto sort_it = ctx->index->sort_index.find(ctx->sort_field);
+    ctx->doc_to_score = (sort_it == ctx->index->sort_index.end()) ? nullptr : sort_it->second;
 }
 
 bool doc_contains_field(const nlohmann::json& doc, const field& a_field,
@@ -612,7 +695,9 @@ void Index::validate_and_preprocess(Index *index,
                 if(default_sorting_field_it != index->sort_index.end()) {
                     auto seq_id_it = default_sorting_field_it->second->find(index_rec.seq_id);
                     if(seq_id_it != default_sorting_field_it->second->end()) {
-                        points = seq_id_it->second;
+                        auto sort_field_it = search_schema.find(default_sorting_field);
+                        points = (sort_field_it != search_schema.end()) ?
+                                 sort_index_value_to_points(sort_field_it.value(), seq_id_it->second) : seq_id_it->second;
                     } else {
                         points = INT64_MIN;
                     }
@@ -765,8 +850,12 @@ void Index::index_field_in_memory(const field& afield, std::vector<index_record>
     bool is_facet_field = (afield.facet && !afield.is_geopoint() && !afield.is_geopolygon());
 
     if(afield.is_string() || is_facet_field) {
-        std::unordered_map<std::string, std::vector<art_document>> token_to_doc_offsets;
-        int64_t max_score = INT64_MIN;
+        struct token_batch_t {
+            std::vector<art_document> documents;
+            int64_t max_score = INT64_MIN;
+        };
+
+        std::unordered_map<std::string, token_batch_t> token_to_doc_offsets;
 
         std::unordered_map<facet_value_id_t, std::vector<uint32_t>, facet_value_id_t::Hash> fvalue_to_seq_ids;
         std::unordered_map<uint32_t, std::vector<facet_value_id_t>> seq_id_to_fvalues;
@@ -874,12 +963,10 @@ void Index::index_field_in_memory(const field& afield, std::vector<index_record>
                 }
             }
 
-            if(record.points > max_score) {
-                max_score = record.points;
-            }
-
             for(auto& token_offsets: field_index_it->second.offsets) {
-                token_to_doc_offsets[token_offsets.first].emplace_back(seq_id, record.points, token_offsets.second);
+                auto& token_batch = token_to_doc_offsets[token_offsets.first];
+                token_batch.documents.emplace_back(seq_id, record.points, token_offsets.second);
+                token_batch.max_score = std::max(token_batch.max_score, record.points);
 
                 if(afield.infix) {
                     auto strhash = StringUtils::hash_wy(token_offsets.first.c_str(), token_offsets.first.size());
@@ -900,13 +987,13 @@ void Index::index_field_in_memory(const field& afield, std::vector<index_record>
 
         for(auto& token_to_doc: token_to_doc_offsets) {
             const std::string& token = token_to_doc.first;
-            std::vector<art_document>& documents = token_to_doc.second;
+            token_batch_t& token_batch = token_to_doc.second;
 
             const auto *key = (const unsigned char *) token.c_str();
             int key_len = (int) token.length() + 1;  // for the terminating \0 char
 
             //LOG(INFO) << "key: " << key << ", art_doc.id: " << art_doc.id;
-            art_inserts(t, key, key_len, max_score, documents);
+            art_inserts(t, key, key_len, token_batch.max_score, token_batch.documents);
         }
     }
 
@@ -7695,6 +7782,24 @@ art_leaf* Index::get_token_leaf(const std::string & field_name, const unsigned c
     std::shared_lock lock(mutex);
     const art_tree *t = search_index.at(field_name);
     return (art_leaf*) art_search(t, token, (int) token_len);
+}
+
+int64_t Index::token_score_from_sort_index(void* obj, uint32_t seq_id) {
+    auto ctx = (token_score_rebuild_ctx*) obj;
+
+    if(ctx->doc_to_score == nullptr) {
+        // the sort field went away mid-walk, so there is nothing left to score against
+        return INT64_MIN;
+    }
+
+    const auto& doc_it = ctx->doc_to_score->find(seq_id);
+
+    if(doc_it == ctx->doc_to_score->end()) {
+        // matches the insert time fallback for docs missing the sort field
+        return INT64_MIN;
+    }
+
+    return ctx->is_float ? float_points(int64_t_to_float(doc_it->second)) : doc_it->second;
 }
 
 const spp::sparse_hash_map<std::string, art_tree *> &Index::_get_search_index() const {

--- a/test/art_test.cpp
+++ b/test/art_test.cpp
@@ -1809,3 +1809,388 @@ TEST(ArtTest, test_encode_float_positive_negative) {
     res = art_tree_destroy(&t);
     ASSERT_TRUE(res == 0);
 }
+
+static int64_t test_map_score_fn(void* obj, uint32_t id) {
+    auto scores = (std::map<uint32_t, int64_t>*) obj;
+    const auto& it = scores->find(id);
+    return (it == scores->end()) ? INT64_MIN : it->second;
+}
+
+static int test_yield_count = 0;
+
+static void test_counting_yield_fn(void* obj) {
+    test_yield_count++;
+}
+
+TEST(ArtTest, test_art_rebuild_max_scores) {
+    art_tree t;
+    art_tree_init(&t);
+
+    art_document doc1(1, 10, {0});
+    art_insert(&t, (const unsigned char *) "apple", 6, &doc1);
+
+    art_document doc2(2, 5, {0});
+    art_insert(&t, (const unsigned char *) "apricot", 8, &doc2);
+
+    art_leaf* apple = (art_leaf *) art_search(&t, (const unsigned char *) "apple", 6);
+    art_leaf* apricot = (art_leaf *) art_search(&t, (const unsigned char *) "apricot", 8);
+    ASSERT_EQ(10, apple->max_score);
+    ASSERT_EQ(5, apricot->max_score);
+
+    // root is an inner node holding both keys
+    ASSERT_EQ(0, ((uintptr_t) t.root & 1));
+    ASSERT_EQ(10, t.root->max_score);
+
+    // a decrease and a raise land in the same pass, and the root follows both
+    std::map<uint32_t, int64_t> scores = {{1, 2}, {2, 100}};
+    art_rebuild_max_scores(&t, test_map_score_fn, NULL, &scores, 0);
+
+    ASSERT_EQ(2, apple->max_score);
+    ASSERT_EQ(100, apricot->max_score);
+    ASSERT_EQ(100, t.root->max_score);
+
+    // the root comes back down too, which the insert path can never do
+    scores[2] = 3;
+    art_rebuild_max_scores(&t, test_map_score_fn, NULL, &scores, 0);
+
+    ASSERT_EQ(2, apple->max_score);
+    ASSERT_EQ(3, apricot->max_score);
+    ASSERT_EQ(3, t.root->max_score);
+
+    // a null score fn leaves everything alone
+    art_rebuild_max_scores(&t, NULL, NULL, &scores, 0);
+    ASSERT_EQ(3, t.root->max_score);
+
+    art_tree_destroy(&t);
+}
+
+TEST(ArtTest, test_art_rebuild_max_scores_multi_doc_leaf) {
+    art_tree t;
+    art_tree_init(&t);
+
+    // one token shared by three docs, so the leaf max is a real max and not just a copy
+    for(uint32_t i = 1; i <= 3; i++) {
+        art_document doc(i, (int64_t) i * 10, {0});
+        art_insert(&t, (const unsigned char *) "apple", 6, &doc);
+    }
+
+    art_leaf* apple = (art_leaf *) art_search(&t, (const unsigned char *) "apple", 6);
+    ASSERT_EQ(30, apple->max_score);
+
+    // dropping the top scorer must surface the next one down
+    std::map<uint32_t, int64_t> scores = {{1, 10}, {2, 20}, {3, 1}};
+    art_rebuild_max_scores(&t, test_map_score_fn, NULL, &scores, 0);
+    ASSERT_EQ(20, apple->max_score);
+
+    // a doc missing from the sort index scores as INT64_MIN and must not win
+    scores.erase(2);
+    art_rebuild_max_scores(&t, test_map_score_fn, NULL, &scores, 0);
+    ASSERT_EQ(10, apple->max_score);
+
+    art_tree_destroy(&t);
+}
+
+TEST(ArtTest, test_art_rebuild_max_scores_yields) {
+    art_tree t;
+    art_tree_init(&t);
+
+    std::map<uint32_t, int64_t> scores;
+
+    for(uint32_t i = 1; i <= 50; i++) {
+        const std::string& key = "token" + std::to_string(i);
+        art_document doc(i, (int64_t) i, {0});
+        art_insert(&t, (const unsigned char *) key.c_str(), (int) key.length() + 1, &doc);
+        scores[i] = (int64_t) i;
+    }
+
+    // budget of 1 posting means a yield after every leaf
+    test_yield_count = 0;
+    art_rebuild_max_scores(&t, test_map_score_fn, test_counting_yield_fn, &scores, 1);
+    ASSERT_EQ(50, test_yield_count);
+
+    // scores still land correctly across all those pauses
+    art_leaf* last = (art_leaf *) art_search(&t, (const unsigned char *) "token50", 8);
+    ASSERT_EQ(50, last->max_score);
+    ASSERT_EQ(50, t.root->max_score);
+
+    // a large budget yields nothing
+    test_yield_count = 0;
+    art_rebuild_max_scores(&t, test_map_score_fn, test_counting_yield_fn, &scores, 1000000);
+    ASSERT_EQ(0, test_yield_count);
+
+    art_tree_destroy(&t);
+}
+
+TEST(ArtTest, test_art_rebuild_max_scores_single_leaf_root) {
+    art_tree t;
+    art_tree_init(&t);
+
+    art_document doc1(1, 10, {0});
+    art_insert(&t, (const unsigned char *) "apple", 6, &doc1);
+
+    // root is the leaf itself, which the walk has to special case
+    ASSERT_EQ(1, ((uintptr_t) t.root & 1));
+
+    std::map<uint32_t, int64_t> scores = {{1, 4}};
+    art_rebuild_max_scores(&t, test_map_score_fn, NULL, &scores, 0);
+
+    art_leaf* apple = (art_leaf *) art_search(&t, (const unsigned char *) "apple", 6);
+    ASSERT_EQ(4, apple->max_score);
+
+    art_tree_destroy(&t);
+}
+
+TEST(ArtTest, test_art_rebuild_max_scores_empty_tree) {
+    art_tree t;
+    art_tree_init(&t);
+
+    std::map<uint32_t, int64_t> scores;
+    art_rebuild_max_scores(&t, test_map_score_fn, NULL, &scores, 0);
+
+    art_tree_destroy(&t);
+}
+
+TEST(ArtTest, test_art_rebuild_max_scores_wide_nodes) {
+    // the other rebuild tests build trees that only ever reach NODE4 and NODE16, so the
+    // NODE48 and NODE256 branches of the child walk never run
+    art_tree t48;
+    art_tree_init(&t48);
+
+    std::map<uint32_t, int64_t> scores;
+
+    // 40 distinct second bytes under a shared first byte lands in NODE48
+    for(uint32_t i = 1; i <= 40; i++) {
+        unsigned char key[3] = {'a', (unsigned char) i, '\0'};
+        art_document doc(i, (int64_t) i, {0});
+        art_insert(&t48, key, 3, &doc);
+        scores[i] = (int64_t) i;
+    }
+
+    ASSERT_EQ(NODE48, t48.root->type);
+    ASSERT_EQ(40, t48.root->num_children);
+
+    art_rebuild_max_scores(&t48, test_map_score_fn, NULL, &scores, 0);
+    ASSERT_EQ(40, t48.root->max_score);
+
+    for(uint32_t i = 1; i <= 40; i++) {
+        unsigned char key[3] = {'a', (unsigned char) i, '\0'};
+        art_leaf* l = (art_leaf *) art_search(&t48, key, 3);
+        ASSERT_EQ((int64_t) i, l->max_score);
+    }
+
+    art_tree_destroy(&t48);
+
+    art_tree t256;
+    art_tree_init(&t256);
+    scores.clear();
+
+    // 200 of them grows it to NODE256
+    for(uint32_t i = 1; i <= 200; i++) {
+        unsigned char key[3] = {'a', (unsigned char) i, '\0'};
+        art_document doc(i, (int64_t) i, {0});
+        art_insert(&t256, key, 3, &doc);
+        scores[i] = (int64_t) i;
+    }
+
+    ASSERT_EQ(NODE256, t256.root->type);
+
+    art_rebuild_max_scores(&t256, test_map_score_fn, NULL, &scores, 0);
+    ASSERT_EQ(200, t256.root->max_score);
+
+    for(uint32_t i = 1; i <= 200; i++) {
+        unsigned char key[3] = {'a', (unsigned char) i, '\0'};
+        art_leaf* l = (art_leaf *) art_search(&t256, key, 3);
+        ASSERT_EQ((int64_t) i, l->max_score);
+    }
+
+    art_tree_destroy(&t256);
+}
+
+static void seed_rebuild_tree(art_tree* t, std::map<uint32_t, int64_t>& scores) {
+    // shared prefixes of differing length, so the tree has real inner nodes and some
+    // keys terminate inside another key's path
+    const char* words[] = {"apple", "applesauce", "apply", "apron", "april",
+                           "banana", "band", "bandana", "bar", "barn", "bat"};
+    uint32_t id = 1;
+
+    for(const char* word: words) {
+        const size_t len = strlen(word);
+
+        // a few docs per token so the leaf max is a real max
+        for(uint32_t k = 0; k < 3; k++) {
+            art_document doc(id, (int64_t) id, {0});
+            art_insert(t, (const unsigned char *) word, (int) len + 1, &doc);
+            scores[id] = (int64_t) id;
+            id++;
+        }
+    }
+}
+
+TEST(ArtTest, test_art_rebuild_max_scores_resume_matches_single_pass) {
+    // the walk drops its lock periodically and re-descends from the root to a saved key.
+    // chunked and unchunked runs have to land on exactly the same scores
+    art_tree single;
+    art_tree chunked;
+    art_tree_init(&single);
+    art_tree_init(&chunked);
+
+    std::map<uint32_t, int64_t> scores;
+    std::map<uint32_t, int64_t> ignored;
+    seed_rebuild_tree(&single, scores);
+    seed_rebuild_tree(&chunked, ignored);
+
+    art_rebuild_max_scores(&single, test_map_score_fn, NULL, &scores, 0);
+
+    // budget of 1 posting forces a yield inside almost every leaf
+    test_yield_count = 0;
+    art_rebuild_max_scores(&chunked, test_map_score_fn, test_counting_yield_fn, &scores, 1);
+    ASSERT_TRUE(test_yield_count > 10);
+
+    const char* words[] = {"apple", "applesauce", "apply", "apron", "april",
+                           "banana", "band", "bandana", "bar", "barn", "bat"};
+
+    for(const char* word: words) {
+        const int len = (int) strlen(word) + 1;
+        art_leaf* a = (art_leaf *) art_search(&single, (const unsigned char *) word, len);
+        art_leaf* b = (art_leaf *) art_search(&chunked, (const unsigned char *) word, len);
+        ASSERT_TRUE(a != nullptr && b != nullptr);
+        ASSERT_EQ(a->max_score, b->max_score);
+    }
+
+    // and the inner nodes agree too, which is what candidate selection actually reads
+    ASSERT_EQ(single.root->max_score, chunked.root->max_score);
+    ASSERT_EQ(33, chunked.root->max_score);
+
+    art_tree_destroy(&single);
+    art_tree_destroy(&chunked);
+}
+
+TEST(ArtTest, test_art_rebuild_max_scores_chunks_large_leaf) {
+    // one token in many documents: the budget has to bound work inside the leaf, not just
+    // between leaves, or this holds the index lock for the whole posting list
+    art_tree t;
+    art_tree_init(&t);
+
+    std::map<uint32_t, int64_t> scores;
+
+    for(uint32_t i = 1; i <= 500; i++) {
+        art_document doc(i, (int64_t) i, {0});
+        art_insert(&t, (const unsigned char *) "token", 6, &doc);
+        scores[i] = (int64_t) i;
+    }
+
+    // a single key means the root is the leaf, which used to skip the yield path entirely
+    ASSERT_EQ(1, ((uintptr_t) t.root & 1));
+
+    test_yield_count = 0;
+    art_rebuild_max_scores(&t, test_map_score_fn, test_counting_yield_fn, &scores, 10);
+
+    // 500 postings at 10 per segment
+    ASSERT_TRUE(test_yield_count >= 40);
+
+    art_leaf* l = (art_leaf *) art_search(&t, (const unsigned char *) "token", 6);
+    ASSERT_EQ(500, l->max_score);
+
+    // the top scorer dropping must still surface the next one down, across all those pauses
+    scores[500] = 1;
+    test_yield_count = 0;
+    art_rebuild_max_scores(&t, test_map_score_fn, test_counting_yield_fn, &scores, 10);
+    ASSERT_EQ(499, l->max_score);
+
+    art_tree_destroy(&t);
+}
+
+struct test_mutating_ctx_t {
+    art_tree* tree;
+    std::map<uint32_t, int64_t>* scores;
+    std::vector<std::string>* to_delete;
+    size_t next_delete;
+};
+
+static int64_t test_ctx_score_fn(void* obj, uint32_t id) {
+    auto ctx = (test_mutating_ctx_t*) obj;
+    const auto& it = ctx->scores->find(id);
+    return (it == ctx->scores->end()) ? INT64_MIN : it->second;
+}
+
+static void test_deleting_yield_fn(void* obj) {
+    // stands in for a writer that takes the index lock while the rebuild has let go of it.
+    // a multi batch filter delete really does run off the collection's batched indexer
+    // queue, so this is reachable, and art_delete frees and collapses nodes: a walk that
+    // held raw node pointers across the yield would resume on freed memory right here
+    auto ctx = (test_mutating_ctx_t*) obj;
+
+    if(ctx->next_delete >= ctx->to_delete->size()) {
+        return;
+    }
+
+    const std::string& key = (*ctx->to_delete)[ctx->next_delete++];
+    void* values = art_delete(ctx->tree, (const unsigned char *) key.c_str(), (int) key.length() + 1);
+    posting_t::destroy_list(values);
+}
+
+TEST(ArtTest, test_art_rebuild_max_scores_survives_concurrent_delete) {
+    art_tree t;
+    art_tree_init(&t);
+
+    std::map<uint32_t, int64_t> scores;
+    std::vector<std::string> keys;
+
+    for(uint32_t i = 0; i < 300; i++) {
+        char buf[16];
+        snprintf(buf, sizeof(buf), "key%03u", i);
+        keys.emplace_back(buf);
+
+        art_document doc(i + 1, (int64_t) (i + 1), {0});
+        art_insert(&t, (const unsigned char *) buf, (int) strlen(buf) + 1, &doc);
+        scores[i + 1] = (int64_t) (i + 1);
+    }
+
+    // delete the odd keys, one per yield. with a budget of one posting the walk yields
+    // after every leaf, so each delete lands ahead of the cursor and takes out siblings
+    // the walk still has pending
+    std::vector<std::string> to_delete;
+    for(uint32_t i = 1; i < 300; i += 2) {
+        char buf[16];
+        snprintf(buf, sizeof(buf), "key%03u", i);
+        to_delete.emplace_back(buf);
+    }
+
+    test_mutating_ctx_t ctx;
+    ctx.tree = &t;
+    ctx.scores = &scores;
+    ctx.to_delete = &to_delete;
+    ctx.next_delete = 0;
+
+    art_rebuild_max_scores(&t, test_ctx_score_fn, test_deleting_yield_fn, &ctx, 1);
+
+    ASSERT_EQ(to_delete.size(), ctx.next_delete);
+
+    // every odd key really is gone, and every even one survived
+    for(uint32_t i = 0; i < 300; i++) {
+        char buf[16];
+        snprintf(buf, sizeof(buf), "key%03u", i);
+        art_leaf* l = (art_leaf *) art_search(&t, (const unsigned char *) buf, (int) strlen(buf) + 1);
+
+        if(i % 2 == 1) {
+            ASSERT_TRUE(l == nullptr) << buf << " should have been deleted";
+        } else {
+            ASSERT_TRUE(l != nullptr) << buf << " should have survived";
+        }
+    }
+
+    // the tree is still walkable and scores correctly: a second clean pass has to reach
+    // every surviving leaf and land on the right value
+    art_rebuild_max_scores(&t, test_ctx_score_fn, NULL, &ctx, 0);
+
+    for(uint32_t i = 0; i < 300; i += 2) {
+        char buf[16];
+        snprintf(buf, sizeof(buf), "key%03u", i);
+        art_leaf* l = (art_leaf *) art_search(&t, (const unsigned char *) buf, (int) strlen(buf) + 1);
+        ASSERT_EQ((int64_t) (i + 1), l->max_score);
+    }
+
+    ASSERT_EQ(299, t.root->max_score);
+
+    art_tree_destroy(&t);
+}

--- a/test/collection_sorting_test.cpp
+++ b/test/collection_sorting_test.cpp
@@ -4503,3 +4503,411 @@ TEST_F(CollectionSortingTest, EvalSumReferencedValidationFailureDoesNotLeak) {
     collectionManager.drop_collection("es_stock");
     collectionManager.drop_collection("es_products");
 }
+
+TEST_F(CollectionSortingTest, TokenScoreRebuildFollowsSortFieldIncrease) {
+    std::vector<field> fields = {field("title", field_types::STRING, false),
+                                 field("points", field_types::INT32, false)};
+
+    Collection* coll = collectionManager.create_collection("token_score_raise", 1, fields, "points").get();
+
+    nlohmann::json doc1;
+    doc1["id"] = "0";
+    doc1["title"] = "apple";
+    doc1["points"] = 100;
+    ASSERT_TRUE(coll->add(doc1.dump()).ok());
+
+    nlohmann::json doc2;
+    doc2["id"] = "1";
+    doc2["title"] = "apricot";
+    doc2["points"] = 10;
+    ASSERT_TRUE(coll->add(doc2.dump()).ok());
+
+    // max_candidates=1: only the token with the highest max_score gets expanded
+    auto results = coll->search("ap", {"title"}, "", {}, {}, {0}, 10, 1, NOT_SET, {true}, 0,
+                                spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(),
+                                10, "", 30, 4, "", 20, {}, {}, {}, 0, "<mark>", "</mark>", {}, 1000, true,
+                                false, true, "", false, 6000 * 1000, 4, 7, fallback, 1).get();
+
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("0", results["hits"][0]["document"]["id"].get<std::string>());
+
+    // update only the sort field of the apricot doc: nothing re-indexes its title,
+    // so the token score is stale until a rebuild is asked for
+    nlohmann::json doc2_update;
+    doc2_update["id"] = "1";
+    doc2_update["points"] = 1000;
+    ASSERT_TRUE(coll->add(doc2_update.dump(), UPDATE).ok());
+
+    results = coll->search("ap", {"title"}, "", {}, {}, {0}, 10, 1, NOT_SET, {true}, 0,
+                           spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(),
+                           10, "", 30, 4, "", 20, {}, {}, {}, 0, "<mark>", "</mark>", {}, 1000, true,
+                           false, true, "", false, 6000 * 1000, 4, 7, fallback, 1).get();
+
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("0", results["hits"][0]["document"]["id"].get<std::string>());
+
+    ASSERT_TRUE(coll->rebuild_token_scores().ok());
+
+    results = coll->search("ap", {"title"}, "", {}, {}, {0}, 10, 1, NOT_SET, {true}, 0,
+                           spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(),
+                           10, "", 30, 4, "", 20, {}, {}, {}, 0, "<mark>", "</mark>", {}, 1000, true,
+                           false, true, "", false, 6000 * 1000, 4, 7, fallback, 1).get();
+
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"].get<std::string>());
+
+    collectionManager.drop_collection("token_score_raise");
+}
+
+static bool token_score_node_is_leaf(const art_node* node) {
+    return (reinterpret_cast<uintptr_t>(node) & 1U) != 0;
+}
+
+static int64_t assert_token_score_subtree_max(const art_node* node) {
+    if(token_score_node_is_leaf(node)) {
+        auto leaf = reinterpret_cast<const art_leaf*>(reinterpret_cast<uintptr_t>(node) & ~uintptr_t(1));
+        return leaf->max_score;
+    }
+
+    std::vector<const art_node*> children;
+    switch(node->type) {
+        case NODE4: {
+            auto n = reinterpret_cast<const art_node4*>(node);
+            children.assign(n->children, n->children + n->n.num_children);
+            break;
+        }
+        case NODE16: {
+            auto n = reinterpret_cast<const art_node16*>(node);
+            children.assign(n->children, n->children + n->n.num_children);
+            break;
+        }
+        case NODE48: {
+            auto n = reinterpret_cast<const art_node48*>(node);
+            for(const art_node* child: n->children) {
+                if(child != nullptr) {
+                    children.push_back(child);
+                }
+            }
+            break;
+        }
+        case NODE256: {
+            auto n = reinterpret_cast<const art_node256*>(node);
+            for(const art_node* child: n->children) {
+                if(child != nullptr) {
+                    children.push_back(child);
+                }
+            }
+            break;
+        }
+        default:
+            ADD_FAILURE() << "Unknown ART node type " << static_cast<int>(node->type);
+            return INT64_MIN;
+    }
+
+    int64_t subtree_max = INT64_MIN;
+    for(const art_node* child: children) {
+        subtree_max = std::max(subtree_max, assert_token_score_subtree_max(child));
+    }
+
+    EXPECT_EQ(subtree_max, node->max_score);
+    return subtree_max;
+}
+
+TEST_F(CollectionSortingTest, BulkIndexUsesPerTokenMaxForArtNodes) {
+    std::vector<field> fields = {field("title", field_types::STRING, false),
+                                 field("points", field_types::INT32, false)};
+
+    Collection* coll = collectionManager.create_collection("token_score_bulk", 1, fields, "points").get();
+
+    // These documents are indexed in one batch. The high score belongs outside the
+    // `aa` subtree, so stamping the batch maximum on each token corrupts that subtree.
+    // Negative values also ensure a newly allocated node does not start with a synthetic 0.
+    std::vector<std::string> docs = {
+        R"({"id":"0","title":"aaa","points":-3})",
+        R"({"id":"1","title":"aab","points":-2})",
+        R"({"id":"2","title":"aac","points":-1})",
+        R"({"id":"3","title":"zzz","points":1000})"
+    };
+    nlohmann::json document;
+    auto import_result = coll->add_many(docs, document, CREATE);
+    ASSERT_EQ(4, import_result["num_imported"].get<size_t>());
+
+    const auto& search_index = coll->_get_index()->_get_search_index();
+    ASSERT_EQ(1, search_index.count("title"));
+    ASSERT_NE(nullptr, search_index.at("title")->root);
+    ASSERT_EQ(1000, assert_token_score_subtree_max(search_index.at("title")->root));
+
+    collectionManager.drop_collection("token_score_bulk");
+}
+
+TEST_F(CollectionSortingTest, TokenScoreRebuildIsDeduplicatedByRaftLogIndex) {
+    std::vector<field> fields = {field("title", field_types::STRING, false),
+                                 field("points", field_types::INT32, false)};
+
+    Collection* coll = collectionManager.create_collection("token_score_replay", 1, fields, "points").get();
+
+    nlohmann::json doc = {{"id", "0"}, {"title", "apple"}, {"points", 10}};
+    ASSERT_TRUE(coll->add(doc.dump()).ok());
+
+    auto first_rebuild = coll->rebuild_token_scores(100);
+    ASSERT_TRUE(first_rebuild.ok());
+    ASSERT_TRUE(first_rebuild.get());
+
+    // Recreate the collection manager to prove that deduplication comes from persisted
+    // application state, not an in-memory flag that disappears on restart.
+    collectionManager.dispose();
+    delete store;
+    store = new Store("/tmp/typesense_test/collection_sorting");
+    collectionManager.init(store, 1.0, "auth_key", quit);
+    ASSERT_TRUE(collectionManager.load(8, 1000).ok());
+
+    coll = collectionManager.get_collection("token_score_replay").get();
+    ASSERT_NE(nullptr, coll);
+
+    auto replayed_rebuild = coll->rebuild_token_scores(100);
+    ASSERT_TRUE(replayed_rebuild.ok());
+    ASSERT_FALSE(replayed_rebuild.get());
+
+    auto newer_rebuild = coll->rebuild_token_scores(101);
+    ASSERT_TRUE(newer_rebuild.ok());
+    ASSERT_TRUE(newer_rebuild.get());
+
+    collectionManager.drop_collection("token_score_replay");
+}
+
+TEST_F(CollectionSortingTest, TokenScoreRebuildRepairsLargeLeafDecrease) {
+    std::vector<field> fields = {field("title", field_types::STRING, false),
+                                 field("points", field_types::INT32, false)};
+
+    Collection* coll = collectionManager.create_collection("token_score_repair", 1, fields, "points").get();
+
+    // 130 docs share the apple token: the old inline repair capped out at 128 and left
+    // this leaf stale forever, which is exactly the case the rebuild has to cover
+    for(size_t i = 0; i < 130; i++) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["title"] = "apple";
+        doc["points"] = (i == 0) ? 1000 : 50;
+        ASSERT_TRUE(coll->add(doc.dump()).ok());
+    }
+
+    nlohmann::json doc2;
+    doc2["id"] = "130";
+    doc2["title"] = "apricot";
+    doc2["points"] = 100;
+    ASSERT_TRUE(coll->add(doc2.dump()).ok());
+
+    auto results = coll->search("ap", {"title"}, "", {}, {}, {0}, 10, 1, NOT_SET, {true}, 0,
+                                spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(),
+                                10, "", 30, 4, "", 20, {}, {}, {}, 0, "<mark>", "</mark>", {}, 1000, true,
+                                false, true, "", false, 6000 * 1000, 4, 7, fallback, 1).get();
+
+    ASSERT_EQ("apple", results["hits"][0]["document"]["title"].get<std::string>());
+
+    nlohmann::json doc_update;
+    doc_update["id"] = "0";
+    doc_update["points"] = 1;
+    ASSERT_TRUE(coll->add(doc_update.dump(), UPDATE).ok());
+
+    ASSERT_TRUE(coll->rebuild_token_scores().ok());
+
+    // apple now tops out at 50, so apricot at 100 takes the only candidate slot
+    results = coll->search("ap", {"title"}, "", {}, {}, {0}, 10, 1, NOT_SET, {true}, 0,
+                           spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(),
+                           10, "", 30, 4, "", 20, {}, {}, {}, 0, "<mark>", "</mark>", {}, 1000, true,
+                           false, true, "", false, 6000 * 1000, 4, 7, fallback, 1).get();
+
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("130", results["hits"][0]["document"]["id"].get<std::string>());
+
+    collectionManager.drop_collection("token_score_repair");
+}
+
+TEST_F(CollectionSortingTest, TokenScoreRebuildRepairsDeletedTopScorer) {
+    std::vector<field> fields = {field("title", field_types::STRING, false),
+                                 field("points", field_types::INT32, false)};
+
+    Collection* coll = collectionManager.create_collection("token_score_delete", 1, fields, "points").get();
+
+    nlohmann::json doc1;
+    doc1["id"] = "0";
+    doc1["title"] = "apple pie";
+    doc1["points"] = 1000;
+    ASSERT_TRUE(coll->add(doc1.dump()).ok());
+
+    nlohmann::json doc2;
+    doc2["id"] = "1";
+    doc2["title"] = "apple tart";
+    doc2["points"] = 1;
+    ASSERT_TRUE(coll->add(doc2.dump()).ok());
+
+    nlohmann::json doc3;
+    doc3["id"] = "2";
+    doc3["title"] = "apricot";
+    doc3["points"] = 100;
+    ASSERT_TRUE(coll->add(doc3.dump()).ok());
+
+    // deleting the doc that set the apple max never lowered the leaf
+    ASSERT_TRUE(coll->remove("0").ok());
+
+    auto results = coll->search("ap", {"title"}, "", {}, {}, {0}, 10, 1, NOT_SET, {true}, 0,
+                                spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(),
+                                10, "", 30, 4, "", 20, {}, {}, {}, 0, "<mark>", "</mark>", {}, 1000, true,
+                                false, true, "", false, 6000 * 1000, 4, 7, fallback, 1).get();
+
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"].get<std::string>());
+
+    ASSERT_TRUE(coll->rebuild_token_scores().ok());
+
+    results = coll->search("ap", {"title"}, "", {}, {}, {0}, 10, 1, NOT_SET, {true}, 0,
+                           spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(),
+                           10, "", 30, 4, "", 20, {}, {}, {}, 0, "<mark>", "</mark>", {}, 1000, true,
+                           false, true, "", false, 6000 * 1000, 4, 7, fallback, 1).get();
+
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("2", results["hits"][0]["document"]["id"].get<std::string>());
+
+    collectionManager.drop_collection("token_score_delete");
+}
+
+TEST_F(CollectionSortingTest, TokenScoreRebuildCoversNonStoredFields) {
+    // the update path could never fix these: a store:false field is absent from the
+    // persisted doc, so there is no text left to re-tokenize
+    field title_field("title", field_types::STRING, false);
+    title_field.store = false;
+
+    std::vector<field> fields = {title_field, field("points", field_types::INT32, false)};
+
+    Collection* coll = collectionManager.create_collection("token_score_nostore", 1, fields, "points").get();
+
+    nlohmann::json doc1;
+    doc1["id"] = "0";
+    doc1["title"] = "apple";
+    doc1["points"] = 100;
+    ASSERT_TRUE(coll->add(doc1.dump()).ok());
+
+    nlohmann::json doc2;
+    doc2["id"] = "1";
+    doc2["title"] = "apricot";
+    doc2["points"] = 10;
+    ASSERT_TRUE(coll->add(doc2.dump()).ok());
+
+    nlohmann::json doc2_update;
+    doc2_update["id"] = "1";
+    doc2_update["points"] = 1000;
+    ASSERT_TRUE(coll->add(doc2_update.dump(), UPDATE).ok());
+
+    ASSERT_TRUE(coll->rebuild_token_scores().ok());
+
+    auto results = coll->search("ap", {"title"}, "", {}, {}, {0}, 10, 1, NOT_SET, {true}, 0,
+                                spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(),
+                                10, "", 30, 4, "", 20, {}, {}, {}, 0, "<mark>", "</mark>", {}, 1000, true,
+                                false, true, "", false, 6000 * 1000, 4, 7, fallback, 1).get();
+
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"].get<std::string>());
+
+    collectionManager.drop_collection("token_score_nostore");
+}
+
+TEST_F(CollectionSortingTest, TokenScoreRebuildWithFloatSortField) {
+    std::vector<field> fields = {field("title", field_types::STRING, false),
+                                 field("volume", field_types::FLOAT, false)};
+
+    Collection* coll = collectionManager.create_collection("token_score_float", 1, fields, "volume").get();
+
+    nlohmann::json doc1;
+    doc1["id"] = "0";
+    doc1["title"] = "apple";
+    doc1["volume"] = 100.5;
+    ASSERT_TRUE(coll->add(doc1.dump()).ok());
+
+    nlohmann::json doc2;
+    doc2["id"] = "1";
+    doc2["title"] = "apricot";
+    doc2["volume"] = 10.5;
+    ASSERT_TRUE(coll->add(doc2.dump()).ok());
+
+    nlohmann::json doc2_update;
+    doc2_update["id"] = "1";
+    doc2_update["volume"] = 5000.5;
+    ASSERT_TRUE(coll->add(doc2_update.dump(), UPDATE).ok());
+
+    // sort_index keeps floats in a different encoding than art scores, so a rebuild
+    // that skipped the conversion would order these backwards
+    ASSERT_TRUE(coll->rebuild_token_scores().ok());
+
+    auto results = coll->search("ap", {"title"}, "", {}, {}, {0}, 10, 1, NOT_SET, {true}, 0,
+                                spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(),
+                                10, "", 30, 4, "", 20, {}, {}, {}, 0, "<mark>", "</mark>", {}, 1000, true,
+                                false, true, "", false, 6000 * 1000, 4, 7, fallback, 1).get();
+
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("1", results["hits"][0]["document"]["id"].get<std::string>());
+
+    doc2_update["volume"] = 0.5;
+    ASSERT_TRUE(coll->add(doc2_update.dump(), UPDATE).ok());
+    ASSERT_TRUE(coll->rebuild_token_scores().ok());
+
+    results = coll->search("ap", {"title"}, "", {}, {}, {0}, 10, 1, NOT_SET, {true}, 0,
+                           spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(),
+                           10, "", 30, 4, "", 20, {}, {}, {}, 0, "<mark>", "</mark>", {}, 1000, true,
+                           false, true, "", false, 6000 * 1000, 4, 7, fallback, 1).get();
+
+    ASSERT_EQ(1, results["hits"].size());
+    ASSERT_EQ("0", results["hits"][0]["document"]["id"].get<std::string>());
+
+    collectionManager.drop_collection("token_score_float");
+}
+
+TEST_F(CollectionSortingTest, TokenScoreRebuildRejectedForStringSortingField) {
+    std::vector<field> fields = {field("title", field_types::STRING, false, false, true, "", 1),
+                                 field("name", field_types::STRING, false, false, true, "", 1)};
+
+    Collection* coll = collectionManager.create_collection("token_score_str_sort", 1, fields, "name").get();
+
+    nlohmann::json doc;
+    doc["id"] = "0";
+    doc["title"] = "apple";
+    doc["name"] = "aaa";
+    ASSERT_TRUE(coll->add(doc.dump()).ok());
+
+    // a string sort field lives in str_sort_index, so the walk would read nothing from
+    // sort_index and still report success. reject instead of lying
+    auto rebuild_op = coll->rebuild_token_scores();
+    ASSERT_FALSE(rebuild_op.ok());
+    ASSERT_EQ(400, rebuild_op.code());
+    ASSERT_TRUE(rebuild_op.error().find("string field") != std::string::npos);
+
+    collectionManager.drop_collection("token_score_str_sort");
+}
+
+TEST_F(CollectionSortingTest, TokenScoreRebuildRejectedWithoutSortingField) {
+    std::vector<field> fields = {field("title", field_types::STRING, false)};
+
+    Collection* coll = collectionManager.create_collection("token_score_unranked", 1, fields).get();
+
+    nlohmann::json doc;
+    doc["id"] = "0";
+    doc["title"] = "apple";
+    ASSERT_TRUE(coll->add(doc.dump()).ok());
+
+    doc["id"] = "1";
+    doc["title"] = "apricot";
+    ASSERT_TRUE(coll->add(doc.dump()).ok());
+
+    // frequency ordered trees keep document counts in max_score, rebuilding would corrupt them
+    auto rebuild_op = coll->rebuild_token_scores();
+    ASSERT_FALSE(rebuild_op.ok());
+    ASSERT_EQ(400, rebuild_op.code());
+
+    auto results = coll->search("ap", {"title"}, "", {}, {}, {0}, 10, 1, NOT_SET, {true}, 0,
+                                spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(),
+                                10, "", 30, 4, "", 20, {}, {}, {}, 0, "<mark>", "</mark>", {}, 1000, true,
+                                false, true, "", false, 6000 * 1000, 4, 7, fallback, 4).get();
+
+    ASSERT_EQ(2, results["hits"].size());
+
+    collectionManager.drop_collection("token_score_unranked");
+}

--- a/test/collection_specific_more_test.cpp
+++ b/test/collection_specific_more_test.cpp
@@ -5142,3 +5142,70 @@ TEST_F(CollectionSpecificMoreTest, PhraseQueryHighlightShouldNotExpandToAllFlatF
 
     collectionManager.drop_collection("phrase_highlight_flat_multiple_occurrences");
 }
+
+TEST_F(CollectionSpecificMoreTest, PrefixSearchWithVolatileSortFieldShouldUseCurrentMaxScore) {
+    // ten distinct tokens share the "qua" prefix but only three candidates are
+    // expanded, so candidate selection is decided purely by art token max_score
+
+    std::vector<field> fields = {
+        field("ticker", field_types::STRING, false),
+        field("volume1h", field_types::FLOAT, false)
+    };
+
+    Collection* coll = collectionManager.create_collection("crypto_test", 1, fields, "volume1h").get();
+
+    for(size_t i = 0; i < 10; i++) {
+        nlohmann::json doc;
+        doc["id"] = std::to_string(i);
+        doc["ticker"] = std::string("qua") + std::string(1, 'a' + i);
+        doc["volume1h"] = (i + 1) * 10.0;
+        ASSERT_TRUE(coll->add(doc.dump()).ok());
+    }
+
+    auto results = coll->search("qua", {"ticker"}, "", {}, {}, {0}, 10, 1, NOT_SET, {true}, 0,
+                                spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(),
+                                10, "", 30, 4, "", 20, {}, {}, {}, 0, "<mark>", "</mark>", {}, 1000, true,
+                                false, true, "", false, 6000 * 1000, 4, 7, fallback, 3).get();
+
+    ASSERT_EQ(3, results["hits"].size());
+    ASSERT_EQ("9", results["hits"][0]["document"]["id"].get<std::string>());
+    ASSERT_EQ("8", results["hits"][1]["document"]["id"].get<std::string>());
+    ASSERT_EQ("7", results["hits"][2]["document"]["id"].get<std::string>());
+
+    // sort-only update of the coldest ticker to the highest volume: its ticker never
+    // re-indexes, so the token score only catches up on a rebuild
+    nlohmann::json doc_update;
+    doc_update["id"] = "0";
+    doc_update["volume1h"] = 100000.0;
+    ASSERT_TRUE(coll->add(doc_update.dump(), UPDATE).ok());
+
+    ASSERT_TRUE(coll->rebuild_token_scores().ok());
+
+    results = coll->search("qua", {"ticker"}, "", {}, {}, {0}, 10, 1, NOT_SET, {true}, 0,
+                           spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(),
+                           10, "", 30, 4, "", 20, {}, {}, {}, 0, "<mark>", "</mark>", {}, 1000, true,
+                           false, true, "", false, 6000 * 1000, 4, 7, fallback, 3).get();
+
+    ASSERT_EQ(3, results["hits"].size());
+    ASSERT_EQ("0", results["hits"][0]["document"]["id"].get<std::string>());
+
+    // and the slot goes back on the way down, which the insert path can never do
+    doc_update["volume1h"] = 1.0;
+    ASSERT_TRUE(coll->add(doc_update.dump(), UPDATE).ok());
+
+    ASSERT_TRUE(coll->rebuild_token_scores().ok());
+
+    results = coll->search("qua", {"ticker"}, "", {}, {}, {0}, 10, 1, NOT_SET, {true}, 0,
+                           spp::sparse_hash_set<std::string>(), spp::sparse_hash_set<std::string>(),
+                           10, "", 30, 4, "", 20, {}, {}, {}, 0, "<mark>", "</mark>", {}, 1000, true,
+                           false, true, "", false, 6000 * 1000, 4, 7, fallback, 3).get();
+
+    ASSERT_EQ(3, results["hits"].size());
+    ASSERT_EQ("9", results["hits"][0]["document"]["id"].get<std::string>());
+
+    for(const auto& hit: results["hits"]) {
+        ASSERT_NE("0", hit["document"]["id"].get<std::string>());
+    }
+
+    collectionManager.drop_collection("crypto_test");
+}

--- a/test/core_api_utils_test.cpp
+++ b/test/core_api_utils_test.cpp
@@ -3999,3 +3999,85 @@ TEST_F(CoreAPIUtilsTest, UnionRemoveDuplicates) {
     ASSERT_EQ("1", response["hits"][3]["document"]["id"]);
     ASSERT_EQ("1", response["hits"][4]["document"]["id"]);
 }
+
+TEST_F(CoreAPIUtilsTest, RebuildTokenScoresParamValidation) {
+    nlohmann::json schema = R"({
+        "name": "token_score_api",
+        "fields": [
+            {"name": "title", "type": "string"},
+            {"name": "points", "type": "int32"}
+        ],
+        "default_sorting_field": "points"
+    })"_json;
+
+    auto coll_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(coll_op.ok());
+
+    std::shared_ptr<http_req> req = std::make_shared<http_req>();
+    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
+
+    // the http layer always fills these in, they must not count as client supplied
+    req->params["collection"] = "token_score_api";
+    req->params["x-typesense-user-id"] = "127.0.0.1";
+    req->params["rebuild_token_scores"] = "true";
+    req->body = "";
+    req->log_index = 1234;
+
+    ASSERT_TRUE(patch_update_collection(req, res));
+    ASSERT_EQ(R"({"rebuild_token_scores":true})", res->body);
+
+    std::string rebuilt_at_log_index;
+    const std::string rebuild_log_key = std::to_string(coll_op.get()->get_collection_id()) + "_" +
+                                        Collection::TOKEN_SCORE_REBUILD_LOG_PREFIX;
+    ASSERT_EQ(StoreStatus::FOUND, store->get(rebuild_log_key, rebuilt_at_log_index));
+    ASSERT_EQ("1234", rebuilt_at_log_index);
+
+    // must be sent by itself
+    req->params["metadata"] = "{}";
+    ASSERT_FALSE(patch_update_collection(req, res));
+    ASSERT_EQ("{\"message\":\"Parameter `rebuild_token_scores` cannot be combined with other parameters.\"}",
+              res->body);
+    req->params.erase("metadata");
+
+    // must be sent without a body
+    req->body = R"({"metadata": {}})";
+    ASSERT_FALSE(patch_update_collection(req, res));
+    ASSERT_EQ("{\"message\":\"Parameter `rebuild_token_scores` must be sent without a request body.\"}", res->body);
+    req->body = "";
+
+    // only `true` is meaningful
+    req->params["rebuild_token_scores"] = "false";
+    ASSERT_FALSE(patch_update_collection(req, res));
+    ASSERT_EQ("{\"message\":\"Parameter `rebuild_token_scores` must be `true`.\"}", res->body);
+
+    // an empty body is still rejected for a normal alter
+    req->params.erase("rebuild_token_scores");
+    ASSERT_FALSE(patch_update_collection(req, res));
+    ASSERT_EQ("{\"message\":\"Bad JSON.\"}", res->body);
+
+    collectionManager.drop_collection("token_score_api");
+}
+
+TEST_F(CoreAPIUtilsTest, RebuildTokenScoresRejectedWithoutSortingField) {
+    nlohmann::json schema = R"({
+        "name": "token_score_api_unranked",
+        "fields": [
+            {"name": "title", "type": "string"}
+        ]
+    })"_json;
+
+    auto coll_op = collectionManager.create_collection(schema);
+    ASSERT_TRUE(coll_op.ok());
+
+    std::shared_ptr<http_req> req = std::make_shared<http_req>();
+    std::shared_ptr<http_res> res = std::make_shared<http_res>(nullptr);
+
+    req->params["collection"] = "token_score_api_unranked";
+    req->params["rebuild_token_scores"] = "true";
+    req->body = "";
+
+    ASSERT_FALSE(patch_update_collection(req, res));
+    ASSERT_EQ(400, res->status_code);
+
+    collectionManager.drop_collection("token_score_api_unranked");
+}


### PR DESCRIPTION
## Change Summary


- add `PATCH /collections/:collection?rebuild_token_scores=true` with an empty body
- use the endpoint after sort-only updates or deletions leave prefix candidate scores stale
- recompute ART leaf and inner-node scores from the live default sort index
- yield the index lock periodically so searches can continue during large rebuilds
- reject rebuilds for collections without a numeric `default_sorting_field`
- persist completed Raft log indexes to avoid repeating rebuilds during replay
- correct bulk indexing to calculate maximum scores per token and preserve float ordering

## PR Checklist
<!--- Put an `x` inside the box : -->
- [ ] I have read and signed the [Contributor License Agreement](https://forms.gle/PZyiY5N2GDQU8GsV9).
